### PR TITLE
Terraform cos automation

### DIFF
--- a/ibmcloud/README.md
+++ b/ibmcloud/README.md
@@ -161,13 +161,21 @@ https://cloud.ibm.com/objectstorage/
 
 First, create a COS service instance if you have not create one. Then, create a COS bucket with the COS instance. The COS service instance and bucket names are necessary to upload a custom VM image.
 
+You can use the Terraform template located at [ibmcloud/terraform/cos](./terraform/cos)to use Terraform to create a COS service instance, COS bucket, and IAM AuthorizationPolicy automatically. These resources are configured to store images. Create a `terraform.tfvars` file in the templates directory that includes these fields:
 
-Next, you need to grant access to COS to import images as described at [https://cloud.ibm.com/docs/vpc?topic=vpc-object-storage-prereq&interface=cli](https://cloud.ibm.com/docs/vpc?topic=vpc-object-storage-prereq&interface=cli).
+```
+ibmcloud_api_key = "<your API key>"
+cos_bucket_name = "<COS bucket name>"
+cos_service_instance_name = "<COS instance name>"
+```
+> **Note:** The environment variable `cos_service_instance_name` in `variables.tf` has the default value `cos-image-instance` which will be used by Terraform if you do not provide a unique value in `terraform.tfvars`.
 
+Then run the Template via the following commands: 
 ```bash
-$ ibmcloud login -r jp-tok -apikey <your API key>
-$ COS_INSTANCE_GUID=$(ibmcloud resource service-instance --output json "$IBMCLOUD_COS_SERVICE_INSTANCE" | jq -r '.[].guid')
-$ ibmcloud iam authorization-policy-create is cloud-object-storage Reader --source-resource-type image --target-service-instance-id $COS_INSTANCE_GUID
+$ cd ibmcloud/terraform/cos
+$ terraform init
+$ terraform plan
+$ terraform apply
 ```
 
 You can use a Terraform template located at [ibmcloud/terraform/podvm-build](./terraform/podvm-build) to use Terraform and Ansible to build a pod VM image on the k8s worker node, upload it to a COS bucket and verify it. The architecture of the pod VM image built on the k8s worker node will be the same as that of the node. For example, a k8s worker node using an Intel **x86** VSI will build an Intel **x86** pod VM image and a k8s worker node using an IBM **s390x** VSI will build an IBM **s390x** pod VM image.

--- a/ibmcloud/terraform/cos/main.tf
+++ b/ibmcloud/terraform/cos/main.tf
@@ -1,0 +1,29 @@
+data "ibm_resource_group" "group" {
+  name = "default"
+}
+
+########## Create a COS instance
+resource "ibm_resource_instance" "cos_instance" {
+  name              = var.cos_service_instance_name
+  service           = "cloud-object-storage"
+  plan              = "standard"
+  location          = "global"
+  resource_group_id = data.ibm_resource_group.group.id
+}
+
+####### Create IAM Authorization Policy
+resource "ibm_iam_authorization_policy" "policy" {
+    source_service_name  = "is"
+    source_resource_type = "image"
+    target_service_name  = "cloud-object-storage"
+    target_resource_instance_id = ibm_resource_instance.cos_instance.guid
+    roles                = ["Reader"]
+}
+
+######## Create COS bucket
+resource "ibm_cos_bucket" "state_bucket" {
+  bucket_name          = var.cos_bucket_name
+  resource_instance_id = ibm_resource_instance.cos_instance.id
+  region_location      = var.ibm_region
+  storage_class        = "standard"
+}

--- a/ibmcloud/terraform/cos/output.tf
+++ b/ibmcloud/terraform/cos/output.tf
@@ -1,0 +1,27 @@
+##############################################################################
+# Outputs
+##############################################################################
+output "resource_group_id" {
+  description = "Resource Group ID"
+  value       = var.resource_group_id
+}
+
+output "s3_region" {
+  description = "S3 Region"
+  value       = ibm_cos_bucket.state_bucket.region_location
+}
+
+output "s3_endpoint_private" {
+  description = "S3 private endpoint"
+  value       = ibm_cos_bucket.state_bucket.s3_endpoint_private
+}
+
+output "s3_endpoint_public" {
+  description = "S3 public endpoint"
+  value       = ibm_cos_bucket.state_bucket.s3_endpoint_public
+}
+
+output "cos_bucket_name" {
+  description = "Bucket Name"
+  value       = ibm_cos_bucket.state_bucket.bucket_name
+}

--- a/ibmcloud/terraform/cos/provider.tf
+++ b/ibmcloud/terraform/cos/provider.tf
@@ -1,0 +1,4 @@
+provider "ibm" {
+  ibmcloud_api_key = var.ibmcloud_api_key
+  region           = var.ibm_region
+}

--- a/ibmcloud/terraform/cos/variables.tf
+++ b/ibmcloud/terraform/cos/variables.tf
@@ -1,0 +1,33 @@
+##############################################################################
+# Input Variables
+##############################################################################
+
+# Resource Group Variables
+variable "resource_group_id" {
+  type        = string
+  description = "The resource group ID where the environment will be created"
+  default     = "default"
+}
+
+variable "ibmcloud_api_key" {
+  description = "API key to login to IBM Cloud"
+  type        = string
+  sensitive   = true
+}
+
+variable "ibm_region" {
+  description = "Name of the Region to deploy in to"
+  type        = string
+  default     = "jp-tok"
+}
+
+variable "cos_bucket_name" {
+  description = "Name of the COS bucket to create"
+  type        = string
+}
+
+variable "cos_service_instance_name" {
+  description = "Name of the COS instance to create"
+  type        = string
+  default     = "cos-image-instance"
+}

--- a/ibmcloud/terraform/cos/versions.tf
+++ b/ibmcloud/terraform/cos/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+    required_providers {
+        ibm = {
+            source = "IBM-Cloud/ibm"
+            version = "~> 1.41.0"
+        }
+    }
+}


### PR DESCRIPTION
Work completed to automate COS creation to store image from Build a 
pod VM image section of terraform/README.md. 
The main.tf file creates the instances. 
This automation allows the user to run a Terraform apply command
to create all the storage required to store an image.

Fixes: #17