### PR TITLE
go: use github.com/yoheiueda/kata-containers tree

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,6 @@ require (
 )
 
 replace (
-	github.com/kata-containers/kata-containers/src/runtime => ../kata-containers/src/runtime
+	github.com/kata-containers/kata-containers/src/runtime => github.com/yoheiueda/kata-containers/src/runtime v0.0.0-20220429130351-22a2aa8a867d
 	google.golang.org/genproto => google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
 )

--- a/go.sum
+++ b/go.sum
@@ -949,6 +949,8 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:
 github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/yoheiueda/kata-containers/src/runtime v0.0.0-20220429130351-22a2aa8a867d h1:53g3EfSv8WjzBPPtUD3AYXW6M4iVYsgs7q2Jo+oXr1k=
+github.com/yoheiueda/kata-containers/src/runtime v0.0.0-20220429130351-22a2aa8a867d/go.mod h1:QEr2z9kUauxDp9PmT8jYGcrlO11pVWVBhAcwNXR1KZ4=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Currently go.mod instructs to replace the
github.com/kata-containers/kata-containers/src/runtime module with one
found on localhost (../kata-containers/src/runtime), which means the
developer must clone the repository manually and place on the right
directory at go root.

However, in practice, the tree github.com/yoheiueda/kata-containers/tree/CCv0-peerpod has been
used as the "official" kata-containers/src/runtime fork at the moment. So to simplify
the project's bootstrap on developers side as well as for a future CI, this
changed the go.mod so that Yohei's tree is explicitly referenced.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>