### PR TITLE
Add creation of the IS SSH key to the cluster Terraform template

### DIFF
--- a/ibmcloud/README.md
+++ b/ibmcloud/README.md
@@ -89,9 +89,18 @@ As usual, you need to create `terraform.tfvars` to specify parameter values. The
 
 ```
 ibmcloud_api_key = "<your API key>"
-ssh_key_name = "<your SSH key name>"
+ssh_pub_key = "<your SSH public key>"
 cluster_name = "<cluster name>"
 ```
+
+> **Hint:** To use a previously imported SSH key, use `terraform import ibm_is_ssh_key.ssh_key <ssh_key.ID>` after you run `terraform init`
+>
+>> You can find your key's ID using the following command `ibmcloud is keys --json | jq '.[] | select(.name == "<key_name>").id'` requires `jq`
+>>
+>> Or visit [https://cloud.ibm.com/vpc-ext/compute/sshKeys](https://cloud.ibm.com/vpc-ext/compute/sshKeys) to manage your keys
+>
+> Addtionally, to avoid the ssh key being deleted use `terraform state rm ibm_is_ssh_key.ssh_key` before `terraform destroy`
+
 > **Hint:** In order to create the cluster based on a different type of VSI image you can overwrite more parameters here e.g. to create a **s390x** based cluster add follow two lines to the `terraform.tfvars` file
 >
 >
@@ -101,7 +110,7 @@ cluster_name = "<cluster name>"
 
 > **Notes:**
 > - `ibmcloud_api_key` is your IBM Cloud API Key that you just created at [https://cloud.ibm.com/iam/apikeys](https://cloud.ibm.com/iam/apikeys).
-> - `ssh_key_name` is a name of your SSH key registered in IBM Cloud. It is used to access a Generation 2 virtual server instance. You can add your SSH key at [https://cloud.ibm.com/vpc-ext/compute/sshKeys](https://cloud.ibm.com/vpc-ext/compute/sshKeys). This ssh key will be installed on control-plane and worker nodes. For more information, about SSH key, see [managing SSH Keys](https://cloud.ibm.com/docs/vpc?topic=vpc-ssh-keys).
+> - `ssh_pub_key` is a ssh public key. It is used to access a Generation 2 virtual server instance. This ssh key will be installed on control-plane and worker nodes. For more information, about SSH keys, see [managing SSH Keys](https://cloud.ibm.com/docs/vpc?topic=vpc-ssh-keys).
 >
 > - `cluster_name` is a name of a Kubernetes cluster. This name is used for the prefix of the names of control-plane and worker nodes. If you want to create another cluster in the same VPC, you need to use a different name for the new cluster.
 > - `instance_profile_name` is a name of IBM Cloud virtual server instance profile. This name is used to create IBM Cloud virtual server instance. For more information, about virtual server instance profile, see [instance profiles](https://cloud.ibm.com/docs/vpc?topic=vpc-profiles).

--- a/ibmcloud/terraform/cluster/main.tf
+++ b/ibmcloud/terraform/cluster/main.tf
@@ -9,13 +9,15 @@ locals {
   controlplane_floating_ip_name = "${local.controlplane_name}-ip"
   worker_name = "${var.cluster_name}-worker"
   worker_floating_ip_name = "${local.worker_name}-ip"
+  ssh_key_name = "${var.cluster_name}-ssh-key"
   controlplane_ip = resource.ibm_is_instance.controlplane.primary_network_interface[0].primary_ipv4_address
   worker_ip = resource.ibm_is_instance.worker.primary_network_interface[0].primary_ipv4_address
   bastion_ip = resource.ibm_is_floating_ip.worker.address
 }
 
-data "ibm_is_ssh_key" "ssh_key" {
-  name = var.ssh_key_name
+resource "ibm_is_ssh_key" "ssh_key" {
+  name = local.ssh_key_name
+  public_key = var.ssh_pub_key
 }
 
 data "ibm_is_image" "k8s_node" {
@@ -40,7 +42,7 @@ resource "ibm_is_instance_template" "k8s_node" {
   profile = var.instance_profile_name
   vpc     = data.ibm_is_vpc.vpc.id
   zone    = var.zone_name
-  keys    = [data.ibm_is_ssh_key.ssh_key.id]
+  keys    = [ibm_is_ssh_key.ssh_key.id]
 
   primary_network_interface {
     subnet = data.ibm_is_subnet.primary.id

--- a/ibmcloud/terraform/cluster/variables.tf
+++ b/ibmcloud/terraform/cluster/variables.tf
@@ -2,7 +2,7 @@
 variable "ibmcloud_api_key" {
     sensitive = true
 }
-variable "ssh_key_name" {}
+variable "ssh_pub_key" {}
 variable "cluster_name" {}
 
 variable "region_name" {


### PR DESCRIPTION
Have switched the cluster Terraform template to use the [ibm_is_ssh_key resource](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/is_ssh_key) over the old data source definition. This reduces the manual effort on the part of the developer.

- [x] Update the Terraform template in `ibmcloud/terraform/cluster` so that the template creates a new SSH key instance rather than using a pre-existing one
- [x] Add the name of the SSH key to the template's `locals` (e.g., construct it using `var.cluster_name` like the other `locals` for the template)
- [x] Make the creation of the instance template in this Terraform template use the newly created SSH key resource
- [x] Add a new variable for the SSH public key value to the Terraform template and remove the SSH key name variables
- [x] Test the updated Terraform template for the create the Kubernetes cluster - you will need to run the `ibmcloud/terraform/common` Terraform template before `ibmcloud/terraform/cluster` to create the VPC, subnets and security groups etc
- [x] Update the README.md file in `ibmcloud/` to reflect the SSH key is added to IBM Cloud automatically and explain how to add your public SSH key to the Terraform template as an input variable

Signed-off-by: jtumber <james.tumber@ibm.com>