### PR TITLE
Add creation of the IS SSH key to the cluster Terraform template

### DIFF
--- a/ibmcloud/terraform/cluster/main.tf
+++ b/ibmcloud/terraform/cluster/main.tf
@@ -9,21 +9,26 @@ locals {
   controlplane_floating_ip_name = "${local.controlplane_name}-ip"
   worker_name = "${var.cluster_name}-worker"
   worker_floating_ip_name = "${local.worker_name}-ip"
-  ssh_key_name = var.user_ssh_key_name == "" ? "${var.cluster_name}-ssh-key" : "${var.user_ssh_key_name}"
   controlplane_ip = resource.ibm_is_instance.controlplane.primary_network_interface[0].primary_ipv4_address
   worker_ip = resource.ibm_is_instance.worker.primary_network_interface[0].primary_ipv4_address
   bastion_ip = resource.ibm_is_floating_ip.worker.address
 }
 
 resource "ibm_is_ssh_key" "created_ssh_key" {
+  # Create the ssh key only if the public key is set
   count = var.ssh_pub_key == "" ? 0 : 1
-  name = local.ssh_key_name
+  name = var.ssh_key_name
   public_key = var.ssh_pub_key
 }
 
 data "ibm_is_ssh_key" "ssh_key" {
+  # Wait if the key needs creating first
   depends_on = [ibm_is_ssh_key.created_ssh_key]
-  name = local.ssh_key_name
+  name = var.ssh_key_name
+}
+
+output "ssh_key_name" {
+  value = var.ssh_key_name
 }
 
 data "ibm_is_image" "k8s_node" {

--- a/ibmcloud/terraform/cluster/main.tf
+++ b/ibmcloud/terraform/cluster/main.tf
@@ -9,13 +9,21 @@ locals {
   controlplane_floating_ip_name = "${local.controlplane_name}-ip"
   worker_name = "${var.cluster_name}-worker"
   worker_floating_ip_name = "${local.worker_name}-ip"
+  ssh_key_name = var.user_ssh_key_name == "" ? "${var.cluster_name}-ssh-key" : "${var.user_ssh_key_name}"
   controlplane_ip = resource.ibm_is_instance.controlplane.primary_network_interface[0].primary_ipv4_address
   worker_ip = resource.ibm_is_instance.worker.primary_network_interface[0].primary_ipv4_address
   bastion_ip = resource.ibm_is_floating_ip.worker.address
 }
 
+resource "ibm_is_ssh_key" "created_ssh_key" {
+  count = var.ssh_pub_key == "" ? 0 : 1
+  name = local.ssh_key_name
+  public_key = var.ssh_pub_key
+}
+
 data "ibm_is_ssh_key" "ssh_key" {
-  name = var.ssh_key_name
+  depends_on = [ibm_is_ssh_key.created_ssh_key]
+  name = local.ssh_key_name
 }
 
 data "ibm_is_image" "k8s_node" {

--- a/ibmcloud/terraform/cluster/variables.tf
+++ b/ibmcloud/terraform/cluster/variables.tf
@@ -2,8 +2,14 @@
 variable "ibmcloud_api_key" {
     sensitive = true
 }
-variable "ssh_key_name" {}
 variable "cluster_name" {}
+
+variable "user_ssh_key_name" {
+    default = ""
+}
+variable "ssh_pub_key" {
+    default = ""
+}
 
 variable "region_name" {
     default = "jp-tok"

--- a/ibmcloud/terraform/cluster/variables.tf
+++ b/ibmcloud/terraform/cluster/variables.tf
@@ -3,10 +3,8 @@ variable "ibmcloud_api_key" {
     sensitive = true
 }
 variable "cluster_name" {}
+variable "ssh_key_name" {}
 
-variable "user_ssh_key_name" {
-    default = ""
-}
 variable "ssh_pub_key" {
     default = ""
 }


### PR DESCRIPTION
Have switched the cluster Terraform template to use the [ibm_is_ssh_key resource](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/is_ssh_key) over the old data source definition. This reduces the manual effort on the part of the developer.

- [x] Update the Terraform template in `ibmcloud/terraform/cluster` so that the template creates a new SSH key instance rather than using a pre-existing one
- [x] Add the name of the SSH key to the template's `locals` (e.g., construct it using `var.cluster_name` like the other `locals` for the template)
- [x] Make the creation of the instance template in this Terraform template use the newly created SSH key resource
- [x] Add a new variable for the SSH public key value to the Terraform template and remove the SSH key name variables
- [x] Test the updated Terraform template for the create the Kubernetes cluster - you will need to run the `ibmcloud/terraform/common` Terraform template before `ibmcloud/terraform/cluster` to create the VPC, subnets and security groups etc
- [x] Update the README.md file in `ibmcloud/` to reflect the SSH key is added to IBM Cloud automatically and explain how to add your public SSH key to the Terraform template as an input variable

Fixes: #24 

Signed-off-by: jtumber-ibm <james.tumber@ibm.com>