### PR TITLE
COS variables now have consistent naming

### DIFF
--- a/ibmcloud/README.md
+++ b/ibmcloud/README.md
@@ -209,8 +209,8 @@ If you used the Terraform templates in [common](./terraform/common) and [cluster
 >     $ ibmcloud account users
 >     ```
 >     If command `ibmcloud account users` displays multiple user IDs, choose the user ID whose state is `ACTIVE`.
-> - `cos_service_instance_name` is the COS Service Instance Name, optional, default to value based on your `cluster_name` tfvar if not set, `${cluster_name}-cos-service-instance`.
-> - `cos_bucket_name` is the COS Bucket Name, optional, default to value based on your `cluster_name` tfvar if not set, `${cluster_name}-cos-bucket`.
+> - `cos_service_instance_name` is the optional variable for COS Service Instance Name with a default value of `cos-image-instance` if not set in `terraform.tfvars`.
+> - `cos_bucket_name` is the COS Bucket Name, which must be unique.
 
 
 > **Notes:**

--- a/ibmcloud/terraform/podvm-build/main.tf
+++ b/ibmcloud/terraform/podvm-build/main.tf
@@ -9,8 +9,6 @@ locals {
   worker_ip = data.ibm_is_instance.worker.primary_network_interface[0].primary_ipv4_address
   bastion_ip = data.ibm_is_floating_ip.worker.address
   zone_name = data.ibm_is_subnet.primary.zone
-  cos_service_instance_name = var.cos_service_instance_name != null ? var.cos_service_instance_name : "${var.cluster_name}-cos-service-instance"
-  cos_bucket_name = var.cos_bucket_name != null ? var.cos_bucket_name : "${var.cluster_name}-cos-bucket"
   ibmcloud_api_endpoint = var.use_ibmcloud_test ? "https://test.cloud.ibm.com" : "https://cloud.ibm.com"
   is_policies_and_roles = flatten([
     for policy in data.ibm_iam_user_policy.user_policies.policies: [
@@ -54,8 +52,8 @@ resource "local_file" "group_vars" {
 
 ibmcloud_api_key: ${var.ibmcloud_api_key}
 ibmcloud_api_endpoint: ${local.ibmcloud_api_endpoint}
-ibmcloud_cos_service_instance: ${local.cos_service_instance_name}
-ibmcloud_cos_bucket: ${local.cos_bucket_name}
+ibmcloud_cos_service_instance: ${var.cos_service_instance_name}
+ibmcloud_cos_bucket: ${var.cos_bucket_name}
 ibmcloud_region_name: ${var.region_name}
 ibmcloud_vpc_name: ${var.vpc_name}
 ibmcloud_vpc_subnet_name: ${var.primary_subnet_name}

--- a/ibmcloud/terraform/podvm-build/variables.tf
+++ b/ibmcloud/terraform/podvm-build/variables.tf
@@ -20,12 +20,10 @@ variable "primary_subnet_name" {
 }
 
 variable "cos_service_instance_name" {
-    default = null
+    default = "cos-image-instance"
 }
 
-variable "cos_bucket_name" {
-    default = null
-}
+variable "cos_bucket_name" {}
 
 variable "use_ibmcloud_test" {
     type = bool


### PR DESCRIPTION
Completed work to have consistent variable names across different 
Terraform templates.
 cos_bucket_name now set in terraform.tfvars and has no default as
 has to be unique.
Removed cos_service_instance_name prefix. Set new default value.

Fixes [#21](https://github.com/confidential-containers/cloud-api-adaptor/issues/21)

Signed-off-by: [Jonah Farrow] [Jonah.Farrow@ibm.com](mailto:Jonah.Farrow@ibm.com)


Completed work to have consistent variable names across documentation. 
/terraform/README now reflects COS variable name changes. 
README now has consistent expectations for COS instance 
 and bucket names.

Fixes [#21](https://github.com/confidential-containers/cloud-api-adaptor/issues/21)

Signed-off-by: [Jonah Farrow] [Jonah.Farrow@ibm.com](mailto:Jonah.Farrow@ibm.com)


## Blocked merge 
Until the following PR is merged first:
https://github.com/confidential-containers/cloud-api-adaptor/pull/27

Please feel free to leave comments on the commits mentioned above.

To leave comments on `automation: split cluster playbook into two` go [here](https://github.com/confidential-containers/cloud-api-adaptor/pull/27):
