### PR TITLE
Fix gofmt errors

### DIFF
--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -32,7 +32,6 @@ func Parse(programName string, args []string, fn func(flags *flag.FlagSet)) {
 
 	}
 
-
 	if err := flags.Parse(args[1:]); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			Exit(0)

--- a/pkg/adaptor/hypervisor/aws/server.go
+++ b/pkg/adaptor/hypervisor/aws/server.go
@@ -8,15 +8,14 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/hypervisor"
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork"
 	"github.com/containerd/ttrpc"
 
 	pb "github.com/kata-containers/kata-containers/src/runtime/protocols/hypervisor"
 )
 
 var logger = log.New(log.Writer(), "[helper/hypervisor] ", log.LstdFlags|log.Lmsgprefix)
-
 
 type server struct {
 	socketPath string
@@ -33,14 +32,14 @@ type server struct {
 
 func NewServer(cfg hypervisor.Config, cloudCfg Config, workerNode podnetwork.WorkerNode, daemonPort string) hypervisor.Server {
 
-     logger.Printf("hypervisor config %v", cfg)
-     logger.Printf("cloud config %v", cloudCfg)
-     ec2Client, err := NewEC2Client(cloudCfg)
-     if err != nil {
-          return nil
-     }
+	logger.Printf("hypervisor config %v", cfg)
+	logger.Printf("cloud config %v", cloudCfg)
+	ec2Client, err := NewEC2Client(cloudCfg)
+	if err != nil {
+		return nil
+	}
 
-    return &server{
+	return &server{
 		socketPath: cfg.SocketPath,
 		service:    newService(ec2Client, &cloudCfg, workerNode, cfg.PodsDir, daemonPort),
 		workerNode: workerNode,

--- a/pkg/adaptor/hypervisor/aws/service.go
+++ b/pkg/adaptor/hypervisor/aws/service.go
@@ -27,9 +27,8 @@ import (
 	pb "github.com/kata-containers/kata-containers/src/runtime/protocols/hypervisor"
 )
 
-
 const (
-	Version       = "0.0.0"
+	Version               = "0.0.0"
 	EC2LaunchTemplateName = "kata"
 )
 
@@ -142,7 +141,6 @@ func (s *hypervisorService) StartVM(ctx context.Context, req *pb.StartVMRequest)
 		return nil, err
 	}
 
-
 	daemonConfig := daemon.Config{
 		PodNamespace: sandbox.namespace,
 		PodName:      sandbox.pod,
@@ -196,7 +194,7 @@ func (s *hypervisorService) StartVM(ctx context.Context, req *pb.StartVMRequest)
 	logger.Printf("created an instance %s for sandbox %s", *result.Instances[0].PublicDnsName, req.Id)
 
 	vmName := fmt.Sprintf("%s-%s-%s-%.8s", s.nodeName, sandbox.namespace, sandbox.pod, sandbox.id)
-        tagInput := &ec2.CreateTagsInput{
+	tagInput := &ec2.CreateTagsInput{
 		Resources: []string{*result.Instances[0].InstanceId},
 		Tags: []types.Tag{
 			{
@@ -206,10 +204,10 @@ func (s *hypervisorService) StartVM(ctx context.Context, req *pb.StartVMRequest)
 		},
 	}
 
-        _, err = MakeTags(context.TODO(), s.ec2Client, tagInput)
-        if err != nil {
-                logger.Printf("failed to tag the instance", err)
-        }
+	_, err = MakeTags(context.TODO(), s.ec2Client, tagInput)
+	if err != nil {
+		logger.Printf("failed to tag the instance", err)
+	}
 
 	podNodeIPs, err := getIPs(result.Instances[0])
 	if err != nil {

--- a/pkg/adaptor/hypervisor/ibmcloud/service.go
+++ b/pkg/adaptor/hypervisor/ibmcloud/service.go
@@ -50,8 +50,8 @@ type hypervisorService struct {
 }
 
 func newService(vpcV1 VpcV1, config *Config, workerNode podnetwork.WorkerNode, podsDir, daemonPort string) pb.HypervisorService {
-        
-        logger.Printf("service config %v", config)
+
+	logger.Printf("service config %v", config)
 
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -191,7 +191,7 @@ func (s *hypervisorService) StartVM(ctx context.Context, req *pb.StartVMRequest)
 		},
 		VPC: &vpcv1.VPCIdentity{ID: &s.serviceConfig.VpcID},
 		PrimaryNetworkInterface: &vpcv1.NetworkInterfacePrototype{
-			Subnet:          &vpcv1.SubnetIdentity{ID: &s.serviceConfig.PrimarySubnetID},
+			Subnet: &vpcv1.SubnetIdentity{ID: &s.serviceConfig.PrimarySubnetID},
 			SecurityGroups: []vpcv1.SecurityGroupIdentityIntf{
 				&vpcv1.SecurityGroupIdentityByID{ID: &s.serviceConfig.PrimarySecurityGroupID},
 			},
@@ -330,8 +330,8 @@ func getIPs(prototype *vpcv1.InstancePrototype, result *vpcv1.Instance) ([]net.I
 }
 
 func (s *hypervisorService) deleteInstance(id string) error {
-        options := &vpcv1.DeleteInstanceOptions{}
-        options.SetID(id)
+	options := &vpcv1.DeleteInstanceOptions{}
+	options.SetID(id)
 	resp, err := s.vpcV1.DeleteInstance(options)
 	if err != nil {
 		logger.Printf("failed to delete an instance: %v and the response is %v", err, resp)

--- a/pkg/adaptor/hypervisor/libvirt/libvirt.go
+++ b/pkg/adaptor/hypervisor/libvirt/libvirt.go
@@ -7,14 +7,14 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
+	libvirt "libvirt.org/go/libvirt"
+	libvirtxml "libvirt.org/go/libvirtxml"
 	"log"
 	"net"
 	"os"
 	"os/exec"
 	"strconv"
 	"time"
-	libvirt "libvirt.org/go/libvirt"
-	libvirtxml "libvirt.org/go/libvirtxml"
 )
 
 type libvirtClient struct {

--- a/pkg/adaptor/hypervisor/libvirt/service.go
+++ b/pkg/adaptor/hypervisor/libvirt/service.go
@@ -25,9 +25,8 @@ import (
 	pb "github.com/kata-containers/kata-containers/src/runtime/protocols/hypervisor"
 )
 
-
 const (
-	Version       = "0.0.0"
+	Version = "0.0.0"
 )
 
 type hypervisorService struct {

--- a/pkg/adaptor/hypervisor/registry/aws.go
+++ b/pkg/adaptor/hypervisor/registry/aws.go
@@ -3,8 +3,8 @@
 package registry
 
 import (
-	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/hypervisor/aws"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/hypervisor"
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/hypervisor/aws"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork"
 )
 

--- a/pkg/adaptor/hypervisor/registry/ibmcloud.go
+++ b/pkg/adaptor/hypervisor/registry/ibmcloud.go
@@ -3,8 +3,8 @@
 package registry
 
 import (
-	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/hypervisor/ibmcloud"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/hypervisor"
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/hypervisor/ibmcloud"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork"
 )
 

--- a/pkg/adaptor/hypervisor/registry/libvirt.go
+++ b/pkg/adaptor/hypervisor/registry/libvirt.go
@@ -3,8 +3,8 @@
 package registry
 
 import (
-	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/hypervisor/libvirt"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/hypervisor"
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/hypervisor/libvirt"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork"
 )
 

--- a/pkg/adaptor/hypervisor/registry/register.go
+++ b/pkg/adaptor/hypervisor/registry/register.go
@@ -1,11 +1,10 @@
 package registry
 
 import (
-	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/hypervisor"
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork"
 )
 
-
-func NewServer(cfg hypervisor.Config, cloudConfig interface{},  workerNode podnetwork.WorkerNode, daemonPort string) hypervisor.Server {
+func NewServer(cfg hypervisor.Config, cloudConfig interface{}, workerNode podnetwork.WorkerNode, daemonPort string) hypervisor.Server {
 	return newServer(cfg, cloudConfig, workerNode, daemonPort)
 }

--- a/pkg/adaptor/hypervisor/types.go
+++ b/pkg/adaptor/hypervisor/types.go
@@ -1,7 +1,7 @@
 package hypervisor
 
 import (
-     "context"
+	"context"
 )
 
 type Server interface {
@@ -11,12 +11,12 @@ type Server interface {
 }
 
 const (
-        DefaultSocketPath = "/run/peerpod/hypervisor.sock"
-        DefaultPodsDir    = "/run/peerpod/pods"
+	DefaultSocketPath = "/run/peerpod/hypervisor.sock"
+	DefaultPodsDir    = "/run/peerpod/pods"
 )
 
 type Config struct {
-        SocketPath        string
-        PodsDir           string
-        HypProvider       string
+	SocketPath  string
+	PodsDir     string
+	HypProvider string
 }


### PR DESCRIPTION
Removed all the format warnings pointed out by gofmt tool so that `make
CLOUD_PROVIDER=ibmcloud fmt` show no errors.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>