### PR TITLE
aws: fix checking of pointer in service.go#getIPs()

### DIFF
--- a/pkg/adaptor/hypervisor/aws/service.go
+++ b/pkg/adaptor/hypervisor/aws/service.go
@@ -280,7 +280,7 @@ func getIPs(instance types.Instance) ([]net.IP, error) {
 		}
 
 		ip := net.ParseIP(*addr)
-		if addr == nil {
+		if ip == nil {
 			return nil, fmt.Errorf("failed to parse pod node IP %q", *addr)
 		}
 		podNodeIPs = append(podNodeIPs, ip)


### PR DESCRIPTION
The `addr` was already checked for `nil`, it is the result of
`net.ParseIP()` (i.e. `ip`) that should be checked too.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>