### PR TITLE
Updating runtime-class.yaml to use node.k8s.io/v1 API rather than the

### DIFF
--- a/ibmcloud/demo/runtime-class.yaml
+++ b/ibmcloud/demo/runtime-class.yaml
@@ -1,4 +1,4 @@
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
   name: kata


### PR DESCRIPTION
deprecated node.k8s.io/v1beta1 to avoid warning message when creating
the RuntimeClass

Fixes #31

Signed-off-by: Dave Hay <david_hay@uk.ibm.com>