### PR TITLE
De-lint the util packages

### DIFF
--- a/pkg/util/http/accesslog/accesslog_test.go
+++ b/pkg/util/http/accesslog/accesslog_test.go
@@ -18,7 +18,9 @@ func TestAcccessLog(t *testing.T) {
 		header["HEADER1"] = []string{"value1"}
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("Hello"))
+		if _, err := w.Write([]byte("Hello")); err != nil {
+			t.Errorf("%v", err)
+		}
 	})
 	logger := NewLogger(mux, WithLogger(log.Default()), WithLabel("test"), WithHeader(), WithBody())
 

--- a/pkg/util/http/upgrader/client.go
+++ b/pkg/util/http/upgrader/client.go
@@ -49,8 +49,6 @@ func WithLogger(logger *log.Logger) Option {
 	}
 }
 
-type emptyLogger log.Logger
-
 func (c *client) printf(format string, v ...interface{}) {
 	if c.logger != nil {
 		c.logger.Printf(format, v...)
@@ -90,7 +88,7 @@ func SendUpgradeRequest(ctx context.Context, serverURL *url.URL, protocol string
 	case "https":
 		tlsConn := tls.Client(tcpConn, c.tlsConfig)
 
-		if err := tlsConn.Handshake(); err != nil {
+		if err = tlsConn.Handshake(); err != nil {
 			return nil, fmt.Errorf("failed to handshake TLS protocol with %s for http upgrade request: %w", serverURL.Host, err)
 		}
 		rawConn = tlsConn
@@ -106,7 +104,7 @@ func SendUpgradeRequest(ctx context.Context, serverURL *url.URL, protocol string
 
 	c.printf("[http/upgrader] connected to a server: %s", serverURL.String())
 
-	if err := req.Write(conn); err != nil {
+	if err = req.Write(conn); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("failed to send an http upgrade request to %s: %w", serverURL.Host, err)
 	}

--- a/pkg/util/http/upgrader/server_test.go
+++ b/pkg/util/http/upgrader/server_test.go
@@ -82,10 +82,10 @@ func (w *mockresponseWriter2) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	buf := bytes.NewBuffer([]byte(""))
 	writer := bufio.NewWriterSize(buf, 1024)
 
-	writer.WriteString("non-empty buffer")
+	_, err := writer.WriteString("non-empty buffer")
 	rw := bufio.NewReadWriter(reader, writer)
 
-	return nil, rw, nil
+	return nil, rw, err
 }
 
 func TestNewConnWriter(t *testing.T) {

--- a/pkg/util/http/upgrader/upgrader_test.go
+++ b/pkg/util/http/upgrader/upgrader_test.go
@@ -36,7 +36,7 @@ func TestUpgrader(t *testing.T) {
 	go func() {
 		defer close(errCh)
 
-		if err := httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err = httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errCh <- err
 			return
 		}
@@ -51,10 +51,10 @@ func TestUpgrader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expect no error, got %v", err)
 	}
-	if _, err := serverConn.Write([]byte(message)); err != nil {
+	if _, err = serverConn.Write([]byte(message)); err != nil {
 		t.Fatalf("Expect no error, got %v", err)
 	}
-	if err := serverConn.Close(); err != nil {
+	if err = serverConn.Close(); err != nil {
 		t.Fatalf("Expect no error, got %v", err)
 	}
 

--- a/pkg/util/netops/netops_test.go
+++ b/pkg/util/netops/netops_test.go
@@ -25,6 +25,9 @@ func TestRoute(t *testing.T) {
 	}
 
 	podns, err := netns.New()
+	if err != nil {
+		t.Fatalf("Failed to create network namespace: %v", err)
+	}
 	defer func() {
 		if err := netns.Set(oldns); err != nil {
 			t.Fatalf("Failed to set a network namespace: %v", err)


### PR DESCRIPTION
Continuing with work start in #39, in this PR it is fixed all the errors pointed by `golangci-lint` in the util packages.

Fixes #32 