### PR TITLE
github: Add commit message check

### DIFF
--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -1,0 +1,93 @@
+name: Commit Message Check
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+env:
+  error_msg: |+
+    See the document below for help on formatting commits for the project.
+
+    https://github.com/confidential-containers/community/blob/main/CONTRIBUTING.md#patch-format
+
+jobs:
+  commit-message-check:
+    runs-on: ubuntu-latest
+    name: Commit Message Check
+    steps:
+      - name: Get PR Commits
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
+        id: "get-pr-commits"
+        uses: tim-actions/get-pr-commits@v1.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Filter out revert commits
+          # The format of a revert commit is as follows:
+          #
+          # Revert "<original-subject-line>"
+          #
+          filter_out_pattern: '^Revert "'
+
+      - name: Commit Body Missing Check
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && ( success() || failure() ) }}
+        uses: tim-actions/commit-body-check@v1.0.2
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
+
+      - name: Check Subject Line Length
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && ( success() || failure() ) }}
+        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
+          pattern: '^.{0,75}(\n.*)*$'
+          error: "Subject too long (max 75)"
+          post_error: ${{ env.error_msg }}
+
+      - name: Check Body Line Length
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && ( success() || failure() ) }}
+        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
+          # Notes:
+          #
+          # - The subject line is not enforced here (see other check), but has
+          #   to be specified at the start of the regex as the action is passed
+          #   the entire commit message.
+          #
+          # - Body lines *can* be longer than the maximum if they start
+          #   with a non-alphabetic character.
+          #
+          #   This allows stack traces, log files snippets, emails, long URLs,
+          #   etc to be specified. Some of these naturally "work" as they start
+          #   with numeric timestamps or addresses. Emails can but quoted using
+          #   the normal ">" character, markdown bullets ("-", "*") are also
+          #   useful for lists of URLs, but it is always possible to override
+          #   the check by simply space indenting the content you need to add.
+          #
+          # - A SoB comment can be any length (as it is unreasonable to penalise
+          #   people with long names/email addresses :)
+          pattern: '^.+(\n([a-zA-Z].{0,149}|[^a-zA-Z\n].*|Signed-off-by:.*|))+$'
+          error: "Body line too long (max 72)"
+          post_error: ${{ env.error_msg }}
+
+      - name: Check Fixes
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && ( success() || failure() ) }}
+        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
+          pattern: '\s*Fixes\s*:?\s*(#\d+|github\.com\/cloud-api-adaptor\/[a-z-.]*#\d+)|^\s*release\s*:'
+          flags: "i"
+          error: 'No "Fixes" found'
+          post_error: ${{ env.error_msg }}
+          one_pass_all_pass: "true"
+
+      - name: Check Subsystem
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && ( success() || failure() ) }}
+        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
+          pattern: '^[\s\t]*[^:\s\t]+[\s\t]*:'
+          error: "Failed to find subsystem in subject"
+          post_error: ${{ env.error_msg }}


### PR DESCRIPTION
- Add in the commit message check based on the
https://github.com/kata-containers/kata-containers/blob/main/.github/workflows/commit-message-check.yaml
given that we have matching commit guidance

Fixes: #45
Signed-off-by: stevenhorsman <steven@uk.ibm.com>