### PR TITLE
ibmcloud: configmap and secret volumes in nginx demo

### DIFF
--- a/ibmcloud/demo/nginx.yaml
+++ b/ibmcloud/demo/nginx.yaml
@@ -7,15 +7,20 @@ metadata:
 spec:
   runtimeClassName: kata
   containers:
-  - name: nginx
-    image: nginx
-    volumeMounts:
-      - name: config-volume
-        mountPath: /etc/config
+    - name: nginx
+      image: nginx
+      volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config
+        - name: secret-volume
+          mountPath: /etc/secret
   volumes:
-  - name: config-volume
-    configMap:
-      name: nginx-config
+    - name: config-volume
+      configMap:
+        name: nginx-config
+    - name: secret-volume
+      secret:
+        secretName: nginx-secret
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -26,16 +31,25 @@ data:
     Hello, world
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  name: nginx-secret
+data:
+  password: MTIzNDU2
+  username: YWRtaW4=
+type: Opaque
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: nginx-service
 spec:
   type: NodePort
   ports:
-  - name: port80
-    port: 80
-    targetPort: 80
-    nodePort: 30080
-    protocol: TCP
+    - name: port80
+      port: 80
+      targetPort: 80
+      nodePort: 30080
+      protocol: TCP
   selector:
     app: nginx

--- a/ibmcloud/terraform/run-nginx-demo/ansible/apply_playbook.yml
+++ b/ibmcloud/terraform/run-nginx-demo/ansible/apply_playbook.yml
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 ---
-
 - hosts: all
   remote_user: root
   tasks:
@@ -36,3 +35,18 @@
         cmd: kubectl exec nginx -- uname -m
       register: peer_pod_architecture
       failed_when: peer_pod_architecture.stdout != k8s_worker_architecture.stdout
+    - name: Check mounted volume from configMap
+      shell:
+        cmd: kubectl exec nginx -- cat /etc/config/example.txt
+      register: volume_configmap_mounted
+      failed_when: volume_configmap_mounted.stdout != 'Hello, world'
+    - name: Check mounted volume from secret - username
+      shell:
+        cmd: kubectl exec nginx -- cat /etc/secret/username
+      register: volume_secret_mounted_username
+      failed_when: volume_secret_mounted_username.stdout != 'admin'
+    - name: Check mounted volume from secret - password
+      shell:
+        cmd: kubectl exec nginx -- cat /etc/secret/password
+      register: volume_secret_mounted_password
+      failed_when: volume_secret_mounted_password.stdout != '123456'


### PR DESCRIPTION
- add a new secret with simple username and password
- use the secret as volume in nignx demo
- add verify configmap and secret volume steps in run-nginx-demo terraform
Fixes: #50
Signed-off by: Da Li Liu<liudali@cn.ibm.com>