### PR TITLE
github: run unit tests workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,7 @@
 # (C) Copyright Red Hat 2022.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Build the project for each cloud provider.
+# Build and run unit tests the project for each cloud provider.
 ---
 name: build
 on: [pull_request]
@@ -48,3 +48,19 @@ jobs:
         run: |
           cd cloud-api-adaptor
           make CLOUD_PROVIDER=${{ matrix.provider }} build
+      - name: Test
+        # TODO: the tests for ibmcloud don't compile. Remove below guard when
+        # they get fixed (see https://github.com/confidential-containers/cloud-api-adaptor/issues/48).
+        if: ${{ matrix.provider != 'ibmcloud' }}
+        working-directory: ${{ github.workspace }}/cloud-api-adaptor
+        run: |
+          go install github.com/jstemmer/go-junit-report@v1.0.0
+          make CLOUD_PROVIDER=${{ matrix.provider }} test | tee tests_report.txt
+          cat tests_report.txt | $(go env GOPATH)/bin/go-junit-report -set-exit-code > tests_report_junit.xml
+      - name: Upload tests report
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: tests_report_junit-${{ matrix.provider }}_${{ matrix.runner }}_${{ matrix.go_version }}
+          path: ${{ github.workspace }}/cloud-api-adaptor/tests_report_junit.xml
+          retention-days: 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,12 +5,10 @@
 ---
 name: build
 on: [pull_request]
-env:
-  GO_VERSION: '1.16'
 jobs:
   build_job:
     name: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
@@ -19,6 +17,10 @@ jobs:
           - aws
           - ibmcloud
           - libvirt
+        runner:
+          - ubuntu-latest
+        go_version:
+          - 1.16
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@v3
@@ -33,10 +35,10 @@ jobs:
           repository: yoheiueda/kata-containers
           ref: CCv0-peerpod
           path: kata-containers
-      - name: Setup Golang version ${{ env.GO_VERSION }}
+      - name: Setup Golang version ${{ matrix.go_version }}
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ matrix.go_version }}
       - name: Install build dependencies
         if: ${{ matrix.provider == 'libvirt' }}
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,7 +55,8 @@ jobs:
         working-directory: ${{ github.workspace }}/cloud-api-adaptor
         run: |
           go install github.com/jstemmer/go-junit-report@v1.0.0
-          make CLOUD_PROVIDER=${{ matrix.provider }} test | tee tests_report.txt
+          sudo -E make CLOUD_PROVIDER=${{ matrix.provider }} test | tee tests_report.txt
+          sudo chmod o+rw tests_report.txt
           cat tests_report.txt | $(go env GOPATH)/bin/go-junit-report -set-exit-code > tests_report_junit.xml
       - name: Upload tests report
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,9 +55,11 @@ jobs:
         working-directory: ${{ github.workspace }}/cloud-api-adaptor
         run: |
           go install github.com/jstemmer/go-junit-report@v1.0.0
+          export CI="true"
           sudo -E make CLOUD_PROVIDER=${{ matrix.provider }} test | tee tests_report.txt
           sudo chmod o+rw tests_report.txt
           cat tests_report.txt | $(go env GOPATH)/bin/go-junit-report -set-exit-code > tests_report_junit.xml
+        shell: bash
       - name: Upload tests report
         uses: actions/upload-artifact@v3
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,9 @@ else
 endif
 
 test:
-	go test -v $(GOFLAGS) -cover $(PACKAGES)
+	# Note: sending stderr to stdout so that tools like go-junit-report can
+	# parse build errors.
+	go test -v $(GOFLAGS) -cover $(PACKAGES) 2>&1
 
 check: fmt vet
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ else
 endif
 
 test:
-	go test -cover $(PACKAGES)
+	go test -v $(GOFLAGS) -cover $(PACKAGES)
 
 check: fmt vet
 

--- a/pkg/adaptor/hypervisor/ibmcloud/server_test.go
+++ b/pkg/adaptor/hypervisor/ibmcloud/server_test.go
@@ -1,6 +1,8 @@
 // (C) Copyright IBM Corp. 2022.
 // SPDX-License-Identifier: Apache-2.0
 
+// +build ibmcloud
+
 package ibmcloud
 
 import (

--- a/pkg/adaptor/hypervisor/ibmcloud/shim_test.go
+++ b/pkg/adaptor/hypervisor/ibmcloud/shim_test.go
@@ -1,6 +1,8 @@
 // (C) Copyright IBM Corp. 2022.
 // SPDX-License-Identifier: Apache-2.0
 
+// +build ibmcloud
+
 package ibmcloud
 
 import (

--- a/pkg/internal/testing/testutils.go
+++ b/pkg/internal/testing/testutils.go
@@ -15,3 +15,12 @@ func SkipTestIfNotRoot(t *testing.T) {
 		t.Skip("This test requires root privileges. Skipping.")
 	}
 }
+
+// SkipTestIfRunningInCI skips the test if running in CI environment.
+func SkipTestIfRunningInCI(t *testing.T) {
+	value, exported := os.LookupEnv("CI")
+
+	if exported && value == "true" {
+		t.Skip("This test is disabled on CI. Skipping.")
+	}
+}

--- a/pkg/internal/testing/testutils.go
+++ b/pkg/internal/testing/testutils.go
@@ -1,0 +1,17 @@
+// (C) Copyright Red Hat 2022.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package testutils provides utilities for testing.
+package testutils
+
+import (
+	"os"
+	"testing"
+)
+
+// SkipTestIfNotRoot skips the test if not running as root user.
+func SkipTestIfNotRoot(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("This test requires root privileges. Skipping.")
+	}
+}

--- a/pkg/podnetwork/podnetwork_test.go
+++ b/pkg/podnetwork/podnetwork_test.go
@@ -6,12 +6,12 @@ package podnetwork
 import (
 	"fmt"
 	"net"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/internal/testing"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork/tunneler"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork/tuntest"
 )
@@ -45,6 +45,7 @@ func (t *mockPodNodeTunneler) Teardown(nsPath, hostInterface string, config *tun
 }
 
 func TestWorkerNode(t *testing.T) {
+	testutils.SkipTestIfNotRoot(t)
 
 	mockTunnelType := "mock"
 	tunneler.Register(mockTunnelType, newMockWorkerNodeTunneler, newMockPodNodeTunneler)
@@ -113,6 +114,7 @@ func TestWorkerNode(t *testing.T) {
 }
 
 func TestPodNode(t *testing.T) {
+	testutils.SkipTestIfNotRoot(t)
 
 	mockTunnelType := "mock"
 	tunneler.Register(mockTunnelType, newMockWorkerNodeTunneler, newMockPodNodeTunneler)
@@ -181,10 +183,7 @@ func TestPodNode(t *testing.T) {
 }
 
 func TestPluginDetectHostInterface(t *testing.T) {
-	if os.Geteuid() != 0 {
-		t.Log("This test requires root privileges. Skipping")
-		return
-	}
+	testutils.SkipTestIfNotRoot(t)
 
 	hostNS := tuntest.NewNamedNS(t, "test-host")
 	defer tuntest.DeleteNamedNS(t, hostNS)

--- a/pkg/podnetwork/tunneler/routing/iptables_test.go
+++ b/pkg/podnetwork/tunneler/routing/iptables_test.go
@@ -4,19 +4,15 @@
 package routing
 
 import (
-	"os"
 	"testing"
 
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/internal/testing"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork/tuntest"
 	"github.com/coreos/go-iptables/iptables"
 )
 
 func TestIPTables(t *testing.T) {
-
-	if os.Geteuid() != 0 {
-		t.Log("This test requires root privileges. Skipping")
-		return
-	}
+	testutils.SkipTestIfNotRoot(t)
 
 	workerNS := tuntest.NewNamedNS(t, "test-host")
 	defer tuntest.DeleteNamedNS(t, workerNS)

--- a/pkg/podnetwork/tunneler/routing/keepalive_test.go
+++ b/pkg/podnetwork/tunneler/routing/keepalive_test.go
@@ -9,12 +9,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/confidential-containers/cloud-api-adaptor/pkg/internal/testing"
+	testutils "github.com/confidential-containers/cloud-api-adaptor/pkg/internal/testing"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork/tuntest"
 	"github.com/vishvananda/netlink"
 )
 
 func TestKeepAlive(t *testing.T) {
+	// TODO: enable this test once https://github.com/confidential-containers/cloud-api-adaptor/issues/52 is fixed
+	testutils.SkipTestIfRunningInCI(t)
 	testutils.SkipTestIfNotRoot(t)
 
 	workerNS := tuntest.NewNamedNS(t, "test-host")

--- a/pkg/podnetwork/tunneler/routing/keepalive_test.go
+++ b/pkg/podnetwork/tunneler/routing/keepalive_test.go
@@ -6,20 +6,16 @@ package routing
 import (
 	"net"
 	"net/http"
-	"os"
 	"testing"
 	"time"
 
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/internal/testing"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork/tuntest"
 	"github.com/vishvananda/netlink"
 )
 
 func TestKeepAlive(t *testing.T) {
-
-	if os.Geteuid() != 0 {
-		t.Log("This test requires root privileges. Skipping")
-		return
-	}
+	testutils.SkipTestIfNotRoot(t)
 
 	workerNS := tuntest.NewNamedNS(t, "test-host")
 	defer tuntest.DeleteNamedNS(t, workerNS)

--- a/pkg/podnetwork/tunneler/routing/tunnel_test.go
+++ b/pkg/podnetwork/tunneler/routing/tunnel_test.go
@@ -6,10 +6,13 @@ package routing
 import (
 	"testing"
 
+	testutils "github.com/confidential-containers/cloud-api-adaptor/pkg/internal/testing"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork/tuntest"
 )
 
 func TestRouting(t *testing.T) {
+	// TODO: enable this test once https://github.com/confidential-containers/cloud-api-adaptor/issues/52 is fixed
+	testutils.SkipTestIfRunningInCI(t)
 
 	tuntest.RunTunnelTest(t, "routing", NewWorkerNodeTunneler, NewPodNodeTunneler, true)
 

--- a/pkg/podnetwork/tuntest/tuntest.go
+++ b/pkg/podnetwork/tuntest/tuntest.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
 	"testing"
 
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/internal/testing"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork/tunneler"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/util/netops"
 	"github.com/coreos/go-iptables/iptables"
@@ -38,11 +38,7 @@ func getIP(t *testing.T, addr string) string {
 }
 
 func RunTunnelTest(t *testing.T, tunnelType string, newWorkerNodeTunneler, newPodNodeTunneler func() tunneler.Tunneler, dedicated bool) {
-
-	if os.Geteuid() != 0 {
-		t.Log("This test requires root privileges. Skipping")
-		return
-	}
+	testutils.SkipTestIfNotRoot(t)
 
 	const (
 		gatewayIP           = "10.128.0.1"

--- a/pkg/util/netops/netops.go
+++ b/pkg/util/netops/netops.go
@@ -463,7 +463,7 @@ func (ns *NS) LinkSetUp(linkName string) error {
 
 // RouteAdd adds a new route
 func (ns *NS) RouteAdd(table int, dest *net.IPNet, gw net.IP, dev string) error {
-	logger.Printf("RouteAdd details: table(%d), dest(%v), gw(%v), dev(%d)", table, dest, gw, dev)
+	logger.Printf("RouteAdd details: table(%d), dest(%v), gw(%v), dev(%s)", table, dest, gw, dev)
 
 	if dest == nil {
 		_, dest, _ = net.ParseCIDR("0.0.0.0/0")

--- a/pkg/util/netops/netops_test.go
+++ b/pkg/util/netops/netops_test.go
@@ -4,18 +4,16 @@
 package netops
 
 import (
-	"os"
 	"runtime"
 	"testing"
 
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/internal/testing"
 	"github.com/vishvananda/netns"
 )
 
 func TestRoute(t *testing.T) {
-	if os.Geteuid() != 0 {
-		t.Log("This test requires root privileges. Skipping")
-		return
-	}
+	testutils.SkipTestIfNotRoot(t)
+
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
@@ -36,10 +34,7 @@ func TestRoute(t *testing.T) {
 }
 
 func TestRouteList(t *testing.T) {
-	if os.Geteuid() != 0 {
-		t.Log("This test requires root privileges. Skipping")
-		return
-	}
+	testutils.SkipTestIfNotRoot(t)
 
 	ns, err := GetNS()
 	if err != nil {


### PR DESCRIPTION
This adds a step on the build workflow in order to run the existing unit tests.

The tests for ibmcloud aren't compiling. I opened the issue #48 and disabled them all from CI.

The tests that need root privileges are refactored so that they use a common utility function for skipping. Even though running the CI pipeline as `sudo` some tests are failing to create network reosurces; those were also disabled from CI (see the issue #52).

I was working to get the test results nicely displayed on Github UI. I investigated the use of either https://github.com/marketplace/actions/junit-report-action or https://github.com/dorny/test-reporter but they both have limitations that didn't make me comfortable to enable them on the project. So for now they aren't used but I decided to keep the code that convert the raw output of the tests into JUnit XML with the hope that one day I could go back to this reporting problem.

All in all, at this point the CI pipelines should be all green but some unit tests are disabled.

Fixes #47 