### PR TITLE
Fix build breaks in unit tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,9 +49,6 @@ jobs:
           cd cloud-api-adaptor
           make CLOUD_PROVIDER=${{ matrix.provider }} build
       - name: Test
-        # TODO: the tests for ibmcloud don't compile. Remove below guard when
-        # they get fixed (see https://github.com/confidential-containers/cloud-api-adaptor/issues/48).
-        if: ${{ matrix.provider != 'ibmcloud' }}
         working-directory: ${{ github.workspace }}/cloud-api-adaptor
         run: |
           go install github.com/jstemmer/go-junit-report@v1.0.0

--- a/pkg/adaptor/hypervisor/ibmcloud/server.go
+++ b/pkg/adaptor/hypervisor/ibmcloud/server.go
@@ -37,9 +37,15 @@ func NewServer(cfg hypervisor.Config, cloudCfg Config, workerNode podnetwork.Wor
 
 	logger.Printf("hypervisor config %v", cfg)
 	logger.Printf("cloud config %v", cloudCfg)
-	vpcV1, err := NewVpcV1(cloudCfg.ApiKey, cloudCfg.IamServiceURL, cloudCfg.VpcServiceURL)
-	if err != nil {
-		return nil
+
+	var vpcV1 VpcV1
+	if cloudCfg.ApiKey != "" {
+		//FIXME: Null ApiKey is used in unit tests
+		var err error
+		vpcV1, err = NewVpcV1(cloudCfg.ApiKey, cloudCfg.IamServiceURL, cloudCfg.VpcServiceURL)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	return &server{


### PR DESCRIPTION
Fixes #48.

These unit tests are complicated due to historical reasons. This PR just fixes the build breaks. 

We will simply the unit tests by eliminating unnecessary tests in future PRs.
 