### PR TITLE
ibmcloud: Strip ssh-key comment

### DIFF
--- a/ibmcloud/terraform/cluster/main.tf
+++ b/ibmcloud/terraform/cluster/main.tf
@@ -21,7 +21,7 @@ resource "ibm_is_ssh_key" "created_ssh_key" {
   # Create the ssh key only if the public key is set
   count = var.ssh_pub_key == "" ? 0 : 1
   name = var.ssh_key_name
-  public_key = var.ssh_pub_key
+  public_key = regex("(ssh-rsa [^ ]+)", var.ssh_pub_key)[0]
 }
 
 data "ibm_is_ssh_key" "ssh_key" {


### PR DESCRIPTION
Removes the comment at the end of ssh public keys which causes unnecessary replacement of the ssh-key.

Fixes: #60

Signed-off-by: jtumber-ibm <james.tumber@ibm.com>