### PR TITLE
deploy: run cloud-api-adaptor from within a pod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.18 AS builder
+ARG CLOUD_PROVIDER
+ENV CLOUD_PROVIDER=${CLOUD_PROVIDER}
+COPY . cloud-api-adaptor
+RUN git clone -b CCv0-peerpod https://github.com/yoheiueda/kata-containers
+WORKDIR cloud-api-adaptor
+RUN make clean
+RUN if [ "$CLOUD_PROVIDER" = "libvirt" ] ; then apt-get update -y && apt-get install -y libvirt-dev libvirt0 genisoimage && apt-get clean; fi
+RUN make
+RUN install cloud-api-adaptor /usr/local/bin/cloud-api-adaptor-$CLOUD_PROVIDER
+RUN install entrypoint.sh /usr/local/bin/
+RUN make clean
+CMD entrypoint.sh

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-.PHONY: all build check fmt vet clean
+.PHONY: all build check fmt vet clean image deploy delete
 ifndef CLOUD_PROVIDER
 $(error CLOUD_PROVIDER is not set)
 endif
@@ -23,6 +23,18 @@ ifeq ($(CLOUD_PROVIDER),libvirt)
 else
 	CGO_ENABLED=0 go build $(GOFLAGS) -o "$@" "cmd/$@/main.go"
 endif
+
+# Build and push docker image to $regestry
+image:
+	hack/build.sh
+
+# Deploy cloud-api-adaptor using the operator, according to install/overlays/$(CLOUD_PROVIDER)/kustomization.yaml
+deploy:
+	kubectl apply -f install/yamls/deploy.yaml
+	kubectl apply -k install/overlays/$(CLOUD_PROVIDER)
+
+delete:
+	kubectl delete -k install/overlays/$(CLOUD_PROVIDER)
 
 test:
 	# Note: sending stderr to stdout so that tools like go-junit-report can

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+CLOUD_PROVIDER=${1:-$CLOUD_PROVIDER}
+CRI_RUNTIME_ENDPOINT=${CRI_RUNTIME_ENDPOINT:-/run/peerpod/cri-runtime.sock}
+optionals+=""
+
+if [[ -S ${CRI_RUNTIME_ENDPOINT} ]]; then # will skip if socket isn't exist in the container
+	optionals+="-cri-runtime-endpoint ${CRI_RUNTIME_ENDPOINT} "
+fi
+
+test_vars() {
+        for i in $@; do
+                [ -z ${!i} ] && echo "\$$i is NOT set" && EXT=1
+        done
+        [[ -n $EXT ]] && exit 1
+}
+
+aws() {
+#test_vars AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_REGION
+set -x
+cloud-api-adaptor-aws aws \
+	-aws-access-key-id ${AWS_ACCESS_KEY_ID} \
+	-aws-secret-key ${AWS_SECRET_ACCESS_KEY} \
+	-aws-region ${AWS_REGION} \
+	-pods-dir /run/peerpod/pods \
+	-aws-lt-name ${PODVM_LAUNCHTEMPLATE_NAME:-kata} \
+	${optionals} \
+	-socket /run/peerpod/hypervisor.sock
+}
+
+libvirt() {
+test_vars LIBVIRT_URI
+set -x
+cloud-api-adaptor-libvirt libvirt \
+	-uri ${LIBVIRT_URI} \
+	-data-dir /opt/data-dir \
+	-pods-dir /run/peerpod/pods \
+	-network-name ${LIBVIRT_NET:-default} \
+	-pool-name ${LIBVIRT_POOL:-default} \
+	${optionals} \
+	-socket /run/peerpod/hypervisor.sock
+}
+
+help_msg() {
+	cat <<EOF
+Usage:
+	CLOUD_PROVIDER=aws|libvirt $0
+or
+	$0 aws|libvirt
+in addition all cloud provider specific env variables must be set and valid
+(CLOUD_PROVIDER is currently set to "$CLOUD_PROVIDER")
+EOF
+}
+
+if [[ "$CLOUD_PROVIDER" == "aws" ]]; then
+	aws
+elif [[ "$CLOUD_PROVIDER" == "libvirt" ]]; then
+	libvirt
+else
+	help_msg
+fi

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+script_dir=$(dirname "$(readlink -f "$0")")
+
+registry="${registry:-quay.io/confidential-containers/cloud-api-adaptor-${CLOUD_PROVIDER}}"
+
+supported_arches=(
+	"linux/amd64"
+)
+
+function setup_env_for_arch() {
+	case "$1" in
+		"linux/amd64")
+			kernel_arch="x86_64"
+			;;
+		(*) echo "$1 is not supported" && exit 1
+	esac
+}
+
+function build_caa_payload() {
+	pushd "${script_dir}/.."
+
+	tag=$(date +%Y%m%d%H%M%s)
+
+	for arch in ${supported_arches[@]}; do
+		setup_env_for_arch "${arch}"
+
+		echo "Building cloud-api-adaptor ${CLOUD_PROVIDER} image for ${arch}"
+		docker buildx build \
+			--build-arg ARCH="${kernel_arch}" \
+			--build-arg CLOUD_PROVIDER="${CLOUD_PROVIDER}" \
+			-f Dockerfile \
+			-t "${registry}:${kernel_arch}-${tag}" \
+			--platform="${arch}" \
+			--load \
+			.
+		docker push "${registry}:${kernel_arch}-${tag}"
+	done
+
+	docker manifest create \
+		${registry}:${tag} \
+		--amend ${registry}:x86_64-${tag}
+
+	docker manifest create \
+		${registry}:latest \
+		--amend ${registry}:x86_64-${tag}
+
+	docker manifest push ${registry}:${tag}
+	docker manifest push ${registry}:latest
+
+	popd
+}
+
+function main() {
+	build_caa_payload
+	# TODO: kustomize with the tag
+}
+
+main "$@"

--- a/install/README.md
+++ b/install/README.md
@@ -131,12 +131,12 @@
 
 ### Building Runtime Payload Image
 
-    Set container registry and image name
+* Set container registry and image name
     ```
     export REGISTRY=<NAMESPACE>/<IMAGE_NAME>
     ```
 
-    Build the container image
+* Build the container image
     ```
     cd runtime-payload
     make binaries
@@ -146,14 +146,26 @@
 
 ### Building Pre-Install Payload Image
 
-    Set container registry and image name
+* Set container registry and image name
     ```
     export REGISTRY=<NAMESPACE>/<IMAGE_NAME>
     ```
 
-    Build the container image
+* Build the container image
     ```
     cd pre-install-payload
     make build
     ```
 
+## Build and install with cloud-api-adaptor running in a pod
+
+* set CLOUD_PROVIDER
+    ```
+    export CLOUD_PROVIDER=<aws|ibmcloud|libvirt>
+    ```
+
+* `make image` builds the container image and push it to `$registry`
+* `make deploy` deploys operator, runtime and cloud-api-adaptor pod in the configured cluster
+    * configure install/overlays/$(CLOUD_PROVIDER)/kustomization.yaml with your own settings
+    * validate kubectl is available in your `$PATH` and `$KUBECONFIG` is set
+* `make delete` deletes the pod deployment from the configured cluster

--- a/install/overlays/aws/cri_runtime_endpoint.yaml
+++ b/install/overlays/aws/cri_runtime_endpoint.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloud-api-adaptor-deployment
+  namespace: confidential-containers-system
+  labels:
+    app: cloud-api-adaptor
+spec:
+  template:
+    spec:
+      containers:
+      - name: cloud-api-adaptor-con
+        volumeMounts:
+        - mountPath: /run/peerpod/cri-runtime.sock # in-container default
+          name: cri-runtime-endpoint
+      volumes:
+      - name: cri-runtime-endpoint
+        type: Socket
+        hostPath:
+          path: /run/containerd/containerd.sock # SET! (crio's default: /var/run/crio/crio.sock)
+
+# to apply this uncomment the patchesStrategicMerge of this file in kustomization.yaml

--- a/install/overlays/aws/kustomization.yaml
+++ b/install/overlays/aws/kustomization.yaml
@@ -1,0 +1,26 @@
+bases:
+- ../../yamls
+nameSuffix: -aws
+
+images:
+- name: kustomize.this/cloud-api-adaptor/image:url
+  newName: quay.io/confidential-containers/cloud-api-adaptor-aws # change image if needed
+  newTag: latest
+
+configMapGenerator:
+- name: peer-pods-cm
+  namespace: confidential-containers-system
+  literals:
+  - CLOUD_PROVIDER="aws"
+  - PODVM_LAUNCHTEMPLATE_NAME="kata"
+
+secretGenerator:
+- name: peer-pods-secret
+  namespace: confidential-containers-system
+  literals:
+  - AWS_ACCESS_KEY_ID="" # set
+  - AWS_SECRET_ACCESS_KEY="" # set
+  - AWS_REGION="" #set
+
+patchesStrategicMerge:
+  #- cri_runtime_endpoint.yaml # set (modify host's runtime cri socket path in the file, default is /run/containerd/containerd.sock)

--- a/install/overlays/libvirt/cri_runtime_endpoint.yaml
+++ b/install/overlays/libvirt/cri_runtime_endpoint.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloud-api-adaptor-deployment
+  namespace: confidential-containers-system
+  labels:
+    app: cloud-api-adaptor
+spec:
+  template:
+    spec:
+      containers:
+      - name: cloud-api-adaptor-con
+        volumeMounts:
+        - mountPath: /run/peerpod/cri-runtime.sock # in-container default
+          name: cri-runtime-endpoint
+      volumes:
+      - name: cri-runtime-endpoint
+        type: Socket
+        hostPath:
+          path: /run/containerd/containerd.sock # SET! (crio's default: /var/run/crio/crio.sock)
+
+# to apply this uncomment the patchesStrategicMerge of this file in kustomization.yaml

--- a/install/overlays/libvirt/kustomization.yaml
+++ b/install/overlays/libvirt/kustomization.yaml
@@ -1,0 +1,25 @@
+bases:
+- ../../yamls
+nameSuffix: -libvirt
+
+images:
+- name: kustomize.this/cloud-api-adaptor/image:url
+  newName: quay.io/confidential-containers/cloud-api-adaptor-libvirt # change image if needed
+  newTag: latest
+
+configMapGenerator:
+- name: peer-pods-cm
+  namespace: confidential-containers-system
+  literals:
+  - CLOUD_PROVIDER="libvirt"
+  - LIBVIRT_URI="qemu+ssh://root@192.168.122.1/system" #set
+  - LIBVIRT_NET="default" # set
+  - LIBVIRT_POOL="default" # set
+
+secretGenerator:
+- name: peer-pods-secret
+  namespace: confidential-containers-system
+  literals:
+
+patchesStrategicMerge:
+  #- cri_runtime_endpoint.yaml # set (modify host's runtime cri socket path in the file, default is /run/containerd/containerd.sock)

--- a/install/yamls/ccruntime-peer-pods-in-pod.yaml
+++ b/install/yamls/ccruntime-peer-pods-in-pod.yaml
@@ -1,0 +1,107 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloud-api-adaptor-deployment
+  namespace: confidential-containers-system
+  labels:
+    app: cloud-api-adaptor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cloud-api-adaptor
+  template:
+    metadata:
+      labels:
+        app: cloud-api-adaptor
+    spec:
+      hostNetwork: true
+      containers:
+      - name: cloud-api-adaptor-con
+        securityContext:
+          capabilities:
+            add: ["NET_ADMIN", "SYS_ADMIN"]
+        image: kustomize.this/cloud-api-adaptor/image:url
+        imagePullPolicy: Always
+        envFrom:
+        - secretRef:
+            name: peer-pods-secret
+        - configMapRef:
+            name: peer-pods-cm
+        command: ["/usr/local/bin/entrypoint.sh"]
+        volumeMounts:
+        - mountPath: /run/peerpod
+          name: pods-dir
+        - mountPath: /run/netns
+          mountPropagation: HostToContainer
+          name: netns
+      volumes:
+      - name: pods-dir # drop?
+        hostPath:
+          path: /run/peerpod
+      - name: netns
+        #readOnly: true
+        hostPath:
+         path: /run/netns
+---
+apiVersion: confidentialcontainers.org/v1beta1
+kind: CcRuntime
+metadata:
+  name: ccruntime-sample
+  namespace: confidential-containers-system
+spec:
+  # Add fields here
+  runtimeName: kata
+  ccNodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker: ""
+  config:
+    installType: bundle
+    payloadImage: quay.io/confidential-containers/peer-pods-runtime-payload:2022072707271658906867
+    installDoneLabel:
+      katacontainers.io/kata-runtime: "true"
+    uninstallDoneLabel:
+      katacontainers.io/kata-runtime: "cleanup"
+    installerVolumeMounts:
+      - mountPath: /etc/containerd/
+        name: containerd-conf
+      - mountPath: /opt/confidential-containers/
+        name: kata-artifacts
+      - mountPath: /var/run/dbus
+        name: dbus
+      - mountPath: /run/systemd
+        name: systemd
+      - mountPath: /usr/local/bin/
+        name: local-bin
+    installerVolumes:
+      - hostPath:
+          path: /etc/containerd/
+          type: ""
+        name: containerd-conf
+      - hostPath:
+          path: /opt/confidential-containers/
+          type: DirectoryOrCreate
+        name: kata-artifacts
+      - hostPath:
+          path: /var/run/dbus
+          type: ""
+        name: dbus
+      - hostPath:
+          path: /run/systemd
+          type: ""
+        name: systemd
+      - hostPath:
+          path: /usr/local/bin/
+          type: ""
+        name: local-bin
+    installCmd: ["/opt/kata-artifacts/scripts/kata-deploy.sh", "install"]
+    uninstallCmd: ["/opt/kata-artifacts/scripts/kata-deploy.sh", "cleanup"]
+    cleanupCmd: ["/opt/kata-artifacts/scripts/kata-deploy.sh", "reset"]
+    environmentVariables:
+      - name: NODE_NAME
+        valueFrom:
+          fieldRef:
+            apiVersion: v1
+            fieldPath: spec.nodeName
+      - name: "CONFIGURE_CC"
+        value: "yes"


### PR DESCRIPTION
Supports only libvirt and aws cloud providers
                                                                          
## Build and install with cloud-api-adaptor running in a pod

* set CLOUD_PROVIDER
    ```
    export CLOUD_PROVIDER=<aws|ibmcloud|libvirt>
    ```

* `make image` builds the container image and push it to `$registry`
* `make deploy` deploys operator, runtime and cloud-api-adaptor pod in the configured cluster
    * configure install/overlays/$(CLOUD_PROVIDER)/kustomization.yaml with your own settings
    * validate kubectl is available in your `$PATH` and `$KUBECONFIG` is set
* `make delete` deletes the pod deployment from the configured cluster
                                                                         

Fixes: #5
Signed-off-by: Snir Sheriber <ssheribe@redhat.com>




**This was tested with aws (single noded) only**
As image was not pushed yet to repo to quickly deploy and test on an aws cluster:
1. Set your credentials on install/overlays/aws/kustomization.yaml (and newImage to: `quay.io/snir/cloud-api-adaptor-aws`)
2. `CLOUD_PROVIDER=aws make deploy`

NOTE:
In this implementation the caa pod is not deployed by the operator itself, we may prefer some other implementation or to use the pre-installtion script to deploy the caa pod, however, it would complicate a bit the development and CI (because of the multiple images and deployment nesting), hence, i'd suggest to use this implementation for now and work on more advanced implementation in different PR when required.

Depends-on: #64
Depends-on: #66 
Depends-on: https://github.com/confidential-containers/operator/pull/59
(operator image for testing:  quay.io/jensfr/confidential-containers-operator:fix-issue-58)