### PR TITLE
Update to the latest CCv0-peerpod branch

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -813,6 +813,7 @@ github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuh
 github.com/opencontainers/selinux v1.10.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
@@ -971,6 +972,7 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
+gitlab.com/nvidia/cloud-native/go-nvlib v0.0.0-20220601114329-47893b162965/go.mod h1:TBB3sR7/jg4RCThC/cgT4fB8mAbbMO307TycfgeR59w=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=

--- a/ibmcloud/README.md
+++ b/ibmcloud/README.md
@@ -356,7 +356,7 @@ disable_guest_seccomp = true
 enable_pprof = true
 enable_debug = true
 [hypervisor.remote]
-remote_hypervisor = "/run/peerpod/hypervisor.sock"
+remote_hypervisor_socket = "/run/peerpod/hypervisor.sock"
 [agent.kata]
 ```
 

--- a/ibmcloud/terraform/cluster/ansible/kata-playbook.yml
+++ b/ibmcloud/terraform/cluster/ansible/kata-playbook.yml
@@ -262,7 +262,7 @@
           enable_pprof = true
           enable_debug = true
           [hypervisor.remote]
-          remote_hypervisor = "/run/peerpod/hypervisor.sock"
+          remote_hypervisor_socket = "/run/peerpod/hypervisor.sock"
           [agent.kata]
           [image]
           service_offload = true


### PR DESCRIPTION
The latest [CCv0-peerpod branch](https://github.com/yoheiueda/kata-containers/tree/CCv0-peerpod) has the following code changes.

* `go.sum` is updated, since the upstream CCv0 branch has been rebased to the latest main branch.
* option name in `config.toml` is changed from remote_hypervisor to remote_hypervisor_socket based on a PR comment

https://github.com/kata-containers/kata-containers/pull/3697#discussion_r908641458

This PR includes necessary changes to synchronized with the latest CCv0-peerpod branch.

