### PR TITLE
 ibmcloud: Obfuscate API key in log file 

### DIFF
--- a/pkg/adaptor/hypervisor/ibmcloud/types.go
+++ b/pkg/adaptor/hypervisor/ibmcloud/types.go
@@ -1,5 +1,15 @@
 package ibmcloud
 
+import (
+	"fmt"
+	"reflect"
+	"sort"
+)
+
+const (
+	keyMask = "********"
+)
+
 type Config struct {
 	ApiKey                   string
 	IamServiceURL            string
@@ -14,4 +24,60 @@ type Config struct {
 	SecondarySecurityGroupID string
 	KeyID                    string
 	VpcID                    string
+}
+
+var configFields []string
+
+// Use reflect to manage list of fields in the Config struct
+func init() {
+	typeOf := reflect.TypeOf(Config{})
+	configFields = make([]string, typeOf.NumField())
+	for i := 0; i < typeOf.NumField(); i++ {
+		configFields[i] = typeOf.Field(i).Name
+	}
+	sort.Strings(configFields)
+}
+
+// Add Stringer interface to return keyMask when outputting ApiKey field
+func (config *Config) String() string {
+	apikey := config.ApiKey
+	if apikey != "" {
+		apikey = keyMask
+	}
+	return fmt.Sprintf(apikey)
+}
+
+// Add custom Formatter to handle different output cases
+// Also return keyMask if the field name is ApiKey
+func (config Config) Format(state fmt.State, verb rune) {
+	switch verb {
+	case 's', 'q':
+		val := config.String()
+		if verb == 'q' {
+			val = fmt.Sprintf("%q", val)
+		}
+		fmt.Fprint(state, val)
+	case 'v':
+		if state.Flag('#') {
+			fmt.Fprintf(state, "%T", config)
+		}
+		fmt.Fprint(state, "{")
+		val := reflect.ValueOf(config)
+		for i, name := range configFields {
+			if state.Flag('#') || state.Flag('+') {
+				fmt.Fprintf(state, "%s:", name)
+			}
+			fld := val.FieldByName(name)
+			// If the field is ApiKey, apply the keyMask
+			if name == "ApiKey" {
+				fmt.Fprint(state, keyMask)
+			} else {
+				fmt.Fprint(state, fld)
+			}
+			if i < len(configFields)-1 {
+				fmt.Fprint(state, " ")
+			}
+		}
+		fmt.Fprint(state, "}")
+	}
 }

--- a/pkg/adaptor/hypervisor/ibmcloud/types.go
+++ b/pkg/adaptor/hypervisor/ibmcloud/types.go
@@ -40,11 +40,9 @@ func init() {
 
 // Add Stringer interface to return keyMask when outputting ApiKey field
 func (config *Config) String() string {
-	apikey := config.ApiKey
-	if apikey != "" {
-		apikey = keyMask
-	}
-	return fmt.Sprintf(apikey)
+	toMask := config
+	toMask.ApiKey = keyMask
+	return fmt.Sprint(toMask)
 }
 
 // Add custom Formatter to handle different output cases

--- a/pkg/adaptor/hypervisor/ibmcloud/types_test.go
+++ b/pkg/adaptor/hypervisor/ibmcloud/types_test.go
@@ -1,0 +1,28 @@
+package ibmcloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestMasking(t *testing.T) {
+	apiKey := "abcdefg"
+	zoneName := "eu-gb"
+	cloudCfg := Config{
+		ApiKey:   apiKey,
+		ZoneName: zoneName,
+	}
+	checkLine := func(verb string) {
+		logline := fmt.Sprintf(verb, &cloudCfg)
+		if strings.Contains(logline, apiKey) {
+			t.Errorf("For verb %s: %s contains the api key: %s", verb, logline, apiKey)
+		}
+		if !strings.Contains(logline, zoneName) {
+			t.Errorf("For verb %s: %s doesn't contain the zone name: %s", verb, logline, zoneName)
+		}
+	}
+	checkLine("%v")
+	checkLine("%s")
+	checkLine("%q")
+}


### PR DESCRIPTION
- Extend types.go to obfuscate IBM Cloud API key in cloud-api-adaptor.log
- Adding types_test.go function

Fixes #83 

Signed-off-by: Dave Hay <david_hay@uk.ibm.com>