### PR TITLE
ibmcloud: Update pod wait logic

### DIFF
--- a/ibmcloud/terraform/run-nginx-demo/ansible/apply_playbook.yml
+++ b/ibmcloud/terraform/run-nginx-demo/ansible/apply_playbook.yml
@@ -14,9 +14,9 @@
       shell:
         cmd: kubectl apply -f runtime-class.yaml -f nginx.yaml
         chdir: cloud-api-adaptor/ibmcloud/demo
-    - name: Pause to start peer pod VM, and pull and start nginx container
-      pause:
-        seconds: 90
+    - name: Wait for pod to be ready
+      shell:
+        cmd: kubectl wait --timeout=300s --for=condition=ready pods/nginx
     - name: Check nginx container has started in the peer pod
       shell:
         cmd: kubectl get pod nginx -o json | jq -r .status.containerStatuses[0].ready


### PR DESCRIPTION
Update the wait logic in terraform template to check for the pod status
rather than be hard-coded to sleep for a certain amount of time

Fixes: #105
Signed-off-by: stevenhorsman <steven@uk.ibm.com>