### PR TITLE
ibmcloud: Run skopeo on host netns of pod VM

### DIFF
--- a/ibmcloud/image/.gitignore
+++ b/ibmcloud/image/.gitignore
@@ -7,5 +7,5 @@
 /umoci
 /files/usr/local/bin/agent-protocol-forwarder
 /files/usr/local/bin/kata-agent
-/files/usr/bin/skopeo
+/files/usr/local/bin/skopeo.bin
 /files/usr/local/bin/umoci

--- a/ibmcloud/image/Makefile
+++ b/ibmcloud/image/Makefile
@@ -36,7 +36,7 @@ UBUNTU_PACKAGES = jq
 
 AGENT_PROTOCOL_FORWARDER = $(FILES_DIR)/usr/local/bin/agent-protocol-forwarder
 KATA_AGENT    = $(FILES_DIR)/usr/local/bin/kata-agent
-SKOPEO        = $(FILES_DIR)/usr/bin/skopeo
+SKOPEO        = $(FILES_DIR)/usr/local/bin/skopeo.bin
 UMOCI         = $(FILES_DIR)/usr/local/bin/umoci
 BINARIES = $(AGENT_PROTOCOL_FORWARDER) $(KATA_AGENT) $(SKOPEO) $(UMOCI)
 

--- a/ibmcloud/image/files/usr/bin/skopeo
+++ b/ibmcloud/image/files/usr/bin/skopeo
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Copyright Confidential Containers Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# This script is a wrapper for the skopeo command.
+#
+# skopeo is invoked from the kata-agent process, which runs as a systemd service defined
+# in /etc/systemd/system/kata-agent.service. This systemd service launches kata-agent in 
+# a newly created network namespace called "netns".  This network namespace is connected to
+# Kubernetes pod network, not host network of the pod VM. The skopeo command is used to 
+# pull images from remote container registries, and requires network access when pulling
+# images. When network accesses to remote registries are restricted by some mechanisms such 
+# as iptables, the skopeo command fails to pull images, and kata-agent fails to create
+# containers.
+#
+# To work around this issue, this wrapper script launches the skopeo command in the the network
+# namespace of the process with PID 1, which is usually the systemd process.
+#
+# TODO: If kata-agent has a mechanism to create a new network namespace in addition to other
+# network namespace such as mount and PID namespaces, we can remote this wrapper script by using
+# that mechanism.
+
+exec nsenter --target 1 --net /usr/local/bin/skopeo.bin "$@"


### PR DESCRIPTION
skopeo is invoked from the kata-agent process, which runs as a systemd
service defined in /etc/systemd/system/kata-agent.service. This systemd
service launches kata-agent in a newly created network namespace called
"netns".  This network namespace is connected to Kubernetes pod network,
not host network of the pod VM. The skopeo command is used to pull
images from remote container registries, and requires network access
when pulling images. When network accesses to remote registries are
restricted by some mechanisms such as iptables, the skopeo command fails
to pull images, and kata-agent fails to create containers.

To work around this issue, this patch adds a wrapper script launches the
skopeo command in the the network namespace of the process with PID 1,
which is usually the systemd process.

Fixes #86

Signed-off-by: Yohei Ueda <yohei@jp.ibm.com>