### PR TITLE
ibmcloud: remove internal sandbox data at the end of StopVM method

### DIFF
--- a/pkg/adaptor/hypervisor/aws/service.go
+++ b/pkg/adaptor/hypervisor/aws/service.go
@@ -262,6 +262,17 @@ func (s *hypervisorService) getSandbox(id string) (*sandbox, error) {
 	return s.sandboxes[sid], nil
 }
 
+func (s *hypervisorService) deleteSandbox(id string) error {
+	sid := sandboxID(id)
+	if id == "" {
+		return errors.New("empty sandbox id")
+	}
+	s.Lock()
+	defer s.Unlock()
+	delete(s.sandboxes, sid)
+	return nil
+}
+
 var errNotReady = errors.New("address not ready")
 
 func getIPs(instance types.Instance) ([]net.IP, error) {
@@ -321,6 +332,9 @@ func (s *hypervisorService) StopVM(ctx context.Context, req *pb.StopVMRequest) (
 	if err := s.workerNode.Teardown(sandbox.netNSPath, sandbox.podNetworkConfig); err != nil {
 		return nil, fmt.Errorf("failed to tear down netns %s: %w", sandbox.netNSPath, err)
 	}
-
+	err = s.deleteSandbox(req.Id)
+	if err != nil {
+		return nil, err
+	}
 	return &pb.StopVMResponse{}, nil
 }

--- a/pkg/adaptor/hypervisor/ibmcloud/service.go
+++ b/pkg/adaptor/hypervisor/ibmcloud/service.go
@@ -295,6 +295,17 @@ func (s *hypervisorService) getSandbox(id string) (*sandbox, error) {
 	return s.sandboxes[sid], nil
 }
 
+func (s *hypervisorService) deleteSandbox(id string) error {
+	sid := sandboxID(id)
+	if id == "" {
+		return errors.New("empty sandbox id")
+	}
+	s.Lock()
+	defer s.Unlock()
+	delete(s.sandboxes, sid)
+	return nil
+}
+
 var errNotReady = errors.New("address not ready")
 
 func getIPs(prototype *vpcv1.InstancePrototype, result *vpcv1.Instance) ([]net.IP, error) {
@@ -360,6 +371,9 @@ func (s *hypervisorService) StopVM(ctx context.Context, req *pb.StopVMRequest) (
 	if err := s.workerNode.Teardown(sandbox.netNSPath, sandbox.podNetworkConfig); err != nil {
 		return nil, fmt.Errorf("failed to tear down netns %s: %w", sandbox.netNSPath, err)
 	}
-
+	err = s.deleteSandbox(req.Id)
+	if err != nil {
+		return nil, err
+	}
 	return &pb.StopVMResponse{}, nil
 }


### PR DESCRIPTION
Fixes: #123

Signed-off by: Da Li Liu <liudali@cn.ibm.com>