### PR TITLE
ibmcloud: create kubelet dir for CSI node plugin

### DIFF
--- a/ibmcloud/image/build.sh
+++ b/ibmcloud/image/build.sh
@@ -195,6 +195,8 @@ chroot "$src_mnt" bash -c 'rm -rf /var/lib/apt/lists/*'
 
 cp -a "$files_dir"/* "$src_mnt"
 
+mkdir -p "$src_mnt/var/lib/kubelet"
+
 umount "$src_mnt/run"
 umount "$src_mnt/dev/pts"
 umount "$src_mnt/dev"


### PR DESCRIPTION
Try to create the dir `/var/lib/kubelet` in peer pod VM in advance, so that it can be mounted to CSI driver node plugin running in peer pod.

Fixes: https://github.com/confidential-containers/cloud-api-adaptor/issues/128
Signed-off-by: Lei Li [cdlleili@cn.ibm.com](mailto:cdlleili@cn.ibm.com)