### PR TITLE
ibmcloud|aws: Mask cloud configuration sensitive fields

### DIFF
--- a/pkg/adaptor/hypervisor/aws/server.go
+++ b/pkg/adaptor/hypervisor/aws/server.go
@@ -33,7 +33,7 @@ type server struct {
 func NewServer(cfg hypervisor.Config, cloudCfg Config, workerNode podnetwork.WorkerNode, daemonPort string) hypervisor.Server {
 
 	logger.Printf("hypervisor config %v", cfg)
-	logger.Printf("cloud config %v", cloudCfg)
+	logger.Printf("cloud config %v", cloudCfg.Redact())
 	ec2Client, err := NewEC2Client(cloudCfg)
 	if err != nil {
 		return nil

--- a/pkg/adaptor/hypervisor/aws/types.go
+++ b/pkg/adaptor/hypervisor/aws/types.go
@@ -1,8 +1,14 @@
 package aws
 
+import "github.com/confidential-containers/cloud-api-adaptor/pkg/util"
+
 type Config struct {
 	AccessKeyId  string
 	SecretKey    string
 	Region       string
 	LoginProfile string
+}
+
+func (c Config) Redact() Config {
+	return *util.RedactStruct(&c, "SecretKey").(*Config)
 }

--- a/pkg/adaptor/hypervisor/aws/types_test.go
+++ b/pkg/adaptor/hypervisor/aws/types_test.go
@@ -1,0 +1,31 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestAWSMasking(t *testing.T) {
+	secretKey := "abcdefg"
+	region := "eu-gb"
+	cloudCfg := Config{
+		SecretKey: secretKey,
+		Region:    region,
+	}
+	checkLine := func(verb string) {
+		logline := fmt.Sprintf(verb, cloudCfg.Redact())
+		if strings.Contains(logline, secretKey) {
+			t.Errorf("For verb %s: %s contains the secret key: %s", verb, logline, secretKey)
+		}
+		if !strings.Contains(logline, region) {
+			t.Errorf("For verb %s: %s doesn't contain the region name: %s", verb, logline, region)
+		}
+	}
+	checkLine("%v")
+	checkLine("%s")
+
+	if cloudCfg.SecretKey != secretKey {
+		t.Errorf("Original SecretKey field value has been overwritten")
+	}
+}

--- a/pkg/adaptor/hypervisor/ibmcloud/server.go
+++ b/pkg/adaptor/hypervisor/ibmcloud/server.go
@@ -39,7 +39,7 @@ type server struct {
 func NewServer(cfg hypervisor.Config, cloudCfg Config, workerNode podnetwork.WorkerNode, daemonPort string) hypervisor.Server {
 
 	logger.Printf("hypervisor config %v", cfg)
-	logger.Printf("cloud config %v", cloudCfg)
+	logger.Printf("cloud config %v", cloudCfg.Redact())
 
 	var vpcV1 VpcV1
 	if cloudCfg.ApiKey != "" {

--- a/pkg/adaptor/hypervisor/ibmcloud/types.go
+++ b/pkg/adaptor/hypervisor/ibmcloud/types.go
@@ -1,5 +1,7 @@
 package ibmcloud
 
+import "github.com/confidential-containers/cloud-api-adaptor/pkg/util"
+
 type Config struct {
 	ApiKey                   string
 	IamServiceURL            string
@@ -14,4 +16,8 @@ type Config struct {
 	SecondarySecurityGroupID string
 	KeyID                    string
 	VpcID                    string
+}
+
+func (c Config) Redact() Config {
+	return *util.RedactStruct(&c, "ApiKey").(*Config)
 }

--- a/pkg/adaptor/hypervisor/ibmcloud/types_test.go
+++ b/pkg/adaptor/hypervisor/ibmcloud/types_test.go
@@ -1,0 +1,31 @@
+package ibmcloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestIBMCloudMasking(t *testing.T) {
+	apiKey := "abcdefg"
+	zoneName := "eu-gb"
+	cloudCfg := Config{
+		ApiKey:   apiKey,
+		ZoneName: zoneName,
+	}
+	checkLine := func(verb string) {
+		logline := fmt.Sprintf(verb, cloudCfg.Redact())
+		if strings.Contains(logline, apiKey) {
+			t.Errorf("For verb %s: %s contains the api key: %s", verb, logline, apiKey)
+		}
+		if !strings.Contains(logline, zoneName) {
+			t.Errorf("For verb %s: %s doesn't contain the zone name: %s", verb, logline, zoneName)
+		}
+	}
+	checkLine("%v")
+	checkLine("%s")
+
+	if cloudCfg.ApiKey != apiKey {
+		t.Errorf("Original ApiKey field value has been overwritten")
+	}
+}

--- a/pkg/util/redacting.go
+++ b/pkg/util/redacting.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"fmt"
+	"reflect"
+)
+
+const replacement = "**********"
+
+func RedactStruct(struc interface{}, fields ...string) interface{} {
+	v := reflect.ValueOf(struc).Elem()
+	if v.Type().Kind() != reflect.Struct {
+		panic(fmt.Sprintf("Unsupported type, %v", v.Type().String()))
+	}
+	for _, field := range fields {
+		f := v.FieldByName(field)
+		if f.Kind() == reflect.String {
+			f.SetString(replacement)
+		} else {
+			f.Set(reflect.Zero(v.Type()))
+		}
+	}
+	return struc
+}


### PR DESCRIPTION
- Created tests to check approach works as designed
- Added utility function to redact provided fields
- Add redacting implementation for IBM cloud and AWS config type

Partial Fixes: #83 (Doesn't solve `ps -ef | grep cloud-api-adaptor` exposure)

Signed-Off-By: James Tumber <james.tumber@ibm.com>