### PR TITLE
ibmcloud: Run udpate-grub to update GRUB configuration

### DIFF
--- a/ibmcloud/image/Makefile
+++ b/ibmcloud/image/Makefile
@@ -59,9 +59,11 @@ push: $(IMAGE_FILE)
 verify: push
 	./verify.sh --image "$(IMAGE_NAME)"
 
+WORDIR = .
+
 $(IMAGE_FILE): $(UBUNTU_IMAGE_FILE) $(BINARIES) $(FILES)
 	rm -f "$(IMAGE_FILE)"
-	./build.sh  --root "$(FILES_DIR)" --packages "$(UBUNTU_PACKAGES)" --base "$(UBUNTU_IMAGE_FILE)" --output "$(IMAGE_FILE)"
+	./build.sh  --root "$(FILES_DIR)" --packages "$(UBUNTU_PACKAGES)" --base "$(UBUNTU_IMAGE_FILE)" --output "$(IMAGE_FILE)"  --workdir "$(WORKDIR)"
 
 $(AGENT_PROTOCOL_FORWARDER): force
 	cd "$(AGENT_PROTOCOL_FORWARDER_SRC)" && $(MAKE) agent-protocol-forwarder

--- a/ibmcloud/image/Makefile
+++ b/ibmcloud/image/Makefile
@@ -59,11 +59,12 @@ push: $(IMAGE_FILE)
 verify: push
 	./verify.sh --image "$(IMAGE_NAME)"
 
+SUDO =
 WORDIR = .
 
 $(IMAGE_FILE): $(UBUNTU_IMAGE_FILE) $(BINARIES) $(FILES)
 	rm -f "$(IMAGE_FILE)"
-	./build.sh  --root "$(FILES_DIR)" --packages "$(UBUNTU_PACKAGES)" --base "$(UBUNTU_IMAGE_FILE)" --output "$(IMAGE_FILE)"  --workdir "$(WORKDIR)"
+	$(SUDO) ./build.sh  --root "$(FILES_DIR)" --packages "$(UBUNTU_PACKAGES)" --base "$(UBUNTU_IMAGE_FILE)" --output "$(IMAGE_FILE)"  --workdir "$(WORKDIR)"
 
 $(AGENT_PROTOCOL_FORWARDER): force
 	cd "$(AGENT_PROTOCOL_FORWARDER_SRC)" && $(MAKE) agent-protocol-forwarder

--- a/ibmcloud/image/build.sh
+++ b/ibmcloud/image/build.sh
@@ -14,12 +14,15 @@ function usage() {
 
 declare -a packages
 
+workdir=.
+
 while (( $# )); do
     case "$1" in
         --base)     base_img_path=$2 ;;
         --output)   dst_img_path=$2 ;;
         --root)     files_dir=$2 ;;
         --packages) IFS=', ' read -a packages <<< "$2" ;;
+        --workdir)  workdir=$2 ;;
         --help)     usage; exit 0 ;;
         *)          usage 1>&2; exit 1;;
     esac
@@ -31,8 +34,9 @@ if [[ -z "${base_img_path-}" || -z "${dst_img_path-}" || -z "${files_dir-}" ]]; 
     exit 1
 fi
 
-src_img_path=src.qcow2
-tmp_img_path=tmp.qcow2
+base_img_path=$(realpath "$base_img_path")
+src_img_path="$workdir/src.qcow2"
+tmp_img_path="$workdir/tmp.qcow2"
 
 src_nbd=/dev/nbd0
 tmp_nbd=/dev/nbd1


### PR DESCRIPTION
This PR adds the following code changes.

## Run update-grub

Run the `udpate-grub` command in `build.sh` to update GRUB configuration.

Fixes #143

## Add SUDO variable

We can build a pod VM image with a non-root user as follows.
```
      make SUDO=sudo build
```
## Add --workdir option

Add an option to change working directory to store temporary QCOW2 images.  We can speed up image builds by storing temporary images on tmpfs.
