### PR TITLE
ibmcloud: add skip_verify_console variable

### DIFF
--- a/ibmcloud/image/verify.sh
+++ b/ibmcloud/image/verify.sh
@@ -54,6 +54,11 @@ while ! ibmcloud is instance $id --output json | jq -e '.status == "running"' > 
     sleep 5
 done
 
+if [[ -n "${SKIP_VERIFY_CONSOLE:-}" ]]; then
+    echo "SKIP_VERIFY_CONSOLE is set. Skipping console check..."
+    exit 0
+fi
+
 echo "Watch console log..."
 
 python3 - "$id" <<'END'

--- a/ibmcloud/terraform/podvm-build/ansible/playbook.yml
+++ b/ibmcloud/terraform/podvm-build/ansible/playbook.yml
@@ -36,6 +36,7 @@
         IBMCLOUD_VPC_SUBNET_NAME: "{{ ibmcloud_vpc_subnet_name }}"
         IBMCLOUD_VPC_REGION: "{{ ibmcloud_region_name }}"
         IBMCLOUD_VPC_ZONE: "{{ ibmcloud_vpc_zone }}"
+        SKIP_VERIFY_CONSOLE: "{{ ibmcloud_skip_verify_console }}"
       shell:
         cmd: |
           . ~/.bashrc


### PR DESCRIPTION
Allows skipping of console output during verify

Fixes: #89
Signed-off-by: Georgina Kinge <georgina.kinge@ibm.com>