### PR TITLE
Fix redaction of sensitive fields

### DIFF
--- a/pkg/adaptor/hypervisor/aws/service.go
+++ b/pkg/adaptor/hypervisor/aws/service.go
@@ -48,7 +48,7 @@ type hypervisorService struct {
 }
 
 func newService(ec2Client *ec2.Client, config *Config, hypervisorConfig *hypervisor.Config, workerNode podnetwork.WorkerNode, podsDir, daemonPort string) pb.HypervisorService {
-	logger.Printf("service config %v", config)
+	logger.Printf("service config %v", config.Redact())
 
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/pkg/adaptor/hypervisor/aws/types.go
+++ b/pkg/adaptor/hypervisor/aws/types.go
@@ -10,5 +10,5 @@ type Config struct {
 }
 
 func (c Config) Redact() Config {
-	return *util.RedactStruct(&c, "SecretKey").(*Config)
+	return *util.RedactStruct(&c, "AccessKeyId", "SecretKey").(*Config)
 }

--- a/pkg/adaptor/hypervisor/ibmcloud/service.go
+++ b/pkg/adaptor/hypervisor/ibmcloud/service.go
@@ -53,7 +53,7 @@ type hypervisorService struct {
 
 func newService(vpcV1 VpcV1, config *Config, hypervisorConfig *hypervisor.Config, workerNode podnetwork.WorkerNode, podsDir, daemonPort string) pb.HypervisorService {
 
-	logger.Printf("service config %v", config)
+	logger.Printf("service config %v", config.Redact())
 
 	hostname, err := os.Hostname()
 	if err != nil {


### PR DESCRIPTION
IBM cloud and AWS implementations not redacting fields from service log. This series fixes the issue.
Fixes: #160