### PR TITLE
ibmcloud: Set skip_verify_console in Terraform configs

### DIFF
--- a/ibmcloud/terraform/main.tf
+++ b/ibmcloud/terraform/main.tf
@@ -57,6 +57,7 @@ module "podvm_build" {
     worker_ip = module.cluster.worker_ip
     bastion_ip = module.cluster.bastion_ip
     podvm_image_name = local.podvm_image_name_with_arch
+    skip_verify_console = var.skip_verify_console
     ansible_dir = "./podvm-build/ansible"
 }
 

--- a/ibmcloud/terraform/podvm-build/main.tf
+++ b/ibmcloud/terraform/podvm-build/main.tf
@@ -11,6 +11,7 @@ locals {
   cos_service_instance_name_or_id = var.cos_service_instance_name != null ? var.cos_service_instance_name : var.cos_service_instance_id
   ibmcloud_api_endpoint = var.use_ibmcloud_test ? "https://test.cloud.ibm.com" : "https://cloud.ibm.com"
   podvm_image_name = var.podvm_image_name != null ? var.podvm_image_name : ""
+  skip_verify_console = var.skip_verify_console ? "true" : ""
 
   is_policies_and_roles = flatten([
     for policy in data.ibm_iam_user_policy.user_policies.policies: [
@@ -64,6 +65,7 @@ ibmcloud_vpc_name: ${var.vpc_name}
 ibmcloud_vpc_subnet_name: ${var.primary_subnet_name}
 ibmcloud_vpc_zone: ${data.ibm_is_subnet.primary.zone}
 ibmcloud_vpc_image_name: ${local.podvm_image_name}
+ibmcloud_skip_verify_console: ${local.skip_verify_console}
 EOF
 }
 

--- a/ibmcloud/terraform/podvm-build/variables.tf
+++ b/ibmcloud/terraform/podvm-build/variables.tf
@@ -61,3 +61,9 @@ variable "ansible_dir" {
     description = "Subdirectory for Ansible playbook, inventory and vars files"
     default = "./ansible"
 }
+
+variable "skip_verify_console" {
+    description = "Set to true to skip checking the console output after starting a virtual server instance using the built pod VM image"
+    type = bool
+    default = true
+}

--- a/ibmcloud/terraform/variables.tf
+++ b/ibmcloud/terraform/variables.tf
@@ -62,3 +62,9 @@ variable "use_ibmcloud_test" {
 variable "zone_name" {
     default = "jp-tok-2"
 }
+
+variable "skip_verify_console" {
+    description = "Set to true to skip checking the console output after starting a virtual server instance using the built pod VM image"
+    type = bool
+    default = true
+}


### PR DESCRIPTION
Fixes: https://github.com/confidential-containers/cloud-api-adaptor/issues/168

Set the skip_verify_console variable in the IBM Cloud
Terraform configurations.

Signed-off-by: Matthew Arnold <mattarno@uk.ibm.com>