### PR TITLE
ibmcloud: Enable cross-region cos endpoints

### DIFF
--- a/ibmcloud/README.md
+++ b/ibmcloud/README.md
@@ -91,6 +91,7 @@ region_name = "<name of an IBM Cloud region>"
 zone_name = "<name of a zone in your IBM Cloud zone region>"
 ssh_pub_key = "<your SSH public key>"
 cos_service_instance_name = "<name of the COS instance to create>"
+cos_bucket_region = "<name of the region to create the COS bucket in>"
 floating_ip_name = "<name of the floating IP to create>"
 image_name = "<name of the image to use for the Kubernetes control plane and worker>"
 instance_profile_name = "<name of the instance profile to use for the Kubernetes control plane and worker>"
@@ -115,6 +116,7 @@ vpc_name = "<vpc name>"
 > - `ssh_key_name` is the name of your SSH key registered in IBM Cloud or the name of a new SSH key if a public key is also provided using the optional the optional `ssh_pub_key` parameter. You can add your SSH key at [https://cloud.ibm.com/vpc-ext/compute/sshKeys](https://cloud.ibm.com/vpc-ext/compute/sshKeys). For more information about SSH keys see [managing SSH Keys](https://cloud.ibm.com/docs/vpc?topic=vpc-ssh-keys). The SSH key will be installed on the Kubernetes control plane and worker nodes and is used to access them from your `development machine`.
 > - `podvm_image_name` is the name of the VPC infrastructure custom image for the peer pod VM that the Kubernetes worker will build. This name will have `-amd64` or `-s390x` appended to it to name the image that eventually gets imported to VPC infrastructure custom images, depending on if the `image_name` parameter for the instance the peer pod VM image is built on uses the amd64 or s390x CPU architecture
 > - `cos_bucket_name` is the name of the COS bucket that will store the peer pod .vsi image. This bucket name must be unique across all IBM Cloud accounts.
+> - `cos_bucket_region` (optional) is the name of the region that the COS bucket will be in, this can be regional (e.g. jp-tok) or cross-regional (e.g. eu). If not provided will be the region specified by `region_name`.
 > - `zone_name` (optional) is the zone in the region Terraform will create the demo environment in. If not set it defaults to `jp-tok-2`.
 > - `ssh_pub_key` (optional) is an variable for a SSH public key which has **not** been registered in IBM Cloud in the targeted region. Terraform will manage this key instead. You cannot register the same SSH public key in the same region twice under different SSHs key names.
 > - `cos_service_instance_name` (optional) is the name of the COS service instance Terraform will create. If not set it defaults to `cos-image-instance`.
@@ -277,12 +279,13 @@ You can use the Terraform configuration located at [ibmcloud/terraform/cos](./te
 ibmcloud_api_key = "<your API key>"
 cos_bucket_name = "<name of the COS bucket to create>"
 cos_service_instance_name = "<name of the COS instance to create>"
+cos_bucket_region = "<name of the region to create the COS bucket in>"
 ```
 
 > **Notes:**
 > - Variables with the same name as variables in the end to end Terraform configuration are as described in that [configuration's parameters](#parameters).
 > - Additional variables and their defaults are defined in the [variables.tf](./terraform/cos/variables.tf) file for this Terraform configuration.
-> - The COS Bucket must be a regional bucket in the same region (default `jp-tok`) as the VPC and VSIs.
+> - The bucket can be regional or cross-regional see [Endpoints & Locations](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-endpoints)
 
 Then run the Template via the following commands: 
 ```bash
@@ -303,6 +306,7 @@ ibmcloud_user_id = "<IBM Cloud User ID>"
 cluster_name = "<cluster name>"
 cos_service_instance_name = "<Name of your COS service instance>" OR cos_service_instance_id = "<ID of your COS service instance>"
 cos_bucket_name = "<Name of your COS bucket name>"
+cos_bucket_region = "<name of the region to create the COS bucket in>"
 ```
 
 If you created your COS resources without using with `cos` Terraform configuration you should provide the name or ID of your existing COS service instance as the `cos_service_instance_name/cos_service_instance_id` parameter and the name of your existing COS bucket as the `cos_bucket_name` parameter. If you created your COS service instance `cos` Terraform configuration you can find the ID of your COS service instance in the outputs of the `cos` Terraform configuration.

--- a/ibmcloud/image/multipart_upload.sh
+++ b/ibmcloud/image/multipart_upload.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+# Copyright Confidential Containers Contributors
+#
+
+set -o errexit -o pipefail -o nounset
+
+function usage() {
+    echo "Usage: $0 --file <file name> --bucket <bucket name> [--size <size of parts 20M-100M>]"
+}
+
+# cleanup, removes the split files and the structure if they have been created by this script
+function cleanup() {
+    rm -f "${original_file}_structure.json"
+    rm -f "$original_file".*
+}
+trap cleanup EXIT
+
+while (( "$#" )); do
+    case "$1" in
+        --file) original_file=$2 ;;
+        --bucket) bucket=$2 ;;
+        --size) split_size=$2 ;;
+        --help) usage; exit 0 ;;
+        *)      usage 1>&2; exit 1;;
+    esac
+    shift 2
+done
+
+# Default to 100M part size
+split_size=${split_size:-100M}
+
+# Requires file and bucket to be specified to continue
+if [[ -z "${original_file-}" || -z "${bucket-}"  ]]; then
+    usage 1>&2
+    exit 1
+fi
+
+# Divide the original file up into smaller sections
+split "$original_file" -b $split_size "$original_file."
+# Create a multipart-upload, need the upload-id for part uploads 
+upload_id=$(ibmcloud cos multipart-upload-create --bucket "$bucket" --key "$original_file" --output JSON | jq -r '.UploadId')
+if [[ -z "$upload_id" ]]; then 
+    echo "Unable to start upload, check permissions" 1>&2
+    exit 1
+else
+    echo "Uploading to "$upload_id""
+fi
+
+# The complete command requires a description of the parts to piece together into the final object
+# This is constructed in JSON, the end result looks something like
+# {"Parts": [ {"ETag": "tagabcdef", "PartNumber": 1 } ... ]}
+structure="{\"Parts\":[]}"
+i=1
+for part in "$original_file".*;
+do 
+    echo "Uploading part ${part} to bucket ${bucket}";
+    etag=$(ibmcloud cos part-upload --bucket "$bucket" --key "$original_file" --upload-id "$upload_id" --part-number $i --body "$part" --output JSON | jq -r '.ETag')
+    structure=$(echo "$structure" | jq --arg etag "$etag" --argjson i $i '.Parts += [{"ETag": $etag, "PartNumber": $i}]')
+    ((i=i+1))
+done
+
+# Temporarily store the structure to file for the cli command
+echo "$structure" > "${original_file}_structure.json"
+ibmcloud cos multipart-upload-complete --bucket "$bucket" --key "$original_file" --upload-id "$upload_id" --multipart-upload "file://${original_file}_structure.json"

--- a/ibmcloud/image/push.sh
+++ b/ibmcloud/image/push.sh
@@ -82,10 +82,16 @@ while image_id=$(ibmcloud is images --output=json --visibility=private | jq -r "
 done
 
 echo -e "\nUploading $image_path to cloud object stroage at "$cos_bucket" with key $object_key\n"
-ibmcloud cos object-put  --bucket "$cos_bucket" --key "$object_key" --body "$image_path"
+./multipart_upload.sh --bucket "$cos_bucket" --file "$image_path"
+
 ibmcloud cos object-head --bucket "$cos_bucket" --key "$object_key"
 
-image_ref="cos://$region/$cos_bucket/$object_key"
+if [[ ! "$region" =~ - ]]; then 
+    location="${region}-geo"
+else 
+    location=$region
+fi
+image_ref="cos://$location/$cos_bucket/$object_key"
 arch=$(uname -m)
 os_name="ubuntu-20-04-${arch/x86_64/amd64}"
 

--- a/ibmcloud/terraform/cos/main.tf
+++ b/ibmcloud/terraform/cos/main.tf
@@ -1,5 +1,6 @@
 locals {
   resource_group_id = var.resource_group_name != null ? data.ibm_resource_group.group[0].id : data.ibm_resource_group.default_group.id
+  cos_bucket_region = var.cos_bucket_region != "" ? var.cos_bucket_region : var.region_name
 }
 
 data "ibm_resource_group" "group" {
@@ -33,6 +34,6 @@ resource "ibm_iam_authorization_policy" "policy" {
 resource "ibm_cos_bucket" "bucket" {
   bucket_name          = var.cos_bucket_name
   resource_instance_id = ibm_resource_instance.cos_instance.id
-  region_location      = var.region_name
+  region_location      = local.cos_bucket_region
   storage_class        = "standard"
 }

--- a/ibmcloud/terraform/cos/output.tf
+++ b/ibmcloud/terraform/cos/output.tf
@@ -30,3 +30,8 @@ output "cos_instance_id" {
   description = "ID of the created COS instance"
   value       = ibm_resource_instance.cos_instance.id
 }
+
+output "cos_bucket_region" {
+  description = "Region of the created COS bucket"
+  value       = ibm_cos_bucket.bucket.region_location
+}

--- a/ibmcloud/terraform/cos/variables.tf
+++ b/ibmcloud/terraform/cos/variables.tf
@@ -31,3 +31,9 @@ variable "cos_service_instance_name" {
   type        = string
   default     = "cos-image-instance"
 }
+
+variable "cos_bucket_region" {
+  description = "Name of the region in which to create the COS instance"
+  type        = string
+  default     = ""
+}

--- a/ibmcloud/terraform/main.tf
+++ b/ibmcloud/terraform/main.tf
@@ -25,6 +25,7 @@ module "cos" {
     region_name = var.region_name
     cos_bucket_name = var.cos_bucket_name
     cos_service_instance_name = var.cos_service_instance_name
+    cos_bucket_region = var.cos_bucket_region
 }
 
 module "cluster" {
@@ -50,6 +51,7 @@ module "podvm_build" {
     ibmcloud_user_id = var.ibmcloud_user_id
     cos_bucket_name = module.cos.cos_bucket_name
     cos_service_instance_id = module.cos.cos_instance_id
+    cos_bucket_region = module.cos.cos_bucket_region
     primary_subnet_name = var.primary_subnet_name
     region_name = var.region_name
     use_ibmcloud_test = var.use_ibmcloud_test

--- a/ibmcloud/terraform/podvm-build/ansible/playbook.yml
+++ b/ibmcloud/terraform/podvm-build/ansible/playbook.yml
@@ -12,7 +12,7 @@
   tasks:
     - name: Set COS service endpoint for IBM Cloud
       set_fact:
-        ibmcloud_cos_service_endpoint: https://s3.{{ ibmcloud_region_name }}.cloud-object-storage.appdomain.cloud
+        ibmcloud_cos_service_endpoint: https://s3.{{ ibmcloud_cos_bucket_region }}.cloud-object-storage.appdomain.cloud
       when: ibmcloud_api_endpoint == "https://cloud.ibm.com"
     - name: Set COS service endpoint for IBM Cloud test
       set_fact:
@@ -30,7 +30,7 @@
         IBMCLOUD_API_ENDPOINT: "{{ ibmcloud_api_endpoint }}"
         IBMCLOUD_COS_SERVICE_INSTANCE: "{{ ibmcloud_cos_service_instance }}"
         IBMCLOUD_COS_BUCKET: "{{ ibmcloud_cos_bucket }}"
-        IBMCLOUD_COS_REGION: "{{ ibmcloud_region_name }}"
+        IBMCLOUD_COS_REGION: "{{ ibmcloud_cos_bucket_region }}"
         IBMCLOUD_COS_SERVICE_ENDPOINT: "{{ ibmcloud_cos_service_endpoint }}"
         IBMCLOUD_VPC_NAME: "{{ ibmcloud_vpc_name }}"
         IBMCLOUD_VPC_SUBNET_NAME: "{{ ibmcloud_vpc_subnet_name }}"

--- a/ibmcloud/terraform/podvm-build/main.tf
+++ b/ibmcloud/terraform/podvm-build/main.tf
@@ -11,6 +11,7 @@ locals {
   cos_service_instance_name_or_id = var.cos_service_instance_name != null ? var.cos_service_instance_name : var.cos_service_instance_id
   ibmcloud_api_endpoint = var.use_ibmcloud_test ? "https://test.cloud.ibm.com" : "https://cloud.ibm.com"
   podvm_image_name = var.podvm_image_name != null ? var.podvm_image_name : ""
+  cos_bucket_region = var.cos_bucket_region != "" ? var.cos_bucket_region : var.region_name
   skip_verify_console = var.skip_verify_console ? "true" : ""
 
   is_policies_and_roles = flatten([
@@ -60,6 +61,7 @@ ibmcloud_api_key: ${var.ibmcloud_api_key}
 ibmcloud_api_endpoint: ${local.ibmcloud_api_endpoint}
 ibmcloud_cos_service_instance: "${local.cos_service_instance_name_or_id}"
 ibmcloud_cos_bucket: ${var.cos_bucket_name}
+ibmcloud_cos_bucket_region: ${local.cos_bucket_region}
 ibmcloud_region_name: ${var.region_name}
 ibmcloud_vpc_name: ${var.vpc_name}
 ibmcloud_vpc_subnet_name: ${var.primary_subnet_name}

--- a/ibmcloud/terraform/podvm-build/variables.tf
+++ b/ibmcloud/terraform/podvm-build/variables.tf
@@ -33,6 +33,10 @@ variable "cos_service_instance_id" {
     default = null
 }
 
+variable "cos_bucket_region" {
+    default = ""
+}
+
 variable "cos_bucket_name" {
     description = "Name of the COS bucket"
 }

--- a/ibmcloud/terraform/variables.tf
+++ b/ibmcloud/terraform/variables.tf
@@ -22,6 +22,10 @@ variable "cos_service_instance_name" {
     default = "cos-image-instance"
 }
 
+variable "cos_bucket_region" {
+    default = ""
+}
+
 variable "floating_ip_name" {
     default = "tok-gateway-ip"
 }


### PR DESCRIPTION
- Allow the user to create and use a cross-region cos bucket
- Made uploads on slower networks more reliable by doing multipart uploads

Fixes #169 

Signed-Off-By: James Tumber <james.tumber@ibm.com>