### PR TITLE
install: enable installation when crio is used

### DIFF
--- a/install/yamls/ccruntime-peer-pods-in-pod.yaml
+++ b/install/yamls/ccruntime-peer-pods-in-pod.yaml
@@ -63,6 +63,8 @@ spec:
     uninstallDoneLabel:
       katacontainers.io/kata-runtime: "cleanup"
     installerVolumeMounts:
+      - mountPath: /etc/crio/
+        name: crio-conf
       - mountPath: /etc/containerd/
         name: containerd-conf
       - mountPath: /opt/confidential-containers/
@@ -74,6 +76,10 @@ spec:
       - mountPath: /usr/local/bin/
         name: local-bin
     installerVolumes:
+      - hostPath:
+          path: /etc/crio/
+          type: ""
+        name: crio-conf
       - hostPath:
           path: /etc/containerd/
           type: ""

--- a/install/yamls/ccruntime-peer-pods-in-pod.yaml
+++ b/install/yamls/ccruntime-peer-pods-in-pod.yaml
@@ -57,7 +57,7 @@ spec:
       node-role.kubernetes.io/worker: ""
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/peer-pods-runtime-payload:2022081017081660151315
+    payloadImage: quay.io/confidential-containers/peer-pods-runtime-payload:2022082911511661773888
     installDoneLabel:
       katacontainers.io/kata-runtime: "true"
     uninstallDoneLabel:

--- a/install/yamls/ccruntime-peer-pods.yaml
+++ b/install/yamls/ccruntime-peer-pods.yaml
@@ -17,6 +17,8 @@ spec:
     uninstallDoneLabel:
       katacontainers.io/kata-runtime: "cleanup"
     installerVolumeMounts:
+      - mountPath: /etc/crio/
+        name: crio-conf
       - mountPath: /etc/containerd/
         name: containerd-conf
       - mountPath: /opt/confidential-containers/
@@ -28,6 +30,10 @@ spec:
       - mountPath: /usr/local/bin/
         name: local-bin
     installerVolumes:
+      - hostPath:
+          path: /etc/crio/
+          type: ""
+        name: crio-conf
       - hostPath:
           path: /etc/containerd/
           type: ""

--- a/install/yamls/ccruntime-peer-pods.yaml
+++ b/install/yamls/ccruntime-peer-pods.yaml
@@ -11,7 +11,7 @@ spec:
       node-role.kubernetes.io/worker: ""
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/peer-pods-runtime-payload:2022081017081660151315
+    payloadImage: quay.io/confidential-containers/peer-pods-runtime-payload:2022082911511661773888
     installDoneLabel:
       katacontainers.io/kata-runtime: "true"
     uninstallDoneLabel:


### PR DESCRIPTION
set its configuration files etc..

Signed-off-by: Snir Sheriber <ssheribe@redhat.com>
Fixes: #184

* io.kubernetes.cri.sandbox-name annotation doesn't propagate with crio, expected to be fixed in crio-1.24.3, meanwhile can be added manually