### PR TITLE
install: add missing ssh_mount file

### DIFF
--- a/install/overlays/libvirt/ssh_mount.yaml
+++ b/install/overlays/libvirt/ssh_mount.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloud-api-adaptor-deployment
+  namespace: confidential-containers-system
+  labels:
+    app: cloud-api-adaptor
+spec:
+  template:
+    spec:
+      containers:
+      - name: cloud-api-adaptor-con
+        volumeMounts:
+        - name: ssh
+          mountPath: "/root/.ssh/"
+          readOnly: true
+      volumes:
+      - name: ssh
+        secret:
+          secretName: ssh-key-secret
+          defaultMode: 0600
+          optional: true
+
+# to apply this uncomment the patchesStrategicMerge of this file in kustomization.yaml


### PR DESCRIPTION
which is needed in order to mount the ssh key with libvirt

Signed-off-by: Snir Sheriber <ssheribe@redhat.com>
Fixes: #192