### PR TITLE
Use normal Unix domain socket for kata-agent

### DIFF
--- a/aws/image/files/etc/systemd/system/agent-protocol-forwarder.service
+++ b/aws/image/files/etc/systemd/system/agent-protocol-forwarder.service
@@ -3,7 +3,7 @@ Description=Agent Protocol Forwarder
 After=network.target
 
 [Service]
-ExecStart=/usr/local/bin/agent-protocol-forwarder -kata-agent-namespace /run/netns/podns -kata-agent-socket @/run/kata-containers/agent.sock
+ExecStart=/usr/local/bin/agent-protocol-forwarder -kata-agent-namespace /run/netns/podns -kata-agent-socket /run/kata-containers/agent.sock
 
 [Install]
 WantedBy=multi-user.target

--- a/azure/image/files/etc/systemd/system/agent-protocol-forwarder.service
+++ b/azure/image/files/etc/systemd/system/agent-protocol-forwarder.service
@@ -3,7 +3,7 @@ Description=Agent Protocol Forwarder
 After=network.target
 
 [Service]
-ExecStart=/usr/local/bin/agent-protocol-forwarder -kata-agent-namespace /run/netns/podns -kata-agent-socket @/run/kata-containers/agent.sock
+ExecStart=/usr/local/bin/agent-protocol-forwarder -kata-agent-namespace /run/netns/podns -kata-agent-socket /run/kata-containers/agent.sock
 
 [Install]
 WantedBy=multi-user.target

--- a/ibmcloud/image/files/etc/systemd/system/agent-protocol-forwarder.service
+++ b/ibmcloud/image/files/etc/systemd/system/agent-protocol-forwarder.service
@@ -3,7 +3,7 @@ Description=Agent Protocol Forwarder
 After=network.target
 
 [Service]
-ExecStart=/usr/local/bin/agent-protocol-forwarder -kata-agent-namespace /run/netns/podns -kata-agent-socket @/run/kata-containers/agent.sock
+ExecStart=/usr/local/bin/agent-protocol-forwarder -kata-agent-namespace /run/netns/podns -kata-agent-socket /run/kata-containers/agent.sock
 
 [Install]
 WantedBy=multi-user.target

--- a/libvirt/image/files/etc/systemd/system/agent-protocol-forwarder.service
+++ b/libvirt/image/files/etc/systemd/system/agent-protocol-forwarder.service
@@ -3,7 +3,7 @@ Description=Agent Protocol Forwarder
 After=network.target
 
 [Service]
-ExecStart=/usr/local/bin/agent-protocol-forwarder -kata-agent-namespace /run/netns/podns -kata-agent-socket @/run/kata-containers/agent.sock
+ExecStart=/usr/local/bin/agent-protocol-forwarder -kata-agent-namespace /run/netns/podns -kata-agent-socket /run/kata-containers/agent.sock
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -27,7 +27,7 @@ const (
 	DefaultListenAddr          = DefaultListenHost + ":" + DefaultListenPort
 	DefaultConfigPath          = "/peerpod/daemon.json"
 	DefaultPodNetworkSpecPath  = "/peerpod/podnetwork.json"
-	DefaultKataAgentSocketPath = "@/run/kata-containers/agent.sock"
+	DefaultKataAgentSocketPath = "/run/kata-containers/agent.sock"
 	DefaultKataAgentNamespace  = ""
 	AgentURLPath               = "/agent"
 )

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -7,12 +7,24 @@ import (
 	"context"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/util/agentproto"
 )
 
+type mockConn struct{}
+
+func (*mockConn) Read(b []byte) (n int, err error)   { return 0, nil }
+func (*mockConn) Write(b []byte) (n int, err error)  { return 0, nil }
+func (*mockConn) Close() error                       { return nil }
+func (*mockConn) LocalAddr() net.Addr                { return nil }
+func (*mockConn) RemoteAddr() net.Addr               { return nil }
+func (*mockConn) SetDeadline(t time.Time) error      { return nil }
+func (*mockConn) SetReadDeadline(t time.Time) error  { return nil }
+func (*mockConn) SetWriteDeadline(t time.Time) error { return nil }
+
 func dummyDialer(ctx context.Context) (net.Conn, error) {
-	return nil, nil
+	return &mockConn{}, nil
 }
 
 func TestNew(t *testing.T) {


### PR DESCRIPTION
kata-agent of the latest CCv0 branch does not use abstract Unix domain socket, when we set KATA_AGENT_SERVER_ADDR as follows.

```
KATA_AGENT_SERVER_ADDR=unix:///run/kata-containers/agent.sock"
```

This patch changes agent-protocol-forwarder to connect to a regular Unix domain socket, instead of a abstract Unix domain socket.

This PR also improve error handling at connecting to kata-agent using Unix domain socket.

Fixes https://github.com/confidential-containers/cloud-api-adaptor/issues/198
