### PR TITLE
ibmcloud: Use variables for source code repos

### DIFF
--- a/ibmcloud/README.md
+++ b/ibmcloud/README.md
@@ -128,6 +128,12 @@ vpc_name = "<vpc name>"
 > - `primary_subnet_name` (optional) is the name of the subnet Terraform will create. If not set it defaults to `tok-primary-subnet`.
 > - `public_gateway_name` (optional) is the name of the public gateway Terraform will create. If not set it defaults to `tok-gateway`.
 > - `vpc_name` (optional) is the name of the VPC Terraform will create. If not set it defaults to `tok-vpc`.
+> - `cloud_api_adaptor_repo` (optional) is the repository URL of Cloud API Adaptor. If not set it defaults to `https://github.com/confidential-containers/cloud-api-adaptor.git`.
+> - `cloud_api_adaptor_branch` (optional) is the branch name of Cloud API Adaptor. If not set it defaults to `staging`.
+> - `kata_containers_repo` (optional) is the repository URL of Kata Containers. If not set it defaults to `https://github.com/yoheiueda/kata-containers.git`.
+> - `kata_containers_branch` (optional) is the branch name of Kata Containers. If not set it defaults to `CCv0-peerpod`.
+> - `containerd_repo` (optional) is the repository URL of containerd. If not set it defaults to `https://github.com/confidential-containers/containerd.git`.
+> - `containerd_branch` (optional) is the branch name of containerd. If not set it defaults to `CC-main`.
 
 > **Hint:** In order to create a cluster based on a different type of VSI image you can use the `instance_profile_name` and `image_name` parameters. E.g., to create a **s390x** architecture based cluster, include the following two lines in the `terraform.tfvars` file
 >
@@ -204,6 +210,17 @@ If you created your VPC, subnet and security group without using the `common` Te
 If you don't have your public key already configured in IBM Cloud you can add
 ```
 ssh_pub_key = "<your SSH public key>"
+```
+
+Additionally,  you can customize source code repositories to be extracted under `/root` of each worker node. By default, the repository URLs and branch names listed below are used to fetch repositories. You can add variable definitions to `terraform.tfvars` to customize them.
+
+```
+cloud_api_adaptor_repo = "https://github.com/confidential-containers/cloud-api-adaptor.git"
+cloud_api_adaptor_branch = "staging"
+kata_containers_repo = "https://github.com/yoheiueda/kata-containers.git"
+kata_containers_branch = "CCv0-peerpod"
+containerd_repo = "https://github.com/confidential-containers/containerd.git"
+containerd_branch = "CC-main"
 ```
 
 > **Hint:** In order to create the cluster based on a different type of VSI image you can overwrite more parameters here e.g. to create a **s390x** based cluster add follow two lines to the `terraform.tfvars` file.

--- a/ibmcloud/terraform/.gitignore
+++ b/ibmcloud/terraform/.gitignore
@@ -2,6 +2,7 @@
 terraform.tfvars
 terraform.tfstate*
 /cluster/ansible/inventory
+/cluster/ansible/group_vars/all
 /podvm-build/ansible/inventory
 /podvm-build/ansible/group_vars/all
 /start-cloud-api-adaptor/ansible/inventory

--- a/ibmcloud/terraform/cluster/ansible/kata-playbook.yml
+++ b/ibmcloud/terraform/cluster/ansible/kata-playbook.yml
@@ -71,9 +71,8 @@
     - name: Install containerd
       shell: |
         set -o errexit -o pipefail
-        containerd_release_tag=$(curl -sL https://api.github.com/repos/containerd/containerd/releases/latest | jq -r .tag_name)
         rm -fr /tmp/containerd
-        git clone -b CC-main https://github.com/confidential-containers/containerd.git /tmp/containerd
+        git clone -b "{{ containerd_branch }}" "{{ containerd_repo }}" /tmp/containerd
         (cd /tmp/containerd && make && make install)
         rm -fr /tmp/containerd
       environment:
@@ -203,7 +202,7 @@
       shell: |
         set -o errexit -o pipefail
         cd /root
-        git clone -b CCv0-peerpod https://github.com/yoheiueda/kata-containers.git
+        git clone -b "{{ kata_containers_branch }}" "{{ kata_containers_repo }}"
       args:
         executable: /bin/bash
         creates: /root/kata-containers
@@ -212,7 +211,7 @@
       shell: |
         set -o errexit -o pipefail
         cd /root
-        git clone -b staging https://github.com/confidential-containers/cloud-api-adaptor.git
+        git clone -b "{{ cloud_api_adaptor_branch }}" "{{ cloud_api_adaptor_repo }}"
       args:
         executable: /bin/bash
         creates: /root/cloud-api-adaptor

--- a/ibmcloud/terraform/cluster/ansible/kube-playbook.yml
+++ b/ibmcloud/terraform/cluster/ansible/kube-playbook.yml
@@ -150,9 +150,8 @@
     - name: Install containerd
       shell: |
         set -o errexit -o pipefail
-        containerd_release_tag=$(curl -sL https://api.github.com/repos/containerd/containerd/releases/latest | jq -r .tag_name)
         rm -fr /tmp/containerd
-        git clone -b CC-main https://github.com/confidential-containers/containerd.git /tmp/containerd
+        git clone -b "{{ containerd_branch }}" "{{ containerd_repo }}" /tmp/containerd
         (cd /tmp/containerd && make && make install)
         rm -fr /tmp/containerd
       environment:

--- a/ibmcloud/terraform/cluster/main.tf
+++ b/ibmcloud/terraform/cluster/main.tf
@@ -99,6 +99,7 @@ EOF
 resource "null_resource" "ansible" {
   triggers = {
     inventry = resource.local_file.inventory.content
+    group_vars = resource.local_file.group_vars.content
   }
 
   provisioner "local-exec" {
@@ -120,4 +121,18 @@ resource "null_resource" "ansible" {
 data "ibm_is_instance" "provisioned_worker" {
   depends_on = [null_resource.ansible]
   name = local.worker_name
+}
+
+resource "local_file" "group_vars" {
+  filename = "${var.ansible_dir}/group_vars/all"
+  content = <<EOF
+---
+
+cloud_api_adaptor_repo: ${var.cloud_api_adaptor_repo}
+cloud_api_adaptor_branch: ${var.cloud_api_adaptor_branch}
+kata_containers_repo: ${var.kata_containers_repo}
+kata_containers_branch: ${var.kata_containers_branch}
+containerd_repo: ${var.containerd_repo}
+containerd_branch: ${var.containerd_branch}
+EOF
 }

--- a/ibmcloud/terraform/cluster/variables.tf
+++ b/ibmcloud/terraform/cluster/variables.tf
@@ -65,3 +65,33 @@ variable "scripts_dir" {
     description = "Subdirectory for shell scripts"
     default = "./scripts"
 }
+
+variable "cloud_api_adaptor_repo" {
+    description = "Repository URL of Cloud API Adaptor"
+    default = "https://github.com/confidential-containers/cloud-api-adaptor.git"
+}
+
+variable "cloud_api_adaptor_branch" {
+    description = "Branch name of Cloud API Adaptor"
+    default = "staging"
+}
+
+variable "kata_containers_repo" {
+    description = "Repository URL of Kata Containers"
+    default = "https://github.com/yoheiueda/kata-containers.git"
+}
+
+variable "kata_containers_branch" {
+    description = "Branch name of Kata Containers"
+    default = "CCv0-peerpod"
+}
+
+variable "containerd_repo" {
+    description = "Repository URL of containerd"
+    default = "https://github.com/confidential-containers/containerd.git"
+}
+
+variable "containerd_branch" {
+    description = "Branch name of containerd"
+    default = "CC-main"
+}

--- a/ibmcloud/terraform/main.tf
+++ b/ibmcloud/terraform/main.tf
@@ -43,6 +43,12 @@ module "cluster" {
     zone_name = var.zone_name
     ansible_dir = "./cluster/ansible"
     scripts_dir = "./cluster/scripts"
+    cloud_api_adaptor_repo = var.cloud_api_adaptor_repo
+    cloud_api_adaptor_branch = var.cloud_api_adaptor_branch
+    kata_containers_repo = var.kata_containers_repo
+    kata_containers_branch = var.kata_containers_branch
+    containerd_repo = var.containerd_repo
+    containerd_branch = var.containerd_branch
 }
 
 module "podvm_build" {

--- a/ibmcloud/terraform/variables.tf
+++ b/ibmcloud/terraform/variables.tf
@@ -72,3 +72,33 @@ variable "skip_verify_console" {
     type = bool
     default = true
 }
+
+variable "cloud_api_adaptor_repo" {
+    description = "Repository URL of Cloud API Adaptor"
+    default = "https://github.com/confidential-containers/cloud-api-adaptor.git"
+}
+
+variable "cloud_api_adaptor_branch" {
+    description = "Branch name of Cloud API Adaptor"
+    default = "staging"
+}
+
+variable "kata_containers_repo" {
+    description = "Repository URL of Kata Containers"
+    default = "https://github.com/yoheiueda/kata-containers.git"
+}
+
+variable "kata_containers_branch" {
+    description = "Branch name of Kata Containers"
+    default = "CCv0-peerpod"
+}
+
+variable "containerd_repo" {
+    description = "Repository URL of containerd"
+    default = "https://github.com/confidential-containers/containerd.git"
+}
+
+variable "containerd_branch" {
+    description = "Branch name of containerd"
+    default = "CC-main"
+}


### PR DESCRIPTION
This patch remove hard-coded source code repository URLs and branch names, and introduce variables to specify them. The default values are the original hard-coded ones.

Fixes #211 
