### PR TITLE
Switch to upstream CCv0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,17 +25,6 @@ jobs:
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@v3
-        with:
-          # Need this to clone the repository side-by-side with kata's.
-          path: cloud-api-adaptor
-      - name: Checkout the Kata Containers fork
-        uses: actions/checkout@v3
-        with:
-          # TODO: this repository is temporary and so should be replaced
-          # once the required changes are merged on kata's repo.
-          repository: yoheiueda/kata-containers
-          ref: CCv0-peerpod
-          path: kata-containers
       - name: Setup Golang version ${{ matrix.go_version }}
         uses: actions/setup-go@v3
         with:
@@ -47,10 +36,8 @@ jobs:
           sudo apt-get install -y libvirt-dev
       - name: Build
         run: |
-          cd cloud-api-adaptor
           make CLOUD_PROVIDER=${{ matrix.provider }} build
       - name: Test
-        working-directory: ${{ github.workspace }}/cloud-api-adaptor
         run: |
           go install github.com/jstemmer/go-junit-report@v1.0.0
           export CI="true"
@@ -63,5 +50,5 @@ jobs:
         if: always()
         with:
           name: tests_report_junit-${{ matrix.provider }}_${{ matrix.runner }}_${{ matrix.go_version }}
-          path: ${{ github.workspace }}/cloud-api-adaptor/tests_report_junit.xml
+          path: ${{ github.workspace }}/tests_report_junit.xml
           retention-days: 1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,17 +19,6 @@ jobs:
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@v3
-        with:
-          # Need this to clone the repository side-by-side with kata's.
-          path: cloud-api-adaptor
-      - name: Checkout the Kata Containers fork
-        uses: actions/checkout@v3
-        with:
-          # TODO: this repository is temporary and so should be replaced
-          # once the required changes are merged on kata's repo.
-          repository: yoheiueda/kata-containers
-          ref: CCv0-peerpod
-          path: kata-containers
       - name: Setup Golang version ${{ matrix.go_version }}
         uses: actions/setup-go@v3
         with:
@@ -39,4 +28,4 @@ jobs:
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.46.2
-          working-directory: ${{ github.workspace }}/cloud-api-adaptor
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.18 AS builder
 ARG CLOUD_PROVIDER
 ENV CLOUD_PROVIDER=${CLOUD_PROVIDER}
 COPY . cloud-api-adaptor
-RUN git clone -b CCv0-peerpod https://github.com/yoheiueda/kata-containers
+RUN git clone -b CCv0 https://github.com/kata-containers/kata-containers
 WORKDIR cloud-api-adaptor
 RUN if [ "$CLOUD_PROVIDER" = "libvirt" ] ; then apt-get update -y && apt-get install -y libvirt-dev; fi
 RUN make

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This repository contains the implementation of Kata [remote hypervisor](https://github.com/yoheiueda/kata-containers/tree/CCv0-peerpod).
+This repository contains the implementation of Kata [remote hypervisor](https://github.com/kata-containers/kata-containers/tree/CCv0).
 The remote hypervisor concept is currently work in progress. The primary purpose of remote hypervisor support is to create
 Kata VMs alongside the Kubernetes worker node VMs, without requiring any nested virtualization support.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -7,7 +7,7 @@
 export BUILD_DIR=$HOME/remote-hyp
 mkdir -p $BUILD_DIR && cd $BUILD_DIR
 
-git clone -b CCv0-peerpod https://github.com/yoheiueda/kata-containers.git
+git clone -b CCv0 https://github.com/kata-containers/kata-containers.git
 git clone https://github.com/confidential-containers/cloud-api-adaptor.git
 cd cloud-api-adaptor
 ```

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/coreos/go-iptables v0.6.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/uuid v1.3.0
-	github.com/kata-containers/kata-containers/src/runtime v0.0.0-00010101000000-000000000000
 	github.com/opencontainers/runtime-spec v1.0.3-0.20211214071223-8958f93039ab
 	github.com/stretchr/testify v1.8.0
 	github.com/vishvananda/netlink v1.1.1-0.20220115184804-dd687eb2f2d4
@@ -56,6 +55,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20220913141151-9b49a6ddc6fd // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
@@ -73,9 +73,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace (
-	github.com/kata-containers/kata-containers/src/runtime => ../kata-containers/src/runtime
-	// The following line is a workaround for the issue descrined in https://github.com/containerd/ttrpc/issues/62
-	// We can remove this workaround when Kata stop using github.com/gogo/protobuf
-	google.golang.org/genproto => google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
-)
+// The following line is a workaround for the issue descrined in https://github.com/containerd/ttrpc/issues/62
+// We can remove this workaround when Kata stop using github.com/gogo/protobuf
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8

--- a/go.sum
+++ b/go.sum
@@ -1108,6 +1108,10 @@ github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaR
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/karrick/godirwalk v1.15.3/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
+github.com/kata-containers/kata-containers v0.0.0-20220913141151-9b49a6ddc6fd h1:qU3kPJB1cBwOwmuYbUnksH+0mTgDsqunPF1kXaW+4r4=
+github.com/kata-containers/kata-containers v0.0.0-20220913141151-9b49a6ddc6fd/go.mod h1:tXmBXaVnZkUP+T6WQrFvfZgZfp17OqxdaDtqMOGUBDM=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20220913141151-9b49a6ddc6fd h1:lfWVfG2l+KjhqYm/wcpPo+eN6KNPnzioncD58oONX3E=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20220913141151-9b49a6ddc6fd/go.mod h1:06RnSkAG8aNZF9GUJMH09b39U+mo0cJPJkLCH8RSXK0=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/ibmcloud/README.md
+++ b/ibmcloud/README.md
@@ -4,7 +4,7 @@ This guide describes how to set up a demo environment on IBM Cloud for peer pod 
 
 This procedure has been confirmed using the following repositories.
 * https://github.com/confidential-containers/cloud-api-adaptor/tree/staging
-* https://github.com/yoheiueda/kata-containers/tree/peerpod-2022.04.04
+* https://github.com/kata-containers/kata-containers/tree/CCv0
 
 The setup procedure includes the following sub tasks.
 
@@ -130,8 +130,8 @@ vpc_name = "<vpc name>"
 > - `vpc_name` (optional) is the name of the VPC Terraform will create. If not set it defaults to `tok-vpc`.
 > - `cloud_api_adaptor_repo` (optional) is the repository URL of Cloud API Adaptor. If not set it defaults to `https://github.com/confidential-containers/cloud-api-adaptor.git`.
 > - `cloud_api_adaptor_branch` (optional) is the branch name of Cloud API Adaptor. If not set it defaults to `staging`.
-> - `kata_containers_repo` (optional) is the repository URL of Kata Containers. If not set it defaults to `https://github.com/yoheiueda/kata-containers.git`.
-> - `kata_containers_branch` (optional) is the branch name of Kata Containers. If not set it defaults to `CCv0-peerpod`.
+> - `kata_containers_repo` (optional) is the repository URL of Kata Containers. If not set it defaults to `https://github.com/kata-containers/kata-containers.git`.
+> - `kata_containers_branch` (optional) is the branch name of Kata Containers. If not set it defaults to `CCv0`.
 > - `containerd_repo` (optional) is the repository URL of containerd. If not set it defaults to `https://github.com/confidential-containers/containerd.git`.
 > - `containerd_branch` (optional) is the branch name of containerd. If not set it defaults to `CC-main`.
 
@@ -217,8 +217,8 @@ Additionally,  you can customize source code repositories to be extracted under 
 ```
 cloud_api_adaptor_repo = "https://github.com/confidential-containers/cloud-api-adaptor.git"
 cloud_api_adaptor_branch = "staging"
-kata_containers_repo = "https://github.com/yoheiueda/kata-containers.git"
-kata_containers_branch = "CCv0-peerpod"
+kata_containers_repo = "https://github.com/kata-containers/kata-containers.git"
+kata_containers_branch = "CCv0"
 containerd_repo = "https://github.com/confidential-containers/containerd.git"
 containerd_branch = "CC-main"
 ```

--- a/ibmcloud/terraform/cluster/variables.tf
+++ b/ibmcloud/terraform/cluster/variables.tf
@@ -78,12 +78,12 @@ variable "cloud_api_adaptor_branch" {
 
 variable "kata_containers_repo" {
     description = "Repository URL of Kata Containers"
-    default = "https://github.com/yoheiueda/kata-containers.git"
+    default = "https://github.com/kata-containers/kata-containers.git"
 }
 
 variable "kata_containers_branch" {
     description = "Branch name of Kata Containers"
-    default = "CCv0-peerpod"
+    default = "CCv0"
 }
 
 variable "containerd_repo" {

--- a/ibmcloud/terraform/variables.tf
+++ b/ibmcloud/terraform/variables.tf
@@ -85,12 +85,12 @@ variable "cloud_api_adaptor_branch" {
 
 variable "kata_containers_repo" {
     description = "Repository URL of Kata Containers"
-    default = "https://github.com/yoheiueda/kata-containers.git"
+    default = "https://github.com/kata-containers/kata-containers.git"
 }
 
 variable "kata_containers_branch" {
     description = "Branch name of Kata Containers"
-    default = "CCv0-peerpod"
+    default = "CCv0"
 }
 
 variable "containerd_repo" {


### PR DESCRIPTION
The PR of remote hypervisor support has been merged.

We can switch from the `CCv0-peerpod` branch at https://github.com/yoheiueda/kata-containers to the `CCv0` branch at https://github.com/kata-containers/kata-containers.

Fixes #215
