### PR TITLE
azure: remove SubnetName and VnetName flags

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -67,7 +67,6 @@ Use the output from the previous command as values for the next one, viz. for fl
   -resourcegroup $RESOURCE_GROUP_NAME \
   -region $LOCATION \
   -subnetid "/subscriptions/..." \
-  -vnetname "<name of virtual network>" \
   -securitygroupid "/subscriptions/... network security group" \
   -instance-size <> \
   -imageid "/subscriptions/... image id generated before"

--- a/cmd/cloud-api-adaptor/main.go
+++ b/cmd/cloud-api-adaptor/main.go
@@ -72,7 +72,6 @@ func (cfg *daemonConfig) Setup() (cmd.Starter, error) {
 			flags.StringVar(&azurecfg.Zone, "zone", "", "Zone")
 			flags.StringVar(&azurecfg.Region, "region", "", "Region")
 			flags.StringVar(&azurecfg.SubnetId, "subnetid", "", "Network Subnet Id")
-			flags.StringVar(&azurecfg.VnetName, "vnetname", "", "Virtual Network Name")
 			flags.StringVar(&azurecfg.SecurityGroupId, "securitygroupid", "", "Security Group Id")
 			flags.StringVar(&azurecfg.Size, "instance-size", "", "Instance size")
 			flags.StringVar(&azurecfg.ImageId, "imageid", "", "Image Id")

--- a/pkg/adaptor/hypervisor/azure/types.go
+++ b/pkg/adaptor/hypervisor/azure/types.go
@@ -8,9 +8,7 @@ type Config struct {
 	ResourceGroupName string
 	Zone              string
 	Region            string
-	SubnetName        string
 	SubnetId          string
-	VnetName          string
 	SecurityGroupName string
 	SecurityGroupId   string
 	Size              string


### PR DESCRIPTION
Tiny cleanup, there are a few properties and flags that are redundant/unused.

Fixes: #221 