### PR TITLE
azure: add provider to documentation

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -14,7 +14,7 @@ cd cloud-api-adaptor
 
 ## Build the binary
 
-Set `CLOUD_PROVIDER` variable to either `aws|ibmcloud|libvirt` depending on your requirement.
+Set `CLOUD_PROVIDER` variable to either `aws|azure|ibmcloud|libvirt` depending on your requirement.
 
 ```
 export CLOUD_PROVIDER=aws

--- a/docs/addnewprovider.md
+++ b/docs/addnewprovider.md
@@ -53,7 +53,7 @@ These methods are required by Kata and a Kata hypervisor needs to implement thes
 
 Add additional files to modularize the code.
 
-See existing providers - `aws|ibmcloud|libvirt`
+See existing providers - `aws|azure|ibmcloud|libvirt`
 
 #### Step 3: Update Continuous Integration (CI) workflows
 

--- a/install/README.md
+++ b/install/README.md
@@ -33,7 +33,7 @@
 
 * set CLOUD_PROVIDER
     ```
-    export CLOUD_PROVIDER=<aws|ibmcloud|libvirt>
+    export CLOUD_PROVIDER=<aws|azure|ibmcloud|libvirt>
     ```
 
 * `make deploy` deploys operator, runtime and cloud-api-adaptor pod in the configured cluster
@@ -83,7 +83,7 @@
 
 * Set CLOUD_PROVIDER
     ```
-    export CLOUD_PROVIDER=<aws|ibmcloud|libvirt>
+    export CLOUD_PROVIDER=<aws|azure|ibmcloud|libvirt>
     ```
 
 * Set container registry and image name


### PR DESCRIPTION
The azure provider was missing in a couple of places in the documentation.

Fixes: #220 

Signed-off-by: Magnus Kulke <magnuskulke@microsoft.com>