### PR TITLE
caa-pod: run in fedora container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ WORKDIR cloud-api-adaptor
 RUN if [ "$CLOUD_PROVIDER" = "libvirt" ] ; then apt-get update -y && apt-get install -y libvirt-dev; fi
 RUN make
 
-FROM golang:1.18
+FROM fedora:36
 ARG CLOUD_PROVIDER
 ENV CLOUD_PROVIDER=${CLOUD_PROVIDER}
-RUN if [ "$CLOUD_PROVIDER" = "libvirt" ] ; then apt-get update -y && apt-get install -y libvirt0 genisoimage && apt-get clean; fi
+RUN if [ "$CLOUD_PROVIDER" = "libvirt" ] ; then dnf install -y libvirt-libs genisoimage /usr/bin/ssh && dnf clean all; fi
 COPY --from=builder /go/cloud-api-adaptor/cloud-api-adaptor /usr/local/bin/cloud-api-adaptor-$CLOUD_PROVIDER
 COPY --from=builder /go/cloud-api-adaptor/entrypoint.sh /usr/local/bin/entrypoint.sh
 CMD entrypoint.sh


### PR DESCRIPTION
to avoid old pkgs security risks

Fixes: #254
Signed-off-by: Snir Sheriber <ssheribe@redhat.com>

**It seems Debian (non-rawhide) based images has a lot of security risk warnings emits by quay's security scanner ([see](https://quay.io/repository/confidential-containers/cloud-api-adaptor-aws?tab=tags)), running in fedora container (build is still on debian) seem to solve all of them AFAIU that's should be safe for the static caa builds and i think it should be fine also for the libvirt build as the libs are installed.**