### PR TITLE
Fix pull image errors when the custom containerd for CCv0 is used with the latest CCv0

### DIFF
--- a/pkg/forwarder/interceptor/interceptor.go
+++ b/pkg/forwarder/interceptor/interceptor.go
@@ -182,3 +182,16 @@ func (i *interceptor) DestroySandbox(ctx context.Context, req *pb.DestroySandbox
 
 	return res, err
 }
+
+func (i *interceptor) PullImage(ctx context.Context, req *pb.PullImageRequest) (*pb.PullImageResponse, error) {
+
+	logger.Printf("PullImage: image: %q, containerID: %q", req.Image, req.ContainerId)
+
+	res, err := i.Redirector.PullImage(ctx, req)
+
+	if err != nil {
+		logger.Printf("PullImage failed with error: %v", err)
+	}
+
+	return res, err
+}


### PR DESCRIPTION
This PR fixes pull image errors when the custom containerd for CCv0 is used with the latest CCv0.

Fixes #259 
