### PR TITLE
Correct pod names reported by cri-o

### DIFF
--- a/pkg/adaptor/hypervisor/aws/service.go
+++ b/pkg/adaptor/hypervisor/aws/service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork/tunneler"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/util/cloudinit"
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/util/hvutil"
 	"github.com/containerd/containerd/pkg/cri/annotations"
 
 	pb "github.com/kata-containers/kata-containers/src/runtime/protocols/hypervisor"
@@ -100,11 +101,12 @@ func (s *hypervisorService) CreateVM(ctx context.Context, req *pb.CreateVMReques
 	if _, exists := s.sandboxes[sid]; exists {
 		return nil, fmt.Errorf("sandbox %s already exists", sid)
 	}
-	pod := req.Annotations[annotations.SandboxName]
+	pod := hvutil.GetPodName(req.Annotations)
 	if pod == "" {
 		return nil, fmt.Errorf("pod name %s is missing in annotations", annotations.SandboxName)
 	}
-	namespace := req.Annotations[annotations.SandboxNamespace]
+
+	namespace := hvutil.GetPodNamespace(req.Annotations)
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace name %s is missing in annotations", annotations.SandboxNamespace)
 	}

--- a/pkg/adaptor/hypervisor/azure/service.go
+++ b/pkg/adaptor/hypervisor/azure/service.go
@@ -27,6 +27,7 @@ import (
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork/tunneler"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/util/cloudinit"
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/util/hvutil"
 	"github.com/containerd/containerd/pkg/cri/annotations"
 
 	pb "github.com/kata-containers/kata-containers/src/runtime/protocols/hypervisor"
@@ -104,11 +105,12 @@ func (s *hypervisorService) CreateVM(ctx context.Context, req *pb.CreateVMReques
 	if _, exists := s.sandboxes[sid]; exists {
 		return nil, fmt.Errorf("sandbox %s already exists", sid)
 	}
-	pod := req.Annotations[annotations.SandboxName]
+	pod := hvutil.GetPodName(req.Annotations)
 	if pod == "" {
 		return nil, fmt.Errorf("pod name %s is missing in annotations", annotations.SandboxName)
 	}
-	namespace := req.Annotations[annotations.SandboxNamespace]
+
+	namespace := hvutil.GetPodNamespace(req.Annotations)
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace name %s is missing in annotations", annotations.SandboxNamespace)
 	}

--- a/pkg/adaptor/hypervisor/ibmcloud/service.go
+++ b/pkg/adaptor/hypervisor/ibmcloud/service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork/tunneler"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/util/cloudinit"
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/util/hvutil"
 	"github.com/containerd/containerd/pkg/cri/annotations"
 
 	pb "github.com/kata-containers/kata-containers/src/runtime/protocols/hypervisor"
@@ -106,11 +107,12 @@ func (s *hypervisorService) CreateVM(ctx context.Context, req *pb.CreateVMReques
 	if _, exists := s.sandboxes[sid]; exists {
 		return nil, fmt.Errorf("sandbox %s already exists", sid)
 	}
-	pod := req.Annotations[annotations.SandboxName]
+	pod := hvutil.GetPodName(req.Annotations)
 	if pod == "" {
 		return nil, fmt.Errorf("pod name %s is missing in annotations", annotations.SandboxName)
 	}
-	namespace := req.Annotations[annotations.SandboxNamespace]
+
+	namespace := hvutil.GetPodNamespace(req.Annotations)
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace name %s is missing in annotations", annotations.SandboxNamespace)
 	}
@@ -153,6 +155,8 @@ func (s *hypervisorService) StartVM(ctx context.Context, req *pb.StartVMRequest)
 	}
 
 	vmName := fmt.Sprintf("%s-%s-%s-%.8s", s.nodeName, sandbox.namespace, sandbox.pod, sandbox.id)
+
+	logger.Printf("StartVM: vmName: %q", vmName)
 
 	daemonConfig := daemon.Config{
 		PodNamespace: sandbox.namespace,

--- a/pkg/adaptor/hypervisor/libvirt/service.go
+++ b/pkg/adaptor/hypervisor/libvirt/service.go
@@ -21,6 +21,7 @@ import (
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork/tunneler"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/util/cloudinit"
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/util/hvutil"
 	"github.com/containerd/containerd/pkg/cri/annotations"
 
 	pb "github.com/kata-containers/kata-containers/src/runtime/protocols/hypervisor"
@@ -96,11 +97,12 @@ func (s *hypervisorService) CreateVM(ctx context.Context, req *pb.CreateVMReques
 	if _, exists := s.sandboxes[sid]; exists {
 		return nil, fmt.Errorf("sandbox %s already exists", sid)
 	}
-	pod := req.Annotations[annotations.SandboxName]
+	pod := hvutil.GetPodName(req.Annotations)
 	if pod == "" {
 		return nil, fmt.Errorf("pod name %s is missing in annotations", annotations.SandboxName)
 	}
-	namespace := req.Annotations[annotations.SandboxNamespace]
+
+	namespace := hvutil.GetPodNamespace(req.Annotations)
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace name %s is missing in annotations", annotations.SandboxNamespace)
 	}

--- a/pkg/adaptor/hypervisor/vsphere/service.go
+++ b/pkg/adaptor/hypervisor/vsphere/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork/tunneler"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/util/cloudinit"
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/util/hvutil"
 	"github.com/containerd/containerd/pkg/cri/annotations"
 
 	pb "github.com/kata-containers/kata-containers/src/runtime/protocols/hypervisor"
@@ -97,11 +98,12 @@ func (s *hypervisorService) CreateVM(ctx context.Context, req *pb.CreateVMReques
 	if _, exists := s.sandboxes[sid]; exists {
 		return nil, fmt.Errorf("sandbox %s already exists", sid)
 	}
-	pod := req.Annotations[annotations.SandboxName]
+	pod := hvutil.GetPodName(req.Annotations)
 	if pod == "" {
 		return nil, fmt.Errorf("pod name %s is missing in annotations", annotations.SandboxName)
 	}
-	namespace := req.Annotations[annotations.SandboxNamespace]
+
+	namespace := hvutil.GetPodNamespace(req.Annotations)
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace name %s is missing in annotations", annotations.SandboxNamespace)
 	}

--- a/pkg/util/hvutil/hvutil.go
+++ b/pkg/util/hvutil/hvutil.go
@@ -1,0 +1,25 @@
+package hvutil
+
+import (
+	"strings"
+
+	cri "github.com/containerd/containerd/pkg/cri/annotations"
+)
+
+func GetPodName(annotations map[string]string) string {
+
+	sandboxName := annotations[cri.SandboxName]
+
+	// cri-o stores the sandbox name in the form of k8s_<pod name>_<namespace>_<uid>_0
+	// Extract the pod name from it.
+	if tmp := strings.Split(sandboxName, "_"); len(tmp) > 1 && tmp[0] == "k8s" {
+		return tmp[1]
+	}
+
+	return sandboxName
+}
+
+func GetPodNamespace(annotations map[string]string) string {
+
+	return annotations[cri.SandboxNamespace]
+}


### PR DESCRIPTION
cri-o reports sandbox names in the different format than containerd.

This patch corrects pod names reported by cri-o so that they are consistent with containerd.

Fixes #261
