### PR TITLE
Remove the skopeo and umoci  from the pod VM image

### DIFF
--- a/aws/image/Makefile
+++ b/aws/image/Makefile
@@ -33,10 +33,15 @@ IMAGE_FILE := $(IMAGE_NAME)
 
 AGENT_PROTOCOL_FORWARDER = $(FILES_DIR)/usr/local/bin/agent-protocol-forwarder
 KATA_AGENT    = $(FILES_DIR)/usr/local/bin/kata-agent
-SKOPEO        = $(FILES_DIR)/usr/bin/skopeo
-UMOCI         = $(FILES_DIR)/usr/local/bin/umoci
 PAUSE         = $(FILES_DIR)/$(PAUSE_BUNDLE)/rootfs/pause
-BINARIES = $(AGENT_PROTOCOL_FORWARDER) $(KATA_AGENT) $(SKOPEO) $(UMOCI) $(PAUSE)
+SKOPEO    = $(FILES_DIR)/usr/bin/skopeo
+UMOCI     = $(FILES_DIR)/usr/local/bin/umoci
+
+BINARIES = $(AGENT_PROTOCOL_FORWARDER) $(KATA_AGENT) $(PAUSE)
+
+ifdef USE_SKOPEO
+BINARIES += $(SKOPEO) $(UMOCI)
+endif
 
 AGENT_PROTOCOL_FORWARDER_SRC = ../..
 
@@ -79,24 +84,31 @@ $(AGENT_PROTOCOL_FORWARDER): force
 	install -D --compare "$(AGENT_PROTOCOL_FORWARDER_SRC)/agent-protocol-forwarder" "$@"
 
 $(KATA_AGENT): force $(STATIC_LIB)
+	cd "$(KATA_AGENT_SRC)/../libs" && $(MAKE) BUILD_TYPE=$(KATA_AGENT_BUILD_TYPE) LIBSECCOMP_LINK_TYPE=static LIBSECCOMP_LIB_PATH=$(dir $(STATIC_LIB))
 	cd "$(KATA_AGENT_SRC)" && $(MAKE) BUILD_TYPE=$(KATA_AGENT_BUILD_TYPE) LIBSECCOMP_LINK_TYPE=static LIBSECCOMP_LIB_PATH=$(dir $(STATIC_LIB))
 	install -D --compare "$(KATA_AGENT_SRC)/target/$(shell uname -m)-unknown-linux-$(if $(findstring s390x,$(shell uname -m)),gnu,musl)/$(KATA_AGENT_BUILD_TYPE)/$(@F)" "$@"
 
 $(STATIC_LIB):
 	$(STATIC_LIB_BUILDER) $(STATIC_LIB_DIR)/kata-libseccomp $(STATIC_LIB_DIR)/kata-gperf
 
+# Skoepo package packages are available in RHEL/CentOS 8 or later and Ubuntu 20.10 or later
 $(SKOPEO_SRC):
 	git clone -b "v$(SKOPEO_VERSION)" "$(SKOPEO_REPO)" "$(SKOPEO_SRC)"
 
-$(SKOPEO): $(SKOPEO_SRC)
+$(SKOPEO_SRC)/bin/skopeo: $(SKOPEO_SRC)
 	cd "$(SKOPEO_SRC)" && make bin/skopeo
+
+$(SKOPEO): $(SKOPEO_SRC)/bin/skopeo
 	install -D --compare "$(SKOPEO_SRC)/bin/skopeo" "$@"
 
+# The umoci release page only publishes amd64 binaries. https://github.com/opencontainers/umoci/releases
 $(UMOCI_SRC):
 	git clone -b "v$(UMOCI_VERSION)" "$(UMOCI_REPO)" "$(UMOCI_SRC)"
 
-$(UMOCI): $(UMOCI_SRC)
+$(UMOCI_SRC)/umoci: $(UMOCI_SRC)
 	cd "$(UMOCI_SRC)" && make
+
+$(UMOCI): $(UMOCI_SRC)/umoci
 	install -D --compare "$(UMOCI_SRC)/umoci" "$@"
 
 $(PAUSE_SRC):

--- a/azure/image/Makefile
+++ b/azure/image/Makefile
@@ -33,10 +33,15 @@ IMAGE_FILE := $(IMAGE_NAME)
 
 AGENT_PROTOCOL_FORWARDER = $(FILES_DIR)/usr/local/bin/agent-protocol-forwarder
 KATA_AGENT    = $(FILES_DIR)/usr/local/bin/kata-agent
-SKOPEO        = $(FILES_DIR)/usr/bin/skopeo
-UMOCI         = $(FILES_DIR)/usr/local/bin/umoci
 PAUSE         = $(FILES_DIR)/$(PAUSE_BUNDLE)/rootfs/pause
-BINARIES = $(AGENT_PROTOCOL_FORWARDER) $(KATA_AGENT) $(SKOPEO) $(UMOCI) $(PAUSE)
+SKOPEO    = $(FILES_DIR)/usr/bin/skopeo
+UMOCI     = $(FILES_DIR)/usr/local/bin/umoci
+
+BINARIES = $(AGENT_PROTOCOL_FORWARDER) $(KATA_AGENT) $(PAUSE)
+
+ifdef USE_SKOPEO
+BINARIES += $(SKOPEO) $(UMOCI)
+endif
 
 AGENT_PROTOCOL_FORWARDER_SRC = ../..
 
@@ -81,24 +86,31 @@ $(AGENT_PROTOCOL_FORWARDER): force
 	install -D --compare "$(AGENT_PROTOCOL_FORWARDER_SRC)/agent-protocol-forwarder" "$@"
 
 $(KATA_AGENT): force $(STATIC_LIB)
+	cd "$(KATA_AGENT_SRC)/../libs" && $(MAKE) BUILD_TYPE=$(KATA_AGENT_BUILD_TYPE) LIBSECCOMP_LINK_TYPE=static LIBSECCOMP_LIB_PATH=$(dir $(STATIC_LIB))
 	cd "$(KATA_AGENT_SRC)" && $(MAKE) BUILD_TYPE=$(KATA_AGENT_BUILD_TYPE) LIBSECCOMP_LINK_TYPE=static LIBSECCOMP_LIB_PATH=$(dir $(STATIC_LIB))
 	install -D --compare "$(KATA_AGENT_SRC)/target/$(shell uname -m)-unknown-linux-$(if $(findstring s390x,$(shell uname -m)),gnu,musl)/$(KATA_AGENT_BUILD_TYPE)/$(@F)" "$@"
 
 $(STATIC_LIB):
 	$(STATIC_LIB_BUILDER) $(STATIC_LIB_DIR)/kata-libseccomp $(STATIC_LIB_DIR)/kata-gperf
 
+# Skoepo package packages are available in RHEL/CentOS 8 or later and Ubuntu 20.10 or later
 $(SKOPEO_SRC):
 	git clone -b "v$(SKOPEO_VERSION)" "$(SKOPEO_REPO)" "$(SKOPEO_SRC)"
 
-$(SKOPEO): $(SKOPEO_SRC)
+$(SKOPEO_SRC)/bin/skopeo: $(SKOPEO_SRC)
 	cd "$(SKOPEO_SRC)" && make bin/skopeo
+
+$(SKOPEO): $(SKOPEO_SRC)/bin/skopeo
 	install -D --compare "$(SKOPEO_SRC)/bin/skopeo" "$@"
 
+# The umoci release page only publishes amd64 binaries. https://github.com/opencontainers/umoci/releases
 $(UMOCI_SRC):
 	git clone -b "v$(UMOCI_VERSION)" "$(UMOCI_REPO)" "$(UMOCI_SRC)"
 
-$(UMOCI): $(UMOCI_SRC)
+$(UMOCI_SRC)/umoci: $(UMOCI_SRC)
 	cd "$(UMOCI_SRC)" && make
+
+$(UMOCI): $(UMOCI_SRC)/umoci
 	install -D --compare "$(UMOCI_SRC)/umoci" "$@"
 
 $(PAUSE_SRC):

--- a/ibmcloud/image/Makefile
+++ b/ibmcloud/image/Makefile
@@ -36,10 +36,15 @@ UBUNTU_PACKAGES = jq
 
 AGENT_PROTOCOL_FORWARDER = $(FILES_DIR)/usr/local/bin/agent-protocol-forwarder
 KATA_AGENT    = $(FILES_DIR)/usr/local/bin/kata-agent
-SKOPEO        = $(FILES_DIR)/usr/bin/skopeo
-UMOCI         = $(FILES_DIR)/usr/local/bin/umoci
 PAUSE         = $(FILES_DIR)/$(PAUSE_BUNDLE)/rootfs/pause
-BINARIES = $(AGENT_PROTOCOL_FORWARDER) $(KATA_AGENT) $(SKOPEO) $(UMOCI) $(PAUSE)
+SKOPEO    = $(FILES_DIR)/usr/bin/skopeo
+UMOCI     = $(FILES_DIR)/usr/local/bin/umoci
+
+BINARIES = $(AGENT_PROTOCOL_FORWARDER) $(KATA_AGENT) $(PAUSE)
+
+ifdef USE_SKOPEO
+BINARIES += $(SKOPEO) $(UMOCI)
+endif
 
 AGENT_PROTOCOL_FORWARDER_SRC = ../..
 
@@ -74,7 +79,7 @@ verify: push
 	./verify.sh --image "$(IMAGE_NAME)"
 
 SUDO =
-WORDIR = .
+WORKDIR = .
 
 $(IMAGE_FILE): $(UBUNTU_IMAGE_FILE) $(BINARIES) $(FILES)
 	rm -f "$(IMAGE_FILE)"
@@ -85,31 +90,38 @@ $(AGENT_PROTOCOL_FORWARDER): force
 	install -D --compare "$(AGENT_PROTOCOL_FORWARDER_SRC)/agent-protocol-forwarder" "$@"
 
 $(KATA_AGENT): force $(STATIC_LIB)
+	cd "$(KATA_AGENT_SRC)/../libs" && $(MAKE) BUILD_TYPE=$(KATA_AGENT_BUILD_TYPE) LIBSECCOMP_LINK_TYPE=static LIBSECCOMP_LIB_PATH=$(dir $(STATIC_LIB))
 	cd "$(KATA_AGENT_SRC)" && $(MAKE) BUILD_TYPE=$(KATA_AGENT_BUILD_TYPE) LIBSECCOMP_LINK_TYPE=static LIBSECCOMP_LIB_PATH=$(dir $(STATIC_LIB))
 	install -D --compare "$(KATA_AGENT_SRC)/target/$(shell uname -m)-unknown-linux-$(if $(findstring s390x,$(shell uname -m)),gnu,musl)/$(KATA_AGENT_BUILD_TYPE)/$(@F)" "$@"
 
 $(STATIC_LIB):
 	$(STATIC_LIB_BUILDER) $(STATIC_LIB_DIR)/kata-libseccomp $(STATIC_LIB_DIR)/kata-gperf
 
+# Skoepo package packages are available in RHEL/CentOS 8 or later and Ubuntu 20.10 or later
 $(SKOPEO_SRC):
 	git clone -b "v$(SKOPEO_VERSION)" "$(SKOPEO_REPO)" "$(SKOPEO_SRC)"
 
-$(SKOPEO): $(SKOPEO_SRC)
+$(SKOPEO_SRC)/bin/skopeo: $(SKOPEO_SRC)
 	cd "$(SKOPEO_SRC)" && make bin/skopeo
+
+$(SKOPEO): $(SKOPEO_SRC)/bin/skopeo
 	install -D --compare "$(SKOPEO_SRC)/bin/skopeo" "$@"
 
+# The umoci release page only publishes amd64 binaries. https://github.com/opencontainers/umoci/releases
 $(UMOCI_SRC):
 	git clone -b "v$(UMOCI_VERSION)" "$(UMOCI_REPO)" "$(UMOCI_SRC)"
 
-$(UMOCI): $(UMOCI_SRC)
+$(UMOCI_SRC)/umoci: $(UMOCI_SRC)
 	cd "$(UMOCI_SRC)" && make
+
+$(UMOCI): $(UMOCI_SRC)/umoci
 	install -D --compare "$(UMOCI_SRC)/umoci" "$@"
 
-$(PAUSE_SRC):
-	$(SKOPEO) --policy "$(FILES_DIR)/etc/containers/policy.json" copy "$(PAUSE_REPO):$(PAUSE_VERSION)" "oci:$(PAUSE_SRC):$(PAUSE_VERSION)"
+$(PAUSE_SRC): $(SKOPEO_SRC)/bin/skopeo
+	$(SKOPEO_SRC)/bin/skopeo --policy "$(FILES_DIR)/etc/containers/policy.json" copy "$(PAUSE_REPO):$(PAUSE_VERSION)" "oci:$(PAUSE_SRC):$(PAUSE_VERSION)"
 
-$(PAUSE): | $(PAUSE_SRC)
-	$(UMOCI) unpack --image "$(PAUSE_SRC):$(PAUSE_VERSION)" "${FILES_DIR}/$(PAUSE_BUNDLE)"
+$(PAUSE): | $(PAUSE_SRC) $(UMOCI_SRC)/umoci
+	$(UMOCI_SRC)/umoci unpack --image "$(PAUSE_SRC):$(PAUSE_VERSION)" "${FILES_DIR}/$(PAUSE_BUNDLE)"
 
 ubuntu: $(UBUNTU_IMAGE_FILE)
 $(UBUNTU_IMAGE_FILE):

--- a/libvirt/image/Makefile
+++ b/libvirt/image/Makefile
@@ -34,10 +34,15 @@ UBUNTU_IMAGE_CHECKSUM := $(shell curl -LO  https://cloud-images.ubuntu.com/"$(UB
 
 AGENT_PROTOCOL_FORWARDER = $(FILES_DIR)/usr/local/bin/agent-protocol-forwarder
 KATA_AGENT    = $(FILES_DIR)/usr/local/bin/kata-agent
-SKOPEO        = $(FILES_DIR)/usr/local/bin/skopeo.bin
-UMOCI         = $(FILES_DIR)/usr/local/bin/umoci
 PAUSE         = $(FILES_DIR)/$(PAUSE_BUNDLE)/rootfs/pause
-BINARIES = $(AGENT_PROTOCOL_FORWARDER) $(KATA_AGENT) $(SKOPEO) $(UMOCI) $(PAUSE)
+SKOPEO    = $(FILES_DIR)/usr/bin/skopeo
+UMOCI     = $(FILES_DIR)/usr/local/bin/umoci
+
+BINARIES = $(AGENT_PROTOCOL_FORWARDER) $(KATA_AGENT) $(PAUSE)
+
+ifdef USE_SKOPEO
+BINARIES += $(SKOPEO) $(UMOCI)
+endif
 
 AGENT_PROTOCOL_FORWARDER_SRC = ../..
 
@@ -82,24 +87,31 @@ $(AGENT_PROTOCOL_FORWARDER): force
 	install -D --compare "$(AGENT_PROTOCOL_FORWARDER_SRC)/agent-protocol-forwarder" "$@"
 
 $(KATA_AGENT): force $(STATIC_LIB)
+	cd "$(KATA_AGENT_SRC)/../libs" && $(MAKE) BUILD_TYPE=$(KATA_AGENT_BUILD_TYPE) LIBSECCOMP_LINK_TYPE=static LIBSECCOMP_LIB_PATH=$(dir $(STATIC_LIB))
 	cd "$(KATA_AGENT_SRC)" && $(MAKE) BUILD_TYPE=$(KATA_AGENT_BUILD_TYPE) LIBSECCOMP_LINK_TYPE=static LIBSECCOMP_LIB_PATH=$(dir $(STATIC_LIB))
 	install -D --compare "$(KATA_AGENT_SRC)/target/$(shell uname -m)-unknown-linux-$(if $(findstring s390x,$(shell uname -m)),gnu,musl)/$(KATA_AGENT_BUILD_TYPE)/$(@F)" "$@"
 
 $(STATIC_LIB):
 	$(STATIC_LIB_BUILDER) $(STATIC_LIB_DIR)/kata-libseccomp $(STATIC_LIB_DIR)/kata-gperf
 
+# Skoepo package packages are available in RHEL/CentOS 8 or later and Ubuntu 20.10 or later
 $(SKOPEO_SRC):
 	git clone -b "v$(SKOPEO_VERSION)" "$(SKOPEO_REPO)" "$(SKOPEO_SRC)"
 
-$(SKOPEO): $(SKOPEO_SRC)
+$(SKOPEO_SRC)/bin/skopeo: $(SKOPEO_SRC)
 	cd "$(SKOPEO_SRC)" && make bin/skopeo
+
+$(SKOPEO): $(SKOPEO_SRC)/bin/skopeo
 	install -D --compare "$(SKOPEO_SRC)/bin/skopeo" "$@"
 
+# The umoci release page only publishes amd64 binaries. https://github.com/opencontainers/umoci/releases
 $(UMOCI_SRC):
 	git clone -b "v$(UMOCI_VERSION)" "$(UMOCI_REPO)" "$(UMOCI_SRC)"
 
-$(UMOCI): $(UMOCI_SRC)
+$(UMOCI_SRC)/umoci: $(UMOCI_SRC)
 	cd "$(UMOCI_SRC)" && make
+
+$(UMOCI): $(UMOCI_SRC)/umoci
 	install -D --compare "$(UMOCI_SRC)/umoci" "$@"
 
 $(PAUSE_SRC):


### PR DESCRIPTION
These patch remove the skopeo and umoci commands from the pod VM image for the following cloud providers.

* ibmcloud
* aws
* libvirt
* azure

We can still install skopeo and umoci commands by setting the optional variable USE_SKOPEO.
