### PR TITLE
Sanitize strings when generating VM name

### DIFF
--- a/pkg/adaptor/hypervisor/aws/service.go
+++ b/pkg/adaptor/hypervisor/aws/service.go
@@ -214,7 +214,7 @@ func (s *hypervisorService) StartVM(ctx context.Context, req *pb.StartVMRequest)
 
 	logger.Printf("created an instance %s for sandbox %s", *result.Instances[0].PublicDnsName, req.Id)
 
-	vmName := fmt.Sprintf("%s-%s-%s-%.8s", s.nodeName, sandbox.namespace, sandbox.pod, sandbox.id)
+	vmName := hvutil.CreateInstanceName(s.nodeName, sandbox.namespace, sandbox.pod, string(sandbox.id))
 	tagInput := &ec2.CreateTagsInput{
 		Resources: []string{*result.Instances[0].InstanceId},
 		Tags: []types.Tag{

--- a/pkg/adaptor/hypervisor/azure/service.go
+++ b/pkg/adaptor/hypervisor/azure/service.go
@@ -184,7 +184,7 @@ func (s *hypervisorService) StartVM(ctx context.Context, req *pb.StartVMRequest)
 	//Convert userData to base64
 	userDataEnc := base64.StdEncoding.EncodeToString([]byte(userData))
 
-	vmName := fmt.Sprintf("%s-%s-%s-%.8s", s.nodeName, sandbox.namespace, sandbox.pod, sandbox.id)
+	vmName := hvutil.CreateInstanceName(s.nodeName, sandbox.namespace, sandbox.pod, string(sandbox.id))
 	diskName := fmt.Sprintf("%s-disk", vmName)
 	nicName := fmt.Sprintf("%s-net", vmName)
 

--- a/pkg/adaptor/hypervisor/ibmcloud/service.go
+++ b/pkg/adaptor/hypervisor/ibmcloud/service.go
@@ -154,7 +154,7 @@ func (s *hypervisorService) StartVM(ctx context.Context, req *pb.StartVMRequest)
 		return nil, err
 	}
 
-	vmName := fmt.Sprintf("%s-%s-%s-%.8s", s.nodeName, sandbox.namespace, sandbox.pod, sandbox.id)
+	vmName := hvutil.CreateInstanceName(s.nodeName, sandbox.namespace, sandbox.pod, string(sandbox.id))
 
 	logger.Printf("StartVM: vmName: %q", vmName)
 

--- a/pkg/adaptor/hypervisor/libvirt/service.go
+++ b/pkg/adaptor/hypervisor/libvirt/service.go
@@ -175,7 +175,7 @@ func (s *hypervisorService) StartVM(ctx context.Context, req *pb.StartVMRequest)
 		return nil, err
 	}
 
-	vmName := fmt.Sprintf("%s-%s-%s-%.8s", s.nodeName, sandbox.namespace, sandbox.pod, sandbox.id)
+	vmName := hvutil.CreateInstanceName(s.nodeName, sandbox.namespace, sandbox.pod, string(sandbox.id))
 	vm := &vmConfig{name: vmName, userData: userData}
 	result, err := CreateInstance(ctx, s.libvirtClient, vm)
 	if err != nil {

--- a/pkg/adaptor/hypervisor/vsphere/service.go
+++ b/pkg/adaptor/hypervisor/vsphere/service.go
@@ -136,7 +136,7 @@ func (s *hypervisorService) CreateVM(ctx context.Context, req *pb.CreateVMReques
 
 	s.sandboxes[sid] = sandbox
 
-	vmname := fmt.Sprintf("%s-%s-%s-%.8s", s.nodeName, sandbox.namespace, sandbox.pod, sandbox.id)
+	vmname := hvutil.CreateInstanceName(s.nodeName, sandbox.namespace, sandbox.pod, string(sandbox.id))
 
 	logger.Printf("create a sandbox %s for pod %s in namespace %s (netns: %s)", req.Id, pod, namespace, sandbox.netNSPath)
 
@@ -152,7 +152,7 @@ func (s *hypervisorService) StartVM(ctx context.Context, req *pb.StartVMRequest)
 		return nil, err
 	}
 
-	vmname := fmt.Sprintf("%s-%s-%s-%.8s", s.nodeName, sandbox.namespace, sandbox.pod, sandbox.id)
+	vmname := hvutil.CreateInstanceName(s.nodeName, sandbox.namespace, sandbox.pod, string(sandbox.id))
 	logger.Printf("StartVM %s", vmname)
 
 	daemonConfig := daemon.Config{
@@ -269,7 +269,7 @@ func (s *hypervisorService) StopVM(ctx context.Context, req *pb.StopVMRequest) (
 		return nil, err
 	}
 
-	vmname := fmt.Sprintf("%s-%s-%s-%.8s", s.nodeName, sandbox.namespace, sandbox.pod, sandbox.id)
+	vmname := hvutil.CreateInstanceName(s.nodeName, sandbox.namespace, sandbox.pod, string(sandbox.id))
 
 	logger.Printf("StopVM %s", vmname)
 

--- a/pkg/util/hvutil/hvutil.go
+++ b/pkg/util/hvutil/hvutil.go
@@ -1,6 +1,7 @@
 package hvutil
 
 import (
+	"fmt"
 	"strings"
 
 	cri "github.com/containerd/containerd/pkg/cri/annotations"
@@ -22,4 +23,30 @@ func GetPodName(annotations map[string]string) string {
 func GetPodNamespace(annotations map[string]string) string {
 
 	return annotations[cri.SandboxNamespace]
+}
+
+func sanitize(input string) string {
+
+	var output string
+
+	for _, c := range strings.ToLower(input) {
+		if !(('a' <= c && c <= 'z') || ('0' <= c && c <= '9') || c == '-') {
+			c = '-'
+		}
+		output += string(c)
+	}
+
+	return output
+}
+
+func CreateInstanceName(nodeName, podNamespace, podName, sandboxID string) string {
+
+	nodeName = sanitize(nodeName)
+	podNamespace = sanitize(podNamespace)
+	podName = sanitize(podName)
+	sandboxID = sanitize(sandboxID)
+
+	vmName := fmt.Sprintf("podvm-%s-%s-%s-%.8s", nodeName, podNamespace, podName, sandboxID)
+
+	return vmName
 }

--- a/pkg/util/hvutil/hvutil_test.go
+++ b/pkg/util/hvutil/hvutil_test.go
@@ -1,0 +1,22 @@
+package hvutil
+
+import "testing"
+
+func TestCreateInstanceName(t *testing.T) {
+
+	namespace := "default"
+	pod := "nginx"
+	sid := "d38339f99f605f18b4bcbce983147ad2d270ba479668d80b3bfa69a6b0237aa7"
+	suffix := namespace + "-" + pod + "-" + sid[:8]
+
+	for node, expected := range map[string]string{
+		"worker1":  "podvm-worker1-" + suffix,
+		"1.2.3.4":  "podvm-1-2-3-4-" + suffix,
+		"worker_1": "podvm-worker-1-" + suffix,
+	} {
+		actual := CreateInstanceName(node, namespace, pod, sid)
+		if actual != expected {
+			t.Errorf("expected %s, got %s", expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
This PR sanitizes input string values, and then generates a VM name.

This function generates a VM instance name from sanitized values of node name, pod namespace, pod name, and sandbox ID.

Fixes #265
