### PR TITLE
azure: populate sandbox vm name earlier

### DIFF
--- a/pkg/adaptor/hypervisor/azure/service.go
+++ b/pkg/adaptor/hypervisor/azure/service.go
@@ -188,6 +188,9 @@ func (s *hypervisorService) StartVM(ctx context.Context, req *pb.StartVMRequest)
 	diskName := fmt.Sprintf("%s-disk", vmName)
 	nicName := fmt.Sprintf("%s-net", vmName)
 
+	// Set the vm name to the sandbox early for cleanup purposes
+	sandbox.vmName = vmName
+
 	// Get NIC using subnet and allow ports on the ssh group
 	vmNIC, err := s.createNetworkInterface(ctx, nicName)
 	if err != nil {
@@ -263,7 +266,6 @@ func (s *hypervisorService) StartVM(ctx context.Context, req *pb.StartVMRequest)
 
 	// Set vsi to instance id
 	sandbox.vsi = *vm.ID
-	sandbox.vmName = vmName
 
 	logger.Printf("created an instance %s for sandbox %s", *vm.Name, req.Id)
 


### PR DESCRIPTION
Fixes: #275

There might be a state in which the creation of a VM has been triggered but the respective api call hasn't returned yet. If a create-vm call is then cancelled at the call site due to a timeout, the VM resources will not be garbage collected, because the sandbox's vm name has not been populated yet.

Signed-off-by: Magnus Kulke <magnuskulke@microsoft.com>