### PR TITLE
ibmcloud: cri-endpoint as optional

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,7 +56,6 @@ cloud-api-adaptor-ibmcloud ibmcloud \
         -primary-security-group-id "${IBMCLOUD_VPC_SG_ID}" \
         -vpc-id "${IBMCLOUD_VPC_ID}" \
         -pods-dir /run/peerpod/pods \
-        -cri-runtime-endpoint "${IBMCLOUD_CRI_RUNTIME_ENDPOINT}" \
 	${optionals} \
         -socket /run/peerpod/hypervisor.sock
 }

--- a/install/overlays/ibmcloud/kustomization.yaml
+++ b/install/overlays/ibmcloud/kustomization.yaml
@@ -24,7 +24,7 @@ configMapGenerator:
   - IBMCLOUD_VPC_SUBNET_ID="" #set
   - IBMCLOUD_VPC_SG_ID="" #set
   - IBMCLOUD_VPC_ID="" #set
-  - IBMCLOUD_CRI_RUNTIME_ENDPOINT="/run/containerd/containerd.sock" #set
+  - CRI_RUNTIME_ENDPOINT="/run/containerd/containerd.sock" #set
   #- PAUSE_IMAGE=" # Uncomment and set if you want to use a specific pause image
 
 secretGenerator:


### PR DESCRIPTION
Align ibmcloud cri-endpoint handling with other providers to avoid duplication in optionals.


Fixes: #279

Signed-off-by: James Tumber <james.tumber@ibm.com>