### PR TITLE
azure: mask sensitive fields in cloud config

### DIFF
--- a/pkg/adaptor/hypervisor/azure/server.go
+++ b/pkg/adaptor/hypervisor/azure/server.go
@@ -35,7 +35,7 @@ type server struct {
 func NewServer(cfg hypervisor.Config, cloudCfg Config, workerNode podnetwork.WorkerNode, daemonPort string) hypervisor.Server {
 
 	logger.Printf("hypervisor config %v", cfg)
-	logger.Printf("cloud config %+v", cloudCfg)
+	logger.Printf("cloud config %+v", cloudCfg.Redact())
 
 	azureClient, err := NewAzureClient(cloudCfg)
 	if err != nil {

--- a/pkg/adaptor/hypervisor/azure/types.go
+++ b/pkg/adaptor/hypervisor/azure/types.go
@@ -1,5 +1,7 @@
 package azure
 
+import "github.com/confidential-containers/cloud-api-adaptor/pkg/util"
+
 type Config struct {
 	SubscriptionId    string
 	ClientId          string
@@ -14,4 +16,8 @@ type Config struct {
 	Size              string
 	ImageId           string
 	SSHKeyPath        string
+}
+
+func (c Config) Redact() Config {
+	return *util.RedactStruct(&c, "ClientId", "TenantId", "ClientSecret").(*Config)
 }

--- a/pkg/adaptor/hypervisor/azure/types_test.go
+++ b/pkg/adaptor/hypervisor/azure/types_test.go
@@ -1,0 +1,40 @@
+//go:build azure
+
+package azure
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestAzureMasking(t *testing.T) {
+	toBeRedacted := map[string]string{
+		"client id":     "a client id",
+		"tenant id":     "a tenant id",
+		"client secret": "a client secret",
+	}
+	region := "a region"
+
+	cloudCfg := Config{
+		ClientId:     toBeRedacted["client id"],
+		TenantId:     toBeRedacted["tenant id"],
+		ClientSecret: toBeRedacted["client secret"],
+		Region:       region,
+	}
+
+	checkLine := func(verb string) {
+		logline := fmt.Sprintf(verb, cloudCfg.Redact())
+		for k, v := range toBeRedacted {
+			if strings.Contains(logline, v) {
+				t.Errorf("For verb %s: %s contains the %s: %s", verb, logline, k, v)
+			}
+		}
+		if !strings.Contains(logline, region) {
+			t.Errorf("For verb %s: %s doesn't contain the region name: %s", verb, logline, region)
+		}
+	}
+
+	checkLine("%v")
+	checkLine("%s")
+}


### PR DESCRIPTION
Use redacted config in log output like in ibmcloud, aws adaptors

Partially Fixes #83

Signed-off-by: Magnus Kulke <magnuskulke@microsoft.com>