### PR TITLE
Makefile: Add help target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,21 @@ SOURCES    := $(shell find $(SOURCEDIRS) -name '*.go' -print)
 all: build
 build: $(BINARIES)
 
+# The help target prints out all targets with their descriptions organized
+# beneath their categories. The categories are represented by '##@' and the
+# target descriptions by '##'. The awk commands is responsible for reading the
+# entire set of makefiles included in this invocation, looking for lines of the
+# file as xyz: ## something, and then pretty-format the target and help. Then,
+# if there's a line with ##@ something, that gets pretty-printed as a category.
+# More info on the usage of ANSI control characters for terminal formatting:
+# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
+# More info on the awk command:
+# http://linuxcommand.org/lc3_adv_awk.php
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
 $(BINARIES): $(SOURCES)
 ifeq ($(CLOUD_PROVIDER),libvirt)
 	go build $(GOFLAGS) -o "$@" "cmd/$@/main.go"
@@ -24,30 +39,44 @@ else
 	CGO_ENABLED=0 go build $(GOFLAGS) -o "$@" "cmd/$@/main.go"
 endif
 
-# Build and push docker image to $regestry
-image:
-	hack/build.sh
+##@ Development
 
-# Deploy cloud-api-adaptor using the operator, according to install/overlays/$(CLOUD_PROVIDER)/kustomization.yaml
-deploy:
-	kubectl apply -f install/yamls/deploy.yaml
-	kubectl apply -k install/overlays/$(CLOUD_PROVIDER)
-
-delete:
-	kubectl delete -k install/overlays/$(CLOUD_PROVIDER)
-
-test:
+.PHONY: test
+test: ## Run tests.
 	# Note: sending stderr to stdout so that tools like go-junit-report can
 	# parse build errors.
 	go test -v $(GOFLAGS) -cover $(PACKAGES) 2>&1
 
-check: fmt vet
+.PHONY: check
+check: fmt vet ## Run go vet and go vet against the code.
 
-fmt:
+.PHONY: fmt
+fmt: ## Run go fmt against code.
 	find $(SOURCEDIRS) -name '*.go' -print0 | xargs -0 gofmt -l -d
 
-vet:
+.PHONY: vet
+vet: ## Run go vet against code.
 	go vet $(PACKAGES)
 
-clean:
+.PHONY: clean
+clean: ## Remove binaries.
 	rm -fr $(BINARIES)
+
+##@ Build
+
+.PHONY: image
+image: ## Build and push docker image to $registry
+	hack/build.sh
+
+##@ Deployment
+
+.PHONY: deploy 
+deploy: ## Deploy cloud-api-adaptor using the operator, according to install/overlays/$(CLOUD_PROVIDER)/kustomization.yaml file.
+	kubectl apply -f install/yamls/deploy.yaml
+	kubectl apply -k install/overlays/$(CLOUD_PROVIDER)
+
+.PHONY: delete
+delete: ## Delete cloud-api-adaptor using the operator, according to install/overlays/$(CLOUD_PROVIDER)/kustomization.yaml file.
+	kubectl delete -k install/overlays/$(CLOUD_PROVIDER)
+
+


### PR DESCRIPTION
This enables to list all the make targets and their descriptions using the `make help` command.

Fixes: #288
Signed-off-by: Kautilya Tripathi <ktripathi@microsoft.com>