### PR TITLE
Use unused IMAGE_NAME for image

### DIFF
--- a/aws/image/Makefile
+++ b/aws/image/Makefile
@@ -9,7 +9,6 @@ SKOPEO_VERSION     = 1.5.0
 UMOCI_VERSION      = 0.4.7
 
 IMAGE_PREFIX := podvm
-UUID = $(shell cat /proc/sys/kernel/random/uuid | cut -c 1-4)
 
 ARCH := $(subst x86_64,amd64,$(shell uname -m))
 
@@ -76,7 +75,7 @@ $(IMAGE_FILE): $(BINARIES) $(FILES)
 		-var account_id=${AWS_ACCOUNT_ID} \
 		-var region=${AWS_REGION} \
 		-var instance_type=${INSTANCE_TYPE} \
-		-var ami_name=peer-pods-ami-${UUID} .
+		-var ami_name=${IMAGE_NAME} .
 	rm -fr toupload
 
 $(AGENT_PROTOCOL_FORWARDER): force

--- a/azure/image/Makefile
+++ b/azure/image/Makefile
@@ -9,7 +9,6 @@ SKOPEO_VERSION     = 1.5.0
 UMOCI_VERSION      = 0.4.7
 
 IMAGE_PREFIX := podvm
-UUID = $(shell cat /proc/sys/kernel/random/uuid | cut -c 1-4)
 
 ARCH := $(subst x86_64,amd64,$(shell uname -m))
 
@@ -78,7 +77,7 @@ $(IMAGE_FILE): $(BINARIES) $(FILES)
 		-var location=${LOCATION} \
 		-var vm_size=${VM_SIZE} \
 		-var resource_group=${RESOURCE_GROUP} \
-		-var az_image_name=peer-pods-ami-${UUID} .
+		-var az_image_name=${IMAGE_NAME} .
 	rm -fr toupload
 
 $(AGENT_PROTOCOL_FORWARDER): force


### PR DESCRIPTION
Final image that is built should have a generic name instead of
something random like uuid.

Signed-off-by: Kautilya Tripathi <ktripathi@microsoft.com>
Fixes: #300 