### PR TITLE
operator: Update kustomize to use DaemonSet

### DIFF
--- a/install/overlays/aws/cri_runtime_endpoint.yaml
+++ b/install/overlays/aws/cri_runtime_endpoint.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
-  name: cloud-api-adaptor-deployment
+  name: cloud-api-adaptor-daemonset
   namespace: confidential-containers-system
   labels:
     app: cloud-api-adaptor

--- a/install/overlays/azure/cri_runtime_endpoint.yaml
+++ b/install/overlays/azure/cri_runtime_endpoint.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
-  name: cloud-api-adaptor-deployment
+  name: cloud-api-adaptor-daemonset
   namespace: confidential-containers-system
   labels:
     app: cloud-api-adaptor

--- a/install/overlays/ibmcloud/cri_runtime_endpoint.yaml
+++ b/install/overlays/ibmcloud/cri_runtime_endpoint.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
-  name: cloud-api-adaptor-deployment
+  name: cloud-api-adaptor-daemonset
   namespace: confidential-containers-system
   labels:
     app: cloud-api-adaptor

--- a/install/overlays/libvirt/cri_runtime_endpoint.yaml
+++ b/install/overlays/libvirt/cri_runtime_endpoint.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
-  name: cloud-api-adaptor-deployment
+  name: cloud-api-adaptor-daemonset
   namespace: confidential-containers-system
   labels:
     app: cloud-api-adaptor

--- a/install/overlays/vsphere/cri_runtime_endpoint.yaml
+++ b/install/overlays/vsphere/cri_runtime_endpoint.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
-  name: cloud-api-adaptor-deployment
+  name: cloud-api-adaptor-daemonset
   namespace: confidential-containers-system
   labels:
     app: cloud-api-adaptor


### PR DESCRIPTION
Update the cri_runtime_endpoint kustomize patch to apply to a DaemonSet called cloud-api-adaptor-daemonset rather than the Deployment called cloud-api-adaptor-deployment to match the change in #297

Fixes: #308
Signed-off-by: stevenhorsman <steven@uk.ibm.com>