### PR TITLE
Add CI for the webhook

### DIFF
--- a/.github/workflows/webhook.yaml
+++ b/.github/workflows/webhook.yaml
@@ -1,0 +1,35 @@
+# Copyright Confidential Containers Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run end-to-end tests if any webhook source files changed.
+---
+name: webhook
+on:
+  pull_request:
+    paths:
+      - 'webhook/**'
+jobs:
+  test-e2e:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: webhook
+    steps:
+      - name: Checkout the pull request code
+        uses: actions/checkout@v3
+      - name: Setup Golang version 1.18
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - name: Install kind
+        run: |
+          go install sigs.k8s.io/kind@v0.16.0
+      - name: Install bats
+        run: |
+          git clone https://github.com/bats-core/bats-core.git
+          cd bats-core
+          ./install.sh ~/.local
+      - name: Run end-to-end tests
+        run: |
+          make test-e2e

--- a/webhook/Makefile
+++ b/webhook/Makefile
@@ -100,7 +100,8 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 .PHONY: kind-cluster
 kind-cluster: ## create a kind cluster for testing 
-	kind create cluster --wait 120s --name "$(KIND_CLUSTER_NAME)"
+	kind create cluster --image "kindest/node:v$(ENVTEST_K8S_VERSION)" \
+		--wait 120s --name "$(KIND_CLUSTER_NAME)"
 	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
 
 .PHONY: kind-delete

--- a/webhook/Makefile
+++ b/webhook/Makefile
@@ -96,7 +96,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 .PHONY: kind-cluster
 kind-cluster: ## create a kind cluster for testing 
-	kind create cluster --name "$(KIND_CLUSTER_NAME)"
+	kind create cluster --wait 120s --name "$(KIND_CLUSTER_NAME)"
 	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
 
 .PHONY: kind-delete

--- a/webhook/Makefile
+++ b/webhook/Makefile
@@ -4,6 +4,8 @@ IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.2
 
+KIND_CLUSTER_NAME ?= webhook
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -94,8 +96,12 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 .PHONY: kind-cluster
 kind-cluster: ## create a kind cluster for testing 
-	kind create cluster --name webhook 
+	kind create cluster --name "$(KIND_CLUSTER_NAME)"
 	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
+
+.PHONY: kind-delete
+kind-delete: ## delete the kind test cluster
+	kind delete cluster --name "$(KIND_CLUSTER_NAME)"
 
 .PHONY: kind-load
 kind-load: ## load the image in the local kind cluster

--- a/webhook/Makefile
+++ b/webhook/Makefile
@@ -61,6 +61,10 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
+.PHONY: test-e2e
+test-e2e: ## Run the end-to-end tests on a local kind cluster.
+	bash ./tests/e2e/run-local.sh
+
 ##@ Build
 
 .PHONY: build

--- a/webhook/docs/DEVELOPMENT.md
+++ b/webhook/docs/DEVELOPMENT.md
@@ -48,6 +48,8 @@ make undeploy IMG=<some-registry>/<user>/peer-pods-webhook:<tag>
 ```
 
 ### Testing
+You can manually test your changes by following the steps:
+
 1. Create the runtimeclass
 ```sh
 kubectl apply -f hack/rc.yaml
@@ -87,3 +89,10 @@ and peer pod vm limit added.
      kata.peerpods.io/vm: "1"
 ```
 
+However, before opening a pull request with your changes, it is recommended that you run
+the end-to-end tests locally. Ensure that you have [bats](https://bats-core.readthedocs.io),
+docker (or podman-docker), and [kind](https://kind.sigs.k8s.io/) installed in your system;
+and then run:
+```sh
+make test-e2e
+```

--- a/webhook/tests/e2e/run-local.sh
+++ b/webhook/tests/e2e/run-local.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+#
+# Copyright Confidential Containers Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Use this script to run the end-to-end tests locally.
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly webhook_dir="$(cd "${script_dir}/../../" && pwd)"
+
+# Whether to run this script in debug mode or not.
+debug=0
+export IMG="peer-pods-webhook:test"
+
+cleanup () {
+	if [ $debug -eq 1 ]; then
+		echo "INFO: running in debug mode. Do not clean up the test environment."
+		return
+	fi
+
+	echo "INFO: clean up the test environment"
+	pushd "$webhook_dir" >/dev/null
+	make kind-delete || true
+	docker rmi "$IMG" || true
+}
+
+# Start the cluster and ensure it is ready to use.
+#
+cluster_up() {
+	pushd "$webhook_dir" >/dev/null
+	make kind-cluster
+	popd >/dev/null
+
+	local cert_manager_ns="cert-manager"
+	local cert_manager_pods="$(kubectl get pods -n "$cert_manager_ns" 2>/dev/null | \
+		grep cert-manager-webhook |awk '{ print $1}')"
+
+	if [ -z "$cert_manager_pods" ]; then
+		echo "ERROR: failed to get the certification manager webhook pods"
+		exit 1
+	fi
+
+	local pod
+	for pod in $cert_manager_pods; do
+		kubectl wait --for=condition=Ready --timeout=60s \
+			-n "$cert_manager_ns" "pod/$pod"
+	done
+}
+
+# Install the webhook and ensure it is ready to use.
+#
+install_webhook() {
+	local ns="peer-pods-webhook-system"
+
+	pushd "$webhook_dir" >/dev/null
+	make deploy
+	popd >/dev/null
+
+	local webhook_pods="$(kubectl get pods -n "$ns" 2>/dev/null | \
+		grep peer-pods-webhook-controller-manager |awk '{ print $1}')"
+
+	if [ -z "$webhook_pods" ];then
+		echo "ERROR: failed to get the webhook controller manager pods"
+		exit 1
+	fi
+
+	local pod
+	for pod in $webhook_pods; do
+		kubectl wait --for=condition=Ready --timeout=60s -n "$ns" \
+			"pod/$pod"
+	done
+}
+
+main() {
+	parse_args $@
+
+	for cmd in bats docker kind; do
+		if ! command -v "$cmd" &>/dev/null; then
+			echo "ERROR: $cmd command is required for this script"
+			exit 1
+		fi
+	done
+
+	trap cleanup EXIT
+
+	echo "INFO: start the test cluster"
+	cluster_up
+
+	pushd "$webhook_dir" >/dev/null
+
+	echo "INFO: build the webhook"
+	make docker-build
+
+	echo "INFO: load the $IMG image into the cluster"
+	make kind-load
+
+	echo "INFO: install the webhook in the cluster"
+	install_webhook
+
+	echo "INFO: run tests"
+	bats tests/e2e/webhook_tests.bats
+
+	popd >/dev/null
+}
+
+parse_args() {
+	while getopts "dh" opt; do
+		case $opt in
+			d) debug=1;;
+			h) usage && exit 0;;
+			*) usage && exit 1;;
+		esac
+	done
+}
+
+usage() {
+	cat <<-EOF
+	Start a k8s cluster with kind, build and install the webhook then
+	run end-to-end tests.
+
+	It requires bats, docker and kind to run.
+
+	Use: $0 [-d] [-h], where:
+	-d: debug mode. It will leave created resources (cluster, image, and etc...)
+	-h: show this usage
+	EOF
+}
+
+main "$@"

--- a/webhook/tests/e2e/webhook_tests.bats
+++ b/webhook/tests/e2e/webhook_tests.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+#
+# Copyright Confidential Containers Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# End-to-end tests.
+#
+test_tags="[webhook]"
+
+# Assert that the pod mutated as expected.
+#
+# Parameters:
+# 	$1: the expected instance type
+# 	$2: the expected VM limits
+# 	$3: the expected VM requests
+#
+# Global variables:
+# 	$pod_file: path to the pod configuration file.
+#
+assert_pod_mutated() {
+	local expect_instance_type="$1"
+	local expect_vm_limits="$2"
+	local expect_vm_requests="$3"
+
+        local actual_instance_type=$(kubectl get -f "$pod_file" \
+                -o jsonpath='{.metadata.annotations.kata\.peerpods\.io/instance_type}')
+        echo "Instance type expected: $expect_instance_type, actual: $actual_instance_type"
+        [ "$expect_instance_type" == "$actual_instance_type" ]
+
+        local actual_vm_limits=$(kubectl get -f "$pod_file" \
+                -o jsonpath='{.spec.containers[0].resources.limits.kata\.peerpods\.io/vm}')
+        echo "VM limits expected: $expect_vm_limits, actual: $actual_vm_limits"
+        [ $expect_vm_limits -eq $actual_vm_limits ]
+
+        local actual_vm_requests=$(kubectl get -f "$pod_file" \
+                -o jsonpath='{.spec.containers[0].resources.requests.kata\.peerpods\.io/vm}')
+        echo "VM requests expected: $expect_vm_requests, actual: $actual_vm_requests"
+        [ $expect_vm_requests -eq $actual_vm_requests ]
+}
+
+setup_file() {
+	export project_dir="$(cd ${BATS_TEST_DIRNAME}/../.. && pwd)"
+	echo "Create runtimeClass"
+	kubectl apply -f "$project_dir/hack/rc.yaml"
+}
+
+setup() {
+	export pod_file="$project_dir/hack/pod.yaml"
+}
+
+teardown() {
+	kubectl delete -f "$pod_file" || true
+}
+
+@test "$test_tags test it can mutate a pod" {
+	kubectl apply -f "$pod_file"
+	assert_pod_mutated "t2.small" 1 1
+}
+
+@test "$test_tags test it should not mutate non-peerpods" {
+	echo "Create a pod without runtimeClassName"
+	cat "$pod_file" | sed -e 's/^\s*runtimeClassName:.*//' | \
+		kubectl apply -f -
+
+	! kubectl get -f ../../hack/pod.yaml -o json | \
+		grep kata\.peerpods
+}
+
+@test "$test_tags test default parameters can be changed" {
+	skip "TODO: This test is not passing"
+	local runtimeclass="kata-wh-test"
+	local instance_type='t2.micro'
+
+	# Create a dummy runtimeClass to use on this test.
+	cat <<-EOF | kubectl apply -f -
+	apiVersion: node.k8s.io/v1
+	handler: ${runtimeclass}
+	kind: RuntimeClass
+	metadata:
+	  name: ${runtimeclass}
+	overhead:
+	  podFixed:
+	    memory: "120Mi"
+	    cpu: "250m"
+	EOF
+
+	kubectl set env deployment/peer-pods-webhook-controller-manager \
+		-n peer-pods-webhook-system TARGET_RUNTIMECLASS="$runtimeclass"
+
+	kubectl set env deployment/peer-pods-webhook-controller-manager \
+		-n peer-pods-webhook-system POD_VM_INSTANCE_TYPE="$instance_type"
+
+	cat "$pod_file" | sed -e 's/^\(\s*runtimeClassName:\).*/\1 '${runtimeclass}'/' | \
+		kubectl apply -f -
+
+	kubectl get -f $pod_file -o json
+	assert_pod_mutated "$instance_type" 1 1
+}


### PR DESCRIPTION
The webhook is a component that can be tested in isolation. You will only required a working Kubernetes cluster (which can be setup with Kind) and the tools to build the webhook itself. So this pull request contain an CI for the webhook which is triggered only and only if the webhook files changed.

The CI is built on a github action, runner script and bats tests. Developers will be able to run the same workflow locally by issuing `make test-e2e`.

Refer to the https://github.com/wainersm/cc-cloud-api-adaptor/actions/runs/3268928340 for a successful execution of the github action.

Note: there is a test case not passing which was marked to skip.

Fixes #291 