### PR TITLE
ibmcloud: Increase remote hypervisor timeout

### DIFF
--- a/ibmcloud/terraform/cluster/ansible/kata-playbook.yml
+++ b/ibmcloud/terraform/cluster/ansible/kata-playbook.yml
@@ -80,7 +80,7 @@
       args:
         executable: /bin/bash
         creates: /usr/local/bin/containerd
-    
+
     - name: Ensure /etc/containerd directory exists
       file:
         path: /etc/containerd
@@ -238,6 +238,7 @@
           enable_debug = true
           [hypervisor.remote]
           remote_hypervisor_socket = "/run/peerpod/hypervisor.sock"
+          remote_hypervisor_timeout = 600
           [agent.kata]
           [image]
           service_offload = true


### PR DESCRIPTION
Increase timeout to 10mins from default 1min to help not error when pulling bigger images

Fixes: #334
Signed-off-by: stevenhorsman <steven@uk.ibm.com>