### PR TITLE
vsphere: use packer to create the podvm template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ skopeo
 
 # IDEs
 .vscode
+
+# Files
+vcenter.auto.pkrvars.hcl
+settings.auto.pkrvars.hcl

--- a/vsphere/README.md
+++ b/vsphere/README.md
@@ -1,0 +1,38 @@
+# Setup instructions
+
+## Prerequisites:
+
+- A configured vCenter instance
+- datacenter, datastore and cluster are required fields
+
+## Creating the vsphere template:
+- Install packer on your system by following the instructions in the following [link](https://learn.hashicorp.com/tutorials/packer/get-started-install-cli)
+- Create the vsphere template
+```
+cd vsphere/image && make
+```
+If successful, you can find the image on your vcenter deployment
+
+## File structure
+- **vcenter.auto.pkrvars.hcl** - The main template.
+- **settings.auto.pkrvars.hcl** - Guest settings referenced by the template file
+- **vcenter.auto.pkrvars.hcl** - Your vCenter config
+
+If settings.auto.pkrvars.hcl and vcenter.auto.pkrvars.hcl are not present, they will be created
+when you first run make. You can also choose to create these files if you prefer.
+
+Please take a look at variables.pkr.hcl for all the variables supported.
+
+Here are a few that you might find useful to configure the guest:
+- *vm_cpu_count*
+  This field configures the number of vcpus for the guest.
+- *vm_guest_size*
+  Determines the amount of guest memory.
+- *vm_disk_size*
+  The size of the virtual hard disk. Please note that installation might fail if the disk size is too small.
+- *vm_network_name*
+  The virtualized network adapter to use. vmxnet3 is the default.
+
+## Potential issues
+The start of the installation uses automated keyboard input. Timing issues may prevent entering
+the shell. Please try experimenting with vm_boot_wait if you encounter this problem.

--- a/vsphere/image/Makefile
+++ b/vsphere/image/Makefile
@@ -1,0 +1,120 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+.PHONY: all check cleanconfig config build clean force
+.DEFAULT_GOAL := all
+SKOPEO_VERSION     = 1.5.0
+UMOCI_VERSION      = 0.4.7
+
+ARCH := $(subst x86_64,amd64,$(shell uname -m))
+
+FILES_DIR := files
+FILES      = $(shell find "$(FILES_DIR)" -type f -o -type l)
+
+AGENT_PROTOCOL_FORWARDER = $(FILES_DIR)/usr/local/bin/agent-protocol-forwarder
+KATA_AGENT    = $(FILES_DIR)/usr/local/bin/kata-agent
+PAUSE         = $(FILES_DIR)/$(PAUSE_BUNDLE)/rootfs/pause
+SKOPEO    = $(FILES_DIR)/usr/bin/skopeo
+UMOCI     = $(FILES_DIR)/usr/local/bin/umoci
+
+BINARIES = $(AGENT_PROTOCOL_FORWARDER) $(KATA_AGENT) $(PAUSE)
+
+ifdef USE_SKOPEO
+BINARIES += $(SKOPEO) $(UMOCI)
+endif
+
+AGENT_PROTOCOL_FORWARDER_SRC = ../..
+
+KATA_AGENT_SRC = ../../../kata-containers/src/agent
+KATA_AGENT_BUILD_TYPE = release
+
+SKOPEO_SRC  = skopeo
+SKOPEO_REPO = https://github.com/containers/skopeo
+
+UMOCI_SRC   = umoci
+UMOCI_REPO  = https://github.com/opencontainers/umoci
+
+# Embed the pause container image
+# https://github.com/arronwy/kata-containers/commit/75b9f3fa3caaae62f49b4733f65cbab0cc87dbee
+PAUSE_SRC     = pause
+PAUSE_REPO    = docker://k8s.gcr.io/pause
+PAUSE_VERSION = 3.6
+PAUSE_BUNDLE  = pause_bundle
+
+# Static libseccomp is necessary for kata-agent
+# https://github.com/kata-containers/kata-containers/issues/5044#issuecomment-1239773921
+STATIC_LIB_BUILDER = ../../../kata-containers/ci/install_libseccomp.sh
+STATIC_LIB_DIR     = $(abspath staticlib)
+STATIC_LIB         = $(STATIC_LIB_DIR)/kata-libseccomp/lib/libseccomp.a
+
+GUESTCONFIG = settings.auto.pkrvars.hcl
+VCENTERCONFIG = vcenter.auto.pkrvars.hcl
+
+check:
+ifeq (, $(shell which packer))
+	$(error "packer executable is not found, I looked here: $(PATH)")
+endif
+ifeq (, $(shell which go))
+	$(error "go executable is not found, I looked here: $(PATH)")
+endif
+	$(if $(strip $(GOPATH)),,$(error "GOPATH is unset, try "export GOPATH=/path/to/go""))
+
+cleanconfig:
+	rm -rf $(VCENTERCONFIG) $(GUESTCONFIG)
+
+config: | check
+	./scripts/createconfig.sh "guest" "$(GUESTCONFIG)"
+	./scripts/createconfig.sh "vcenter" "$(VCENTERCONFIG)"
+
+build: | config $(BINARIES) $(FILES)
+	rm -rf files.tar
+	cd files && tar cf ../files.tar *
+	packer build .
+
+$(AGENT_PROTOCOL_FORWARDER): force
+	cd "$(AGENT_PROTOCOL_FORWARDER_SRC)" && CLOUD_PROVIDER=vsphere $(MAKE) agent-protocol-forwarder
+	install -D --compare "$(AGENT_PROTOCOL_FORWARDER_SRC)/agent-protocol-forwarder" "$@"
+
+$(KATA_AGENT): force $(STATIC_LIB)
+	cd "$(KATA_AGENT_SRC)/../libs" && $(MAKE) BUILD_TYPE=$(KATA_AGENT_BUILD_TYPE) LIBSECCOMP_LINK_TYPE=static LIBSECCOMP_LIB_PATH=$(dir $(STATIC_LIB))
+	cd "$(KATA_AGENT_SRC)" && $(MAKE) BUILD_TYPE=$(KATA_AGENT_BUILD_TYPE) LIBSECCOMP_LINK_TYPE=static LIBSECCOMP_LIB_PATH=$(dir $(STATIC_LIB))
+	install -D --compare "$(KATA_AGENT_SRC)/target/$(shell uname -m)-unknown-linux-$(if $(findstring s390x,$(shell uname -m)),gnu,musl)/$(KATA_AGENT_BUILD_TYPE)/$(@F)" "$@"
+
+$(STATIC_LIB):
+	$(STATIC_LIB_BUILDER) $(STATIC_LIB_DIR)/kata-libseccomp $(STATIC_LIB_DIR)/kata-gperf
+
+# Skoepo package packages are available in RHEL/CentOS 8 or later and Ubuntu 20.10 or later
+$(SKOPEO_SRC):
+	git clone -b "v$(SKOPEO_VERSION)" "$(SKOPEO_REPO)" "$(SKOPEO_SRC)"
+
+$(SKOPEO_SRC)/bin/skopeo: $(SKOPEO_SRC)
+	cd "$(SKOPEO_SRC)" && make bin/skopeo
+
+$(SKOPEO): $(SKOPEO_SRC)/bin/skopeo
+	install -D --compare "$(SKOPEO_SRC)/bin/skopeo" "$@"
+
+# The umoci release page only publishes amd64 binaries. https://github.com/opencontainers/umoci/releases
+$(UMOCI_SRC):
+	git clone -b "v$(UMOCI_VERSION)" "$(UMOCI_REPO)" "$(UMOCI_SRC)"
+
+$(UMOCI_SRC)/umoci: $(UMOCI_SRC)
+	cd "$(UMOCI_SRC)" && make
+
+$(UMOCI): $(UMOCI_SRC)/umoci
+	install -D --compare "$(UMOCI_SRC)/umoci" "$@"
+
+$(PAUSE_SRC): $(SKOPEO_SRC)/bin/skopeo
+	$(SKOPEO_SRC)/bin/skopeo --policy "$(FILES_DIR)/etc/containers/policy.json" copy "$(PAUSE_REPO):$(PAUSE_VERSION)" "oci:$(PAUSE_SRC):$(PAUSE_VERSION)"
+
+$(PAUSE): | $(PAUSE_SRC) $(UMOCI_SRC)/umoci
+	$(UMOCI_SRC)/umoci unpack --rootless --image "$(PAUSE_SRC):$(PAUSE_VERSION)" "${FILES_DIR}/$(PAUSE_BUNDLE)"
+
+clean:	cleanconfig
+	rm -f $(BINARIES)
+	rm -rf staticlib
+	rm -rf files.tar
+	rm -fr "$(SKOPEO_SRC)" "$(UMOCI_SRC)" "$(PAUSE_SRC)" "$(FILES_DIR)/$(PAUSE_BUNDLE)"
+
+all: build
+
+force:

--- a/vsphere/image/data/user-data.pkr.hcl
+++ b/vsphere/image/data/user-data.pkr.hcl
@@ -1,0 +1,107 @@
+#cloud-config
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Ubuntu Server 20.04 LTS
+
+autoinstall:
+  version: 1
+  apt:
+    geoip: true
+    preserve_sources_list: false
+    primary:
+      - arches: [amd64, i386]
+        uri: http://us.archive.ubuntu.com/ubuntu
+      - arches: [default]
+        uri: http://ports.ubuntu.com/ubuntu-ports
+  early-commands:
+    - sudo systemctl stop ssh
+  locale: en_US.UTF-8
+  keyboard:
+    layout: ${vm_guest_os_keyboard}
+  storage:
+    config:
+      - ptable: gpt
+        path: /dev/sda
+        wipe: superblock
+        type: disk
+        id: disk-sda
+      - device: disk-sda
+        size: 500M
+        wipe: superblock
+        flag: boot
+        number: 1
+        grub_device: true
+        type: partition
+        id: partition-0
+      - fstype: fat32
+        volume: partition-0
+        label: EFIFS
+        type: format
+        id: format-efi
+      - device: disk-sda
+        size: 500M
+        wipe: superblock
+        number: 2
+        type: partition
+        id: partition-1
+      - fstype: xfs
+        volume: partition-1
+        label: BOOTFS
+        type: format
+        id: format-boot
+      - device: disk-sda
+        size: -1
+        wipe: superblock
+        number: 3
+        type: partition
+        id: partition-2
+      - name: sysvg
+        devices:
+          - partition-2
+        type: lvm_volgroup
+        id: lvm_volgroup-0
+      - name: root
+        volgroup: lvm_volgroup-0
+        size: -1
+        wipe: superblock
+        type: lvm_partition
+        id: lvm_partition-root
+      - fstype: xfs
+        volume: lvm_partition-root
+        type: format
+        label: ROOTFS
+        id: format-root
+      - path: /
+        device: format-root
+        type: mount
+        id: mount-root
+      - path: /boot
+        device: format-boot
+        type: mount
+        id: mount-boot
+      - path: /boot/efi
+        device: format-efi
+        type: mount
+        id: mount-efi
+  identity:
+    hostname: ${vm_guest_hostname}
+    username: ${build_username}
+    password: ${build_password_encrypted}
+  ssh:
+    install-server: true
+    allow-pw: true
+  packages:
+    - openssh-server
+    - open-vm-tools
+    - cloud-init
+  user-data:
+    disable_root: false
+    timezone: ${vm_guest_os_timezone}
+  late-commands:
+    - sed -i -e 's/^#\?PasswordAuthentication.*/PasswordAuthentication yes/g' /target/etc/ssh/sshd_config
+    - echo '${build_username} ALL=(ALL) NOPASSWD:ALL' > /target/etc/sudoers.d/${build_username}
+    - curtin in-target --target=/target -- chmod 440 /etc/sudoers.d/${build_username}

--- a/vsphere/image/files/etc/agent-config.toml
+++ b/vsphere/image/files/etc/agent-config.toml
@@ -1,0 +1,45 @@
+
+# This disables signature verification which now defaults to true.
+# We should consider a better solution. See #331 for more info
+enable_signature_verification=false
+
+# When using the agent-config.toml the KATA_AGENT_SERVER_ADDR env var seems to be ignored, so set it here
+server_addr="unix:///run/kata-containers/agent.sock"
+
+# temp workaround for kata-containers/kata-containers#5590
+[endpoints]
+allowed = [
+"AddARPNeighborsRequest",
+"AddSwapRequest",
+"CloseStdinRequest",
+"CopyFileRequest",
+"CreateContainerRequest",
+"CreateSandboxRequest",
+"DestroySandboxRequest",
+"ExecProcessRequest",
+"GetMetricsRequest",
+"GetOOMEventRequest",
+"GuestDetailsRequest",
+"ListInterfacesRequest",
+"ListRoutesRequest",
+"MemHotplugByProbeRequest",
+"OnlineCPUMemRequest",
+"PauseContainerRequest",
+"PullImageRequest",
+"ReadStreamRequest",
+"RemoveContainerRequest",
+"ReseedRandomDevRequest",
+"ResumeContainerRequest",
+"SetGuestDateTimeRequest",
+"SignalProcessRequest",
+"StartContainerRequest",
+"StartTracingRequest",
+"StatsContainerRequest",
+"StopTracingRequest",
+"TtyWinResizeRequest",
+"UpdateContainerRequest",
+"UpdateInterfaceRequest",
+"UpdateRoutesRequest",
+"WaitProcessRequest",
+"WriteStreamRequest"
+]

--- a/vsphere/image/files/etc/cloud/cloud.cfg.d/06_podvm.cfg
+++ b/vsphere/image/files/etc/cloud/cloud.cfg.d/06_podvm.cfg
@@ -1,0 +1,1 @@
+datasource_list: [ VMware, None ]

--- a/vsphere/image/files/etc/containers/policy.json
+++ b/vsphere/image/files/etc/containers/policy.json
@@ -1,0 +1,3 @@
+{
+    "default": [{"type": "insecureAcceptAnything"}]
+}

--- a/vsphere/image/files/etc/systemd/system/agent-protocol-forwarder.service
+++ b/vsphere/image/files/etc/systemd/system/agent-protocol-forwarder.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Agent Protocol Forwarder
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/agent-protocol-forwarder -kata-agent-namespace /run/netns/podns -kata-agent-socket /run/kata-containers/agent.sock
+
+[Install]
+WantedBy=multi-user.target

--- a/vsphere/image/files/etc/systemd/system/kata-agent.service
+++ b/vsphere/image/files/etc/systemd/system/kata-agent.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Kata Agent
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/kata-agent --config /etc/agent-config.toml
+ExecStartPre=ip netns add podns
+ExecStartPre=ip netns exec podns ip link set lo up
+ExecStopPost=ip netns delete podns
+#Environment="KATA_AGENT_SERVER_ADDR=unix:///run/kata-containers/agent.sock"
+SyslogIdentifier=kata-agent
+
+[Install]
+WantedBy=multi-user.target

--- a/vsphere/image/files/etc/systemd/system/multi-user.target.wants/agent-protocol-forwarder.service
+++ b/vsphere/image/files/etc/systemd/system/multi-user.target.wants/agent-protocol-forwarder.service
@@ -1,0 +1,1 @@
+../agent-protocol-forwarder.service

--- a/vsphere/image/files/etc/systemd/system/multi-user.target.wants/kata-agent.service
+++ b/vsphere/image/files/etc/systemd/system/multi-user.target.wants/kata-agent.service
@@ -1,0 +1,1 @@
+../kata-agent.service

--- a/vsphere/image/files/etc/systemd/system/multi-user.target.wants/run-kata\x2dcontainers-shared-containers.mount
+++ b/vsphere/image/files/etc/systemd/system/multi-user.target.wants/run-kata\x2dcontainers-shared-containers.mount
@@ -1,0 +1,1 @@
+../run-kata\x2dcontainers-shared-containers.mount

--- a/vsphere/image/files/etc/systemd/system/multi-user.target.wants/run-kata\x2dcontainers.mount
+++ b/vsphere/image/files/etc/systemd/system/multi-user.target.wants/run-kata\x2dcontainers.mount
@@ -1,0 +1,1 @@
+../run-kata\x2dcontainers.mount

--- a/vsphere/image/files/etc/systemd/system/run-kata\x2dcontainers-shared-containers.mount
+++ b/vsphere/image/files/etc/systemd/system/run-kata\x2dcontainers-shared-containers.mount
@@ -1,0 +1,12 @@
+[Unit]
+Description=Mount unit for /run/kata-containers/shared/containers
+Before=kata-agent.service
+
+[Mount]
+What=tmpfs
+Where=/run/kata-containers/shared/containers
+Type=tmpfs
+Options=mode=755
+
+[Install]
+WantedBy=multi-user.target

--- a/vsphere/image/files/etc/systemd/system/run-kata\x2dcontainers.mount
+++ b/vsphere/image/files/etc/systemd/system/run-kata\x2dcontainers.mount
@@ -1,0 +1,12 @@
+[Unit]
+Description=Mount unit for /run/kata-containers
+Before=kata-agent.service
+
+[Mount]
+What=tmpfs
+Where=/run/kata-containers
+Type=tmpfs
+Options=mode=755
+
+[Install]
+WantedBy=multi-user.target

--- a/vsphere/image/scripts/createconfig.sh
+++ b/vsphere/image/scripts/createconfig.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+ACTION="$1"
+CONF="$2"
+GREEN='\033[0;32m'
+NOCOLOR='\033[0m'
+default_guest_config=$(cat <<EOF
+/*
+    DESCRIPTION:
+    Ubuntu Server 20.04 LTS variables used by the Packer Plugin for VMware vSphere (vsphere-iso).
+*/
+
+// Guest Operating System Metadata
+vm_guest_os_language = "en_US"
+vm_guest_os_keyboard = "us"
+vm_guest_os_timezone = "UTC"
+vm_guest_os_type = "ubuntu64Guest"
+
+
+// Virtual Machine Hardware Settings
+vm_firmware              = "efi"
+vm_cpu_count             = 2
+vm_mem_size              = 2048
+// too small a disk size can break the install
+vm_disk_size             = 6250
+vm_disk_thin_provisioned = true
+vm_interface_name         = "vmxnet3"
+vm_network_name           = "VM Network"
+vm_hostname		  = "podvm"
+
+// Removable Media Settings
+iso_url            = "https://releases.ubuntu.com/focal/ubuntu-20.04.5-live-server-amd64.iso"
+iso_checksum_value = "5035be37a7e9abbdc09f0d257f3e33416c1a0fb322ba860d42d74aa75c3468d4"
+
+// Boot Settings
+vm_boot_wait  = "2s"
+
+// Communicator Settings
+ssh_port    = 22
+ssh_timeout = "15m"
+EOF
+)
+case "$ACTION" in
+    "vcenter")
+	[ -e "$CONF" ] && echo "$CONF already exists, not overwriting" && exit 0
+	read -p "vCenter URL(without https://): " vcenter
+	read -p "Datacenter: " datacenter
+	read -p "vCenter username: " username
+	read -s -p "vCenter password: " password; echo
+	read -p "Datastore: " datastore
+	read -p "Cluster: " cluster
+	read -p "Template Name: " template
+	cat << EOF > $CONF
+//vCenter configuration settings
+vcenter_server = "${vcenter}"
+datacenter = "${datacenter}"
+vcenter_username = "${username}"
+vcenter_password = "${password}"
+datastore = "${datastore}"
+cluster = "${cluster}"
+template = "${template}"
+EOF
+	printf "${GREEN} Created vcenter config file $CONF with user provided values"
+	cat "$CONF"
+	printf "${NOCOLOR}"
+	;;
+    "guest")
+	[ -e "$CONF" ] && echo "$CONF already exists, not overwriting" && exit 0
+	echo "Writing default guest config to $CONF"
+	echo -e "$default_guest_config" > $CONF
+	printf  "${GREEN} Created guest config file $CONF with default values \n"
+	cat $CONF
+	printf "${NOCOLOR}"
+	;;
+    *)
+	echo "invalid input"
+	exit 1
+	;;
+esac

--- a/vsphere/image/variables.pkr.hcl
+++ b/vsphere/image/variables.pkr.hcl
@@ -1,0 +1,158 @@
+/*
+    DESCRIPTION:
+    Ubuntu Server 20.04 LTS variables using the Packer Builder for VMware vSphere (vsphere-iso).
+*/
+
+// vSphere Credentials
+
+variable "vcenter_server" {
+  type        = string
+  description = "The fully qualified domain name or IP address of the vCenter Server instance"
+  default = null
+}
+
+variable "vcenter_username" {
+  type        = string
+  description = "vCenter login, do not use vsphere credentials here!"
+  default = null
+}
+
+variable "datacenter" {
+  type        = string
+  description = "The name of the target datacenter"
+  default = null
+}
+
+variable "vcenter_password" {
+  type        = string
+  description = "vCenter password"
+  default = null
+}
+
+variable "datastore" {
+  type        = string
+  description = "The name of the target datastore"
+  default = null
+}
+
+variable "cluster" {
+  type        = string
+  description = "The name of the target cluster"
+  default = null
+}
+
+variable "template" {
+  type        = string
+  description = "The name of the template to use"
+  default = null
+}
+
+variable "vm_guest_os_type" {
+  type        = string
+  description = "Guest OS type"
+  default = null
+}
+
+variable "vm_guest_os_language" {
+  type        = string
+  description = "Guest OS language"
+  default = "en_US"
+}
+
+variable "vm_guest_os_keyboard" {
+  type        = string
+  description = "Guest OS keyboard"
+  default = "us"
+}
+
+variable "vm_guest_os_timezone" {
+  type        = string
+  description = "Guest OS timezone"
+  default = "UTC"
+}
+
+variable "vm_firmware" {
+  type        = string
+  description = "Guest os bios - legacy or efi"
+  default = "efi"
+}
+
+variable "vm_cpu_count" {
+  type        = number
+  description = "Number of guest cpus"
+}
+
+variable "vm_mem_size" {
+  type        = number
+  description = "Guest memory"
+}
+
+variable "vm_disk_size" {
+  type        = number
+  description = "Guest disk size"
+}
+
+variable "vm_disk_thin_provisioned" {
+  type        = string
+  description = "Thin provisioning"
+  default = "true"
+}
+
+variable "vm_interface_name" {
+  type        = string
+  description = "interface name"
+  default = null
+}
+
+variable "vm_network_name" {
+  type        = string
+  description = "Network name"
+  default = "VM Network"
+}
+
+variable "iso_url" {
+  type        = string
+  description = "URL of installation iso"
+  default = null
+}
+
+variable "iso_checksum_value" {
+  type        = string
+  description = "Checksum of installation iso"
+  default = null
+}
+
+variable "vm_boot_wait" {
+  type        = string
+  description = "Wait time for guest keyboard input"
+  default = "2s"
+}
+
+variable "ssh_port" {
+  type        = number
+  description = "ssh port"
+  default = 22
+}
+
+variable "ssh_timeout" {
+  type        = string
+  description = "time to wait for ssh to be alive in the guest"
+}
+
+variable "convert_to_template" {
+  type        = bool
+  description = "time to wait for ssh to be alive in the guest"
+  default = true
+}
+
+variable "insecure_connection" {
+  type        = bool
+  description = "time to wait for ssh to be alive in the guest"
+  default = true
+}
+
+variable "vm_hostname" {
+  type        = string
+  description = "name of the podvm guest, by default time is suffixed"
+  default = "podvm"
+}

--- a/vsphere/image/vsphere-ubuntu.pkr.hcl
+++ b/vsphere/image/vsphere-ubuntu.pkr.hcl
@@ -1,0 +1,99 @@
+//  BLOCK: source
+//  Defines the builder configuration blocks.
+
+//  BLOCK: build
+//  Defines the builders to run, provisioners, and post-processors.
+
+locals {
+  data_source_content = {
+    "/meta-data" = file("${abspath(path.root)}/data/meta-data")
+    "/user-data" = templatefile("${abspath(path.root)}/data/user-data.pkr.hcl", {
+      build_username           = "peerpod"
+      build_password           = "peerp0d"
+      build_password_encrypted = "$y$j9T$ifwkDEP8Rb9c47stpEGuF1$wT/v1.7ci8lEnD7rLmEqkzFmXuHwpHqhvjg3HQp7hm8"
+      vm_guest_os_language     = "${var.vm_guest_os_language}"
+      vm_guest_os_keyboard     = "${var.vm_guest_os_keyboard}"
+      vm_guest_os_timezone     = "${var.vm_guest_os_timezone}"
+      vm_guest_hostname        = "${var.vm_hostname}"
+    })
+    }
+  data_source_command = "ds=\"nocloud\""
+}
+
+source "vsphere-iso" "ubuntu" {
+// vcenter settings
+  vcenter_server          = "${var.vcenter_server}"
+  username                = "${var.vcenter_username}"
+  datacenter              = "${var.datacenter}"
+  password                = "${var.vcenter_password}"
+  datastore               = "${var.datastore}"
+  cluster	          = "${var.cluster}"
+  insecure_connection     = "${var.insecure_connection}"
+  guest_os_type           = "${var.vm_guest_os_type}"
+
+// whether to create a template and if yes, the name
+  vm_name                 = "${var.template}"
+  convert_to_template     = "${var.convert_to_template}"
+
+// ssh user/pass to the guest, same as cloudinit data
+  ssh_username            = "peerpod"
+  ssh_password            = "peerp0d"
+  ssh_timeout  		  = "${var.ssh_timeout}"
+
+// VM resources
+  CPUs                    = var.vm_cpu_count
+  RAM                     = var.vm_mem_size
+  RAM_reserve_all         = true
+
+  disk_controller_type    = ["pvscsi"]
+  storage {
+    disk_size             = var.vm_disk_size
+    disk_thin_provisioned = var.vm_disk_thin_provisioned
+  }
+
+  network_adapters {
+    network               = "${var.vm_network_name}"
+    network_card          = "${var.vm_interface_name}"
+  }
+
+
+// Attach cloudinit config as a disk
+  cd_content              = local.data_source_content
+  cd_label                = "cidata"
+  firmware                = "${var.vm_firmware}"
+
+// iso path and checksum
+  iso_url                 = "${var.iso_url}"
+  iso_checksum            = "${var.iso_checksum_value}"
+
+// boot command for autoinstall
+  boot_wait               = "2s"
+  boot_command = [
+    "c",
+    "linux /casper/vmlinuz --- autoinstall ${local.data_source_command}",
+    "<enter><wait>",
+    "initrd /casper/initrd",
+    "<enter><wait>",
+    "boot",
+    "<enter>"
+  ]
+}
+
+
+build {
+  sources = ["source.vsphere-iso.ubuntu"]
+
+  provisioner "file" {
+    source      = "./files.tar"
+    destination = "/tmp/"
+  }
+
+ provisioner "shell" {
+    inline = [
+// delete preinstalled configs so that we can choose our own datasource
+      "cd /etc/cloud/cloud.cfg.d && sudo rm -rf 99-installer.cfg && sudo rm -rf 90_dpkg.cfg",
+      "cd /tmp && sudo tar xf files.tar -C /",
+      "rm /tmp/files.tar"
+   ]
+  }
+}


### PR DESCRIPTION
v2: 
Added a few changes as pointed out in the reviews
 - Added the option to configure disk size by the user 
 - Cleaned up clutter in the Makefile and moved information gathering to a script
 - Renamed data/user-data.pkrtpl.hcl to data/user-data.pkr.hcl
 - Removed settings.auto.pkrvars.hcl, this will be created when building the template by the above script
 - Added *auto*.hcl files to .gitignore
 - Added a README
 - Fix for #339 (included in a previous push)

Mostly, derived from its libvirt counterpart, this script creates an esx guest from a standard ubuntu iso and then converts it into a template.

Standard settings are in settings.auto.pkrvars.hcl. vsphere config is expected in vsphere.auto.pkrvals.hcl which will be created by the Makefile if not present; user-data.pkrtpl.hcl contains the autoinstall template.

The automated input of characters at boot to start autoinstall is kind of flaky, the currently working sequence is defined in boot_command of the main script.

Fixes: #337 
Signed-off-by: Bandan Das <bsd@redhat.com>