### PR TITLE
Rename AZURE_SECRET to AZURE_CLIENT_SECRET

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,7 +46,7 @@ exec cloud-api-adaptor-aws aws \
 }
 
 azure() {
-test_vars AZURE_CLIENT_ID AZURE_SECRET AZURE_TENANT_ID
+test_vars AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID
 set -x
 
 exec cloud-api-adaptor-azure azure \

--- a/install/overlays/azure/kustomization.yaml
+++ b/install/overlays/azure/kustomization.yaml
@@ -28,7 +28,7 @@ secretGenerator:
   namespace: confidential-containers-system
   literals:
   - AZURE_CLIENT_ID="" # set
-  - AZURE_SECRET="" # set
+  - AZURE_CLIENT_SECRET="" # set
   - AZURE_TENANT_ID="" #set
 - name: ssh-key-secret
   namespace: confidential-containers-system


### PR DESCRIPTION
Fixes: #340

The latter is the proper env name and it's also used in code.

Signed-off-by: Magnus Kulke <magnuskulke@microsoft.com>