### PR TITLE
all: remove redundant cri runtime endpoint configuration

### DIFF
--- a/install/overlays/aws/cri_runtime_endpoint.yaml
+++ b/install/overlays/aws/cri_runtime_endpoint.yaml
@@ -11,7 +11,7 @@ spec:
       containers:
       - name: cloud-api-adaptor-con
         volumeMounts:
-        - mountPath: /run/peerpod/cri-runtime.sock # in-container default
+        - mountPath: /run/peerpod/cri-runtime.sock # in-container CRI_RUNTIME_ENDPOINT default
           name: cri-runtime-endpoint
       volumes:
       - name: cri-runtime-endpoint

--- a/install/overlays/azure/cri_runtime_endpoint.yaml
+++ b/install/overlays/azure/cri_runtime_endpoint.yaml
@@ -11,7 +11,7 @@ spec:
       containers:
       - name: cloud-api-adaptor-con
         volumeMounts:
-        - mountPath: /run/peerpod/cri-runtime.sock # in-container default
+        - mountPath: /run/peerpod/cri-runtime.sock # in-container CRI_RUNTIME_ENDPOINT default
           name: cri-runtime-endpoint
       volumes:
       - name: cri-runtime-endpoint

--- a/install/overlays/azure/kustomization.yaml
+++ b/install/overlays/azure/kustomization.yaml
@@ -15,7 +15,6 @@ configMapGenerator:
   namespace: confidential-containers-system
   literals:
   - CLOUD_PROVIDER="azure"
-  - CRI_RUNTIME_ENDPOINT="/run/containerd/containerd.sock" #set
   - AZURE_SUBSCRIPTION_ID="" #set
   - AZURE_REGION="eastus" #set
   - AZURE_INSTANCE_SIZE="Standard_D8as_v5" #set

--- a/install/overlays/ibmcloud/cri_runtime_endpoint.yaml
+++ b/install/overlays/ibmcloud/cri_runtime_endpoint.yaml
@@ -11,7 +11,7 @@ spec:
       containers:
       - name: cloud-api-adaptor-con
         volumeMounts:
-        - mountPath: /run/peerpod/cri-runtime.sock # in-container default
+        - mountPath: /run/peerpod/cri-runtime.sock # in-container CRI_RUNTIME_ENDPOINT default
           name: cri-runtime-endpoint
       volumes:
       - name: cri-runtime-endpoint

--- a/install/overlays/ibmcloud/kustomization.yaml
+++ b/install/overlays/ibmcloud/kustomization.yaml
@@ -24,7 +24,6 @@ configMapGenerator:
   - IBMCLOUD_VPC_SUBNET_ID="" #set
   - IBMCLOUD_VPC_SG_ID="" #set
   - IBMCLOUD_VPC_ID="" #set
-  - CRI_RUNTIME_ENDPOINT="/run/containerd/containerd.sock" #set
   #- PAUSE_IMAGE=" # Uncomment and set if you want to use a specific pause image
 
 secretGenerator:

--- a/install/overlays/libvirt/cri_runtime_endpoint.yaml
+++ b/install/overlays/libvirt/cri_runtime_endpoint.yaml
@@ -11,7 +11,7 @@ spec:
       containers:
       - name: cloud-api-adaptor-con
         volumeMounts:
-        - mountPath: /run/peerpod/cri-runtime.sock # in-container default
+        - mountPath: /run/peerpod/cri-runtime.sock # in-container CRI_RUNTIME_ENDPOINT default
           name: cri-runtime-endpoint
       volumes:
       - name: cri-runtime-endpoint

--- a/install/overlays/vsphere/cri_runtime_endpoint.yaml
+++ b/install/overlays/vsphere/cri_runtime_endpoint.yaml
@@ -11,7 +11,7 @@ spec:
       containers:
       - name: cloud-api-adaptor-con
         volumeMounts:
-        - mountPath: /run/peerpod/cri-runtime.sock # in-container default
+        - mountPath: /run/peerpod/cri-runtime.sock # in-container CRI_RUNTIME_ENDPOINT default
           name: cri-runtime-endpoint
       volumes:
       - name: cri-runtime-endpoint


### PR DESCRIPTION
Setting CRI_RUNTIME_ENDPOINT defines only the in-container side socket path, the pre-defined default fixed address should work for both containerd and crio.

Fixes: #333
Signed-off-by: Snir Sheriber <ssheribe@redhat.com>