### PR TITLE
libvirt: add e2e demo code and documentation

### DIFF
--- a/libvirt/README.md
+++ b/libvirt/README.md
@@ -44,3 +44,286 @@ If you want to set default password for podvm debugging then you can use guestfi
 
 Refer to the [cloud-api-adaptor deployment instructions](../install/README.md#deploy-cloud-api-adaptor)
 * If your libvirt host is not configured to be passwordless make sure you set ssh-key-secret in the [kustomization file](../install/overlays/libvirt/kustomization.yaml)
+
+# Creating an end-to-end environment for testing and development
+
+In this section you will learn how to setup an environment in your local machine to run peer pods with
+the libvirt cloud API adaptor. Bear in mind that many different tools can be used to setup the environment
+and here we just make suggestions of tools that seems used by most of the peer pods developers.
+
+## Requirements
+
+You must have a Linux/KVM system with libvirt installed and the following tools:
+
+- docker (or podman-docker)
+- [kubectl](https://kubernetes.io/docs/reference/kubectl/)
+- [kcli](https://kcli.readthedocs.io/en/latest/)
+
+Assume that you have a 'default' network and storage pools created in libvirtd system instance (`qemu:///system`). However,
+if you have a different pool name then the scripts should be able to handle it properly.
+
+## Create the Kubernetes cluster
+
+Use the [`kcli_cluster.sh`](./kcli_cluster.sh) script to create a simple two VMs (one control plane and one worker) cluster
+with the kcli tool, as:
+
+```
+./kcli_cluster.sh create
+```
+
+With `kcli_cluster.sh` you can configure the libvirt network and storage pools that the cluster VMs will be created, among
+other parameters. Run `./kcli_cluster.sh -h` to see the help for further information.
+
+If everything goes well you will be able to see the cluster running after setting your Kubernetes config with:
+
+`export KUBECONFIG=$HOME/.kcli/clusters/peer-pods/auth/kubeconfig`
+
+For example, shown below:
+
+```
+$ kcli list kube
++-----------+---------+-----------+-----------------------------------------+
+|  Cluster  |   Type  |    Plan   |                  Vms                    |
++-----------+---------+-----------+-----------------------------------------+
+| peer-pods | generic | peer-pods | peer-pods-ctlplane-0,peer-pods-worker-0 |
++-----------+---------+-----------+-----------------------------------------+
+$ kubectl get nodes
+NAME                 STATUS   ROLES                  AGE     VERSION
+peer-pods-ctlplane-0 Ready    control-plane,master   6m8s    v1.25.3
+peer-pods-worker-0   Ready    worker                 2m47s   v1.25.3
+```
+
+## Prepare the Pod VM volume
+
+In order to build the Pod VM without installing the build tools, you can use the Dockerfiles hosted on [../podvm](../podvm) directory to run the entire process inside a container.
+
+To build a Ubuntu VM image, run:
+
+```
+$ cd ../podvm
+$ docker build --no-cache -t podvm_builder -f Dockerfile.podvm_builder .
+$ docker build --no-cache -t podvm_libvirt --build-arg BUILDER_IMG=podvm_builder:latest \
+	--build-arg CLOUD_PROVIDER=libvirt -f Dockerfile.podvm .
+```
+
+The qcow2 image file will be created inside the `podvm_libvirt` image and can be extracted as shown below:
+
+```
+$ podvm_container=$(docker create podvm_libvirt:latest /bin/bash)
+$ file_name=$(docker export ${podvm_container} | tar -t | grep podvm)
+$ docker cp ${podvm_container}:${file_name} podvm.qcow2
+$ docker rm ${podvm_container}
+```
+
+Next you will need to create a volume on libvirt's system storage and upload the image content. That volume is used by
+the cloud-api-adaptor program to instantiate a new Pod VM. Still on the `image` directory, you should run the following
+commands:
+
+```
+$ export IMAGE=<full-path-to-qcow2>
+
+$ virsh vol-create-as --pool default --name podvm-base.qcow2 --capacity 20G --allocation 2G --prealloc-metadata --format qcow2
+$ virsh vol-upload --vol podvm-base.qcow2 $IMAGE --pool default --sparse
+```
+
+You should see that the `podvm-base.qcow2` volume was properly created:
+
+```
+$ virsh -c qemu:///system vol-info --pool default podvm-base.qcow2
+Name:           podvm-base.qcow2
+Type:           file
+Capacity:       6.00 GiB
+Allocation:     631.52 MiB
+```
+
+## Install and configure Confidential Containers and cloud-api-adaptor in the cluster
+
+The easiest way to install the cloud-api-adaptor along with Confidential Containers in the cluster is through the
+Kubernetes operator available in the `install` directory of this repository.
+
+Start by creating a public/private RSA key pair that will be used by the cloud-api-provider program, running on the
+cluster workers, to connect with your local libvirtd instance without password authentication. Assume you are in the
+`libvirt` directory, do:
+
+```
+$ cd ../install/overlays/libvirt
+$ ssh-keygen -f ./id_rsa -N ""
+$ cat id_rsa.pub >> ~/.ssh/authorized_keys
+```
+**Note**: ensure that `~/.ssh/authorized_keys` has the right permissions (read/write for the user only) otherwise the
+authentication can silently fail. You can run `chmod 600 ~/.ssh/authorized_keys` to set the right permissions.
+
+You will need to figure out the IP address of your local host (e.g. 192.168.122.1). Then try to remote connect with
+libvirt to check the keys setup is fine, for example:
+
+```
+$ virsh -c "qemu+ssh://$USER@192.168.122.1/system?keyfile=$(pwd)/id_rsa" nodeinfo
+CPU model:           x86_64
+CPU(s):              12
+CPU frequency:       1084 MHz
+CPU socket(s):       1
+Core(s) per socket:  6
+Thread(s) per core:  2
+NUMA cell(s):        1
+Memory size:         32600636 KiB
+```
+
+Now you should finally install the Kubernetes operator in the cluster with the help of the [`install_operator.sh`](./install_operator.sh) script. Ensure that you have your IP address exported in the environment, as shown below, then run the install script:
+
+```
+$ cd ../../../libvirt/
+$ export LIBVIRT_IP="192.168.122.1"
+$ export SSH_KEY_FILE="id_rsa"
+$ ./install_operator.sh
+```
+
+If everything goes well you will be able to see the operator's controller manager and cloud-api-adaptor Pods running:
+
+```
+$ kubectl get pods -n confidential-containers-system
+NAME                                              READY   STATUS    RESTARTS   AGE
+cc-operator-controller-manager-5df7584679-5dbmr   2/2     Running   0          3m58s
+cloud-api-adaptor-daemonset-libvirt-vgj2s         1/1     Running   0          3m57s
+$ kubectl logs pod/cloud-api-adaptor-daemonset-libvirt-vgj2s -n confidential-containers-system
++ exec cloud-api-adaptor-libvirt libvirt -uri 'qemu+ssh://wmoschet@192.168.122.1/system?no_verify=1' -data-dir /opt/data-dir -pods-dir /run/peerpod/pods -network-name default -pool-name default -socket /run/peerpod/hypervisor.sock
+2022/11/09 18:18:00 [helper/hypervisor] hypervisor config {/run/peerpod/hypervisor.sock  k8s.gcr.io/pause:3.7 /run/peerpod/pods libvirt}
+2022/11/09 18:18:00 [helper/hypervisor] cloud config {qemu+ssh://wmoschet@192.168.122.1/system?no_verify=1 default default /opt/data-dir}
+2022/11/09 18:18:00 [helper/hypervisor] service config &{qemu+ssh://wmoschet@192.168.122.1/system?no_verify=1 default default /opt/data-dir}
+```
+
+You will also notice that Kubernetes [*runtimeClass*](https://kubernetes.io/docs/concepts/containers/runtime-class/) resources
+were created on the cluster, as for example:
+
+```
+$ kubectl get runtimeclass
+NAME        HANDLER     AGE
+kata        kata        7m41s
+kata-clh    kata-clh    7m41s
+kata-qemu   kata-qemu   7m41s
+```
+
+## Create a sample peer-pods pod
+
+At this point everything should be fine to get a sample Pod created. Let's first list the running VMs so that we can later check
+the Pod VM will be really running. Notice below that we got only the cluster node VMs up:
+
+```
+$ virsh -c qemu:///system list
+ Id   Name                   State
+------------------------------------
+ 3    peer-pods-ctlplane-0   running
+ 4    peer-pods-worker-0     running
+```
+
+Create the *sample_busybox.yaml* file with the following content:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: busybox
+  name: busybox
+spec:
+  containers:
+  - image: quay.io/prometheus/busybox
+    name: busybox
+    resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+  runtimeClassName: kata
+```
+
+And create the Pod:
+
+```
+$ kubectl apply -f sample_busybox.yaml
+pod/busybox created
+$ kubectl wait --for=condition=Ready pod/busybox
+pod/busybox condition met
+```
+
+Check that the Pod VM is up and running. See on the following listing that *podvm-busybox-88a70031* was
+created:
+
+```
+$ virsh -c qemu:///system list
+ Id   Name                     State
+----------------------------------------
+ 5    peer-pods-ctlplane-0     running
+ 6    peer-pods-worker-0       running
+ 7    podvm-busybox-88a70031   running
+```
+
+You should also check that the container is running fine. For example, compare the kernels are different as shown below:
+
+```
+$ uname -r
+5.17.12-100.fc34.x86_64
+$ kubectl exec pod/busybox -- uname -r
+5.4.0-131-generic
+```
+
+The peer-pods pod can be deleted as any regular pod. On the listing below the pod was removed and you can note that the
+Pod VM no longer exists on Libvirt:
+
+```
+$ kubectl delete -f sample_busybox.yaml
+pod "busybox" deleted
+$ virsh -c qemu:///system list
+ Id   Name                 State
+------------------------------------
+ 5    peer-pods-ctlplane-0 running
+ 6    peer-pods-worker-0   running
+```
+
+## Delete Confidential Containers and cloud-api-adaptor from the cluster
+
+You might want to reinstall the Confidential Containers and cloud-api-adaptor into your cluster. There are two options:
+
+1. Delete the Kubernetes cluster entirely and start over. In this case you should just run `./kcli_cluster.sh delete` to
+   wipe out the cluster created with kcli
+1. Uninstall the operator resources then install them again with the `install_operator.sh` script
+
+Let's show you how to delete the operator resources. On the listing below you can see the actual pods running on
+the *confidential-containers-system* namespace:
+
+```
+$ kubectl get pods -n confidential-containers-system
+NAME                                             READY   STATUS    RESTARTS   AGE
+cc-operator-controller-manager-fbb5dcf9d-h42nn   2/2     Running   0          20h
+cc-operator-daemon-install-fkkzz                 1/1     Running   0          20h
+cloud-api-adaptor-daemonset-libvirt-lxj7v        1/1     Running   0          20h
+```
+
+In order to remove the *\*-daemon-install-\** and *\*-cloud-api-adaptor-daemonset-\** pods, run the following command from the
+root directory:
+
+```
+$ CLOUD_PROVIDER=libvirt make delete
+```
+
+It can take some minutes to get those pods deleted, afterwards you will notice that only the *controller-manager* is
+still up. Below is shown how to delete that pod and associated resources as well:
+
+```
+$ kubectl get pods -n confidential-containers-system
+NAME                                             READY   STATUS    RESTARTS   AGE
+cc-operator-controller-manager-fbb5dcf9d-h42nn   2/2     Running   0          20h
+$ kubectl delete -f install/yamls/deploy.yaml
+namespace "confidential-containers-system" deleted
+serviceaccount "cc-operator-controller-manager" deleted
+role.rbac.authorization.k8s.io "cc-operator-leader-election-role" deleted
+clusterrole.rbac.authorization.k8s.io "cc-operator-manager-role" deleted
+clusterrole.rbac.authorization.k8s.io "cc-operator-metrics-reader" deleted
+clusterrole.rbac.authorization.k8s.io "cc-operator-proxy-role" deleted
+rolebinding.rbac.authorization.k8s.io "cc-operator-leader-election-rolebinding" deleted
+clusterrolebinding.rbac.authorization.k8s.io "cc-operator-manager-rolebinding" deleted
+clusterrolebinding.rbac.authorization.k8s.io "cc-operator-proxy-rolebinding" deleted
+configmap "cc-operator-manager-config" deleted
+service "cc-operator-controller-manager-metrics-service" deleted
+deployment.apps "cc-operator-controller-manager" deleted
+customresourcedefinition.apiextensions.k8s.io "ccruntimes.confidentialcontainers.org" deleted
+$ kubectl get pods -n confidential-containers-system
+No resources found in confidential-containers-system namespace.
+```

--- a/libvirt/install_operator.sh
+++ b/libvirt/install_operator.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+#
+# Copyright Confidential Containers Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install the CAA operator in a Kubernetes cluster.
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+LIBVIRT_IP="${LIBVIRT_IP:-}"
+LIBVIRT_USER="${LIBVIRT_USER:-$USER}"
+LIBVIRT_NET="${LIBVIRT_NET:-default}"
+LIBVIRT_POOL="${LIBVIRT_POOL:-default}"
+SSH_KEY_FILE="${SSH_KEY_FILE:-}"
+
+# Apply the 'node-role.kubernetes.io/worker' label on all worker nodes.
+#
+label_workers() {
+	local workers
+	local label='node-role.kubernetes.io/worker'
+
+	workers="$(kubectl get nodes --no-headers | grep '\<worker\>' | awk '{ print $1 }')"
+	for nodename in $workers; do
+		if ! kubectl get "node/${nodename}" -o jsonpath='{.metadata.labels}' | \
+			grep "$label" >/dev/null; then
+			kubectl label node "$nodename" "${label}="
+		fi
+	done
+}
+
+usage() {
+	cat <<-EOF
+	Install cloud-api-adaptor in the Kubernetes cluster.
+	You must have KUBECONFIG and LIBVIRT_IP exported in the environment.
+
+	Use: $0 [-h|help]
+
+	Use the following environment variables to change the installation
+	parameters:
+	LIBVIRT_IP    (required)
+	LIBVIRT_USER  (default "$LIBVIRT_USER")
+	LIBVIRT_NET   (default "$LIBVIRT_NET")
+	LIBVIRT_POOL  (default "$LIBVIRT_POOL")
+	SSH_KEY_FILE  (default "$SSH_KEY_FILE")
+	EOF
+}
+# Wait all pods on confidential containers namespace be ready.
+#
+wait_pods() {
+	local ns="confidential-containers-system"
+	local pods="$(kubectl get pods --no-headers -n "$ns" | \
+		awk '{ print $1 }')"
+	for pod in $pods; do
+		kubectl wait --for=condition=Ready --timeout 120s -n "$ns" "pod/${pod}"
+	done
+}
+
+main() {
+	# Parse arguments.
+	#
+	if [ -n "${1:-}" ]; then
+		case "$1" in
+			-h|help) usage && exit 0;;
+			*)
+				echo "Unknown command: $1"
+				usage && exit 1;;
+		esac
+	fi
+
+	local var
+	for var in KUBECONFIG LIBVIRT_IP; do
+		if eval "[ -z \${${var}:-} ]"; then
+			echo "ERROR: variable '$var' is not exported"
+			usage
+			exit 1
+		fi
+	done
+
+	label_workers
+
+	local kustomization_file="$script_dir/../install/overlays/libvirt/kustomization.yaml"
+	if [ ! -f "$kustomization_file" ]; then
+		echo "ERROR: kustomization file not found: $kustomization_file"
+		exit 1
+	fi
+
+	[ "$LIBVIRT_NET" == "default" ] || \
+		sed -i -e 's/\(\s\+-\sLIBVIRT_NET=\).*/\1"'"${LIBVIRT_NET}"'"/' \
+		"$kustomization_file"
+	[ "$LIBVIRT_POOL" == "default" ] || \
+		sed -i -e 's/\(\s\+-\sLIBVIRT_POOL=\).*/\1"'"${LIBVIRT_POOL}"'"/' \
+		"$kustomization_file"
+	[ "$SSH_KEY_FILE" == "default" ] || \
+		sed -i -e 's@\(\s\+\)#\?- id_rsa.*@\1- '"$SSH_KEY_FILE"'@' \
+		"$kustomization_file"
+
+	local libvirt_uri="qemu+ssh://${LIBVIRT_USER}@${LIBVIRT_IP}/system?no_verify=1"
+	sed -i -e 's#\(\s\+- LIBVIRT_URI=\).*#\1"'"${libvirt_uri}"'"#' \
+		"$kustomization_file"
+
+	# Finally install the operator
+	(cd "$script_dir/.." && make CLOUD_PROVIDER=libvirt deploy)
+
+	wait_pods
+}
+
+main "$@"

--- a/libvirt/kcli_cluster.sh
+++ b/libvirt/kcli_cluster.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+#
+# Copyright Confidential Containers Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Manage Kubernetes clusters with kcli.
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CLUSTER_DISK_SIZE="${CLUSTER_DISK_SIZE:-20}"
+CLUSTER_CONTROL_NODES="${CLUSTER_CONTROL_NODES:-1}"
+CLUSTER_NAME="${CLUSTER_NAME:-peer-pods}"
+CLUSTER_IMAGE="${CLUSTER_IMAGE:-ubuntu2004}"
+CLUSTER_WORKERS="${CLUSTER_WORKERS:-1}"
+LIBVIRT_NETWORK="${LIBVIRT_NETWORK:-default}"
+LIBVIRT_POOL="${LIBVIRT_POOL:-default}"
+
+# Wait until the command return true.
+#
+# Parameters:
+#   $1 - wait time.
+#   $2 - sleep time.
+#   $3 - the command to run.
+#
+wait_for_process() {
+	local wait_time="$1"
+	local sleep_time="$2"
+	local cmd="$3"
+
+	while ! eval "$cmd" && [ "$wait_time" -gt 0 ]; do
+		sleep "$sleep_time"
+		wait_time=$((wait_time-"$sleep_time"))
+	done
+
+	[ "$wait_time" -ge 0 ]
+}
+
+# Create the cluster.
+#
+create () {
+	kcli create kube generic \
+		-P domain="kata.com" \
+		-P pool="$LIBVIRT_POOL" \
+		-P ctlplanes="$CLUSTER_CONTROL_NODES" \
+		-P workers="$CLUSTER_WORKERS" \
+		-P network="$LIBVIRT_NETWORK" \
+		-P image="$CLUSTER_IMAGE" \
+		-P sdn=flannel \
+		-P nfs=false \
+		-P disk_size="$CLUSTER_DISK_SIZE" \
+		"$CLUSTER_NAME"
+
+	export KUBECONFIG=$HOME/.kcli/clusters/peer-pods/auth/kubeconfig
+
+	local cmd="kubectl get nodes | grep '\<Ready\>.*worker'"
+	echo "Wait at least one worker be Ready"
+	if ! wait_for_process "330" "30" "$cmd"; then
+		echo "ERROR: worker nodes not ready."
+		kubectl get nodes
+		exit 1
+	fi
+
+	# Ensure that system pods are running or completed.
+	cmd="[ \$(kubectl get pods -A --no-headers | grep -v 'Running\|Completed' | wc -l) -eq 0 ]"
+	echo "Wait system pods be running or completed"
+	if ! wait_for_process "90" "30" "$cmd"; then
+		echo "ERROR: not all pods are Running or Completed."
+		kubectl get pods -A
+		exit 1
+	fi
+}
+
+# Delete the cluster.
+#
+delete () {
+	kcli delete -y kube "${CLUSTER_NAME}"
+}
+
+usage () {
+	cat <<-EOF
+	Create/delete a Kubernetes cluster with kcli tool.
+
+	Use: $0 [-h|help] COMMAND
+	where COMMAND can be:
+	create    Create the cluster. Use the following environment variables
+	          to change the creation parameters:
+	          CLUSTER_DISK_SIZE       (default "${CLUSTER_DISK_SIZE}")
+	          CLUSTER_IMAGE           (default "${CLUSTER_IMAGE}")
+	          CLUSTER_CONTROL_NODES   (default "${CLUSTER_CONTROL_NODES}")
+	          CLUSTER_NAME            (default "${CLUSTER_NAME}")
+	          LIBVIRT_NETWORK         (default "${LIBVIRT_NETWORK}")
+	          LIBVIRT_POOL            (default "${LIBVIRT_POOL}")
+	          CLUSTER_WORKERS         (default "${CLUSTER_WORKERS}").
+	delete    Delete the cluster. Specify the cluster name with
+	          CLUSTER_NAME (default "${CLUSTER_NAME}").
+	EOF
+}
+
+main() {
+	if ! command -v kcli >/dev/null; then
+		echo "ERROR: kcli command is required. See https://kcli.readthedocs.io/en/latest/#installation"
+		exit 1
+	fi
+
+	# Parse arguments.
+	#
+	if [ "$#" -lt 1 ]; then
+		usage
+		exit 1
+	fi
+	case "$1" in
+		-h|help)
+			usage
+			exit 0;;
+		create) create;;
+		delete) delete;;
+		*)
+			echo "Unknown command: $1"
+			usage
+			exit 1;;
+	esac
+}
+
+main "$@"


### PR DESCRIPTION
In https://github.com/confidential-containers/cloud-api-adaptor/issues/16#issuecomment-1292524184 I drafted a framework that we could be using for running e2e tests on CI. To continue that work I want to create an implementation for libvirt because developers can run on their own workstation and this should allow others to test the framework.

But soon I realized the information to build an environment to develop for libvirt is spread in the repository or simply missing. Then I started fixing some stuffs and automating some steps. This pull request contain that work. Apart from using the changes I propose here on CI, I think it will be useful for developers setting up their environments for testing locally.