### PR TITLE
all: introduce common image directory

### DIFF
--- a/podvm/Makefile.inc
+++ b/podvm/Makefile.inc
@@ -1,0 +1,108 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# This file contains the common build steps across the providers
+# Including building the required binaries from source
+# It is to be included via `include ../../podvm/Makefile.inc` in
+# each of the cloud provider podvm image Makefiles
+
+UBUNTU_RELEASE     = focal
+SKOPEO_VERSION     = 1.5.0
+UMOCI_VERSION      = 0.4.7
+
+IMAGE_PREFIX := podvm
+
+ARCH := $(subst x86_64,amd64,$(shell uname -m))
+
+FILES_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))/files
+
+ifndef IMAGE_NAME
+COMMIT := $(shell	commit=$$(git describe --match '' --dirty --always) && \
+					if [ -n "$$(git ls-files --other --exclude-per-directory .gitignore "$(FILES_DIR)")" ]; then \
+						commit="$${commit%-dirty}-dirty"; \
+					fi && \
+	                echo "$$commit")
+ifndef COMMIT
+$(error Failed to derive an image name. Explicitly define IMAGE_NAME)
+endif
+IMAGE_NAME := $(IMAGE_PREFIX)-$(COMMIT)-$(ARCH)
+endif
+
+IMAGE_SUFFIX ?= ""
+IMAGE_FILE := $(IMAGE_NAME)$(IMAGE_SUFFIX)
+
+
+AGENT_PROTOCOL_FORWARDER = $(FILES_DIR)/usr/local/bin/agent-protocol-forwarder
+KATA_AGENT    = $(FILES_DIR)/usr/local/bin/kata-agent
+PAUSE         = $(FILES_DIR)/$(PAUSE_BUNDLE)/rootfs/pause
+SKOPEO    = $(FILES_DIR)/usr/bin/skopeo
+UMOCI     = $(FILES_DIR)/usr/local/bin/umoci
+
+BINARIES = $(AGENT_PROTOCOL_FORWARDER) $(KATA_AGENT) $(PAUSE)
+
+ifdef USE_SKOPEO
+BINARIES += $(SKOPEO) $(UMOCI)
+endif
+
+AGENT_PROTOCOL_FORWARDER_SRC = ../..
+
+KATA_AGENT_SRC = ../../../kata-containers/src/agent
+KATA_AGENT_BUILD_TYPE = release
+
+SKOPEO_SRC  = skopeo
+SKOPEO_REPO = https://github.com/containers/skopeo
+
+UMOCI_SRC   = umoci
+UMOCI_REPO  = https://github.com/opencontainers/umoci
+
+# Embed the pause container image
+# https://github.com/arronwy/kata-containers/commit/75b9f3fa3caaae62f49b4733f65cbab0cc87dbee
+PAUSE_SRC     = pause
+PAUSE_REPO    = docker://k8s.gcr.io/pause
+PAUSE_VERSION = 3.6
+PAUSE_BUNDLE  = pause_bundle
+
+# Static libseccomp is necessary for kata-agent
+# https://github.com/kata-containers/kata-containers/issues/5044#issuecomment-1239773921
+STATIC_LIBSECCOMP_BUILDER = ../../../kata-containers/ci/install_libseccomp.sh
+STATIC_LIBSECCOMP_DIR     = $(abspath staticlib)
+STATIC_LIBSECCOMP         = $(STATIC_LIBSECCOMP_DIR)/kata-libseccomp/lib/libseccomp.a
+
+$(AGENT_PROTOCOL_FORWARDER): force
+	cd "$(AGENT_PROTOCOL_FORWARDER_SRC)" && $(MAKE) agent-protocol-forwarder
+	install -D --compare "$(AGENT_PROTOCOL_FORWARDER_SRC)/agent-protocol-forwarder" "$@"
+
+$(KATA_AGENT): force $(STATIC_LIBSECCOMP)
+	cd "$(KATA_AGENT_SRC)/../libs" && $(MAKE) BUILD_TYPE=$(KATA_AGENT_BUILD_TYPE) LIBSECCOMP_LINK_TYPE=static LIBSECCOMP_LIB_PATH=$(dir $(STATIC_LIBSECCOMP))
+	cd "$(KATA_AGENT_SRC)" && $(MAKE) BUILD_TYPE=$(KATA_AGENT_BUILD_TYPE) LIBSECCOMP_LINK_TYPE=static LIBSECCOMP_LIB_PATH=$(dir $(STATIC_LIBSECCOMP))
+	install -D --compare "$(KATA_AGENT_SRC)/target/$(shell uname -m)-unknown-linux-$(if $(findstring s390x,$(shell uname -m)),gnu,musl)/$(KATA_AGENT_BUILD_TYPE)/$(@F)" "$@"
+
+$(STATIC_LIBSECCOMP):
+	$(STATIC_LIBSECCOMP_BUILDER) $(STATIC_LIBSECCOMP_DIR)/kata-libseccomp $(STATIC_LIBSECCOMP_DIR)/kata-gperf
+
+# Skoepo package packages are available in RHEL/CentOS 8 or later and Ubuntu 20.10 or later
+$(SKOPEO_SRC):
+	git clone -b "v$(SKOPEO_VERSION)" "$(SKOPEO_REPO)" "$(SKOPEO_SRC)"
+
+$(SKOPEO_SRC)/bin/skopeo: $(SKOPEO_SRC)
+	cd "$(SKOPEO_SRC)" && make bin/skopeo
+
+$(SKOPEO): $(SKOPEO_SRC)/bin/skopeo
+	install -D --compare "$(SKOPEO_SRC)/bin/skopeo" "$@"
+
+# The umoci release page only publishes amd64 binaries. https://github.com/opencontainers/umoci/releases
+$(UMOCI_SRC):
+	git clone -b "v$(UMOCI_VERSION)" "$(UMOCI_REPO)" "$(UMOCI_SRC)"
+
+$(UMOCI_SRC)/umoci: $(UMOCI_SRC)
+	cd "$(UMOCI_SRC)" && make
+
+$(UMOCI): $(UMOCI_SRC)/umoci
+	install -D --compare "$(UMOCI_SRC)/umoci" "$@"
+
+$(PAUSE_SRC): $(SKOPEO_SRC)/bin/skopeo
+	$(SKOPEO_SRC)/bin/skopeo --policy "$(FILES_DIR)/etc/containers/policy.json" copy "$(PAUSE_REPO):$(PAUSE_VERSION)" "oci:$(PAUSE_SRC):$(PAUSE_VERSION)"
+
+$(PAUSE): | $(PAUSE_SRC) $(UMOCI_SRC)/umoci
+	$(UMOCI_SRC)/umoci unpack --rootless --image "$(PAUSE_SRC):$(PAUSE_VERSION)" "${FILES_DIR}/$(PAUSE_BUNDLE)"

--- a/podvm/copy-files.sh
+++ b/podvm/copy-files.sh
@@ -1,0 +1,13 @@
+# copy-files.sh is used to copy required files into 
+# the correct location on the podvm image
+
+sudo mkdir -p /etc/containers
+sudo cp /tmp/files/etc/agent-config.toml /etc/agent-config.toml
+sudo cp -a /tmp/files/etc/containers/* /etc/containers/
+sudo cp -a /tmp/files/etc/systemd/* /etc/systemd/
+
+
+sudo mkdir -p /usr/local/bin
+sudo cp -a /tmp/files/usr/* /usr/
+
+sudo cp -a /tmp/files/pause_bundle /

--- a/podvm/files/etc/agent-config.toml
+++ b/podvm/files/etc/agent-config.toml
@@ -1,0 +1,44 @@
+# This disables signature verification which now defaults to true.
+# We should consider a better solution. See #331 for more info
+enable_signature_verification=false
+
+# When using the agent-config.toml the KATA_AGENT_SERVER_ADDR env var seems to be ignored, so set it here
+server_addr="unix:///run/kata-containers/agent.sock"
+
+# temp workaround for kata-containers/kata-containers#5590
+[endpoints]
+allowed = [
+"AddARPNeighborsRequest",
+"AddSwapRequest",
+"CloseStdinRequest",
+"CopyFileRequest",
+"CreateContainerRequest",
+"CreateSandboxRequest",
+"DestroySandboxRequest",
+"ExecProcessRequest",
+"GetMetricsRequest",
+"GetOOMEventRequest",
+"GuestDetailsRequest",
+"ListInterfacesRequest",
+"ListRoutesRequest",
+"MemHotplugByProbeRequest",
+"OnlineCPUMemRequest",
+"PauseContainerRequest",
+"PullImageRequest",
+"ReadStreamRequest",
+"RemoveContainerRequest",
+"ReseedRandomDevRequest",
+"ResumeContainerRequest",
+"SetGuestDateTimeRequest",
+"SignalProcessRequest",
+"StartContainerRequest",
+"StartTracingRequest",
+"StatsContainerRequest",
+"StopTracingRequest",
+"TtyWinResizeRequest",
+"UpdateContainerRequest",
+"UpdateInterfaceRequest",
+"UpdateRoutesRequest",
+"WaitProcessRequest",
+"WriteStreamRequest"
+]

--- a/podvm/files/etc/containers/policy.json
+++ b/podvm/files/etc/containers/policy.json
@@ -1,0 +1,3 @@
+{
+    "default": [{"type": "insecureAcceptAnything"}]
+}

--- a/podvm/files/etc/systemd/system/agent-protocol-forwarder.service
+++ b/podvm/files/etc/systemd/system/agent-protocol-forwarder.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Agent Protocol Forwarder
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/agent-protocol-forwarder -kata-agent-namespace /run/netns/podns -kata-agent-socket /run/kata-containers/agent.sock
+
+[Install]
+WantedBy=multi-user.target

--- a/podvm/files/etc/systemd/system/kata-agent.service
+++ b/podvm/files/etc/systemd/system/kata-agent.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Kata Agent
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/kata-agent --config /etc/agent-config.toml
+ExecStartPre=ip netns add podns
+ExecStartPre=ip netns exec podns ip link set lo up
+ExecStopPost=ip netns delete podns
+# Now specified in the agent-config.toml Environment="KATA_AGENT_SERVER_ADDR=unix:///run/kata-containers/agent.sock"
+SyslogIdentifier=kata-agent
+
+[Install]
+WantedBy=multi-user.target

--- a/podvm/files/etc/systemd/system/multi-user.target.wants/agent-protocol-forwarder.service
+++ b/podvm/files/etc/systemd/system/multi-user.target.wants/agent-protocol-forwarder.service
@@ -1,0 +1,1 @@
+../agent-protocol-forwarder.service

--- a/podvm/files/etc/systemd/system/multi-user.target.wants/kata-agent.service
+++ b/podvm/files/etc/systemd/system/multi-user.target.wants/kata-agent.service
@@ -1,0 +1,1 @@
+../kata-agent.service

--- a/podvm/files/etc/systemd/system/multi-user.target.wants/run-image.mount
+++ b/podvm/files/etc/systemd/system/multi-user.target.wants/run-image.mount
@@ -1,0 +1,1 @@
+../run-image.mount

--- a/podvm/files/etc/systemd/system/multi-user.target.wants/run-kata\x2dcontainers.mount
+++ b/podvm/files/etc/systemd/system/multi-user.target.wants/run-kata\x2dcontainers.mount
@@ -1,0 +1,1 @@
+../run-kata\x2dcontainers.mount

--- a/podvm/files/etc/systemd/system/run-image.mount
+++ b/podvm/files/etc/systemd/system/run-image.mount
@@ -1,0 +1,12 @@
+[Unit]
+Description=Mount unit for /run/image
+Before=kata-agent.service
+
+[Mount]
+What=/image
+Where=/run/image
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/podvm/files/etc/systemd/system/run-kata\x2dcontainers.mount
+++ b/podvm/files/etc/systemd/system/run-kata\x2dcontainers.mount
@@ -1,0 +1,12 @@
+[Unit]
+Description=Mount unit for /run/kata-containers
+Before=kata-agent.service
+
+[Mount]
+What=/kata-containers
+Where=/run/kata-containers
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- Adds Makefile which has the common code between providers
- Common files, copy-files.sh, services, etc

Each providers Makefile will be a child of their provider `aws/Makefile` vs `aws/image/Makefile`
Therefore I have updated the relative paths for this

Each provider can implement their own targets as there is variation (build, push, etc)

Fixes #314
Signed-off-by: James Tumber <james.tumber@ibm.com>