### PR TITLE
Use ssh-copy-id -f if the OS is MacOS (Darwin)

### DIFF
--- a/ibmcloud/terraform/cluster/scripts/keygen.sh
+++ b/ibmcloud/terraform/cluster/scripts/keygen.sh
@@ -68,7 +68,9 @@ for host in "${hosts[@]}"; do
         trap stop 0
 
         ssh "${opts[@]}" -o ExitOnForwardFailure=yes -S "$ssh_ctl_sock" -L "$port:$host:22" -M -f -N -l root "$bastion"
-        ssh-copy-id "${opts[@]}" -i "$key.pub" -p "$port" root@localhost
+        [[ $(uname) = "Darwin" ]] && force_option="-f"
+        ssh-copy-id ${force_option:-} "${opts[@]}" -i "$key.pub" -p "$port" root@localhost
+        
         ssh-keygen -R "[localhost]:$port" -f "$ssh_known_hosts"
     )
 done


### PR DESCRIPTION
When running on MacOS `ssh-copy-id` without the force (`-f`) flag fails to set up the SSH keys on the k8s worker and k8s control plane node correctly, resulting in this warning:

```
module.cluster.null_resource.ansible (local-exec): /usr/bin/ssh-copy-id: WARNING: All keys were skipped because they already exist on the remote system.
module.cluster.null_resource.ansible (local-exec): 		(if you think this is a mistake, you may want to use -f option)

module.cluster.null_resource.ansible (local-exec): # Host [localhost]:22022 found: line 2
module.cluster.null_resource.ansible (local-exec): /var/folders/tq/4s_zl3fx5xq4vf7ts_bd1q3w0000gn/T/tmp.AVcdIjrx/known_hosts updated.
module.cluster.null_resource.ansible (local-exec): Original contents retained as /var/folders/tq/4s_zl3fx5xq4vf7ts_bd1q3w0000gn/T/tmp.AVcdIjrx/known_hosts.old
module.cluster.null_resource.ansible (local-exec): Exit request sent.
module.cluster.null_resource.ansible (local-exec): /usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/var/folders/tq/4s_zl3fx5xq4vf7ts_bd1q3w0000gn/T/tmp.AVcdIjrx/id_ed25519.pub"
module.cluster.null_resource.ansible (local-exec): /usr/bin/ssh-copy-id: INFO: attempting to log in with the new key(s), to filter out any that are already installed

module.cluster.null_resource.ansible (local-exec): /usr/bin/ssh-copy-id: WARNING: All keys were skipped because they already exist on the remote system.
module.cluster.null_resource.ansible (local-exec): 		(if you think this is a mistake, you may want to use -f option)
```

and eventually this error later on in running the Ansible playbook:

```
│ kubeadm join 10.242.0.4:6443 --token p9... \
│ 	--discovery-token-ca-cert-hash sha256:b6f0602de63a26a223b33338b1a55beede1fca427b115b93e0771efd7406cef3 
│ namespace/kube-flannel created
│ clusterrole.rbac.authorization.k8s.io/flannel created
│ clusterrolebinding.rbac.authorization.k8s.io/flannel created
│ serviceaccount/flannel created
│ configmap/kube-flannel-cfg created
│ daemonset.apps/kube-flannel-ds created
│ Warning: Permanently added '161.156.200.76' (ED25519) to the list of known hosts.
│ Warning: Permanently added '10.242.0.5' (ED25519) to the list of known hosts.
│ + true
│ Warning: Permanently added '10.242.0.4' (ECDSA) to the list of known hosts.
│ root@10.242.0.4: Permission denied (publickey).
│ tar: This does not look like a tar archive
│ tar: Exiting with failure status due to previous errors
│ failed to load admin kubeconfig: open /root/.kube/config: no such file or directory
│ To see the stack trace of this error execute with --v=5 or higher
│ bash: line 3: --cri-socket: command not found
```

MacOS tested on:

```
uname -a
Darwin <redacted> 21.6.0 Darwin Kernel Version 21.6.0: Mon Aug 22 20:19:52 PDT 2022; root:xnu-8020.140.49~2/RELEASE_ARM64_T6000 arm64
```

Signed-off-by: Matthew Arnold <mattarno@uk.ibm.com>