### PR TITLE
azure: remove manual route creation

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -51,46 +51,7 @@ PEER_POD_NAME="OUTPUT_FROM_ABOVE"
 
 # Running cloud-api-adaptor
 
-You need to create a routing table and add that table to your VNET subnet.
-
-- Find your private IP of the k8s host
-
-```bash
-PRIVATE_IP=$(az vm list-ip-addresses --resource-group "${RESOURCE_GROUP}" --name "${VM_NAME}" --query '[0].virtualMachine.network.privateIpAddresses[0]' -o tsv)
-```
-
-- Find CIDR on the k8s host
-
-```bash
-kubectl get -o jsonpath='{.items[0].spec.cidr}' blockaffinities && echo
-```
-
-- Create routing table and route
-
-```bash
-export CIDR="REPLACE_ME" # From the output above
-
-ROUTE_TABLE="calico-routes"
-
-az network route-table create -g "${RESOURCE_GROUP}" -n "${ROUTE_TABLE}"
-
-az network route-table route create -g "${RESOURCE_GROUP}" \
-  --route-table-name "${ROUTE_TABLE}" \
-  -n master-route \
-  --next-hop-type VirtualAppliance \
-  --address-prefix "${CIDR}" \
-  --next-hop-ip-address "${PRIVATE_IP}"
-```
-
-- Update VNET's subnet with the routing table
-
-```bash
-az network vnet subnet update -g "${RESOURCE_GROUP}" \
-  -n "${VM_NAME}"Subnet \
-  --vnet-name "${VM_NAME}"VNET \
-  --network-security-group "${VM_NAME}"NSG \
-  --route-table "${route_table_name}"
-```
+- If using Calico CNI, [configure](https://projectcalico.docs.tigera.io/networking/vxlan-ipip#configure-vxlan-encapsulation-for-all-inter-workload-traffic) VXLAN encapsulation for all inter workload traffic.
 
 - Create Service Principal for the CAA
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,6 +47,7 @@ exec cloud-api-adaptor-azure azure \
   -region "${AZURE_REGION}" \
   -instance-size "${AZURE_INSTANCE_SIZE}" \
   -resourcegroup "${AZURE_RESOURCE_GROUP}" \
+  -vxlan-port 8472 \
   -subnetid "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP}/providers/Microsoft.Network/virtualNetworks/${AZURE_VM_NAME}VNET/subnets/${AZURE_VM_NAME}Subnet" \
   -securitygroupid "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP}/providers/Microsoft.Network/networkSecurityGroups/${AZURE_VM_NAME}NSG" \
   -imageid "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP}/providers/Microsoft.Compute/images/${AZURE_IMAGE}" \


### PR DESCRIPTION
When using Calico CNI, it was unexpectedly dropping VXLAN packets unrelated to calico. To avoid manual route creation one has to configure VXLAN encapsulation on calico and a new VXLAN UDP port is used rather than the default one.

Fixes: #359
Signed-off-by: Kautilya Tripathi <ktripathi@microsoft.com>