### PR TITLE
WIP: tests/e2e: Introduce a e2e framework for testing

### DIFF
--- a/libvirt/README.md
+++ b/libvirt/README.md
@@ -58,3 +58,229 @@ mkdir -p /opt/data-dir
 
 ```
 
+# Creating an end-to-end environment for testing and development
+
+In this section you will learn how to setup an environment in your local machine to run peer pods with
+the libvirt cloud API adaptor. Bear in mind that many different tools can be used to setup the environment
+and here we just make suggestions of tools that seems used by most of the peer pods developers.
+
+## Requirements
+
+You must have a Linux/KVM system with libvirt installed and the following tools:
+
+- docker (or podman-docker)
+- [kubectl](https://kubernetes.io/docs/reference/kubectl/)
+- [kcli](https://kcli.readthedocs.io/en/latest/)
+
+Assume that you have a 'default' network and storage pools created in libvirtd system instance (`qemu:///system`). However,
+if you have a different pool name then the scripts should be able to handle it properly.
+
+## Create the Kubernetes cluster
+
+Use the [`kcli_cluster.sh`](./kcli_cluster.sh) script to create a simple two VMs (one master and one worker) cluster
+with the kcli tool, as:
+
+```
+./kcli_cluster.sh create
+```
+
+With `kcli_cluster.sh` you can configure the libvirt network and storage pools that the cluster VMs will be created, among
+other parameters. Run `./kcli_cluster.sh -h` to see the help for further information.
+
+If everything goes well you will be able to see the cluster running after setting your Kubernetes config with:
+
+`export KUBECONFIG=$HOME/.kcli/clusters/peer-pods/auth/kubeconfig`
+
+For example, shown below:
+
+```
+$ kcli list kube
++-----------+---------+-----------+---------------------------------------+
+|  Cluster  |   Type  |    Plan   |                  Vms                  |
++-----------+---------+-----------+---------------------------------------+
+| peer-pods | generic | peer-pods | peer-pods-master-0,peer-pods-worker-0 |
++-----------+---------+-----------+---------------------------------------+
+$ kubectl get nodes
+NAME                 STATUS   ROLES                  AGE     VERSION
+peer-pods-master-0   Ready    control-plane,master   6m8s    v1.25.3
+peer-pods-worker-0   Ready    worker                 2m47s   v1.25.3
+```
+
+## Prepare the Pod VM volume
+
+In order to build the Pod VM without installing the build tools, you should use the `docker-build` Makefile target that will
+run the entire process inside a container.
+
+Ensure that the Kata Containers repository is cloned side-by-side with the cloud-api-provider's, as both repositories will be
+mounted as volumes in the container environment. Refer to [docs/DEVELOPMENT.md](/docs/DEVELOPMENT.md) for further
+information about setup of the sources.
+
+Then run:
+
+```
+$ cd image
+$ make docker-build
+```
+
+The qcow2 image file will be created at the `output` directory as shown below:
+
+```
+$ ls output/
+podvm-7da706d-dirty-amd64.qcow2
+```
+
+Next you will need to create a volume on libvirt's system storage and upload the image content. That volume is used by
+the cloud-api-adaptor program to instantiate a new Pod VM. Still on the `image` directory, you should run `make push` just
+like below:
+
+```
+$ make push
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100  5394  100  5394    0     0   6421      0 --:--:-- --:--:-- --:--:--  6421
+virsh -c qemu:///system vol-create-as --pool default --name podvm-base.qcow2 \
+	--capacity 107374182400 --allocation 2361393152 --prealloc-metadata \
+	--format qcow2
+Vol podvm-base.qcow2 created
+
+virsh -c qemu:///system vol-upload --vol podvm-base.qcow2 output/podvm-7da706d-dirty-amd64.qcow2 \
+	--pool default --sparse
+```
+
+You should see that the `podvm-base.qcow2` volume was proper created:
+
+```
+$ virsh -c qemu:///system vol-info --pool default podvm-base.qcow2
+Name:           podvm-base.qcow2
+Type:           file
+Capacity:       6.00 GiB
+Allocation:     631.52 MiB
+```
+
+## Install and configure Confidential Containers and cloud-api-adaptor in the cluster
+
+The easiest way to install the cloud-api-adaptor along with Confidential Containers in the cluster is through the
+Kubernetes operator available in the `install` directory of this repository.
+
+Start by creating a public/private RSA key pair that will be used by the cloud-api-provider program, running on the
+cluster workers, to connect with your local libvirtd instance without password authentication. Assume you are in the
+`libvirt` directory, do:
+
+```
+$ cd ../install/overlays/libvirt
+$ ssh-keygen -f ./id_rsa -N ""
+$ cat id_rsa.pub >> ~/.ssh/authorized_keys
+```
+**Note**: ensure that `~/.ssh/authorized_keys` has the right permissions (read/write for the user only) otherwise the
+authentication can silently fail.
+
+You will need to figure out the IP address of your local host (e.g. 192.168.1.107). Then try to remote connect with
+libvirt to check the keys setup is fine, for example:
+
+```
+$ virsh -c "qemu+ssh://$USER@192.168.1.107/system?keyfile=$(pwd)/id_rsa" nodeinfo
+CPU model:           x86_64
+CPU(s):              12
+CPU frequency:       1084 MHz
+CPU socket(s):       1
+Core(s) per socket:  6
+Thread(s) per core:  2
+NUMA cell(s):        1
+Memory size:         32600636 KiB
+```
+
+Now you should finally install the Kubernetes operator in the cluster with the help of the [`install_operator.sh`](./install_operator.sh) script. Ensure that you have your IP address exported in the environment, as shown below, then run the install script:
+
+```
+$ cd ../../../libvirt/
+$ export LIBVIRT_IP="192.168.1.107"
+$ export SSH_KEY_FILE="id_rsa"
+$ ./install_operator.sh
+```
+
+If everything goes well you will be able to see the operator's controller manager and cloud-api-adaptor Pods running:
+
+```
+$ kubectl get pods -n confidential-containers-system
+NAME                                              READY   STATUS    RESTARTS   AGE
+cc-operator-controller-manager-5df7584679-5dbmr   2/2     Running   0          3m58s
+cloud-api-adaptor-daemonset-libvirt-vgj2s         1/1     Running   0          3m57s
+$ kubectl logs pod/cloud-api-adaptor-daemonset-libvirt-vgj2s -n confidential-containers-system
++ exec cloud-api-adaptor-libvirt libvirt -uri 'qemu+ssh://wmoschet@192.168.1.107/system?no_verify=1' -data-dir /opt/data-dir -pods-dir /run/peerpod/pods -network-name default -pool-name default -socket /run/peerpod/hypervisor.sock
+2022/11/09 18:18:00 [helper/hypervisor] hypervisor config {/run/peerpod/hypervisor.sock  k8s.gcr.io/pause:3.7 /run/peerpod/pods libvirt}
+2022/11/09 18:18:00 [helper/hypervisor] cloud config {qemu+ssh://wmoschet@192.168.1.107/system?no_verify=1 default default /opt/data-dir}
+2022/11/09 18:18:00 [helper/hypervisor] service config &{qemu+ssh://wmoschet@192.168.1.107/system?no_verify=1 default default /opt/data-dir}
+```
+
+You will also notice that Kubernetes [*runtimeClass*](https://kubernetes.io/docs/concepts/containers/runtime-class/) resources
+were created on the cluster, as for example:
+
+```
+$ kubectl get runtimeclass
+NAME        HANDLER     AGE
+kata        kata        7m41s
+kata-clh    kata-clh    7m41s
+kata-qemu   kata-qemu   7m41s
+```
+
+## Create a sample peer-pods pod
+
+At this point everything should be fine to get a sample Pod created. Let's first list the running VMs so that we can later check
+the Pod VM will be really running. Notice below that we got only the cluster node VMs up:
+
+```
+$ virsh -c qemu:///system list
+ Id   Name                 State
+------------------------------------
+ 3    peer-pods-master-0   running
+ 4    peer-pods-worker-0   running
+```
+
+Create the *sample_busybox.yaml* file with the following content:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: busybox
+  name: busybox
+spec:
+  containers:
+  - image: quay.io/prometheus/busybox
+    name: busybox
+    resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+  runtimeClassName: kata
+```
+
+And create the Pod:
+
+```
+$ kubectl apply -f sample_busybox.yaml
+pod/busybox created
+$ kubectl wait --for=condition=Ready pod/busybox
+pod/busybox condition met
+```
+
+Check that the Pod VM is up and running. See on the following listing that *podvm-busybox-88a70031* was
+created:
+
+```
+$ virsh -c qemu:///system list
+ Id   Name                     State
+----------------------------------------
+ 5    peer-pods-master-0       running
+ 6    peer-pods-worker-0       running
+ 7    podvm-busybox-88a70031   running
+```
+
+You should also check that the container is running fine. For example, compare the kernels are different as shown below:
+
+```
+$ uname -r
+5.17.12-100.fc34.x86_64
+$ kubectl exec pod/busybox -- uname -r
+5.4.0-131-generic
+```

--- a/libvirt/image/Dockerfile_ubuntu.podvm_builder
+++ b/libvirt/image/Dockerfile_ubuntu.podvm_builder
@@ -1,0 +1,37 @@
+# Copyright Confidential Containers Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Creates a builder container image that should be used to build the Pod VM
+# disk inside a container.
+#
+FROM ubuntu:20.04
+
+ARG GO_VERSION="1.18.7"
+ARG PROTOC_VERSION="3.11.4"
+ARG RUST_VERSION="1.62.0"
+
+ENV CAA_SRC_DIR /src/cloud-api-adaptor
+ENV DEBIAN_FRONTEND noninteractive
+ENV GOPATH /src
+ENV PATH /usr/local/go/bin:$PATH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+WORKDIR ${CAA_SRC_DIR}/libvirt/image
+
+RUN apt-get update -y && \
+    apt-get install -y build-essential cloud-image-utils curl git gnupg \
+        libdevmapper-dev libgpgme-dev lsb-release pkg-config qemu-kvm \
+        musl-tools unzip wget && \
+    curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
+    echo "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee -a /etc/apt/sources.list && \
+    apt-get update && apt-get install -y packer && \
+    curl https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz -o go${GO_VERSION}.linux-amd64.tar.gz && \
+    rm -rf /usr/local/go && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
+    rm -f go${GO_VERSION}.linux-amd64.tar.gz && \
+    curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "${RUST_VERSION}" && source "$HOME/.cargo/env" && \
+    rustup target add x86_64-unknown-linux-musl && ln -sf /usr/bin/g++ /bin/musl-g++ && \
+    wget https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip && \
+    unzip protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local && rm -f protoc-${PROTOC_VERSION}-linux-x86_64.zip && \
+    git config --global --add safe.directory ${CAA_SRC_DIR}

--- a/libvirt/image/Makefile
+++ b/libvirt/image/Makefile
@@ -8,6 +8,8 @@ UBUNTU_RELEASE     = focal
 SKOPEO_VERSION     = 1.5.0
 UMOCI_VERSION      = 0.4.7
 
+PROJECT_DIR        = $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/../../)
+
 IMAGE_PREFIX := podvm
 ARCH := $(subst x86_64,amd64,$(shell uname -m))
 
@@ -120,6 +122,19 @@ $(PAUSE_SRC): $(SKOPEO_SRC)/bin/skopeo
 $(PAUSE): | $(PAUSE_SRC) $(UMOCI_SRC)/umoci
 	$(UMOCI_SRC)/umoci unpack --rootless --image "$(PAUSE_SRC):$(PAUSE_VERSION)" "${FILES_DIR}/$(PAUSE_BUNDLE)"
 
+docker-build:
+	docker build -t caa-libvirt-ubuntu-podvm-builder \
+	-f Dockerfile_ubuntu.podvm_builder .
+	docker run --rm \
+		-v $(PROJECT_DIR):/src/cloud-api-adaptor \
+		-v $(abspath $(PROJECT_DIR)/../kata-containers):/src/kata-containers \
+		-e UID=$(shell id -u) \
+		-e GID=$(shell id -g) \
+		caa-libvirt-ubuntu-podvm-builder \
+		bash -c 'trap "chown -R -f "$$UID:$$GID" output staticlib $(SKOPEO_SRC) \
+		$(UMOCI_SRC) $(PAUSE_SRC) $(FILES_DIR)/$(PAUSE_BUNDLE) $(FILES_DIR)/usr \
+		../../agent-protocol-forwarder || true" EXIT; \
+		source ~/.cargo/env && CLOUD_PROVIDER=libvirt make build'
 clean:
 	rm -f "$(IMAGE_FILE)" "$(UBUNTU_IMAGE_FILE)" $(BINARIES)
 	rm -fr "$(SKOPEO_SRC)" "$(UMOCI_SRC)" "$(PAUSE_SRC)" "$(FILES_DIR)/$(PAUSE_BUNDLE)"

--- a/libvirt/image/Makefile
+++ b/libvirt/image/Makefile
@@ -70,6 +70,9 @@ STATIC_LIB_BUILDER = ../../../kata-containers/ci/install_libseccomp.sh
 STATIC_LIB_DIR     = $(abspath staticlib)
 STATIC_LIB         = $(STATIC_LIB_DIR)/kata-libseccomp/lib/libseccomp.a
 
+LIBVIRT_POOL     := default
+LIBVIRT_VOL_NAME := podvm-base.qcow2
+
 build: $(IMAGE_FILE)
 
 $(IMAGE_FILE): $(BINARIES) $(FILES)
@@ -141,3 +144,17 @@ clean:
 
 .PHONY: force
 force:
+
+.PHONY: push
+push:
+	@ if ! virsh -c qemu:///system vol-list --pool "$(LIBVIRT_POOL)" | \
+		grep -q "$(LIBVIRT_VOL_NAME)"; then \
+		virsh -c qemu:///system vol-create-as \
+			--pool $(LIBVIRT_POOL) \
+			--name "$(LIBVIRT_VOL_NAME)" \
+			--capacity 20G --allocation 2G --prealloc-metadata \
+			--format qcow2; \
+	fi
+	virsh -c qemu:///system vol-upload \
+		--vol podvm-base.qcow2 output/$(IMAGE_FILE) \
+		--pool $(LIBVIRT_POOL) --sparse

--- a/libvirt/install_operator.sh
+++ b/libvirt/install_operator.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+#
+# Copyright Confidential Containers Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install the CAA operator in a Kubernetes cluster.
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+LIBVIRT_IP="${LIBVIRT_IP:-}"
+LIBVIRT_USER="${LIBVIRT_USER:-$USER}"
+LIBVIRT_NET="${LIBVIRT_NET:-default}"
+LIBVIRT_POOL="${LIBVIRT_POOL:-default}"
+SSH_KEY_FILE="${SSH_KEY_FILE:-}"
+
+# Apply the 'node-role.kubernetes.io/worker' label on all worker nodes.
+#
+label_workers() {
+	local workers
+	local label='node-role.kubernetes.io/worker'
+
+	workers="$(kubectl get nodes --no-headers | grep '\<worker\>' | awk '{ print $1 }')"
+	for nodename in $workers; do
+		if ! kubectl get "node/${nodename}" -o jsonpath='{.metadata.labels}' | \
+			grep "$label" >/dev/null; then
+			kubectl label node "$nodename" "${label}="
+		fi
+	done
+}
+
+usage() {
+	cat <<-EOF
+	Install cloud-api-adaptor in the Kubernetes cluster.
+	You must have KUBECONFIG and LIBVIRT_IP exported in the environment.
+
+	Use: $0 [-h|help]
+
+	Use the following environment variables to change the installation
+	parameters:
+	LIBVIRT_IP    (required)
+	LIBVIRT_USER  (default "$LIBVIRT_USER")
+	LIBVIRT_NET   (default "$LIBVIRT_NET")
+	LIBVIRT_POOL  (default "$LIBVIRT_POOL")
+	SSH_KEY_FILE  (default "$SSH_KEY_FILE")
+	EOF
+}
+# Wait all pods on confidential containers namespace be ready.
+#
+wait_pods() {
+	local ns="confidential-containers-system"
+	local pods="$(kubectl get pods --no-headers -n "$ns" | \
+		awk '{ print $1 }')"
+	for pod in $pods; do
+		kubectl wait --for=condition=Ready --timeout 120s -n "$ns" "pod/${pod}"
+	done
+}
+
+main() {
+	# Parse arguments.
+	#
+	if [ -n "${1:-}" ]; then
+		case "$1" in
+			-h|help) usage && exit 0;;
+			*)
+				echo "Unknown command: $1"
+				usage && exit 1;;
+		esac
+	fi
+
+	local var
+	for var in KUBECONFIG LIBVIRT_IP; do
+		if eval "[ -z \${${var}:-} ]"; then
+			echo "ERROR: variable '$var' is not exported"
+			usage
+			exit 1
+		fi
+	done
+
+	label_workers
+
+	local kustomization_file="$script_dir/../install/overlays/libvirt/kustomization.yaml"
+	if [ ! -f "$kustomization_file" ]; then
+		echo "ERROR: kustomization file not found: $kustomization_file"
+		exit 1
+	fi
+
+	[ "$LIBVIRT_NET" == "default" ] || \
+		sed -i -e 's/\(\s\+-\sLIBVIRT_NET=\).*/\1"'"${LIBVIRT_NET}"'"/' \
+		"$kustomization_file"
+	[ "$LIBVIRT_POOL" == "default" ] || \
+		sed -i -e 's/\(\s\+-\sLIBVIRT_POOL=\).*/\1"'"${LIBVIRT_POOL}"'"/' \
+		"$kustomization_file"
+	[ "$SSH_KEY_FILE" == "default" ] || \
+		sed -i -e 's@\(\s\+\)#\?- id_rsa.*@\1- '"$SSH_KEY_FILE"'@' \
+		"$kustomization_file"
+
+	local libvirt_uri="qemu+ssh://${LIBVIRT_USER}@${LIBVIRT_IP}/system?no_verify=1"
+	sed -i -e 's#\(\s\+- LIBVIRT_URI=\).*#\1"'"${libvirt_uri}"'"#' \
+		"$kustomization_file"
+
+	# Finally install the operator
+	(cd "$script_dir/.." && make CLOUD_PROVIDER=libvirt deploy)
+
+	wait_pods
+}
+
+main "$@"

--- a/libvirt/kcli_cluster.sh
+++ b/libvirt/kcli_cluster.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+#
+# Copyright Confidential Containers Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Manage Kubernetes clusters with kcli.
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CLUSTER_DISK_SIZE="${CLUSTER_DISK_SIZE:-20}"
+CLUSTER_MASTERS="${CLUSTER_MASTERS:-1}"
+CLUSTER_NAME="${CLUSTER_NAME:-peer-pods}"
+CLUSTER_IMAGE="${CLUSTER_IMAGE:-ubuntu2004}"
+CLUSTER_WORKERS="${CLUSTER_WORKERS:-1}"
+LIBVIRT_NETWORK="${LIBVIRT_NETWORK:-default}"
+LIBVIRT_POOL="${LIBVIRT_POOL:-default}"
+
+# Wait until the command return true.
+#
+# Parameters:
+#   $1 - wait time.
+#   $2 - sleep time.
+#   $3 - the command to run.
+#
+wait_for_process() {
+	local wait_time="$1"
+	local sleep_time="$2"
+	local cmd="$3"
+
+	while ! eval "$cmd" && [ "$wait_time" -gt 0 ]; do
+		sleep "$sleep_time"
+		wait_time=$((wait_time-"$sleep_time"))
+	done
+
+	[ "$wait_time" -ge 0 ]
+}
+
+# Create the cluster.
+#
+create () {
+	kcli create kube generic \
+		-P domain="kata.com" \
+		-P pool="$LIBVIRT_POOL" \
+		-P masters="$CLUSTER_MASTERS" \
+		-P workers="$CLUSTER_WORKERS" \
+		-P network="$LIBVIRT_NETWORK" \
+		-P image="$CLUSTER_IMAGE" \
+		-P sdn=flannel \
+		-P nfs=false \
+		-P disk_size="$CLUSTER_DISK_SIZE" \
+		"$CLUSTER_NAME"
+
+	export KUBECONFIG=$HOME/.kcli/clusters/peer-pods/auth/kubeconfig
+
+	local cmd="kubectl get nodes | grep '\<Ready\>.*worker'"
+	echo "Wait at least one worker be Ready"
+	if ! wait_for_process "330" "30" "$cmd"; then
+		echo "ERROR: worker nodes not ready."
+		kubectl get nodes
+		exit 1
+	fi
+
+	# Ensure that system pods are running or completed.
+	cmd="[ \$(kubectl get pods -A --no-headers | grep -v 'Running\|Completed' | wc -l) -eq 0 ]"
+	echo "Wait system pods be running or completed"
+	if ! wait_for_process "90" "30" "$cmd"; then
+		echo "ERROR: not all pods are Running or Completed."
+		kubectl get pods -A
+		exit 1
+	fi
+}
+
+# Delete the cluster.
+#
+delete () {
+	kcli delete -y kube "${CLUSTER_NAME}"
+}
+
+usage () {
+	cat <<-EOF
+	Create/delete a Kubernetes cluster with kcli tool.
+
+	Use: $0 [-h|help] COMMAND
+	where COMMAND can be:
+	create    Create the cluster. Use the following environment variables
+	          to change the creation parameters:
+	          CLUSTER_DISK_SIZE (default "${CLUSTER_DISK_SIZE}")
+	          CLUSTER_IMAGE     (default "${CLUSTER_IMAGE}")
+	          CLUSTER_MASTERS   (default "${CLUSTER_MASTERS}")
+	          CLUSTER_NAME      (default "${CLUSTER_NAME}")
+	          LIBVIRT_NETWORK   (default "${LIBVIRT_NETWORK}")
+	          LIBVIRT_POOL      (default "${LIBVIRT_POOL}")
+	          CLUSTER_WORKERS   (default "${CLUSTER_WORKERS}").
+	delete    Delete the cluster. Specify the cluster name with
+	          CLUSTER_NAME (default "${CLUSTER_NAME}").
+	EOF
+}
+
+main() {
+	if ! command -v kcli >/dev/null; then
+		echo "ERROR: kcli command is required. See https://kcli.readthedocs.io/en/latest/#installation"
+		exit 1
+	fi
+
+	# Parse arguments.
+	#
+	if [ "$#" -lt 1 ]; then
+		usage
+		exit 1
+	fi
+	case "$1" in
+		-h|help)
+			usage
+			exit 0;;
+		create) create;;
+		delete) delete;;
+		*)
+			echo "Unknown command: $1"
+			usage
+			exit 1;;
+	esac
+}
+
+main "$@"

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,54 @@
+# Running end-to-end tests
+
+This directory contain the framework to run complete end-to-end (e2e) tests, i.e., since the build
+of software to its installation on provisioned cloud resources and until effectively run tests.
+
+As long as the cloud provider has implemented support on this framework, you can run the tests
+as shown below for *libvirt*:
+
+```
+$ cd python
+$ CLOUD_PROVIDER=libvirt python3 main.py
+```
+
+# Adding support for a new provider
+
+In order to add a test pipeline for a new cloud provider, you will need to
+create a new class and implement the abstract `base.PipelineABC` methods (decorated with `@abstractmethod`).
+
+Create a new python file (.py) with the name of the provider. For example, suppose that
+`awsomeprovider` is the provider's name as you export in the `CLOUD_PROVIDER` variable
+in order to build the cloud-api-adaptor binaries, then you **must** create the `awsomeprovider.py` file.
+
+Then you should create a concrete class that implement the abstract methods and properties of the
+`base.PipelineABC` class. Following the example above, a snippet of `awsomeprovider.py` should look like below:
+
+```python
+from base import PipelineABC
+
+class AwsomeproviderPipeline(PipelineABC):
+
+def get_required_commands(self):
+    """
+    Implement :func:`base.PipelineABC.get_required_commands`.
+    """
+    return ['awsomeprovider-cli']
+
+def get_required_envvars(self):
+    """
+    Implement :func:`base.PipelineABC.get_required_envvars`.
+    """
+    return ['AWSOMEPROVIDER_AUTH_NAME', 'AWSOMEPROVIDER_AUTH_TOKEN']
+
+@step
+def step_foo(self, log):
+	"""
+    Implement :func:`base.PipelineABC.step_foo`.
+    """
+    # My implementation of step_foo
+
+(...)
+```
+
+>Note: It is important to create the python file and class right names because the pipeline
+implementations are loaded on runtime based on standardized names.

--- a/tests/e2e/python/base.py
+++ b/tests/e2e/python/base.py
@@ -1,0 +1,161 @@
+"""
+Copyright Confidential Containers Contributors
+SPDX-License-Identifier: Apache-2.0
+
+This module contains base classes and methods to implement end-to-end test pipelines.
+"""
+from abc import ABC
+from abc import abstractmethod
+from shutil import which
+from pathlib import Path
+
+import logging
+import os
+import sys
+
+def get_project_dir():
+    """
+    Return the project absolute path.
+    """
+    # tests/e2e/python/../../
+    return Path(__file__).absolute().parent.parent.parent.parent
+
+class PipelineABC(ABC):
+    """
+    Represents a end-to-end test pipeline for peer pods.
+
+    This is an abstract class that should have implementation for each cloud provider.
+    """
+
+    @abstractmethod
+    def get_required_commands(self):
+        """
+        Return a list of required commands required to run the pipeline. Return an empty
+        list if none is required.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_required_envvars(self):
+        """
+        Return a list of required environment variables to run the pipeline. Return an empty
+        list if none is required.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def pipeline_setup(self):
+        """
+        Run immediately before the pipeline steps.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def pipeline_teardown(self):
+        """
+        Run after the last pipeline step regardless if the pipeline failed.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def step_vpc_create(self, log):
+        """
+        Step create VPC (Virtual Private Cloud).
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def step_cluster_create(self, log):
+        """
+        Step create the Kubernetes cluster.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def step_podvm_create(self, log):
+        """
+        Step create the Podvm.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def step_install_peerpods(self, log):
+        """
+        Step install Peer Pods.
+        """
+        raise NotImplementedError
+
+    def check_commands(self, log):
+        """
+        Check the required commands are installed in the local system.
+        """
+        for cmd in self.get_required_commands():
+            if which(cmd) is None:
+                log.error("ERROR: command '%s' not found", cmd)
+                sys.exit(1)
+
+    def check_envvars(self, log):
+        """
+        Check the required environment variables are exported.
+        """
+        for envvar in self.get_required_envvars():
+            if os.getenv(envvar) is None:
+                log.error("ERROR: environment variable '%s' is not exported", envvar)
+                sys.exit(1)
+
+    def run(self):
+        """
+        Run the pipeline on local host.
+        """
+        ret = 0
+        log = logging.getLogger(__name__)
+
+        self.check_commands(log)
+        self.check_envvars(log)
+
+        print('\033[95mPIPELINE::SETUP\033[0m')
+        if self.pipeline_setup() != 0:
+            self.pipeline_teardown()
+            sys.exit(1)
+        print('\033[95mEND PIPELINE::SETUP\033[0m')
+
+        # Run the steps.
+        #
+        try:
+            self.step_vpc_create(log)
+            self.step_cluster_create(log)
+            self.step_podvm_create(log)
+            self.step_install_peerpods(log)
+        except StepException as ex:
+            ret = 1
+            log.error("ERROR: step failed. Cause: %s", ex)
+
+        print('\033[95mPIPELINE::TEARDOWN\033[0m')
+        self.pipeline_teardown()
+        print('\033[95mEND PIPELINE::TEARDOWN\033[0m')
+
+        return ret
+
+def step(func):
+    """
+    Decorate the step function so that start and end messages are printed
+    Use to mark the step functions in the implementer class, for example:
+    ```
+    class ProviderPipeline(PipelineABC)
+
+    @step
+    def step_vpc_create(self, log):
+        # Provider VPC create implementation.
+        pass
+    ```
+    """
+    def wrapper(self, log):
+        print('\033[95mSTEP::start::' + func.__name__ + '\033[0m')
+        func(self, log)
+        print('\033[95mSTEP::end::' + func.__name__ + '\033[0m')
+    return wrapper
+
+class StepException(Exception):
+    """
+    Exception if something bad goes in the step execution.
+    """

--- a/tests/e2e/python/libvirt.py
+++ b/tests/e2e/python/libvirt.py
@@ -1,0 +1,145 @@
+"""
+Copyright Confidential Containers Contributors
+SPDX-License-Identifier: Apache-2.0
+
+This module contain the pipeline implementation for Libvirt.
+"""
+import os
+from subprocess import run
+from subprocess import CalledProcessError
+from tempfile import TemporaryDirectory
+from base import get_project_dir
+from base import PipelineABC
+from base import step
+from base import StepException
+
+class LibvirtPipeline(PipelineABC):
+    """
+    Implement the pipeline for libvirt.
+    """
+
+    network = 'default'
+    storage_pool = 'default'
+    uri = 'qemu:///system'
+    workdir = None
+
+    def __init__(self):
+        self.libvirt_dir = os.path.join(get_project_dir(), "libvirt")
+
+    def get_required_commands(self):
+        """
+        Implement :func:`base.PipelineABC.get_required_commands`.
+        """
+        return ['docker', 'kcli', 'kubectl', 'virsh']
+
+    def get_required_envvars(self):
+        """
+        Implement :func:`base.PipelineABC.get_required_envvars`.
+        """
+        return []
+
+    def pipeline_setup(self):
+        """
+        Implement :func:`base.PipelineABC.pipeline_setup`.
+        """
+        self.workdir = TemporaryDirectory(prefix='caa-tests-libvirt-')
+        return 0
+
+    def pipeline_teardown(self):
+        """
+        Implement :func:`base.PipelineABC.pipeline_teardown`.
+        """
+        if self.workdir:
+            self.workdir.cleanup()
+
+    @step
+    def step_vpc_create(self, log):
+        """
+        Implement :func:`base.PipelineABC.step_vpc_create`.
+        """
+        try:
+            run('virsh -c %s net-info %s' % (self.uri, self.network),
+                shell=True, check=True)
+        except CalledProcessError:
+            raise StepException("Libvirt network '%s' should be created beforehand" %
+                self.network)
+        try:
+            res = run('virsh -c %s pool-info %s' % (self.uri, self.storage_pool),
+                shell=True, check=True, capture_output=True, encoding='utf-8')
+            # TODO grep the output for status running
+            print(res.stdout)
+        except CalledProcessError:
+            #log.error(res.stdout)
+            raise StepException("Libvirt storage pool '%s' should be created beforehand" %
+                self.storage_pool)
+
+    @step
+    def step_cluster_create(self, log):
+        """
+        Implement :func:`base.PipelineABC.step_cluster_create`.
+        """
+        try:
+            run('./kcli_cluster.sh create', shell=True, check=True,
+                cwd=self.libvirt_dir)
+            os.environ['KUBECONFIG'] = os.getenv('HOME') + \
+                '/.kcli/clusters/peer-pods/auth/kubeconfig'
+        except CalledProcessError:
+            raise StepException("Failed to create the cluster")
+
+    @step
+    def step_podvm_create(self, log):
+        """
+        Implement :func:`base.PipelineABC.step_podvm_create`.
+        """
+        image_dir = os.path.join(self.libvirt_dir, "image")
+
+        try:
+            run('make docker-build', shell=True, check=True,
+                cwd=image_dir)
+        except CalledProcessError:
+            raise StepException("Failed to create the podvm qcow2 file")
+
+        try:
+            run('make push', shell=True, check=True,
+                cwd=image_dir)
+        except CalledProcessError:
+            raise StepException("Failed to create the podvm volume in libvirt")
+
+    @step
+    def step_install_peerpods(self, log):
+        """
+        Implement :func:`base.PipelineABC.step_install_peerpods`.
+        """
+        overlays_dir = os.path.join(get_project_dir(), "install", "overlays",
+            "libvirt")
+        id_rsa_file = os.path.join(overlays_dir, "id_rsa")
+        id_rsa_pub_file = id_rsa_file + '.pub'
+        authorized_keys_file = os.path.join(os.getenv('HOME'), '.ssh', 'authorized_keys')
+
+        try:
+            # TODO: revisit that algorithm:
+            #        - ~/.ssh might not exist
+            #        - ~/.ssh/authorized_keys might not exist and it will be created
+            #          wrong permissions
+            #        - user might pass a key pair
+            #
+            if os.path.exists(id_rsa_file):
+                os.remove(id_rsa_file)
+            if os.path.exists(id_rsa_pub_file):
+                os.remove(id_rsa_pub_file)
+            run('ssh-keygen -f %s -N ""' % id_rsa_file, shell=True, check=True)
+            with open(authorized_keys_file, 'a+b') as auth_file:
+                with open(id_rsa_pub_file, 'r+b') as pub_file:
+                    auth_file.write(pub_file.read())
+
+            os.environ['SSH_KEY_FILE'] = os.path.basename(id_rsa_file)
+        except CalledProcessError:
+            raise StepException("Failed to create a pair of SSH keys")
+
+        try:
+            # TODO: figure out the IP on runtime.
+            os.environ['LIBVIRT_IP'] = "192.168.1.107"
+            run('./install_operator.sh', shell=True, check=True,
+                cwd=self.libvirt_dir)
+        except CalledProcessError:
+            raise StepException("Failed to install peer pods")

--- a/tests/e2e/python/main.py
+++ b/tests/e2e/python/main.py
@@ -1,0 +1,31 @@
+"""
+Copyright Confidential Containers Contributors
+SPDX-License-Identifier: Apache-2.0
+"""
+#!/usr/bin/env python3
+
+import importlib
+import os
+import sys
+
+def main():
+    cloud_provider = os.getenv('CLOUD_PROVIDER')
+    if cloud_provider is None:
+        print("ERROR: 'CLOUD_PROVIDER' variable should be exported")
+        return 1
+
+    try:
+        module = importlib.import_module(cloud_provider)
+        class_name = cloud_provider.capitalize() + 'Pipeline'
+        pipeline = getattr(module, class_name)()
+    except ModuleNotFoundError:
+        print("ERROR: not found '%s' module with the implemeting pipeline." % cloud_provider)
+        return 1
+    except AttributeError:
+        print("ERRO: pipeline class '%s' not found on '%s' module" % (class_name, module.__name__))
+        return 1
+
+    return pipeline.run()
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
[WORK IN PROGRESS but I'd like to hear anyone comments/suggestions before moving on]

Cc @stevenhorsman @jtumber-ibm 

### What I'm trying to achieve...

... is to find a way to reused the existing code to run the *same* end-to-end tests regardless of cloud provider specific details.

@stevenhorsman  start the CI discussion on https://github.com/confidential-containers/cloud-api-adaptor/issues/16 . In https://github.com/confidential-containers/cloud-api-adaptor/issues/16#issuecomment-1292524184 I shared some snippets of code with the ideas i had in mind. Now, I am sending a code that although not complete, it is functional so that we could continue the discussion in something concrete. 

###  How I see this being used

I envision the e2e tests being executed on the developers' workstation with a simple `CLOUD_PROVIDER=awesome make test-e2e` command. He/she would need to export some environment variables with information to run the pipeline on the *awesome* provider; for example, the user and authorization token.

Likewise on CI, whether Github actions or Jenkins, the right environment variables are exported on the environment by the CI system.  Same `make test-e2e` command is executed.

On CI I expect that the framework will be able to install dependent software (e.g. `packer`, `terraform`...) as well. It is is a work to be done (and designed), see next section.

### What I did not addressed (yet)

  - Installation of dependent software. Examples: `packer` to build podvm images, `terraform` to provision VPC, and so on. I would like to install software only and only if running on CI context, or if the developer set a flag allow to perform installations on his/her machine.
  - Effectively run the tests once the test environment is completed (i.e. peers pods installed)
  - pipeline teardown. At the end of the execution the resources created are destroyed. However, I would like to have flag (`DEBUG=true`) that prevents the teardown from being executed; this way it keeps the environment intact for debugging failure or even allowing the developer use to implement features.   

### Why Python?

I wrote a draft this framework in bash (https://github.com/confidential-containers/cloud-api-adaptor/issues/16#issuecomment-1292524184) then I realized I was using object oriented programming (OOP) concepts that would be better implement with a native OOP language.

I thought re-write it in golang which is the peer pods language, but two things hold me back:
 1. Golang is not OOP
 2. Peer poods can end being re-written on Rust as has happened recently with Kata Containers. I didn't want to re-implement this framework although it would be cool to learn Rust :)

In a remote past I did some stuffs in Python, so finally I decided for using that language. I am not an expert on Python and I understand that the vast community members might not be either, but I don´t believe the pipeline implementers will need to learn deep Python to extend the framework; I do believe that the framework will be just a glue for scripts (bash, ansible...etc) that actually will perform the tasks. 

### Few more words

 - Don't pay attention to the small implementation details, I am more concerned about higher level details at this point.
 - Don't hesitate to criticize hard this proposal
 - This code can be threw to the garbage if we think it is too complex or not what we collectively agree on 'what is wanted' 
 - This PR depends on https://github.com/confidential-containers/cloud-api-adaptor/pull/345