### PR TITLE
podnetwork: Fix networking when using OVS

### DIFF
--- a/pkg/podnetwork/tunneler/tunneler.go
+++ b/pkg/podnetwork/tunneler/tunneler.go
@@ -15,6 +15,7 @@ type Tunneler interface {
 
 type Config struct {
 	PodIP         string
+	PodHwAddr     string   `json:"pod-hw-addr"`
 	Routes        []*Route `json:"routes"`
 	InterfaceName string   `json:"interface"`
 	MTU           int      `json:"mtu"`

--- a/pkg/podnetwork/tunneler/vxlan/podnode.go
+++ b/pkg/podnetwork/tunneler/vxlan/podnode.go
@@ -62,6 +62,10 @@ func (t *podNodeTunneler) Setup(nsPath string, podNodeIPs []net.IP, config *tunn
 		return fmt.Errorf("failed to move vxlan interface %s to netns %s: %w", podVxlanInterface, podNS.Path, err)
 	}
 
+	if err := podNS.SetHardwareAddr(podVxlanInterface, config.PodHwAddr); err != nil {
+		return fmt.Errorf("failed to set pod Mac %s on %s: %w", config.PodHwAddr, podVxlanInterface, err)
+	}
+
 	mtu := int(config.MTU)
 	if mtu > maxMTU {
 		mtu = maxMTU

--- a/pkg/podnetwork/tuntest/tuntest.go
+++ b/pkg/podnetwork/tuntest/tuntest.go
@@ -17,6 +17,7 @@ import (
 
 type testPod struct {
 	podAddr                       string
+	podHwAddr                     string
 	podNodePrimaryAddr            string
 	podNodeSecondaryAddr          string
 	workerPodNS, podNS, podNodeNS *netops.NS
@@ -48,8 +49,8 @@ func RunTunnelTest(t *testing.T, tunnelType string, newWorkerNodeTunneler, newPo
 	)
 
 	pods := []*testPod{
-		{podAddr: "10.128.0.2/24", podNodePrimaryAddr: "10.10.1.2/16", podNodeSecondaryAddr: "192.168.0.2/24"},
-		{podAddr: "10.128.0.3/24", podNodePrimaryAddr: "10.10.1.3/16", podNodeSecondaryAddr: "192.168.0.3/24"},
+		{podAddr: "10.128.0.2/24", podHwAddr: "0a:58:0a:84:03:ce", podNodePrimaryAddr: "10.10.1.2/16", podNodeSecondaryAddr: "192.168.0.2/24"},
+		{podAddr: "10.128.0.3/24", podHwAddr: "0a:58:0a:84:03:cf", podNodePrimaryAddr: "10.10.1.3/16", podNodeSecondaryAddr: "192.168.0.3/24"},
 	}
 
 	bridgeNS := NewNamedNS(t, "test-bridge")
@@ -102,6 +103,7 @@ func RunTunnelTest(t *testing.T, tunnelType string, newWorkerNodeTunneler, newPo
 		LinkSetMaster(t, workerNS, veth, "cni0")
 
 		AddrAdd(t, pod.workerPodNS, "eth0", pod.podAddr)
+		HwAddrAdd(t, pod.workerPodNS, "eth0", pod.podHwAddr)
 		RouteAdd(t, pod.workerPodNS, "", gatewayIP, "eth0")
 
 		pod.podNodeNS = NewNamedNS(t, fmt.Sprintf("test-podvm%d", i))
@@ -125,6 +127,7 @@ func RunTunnelTest(t *testing.T, tunnelType string, newWorkerNodeTunneler, newPo
 
 		pod.config = &tunneler.Config{
 			PodIP:         pod.podAddr,
+			PodHwAddr:     pod.podHwAddr,
 			Routes:        []*tunneler.Route{{Dst: "", GW: "10.128.0.1", Dev: ""}},
 			InterfaceName: "eth0",
 			MTU:           1500,

--- a/pkg/podnetwork/tuntest/util.go
+++ b/pkg/podnetwork/tuntest/util.go
@@ -104,6 +104,14 @@ func AddrAdd(t *testing.T, ns *netops.NS, name, addr string) {
 	}
 }
 
+func HwAddrAdd(t *testing.T, ns *netops.NS, name, hwAddr string) {
+	t.Helper()
+
+	if err := ns.SetHardwareAddr(name, hwAddr); err != nil {
+		t.Fatalf("failed to add %s to %s: %v", hwAddr, name, err)
+	}
+}
+
 func RouteAdd(t *testing.T, ns *netops.NS, dest, gw, dev string) {
 	t.Helper()
 

--- a/pkg/podnetwork/workernode.go
+++ b/pkg/podnetwork/workernode.go
@@ -114,7 +114,14 @@ func (n *workerNode) Inspect(nsPath string) (*tunneler.Config, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	config.PodIP = podIP
+	config.PodHwAddr, err = podNS.GetHardwareAddr(podInterface)
+	if err != nil {
+		logger.Printf("failed to get Mac address of the Pod interface")
+		return nil, fmt.Errorf("failed to get Mac address for Pod interface %s: %w", podInterface, err)
+	}
+
 	config.InterfaceName = podInterface
 
 	mtu, err := podNS.GetMTU(podInterface)


### PR DESCRIPTION
When using OVS (OpenvSwitch) based CNIs like openshift-sdn or ovn-kubernetes, POD IPs are unreachable from the cluster nodes (worker or controller).
There are two issues at play here
- OVS based CNIs uses flow rules specific to the mac address of pod. And the pod mac address is used from the CNI created namespace on the worker node. However the container process which runs in the Pod VM uses a different mac address and unless the flow rules are updated with the mac address from the Pod VM, Pod IP is not reachable from the cluster nodes
- Certain CNIs (eg ovn-kubernetes) disables ARP broadcast and uses the pod mac address assigned by the CNI. However it doesn't matches with the mac address used in Pod VM and hence packets are received by the Pod VM with incorrect dst address over the vxlan tunnel

To fix the issues, this PR uses the CNI assigned MAC address for the POD VM vxlan0 interface.

Fixes: #369
Signed-off-by: Pradipta Banerjee <pradipta.banerjee@gmail.com>