### PR TITLE
vsphere: Ensure pod VMs get unique DHCP ip

### DIFF
--- a/vsphere/image/misc-settings.sh
+++ b/vsphere/image/misc-settings.sh
@@ -1,0 +1,13 @@
+# Uncomment the awk statement if you want to use mac as
+# dhcp-identifier in Ubuntu
+#awk '/^[[:space:]-]*dhcp4/{ split($0,arr,/dhcp4.*/)
+#                           gsub(/-/," ", arr[1])
+#                           rep=arr[1]
+#                           print $0}
+#                      rep{ printf "%s%s\n", rep, "dhcp-identifier: mac"
+#                      rep=""
+#                      next} 1' /etc/netplan/50-cloud-init.yaml | sudo tee /etc/netplan/50-cloud-init.yaml
+
+# This ensures machine-id is generated during first boot and a unique
+# dhcp IP is assigned to the VM
+sudo echo -n > /etc/machine-id

--- a/vsphere/image/vsphere-ubuntu.pkr.hcl
+++ b/vsphere/image/vsphere-ubuntu.pkr.hcl
@@ -96,4 +96,16 @@ build {
       "rm /tmp/files.tar"
    ]
   }
+
+ provisioner "file" {
+    source      = "misc-settings.sh"
+    destination = "~/misc-settings.sh"
+  }
+
+  provisioner "shell" {
+    remote_folder = "~"
+    inline = [
+      "sudo bash ~/misc-settings.sh"
+    ]
+  }
 }


### PR DESCRIPTION
Remove machine-id when creating base qcow2 image for Pod VM. This ensures that pod VMs created from the same image gets unique DHCP ips.

Backported from the libvirt version for #376 

Fixes: #363

Signed-off-by: Pradipta Banerjee <pradipta.banerjee@gmail.com>
Signed-off-by: Bandan Das <bsd@redhat.com>