### PR TITLE
podvm: restart agent-protocol-forwarder on failure

### DIFF
--- a/aws/image/files/etc/systemd/system/agent-protocol-forwarder.service
+++ b/aws/image/files/etc/systemd/system/agent-protocol-forwarder.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Agent Protocol Forwarder
-After=network.target
+After=cloud-init.target
+Wants=cloud-init.target
+DefaultDependencies=no
 
 [Service]
 ExecStart=/usr/local/bin/agent-protocol-forwarder -kata-agent-namespace /run/netns/podns -kata-agent-socket /run/kata-containers/agent.sock

--- a/azure/image/files/etc/systemd/system/agent-protocol-forwarder.service
+++ b/azure/image/files/etc/systemd/system/agent-protocol-forwarder.service
@@ -1,6 +1,9 @@
 [Unit]
 Description=Agent Protocol Forwarder
-After=network.target
+After=cloud-init.target
+Wants=cloud-init.target
+DefaultDependencies=no
+
 
 [Service]
 ExecStart=/usr/local/bin/agent-protocol-forwarder -kata-agent-namespace /run/netns/podns -kata-agent-socket /run/kata-containers/agent.sock

--- a/libvirt/image/files/etc/systemd/system/agent-protocol-forwarder.service
+++ b/libvirt/image/files/etc/systemd/system/agent-protocol-forwarder.service
@@ -1,6 +1,9 @@
 [Unit]
 Description=Agent Protocol Forwarder
-After=network.target
+After=cloud-init.target
+Wants=cloud-init.target
+DefaultDependencies=no
+
 
 [Service]
 ExecStart=/usr/local/bin/agent-protocol-forwarder -kata-agent-namespace /run/netns/podns -kata-agent-socket /run/kata-containers/agent.sock

--- a/podvm/files/etc/systemd/system/agent-protocol-forwarder.service
+++ b/podvm/files/etc/systemd/system/agent-protocol-forwarder.service
@@ -1,6 +1,9 @@
 [Unit]
 Description=Agent Protocol Forwarder
-After=network.target
+After=cloud-init.target
+Wants=cloud-init.target
+DefaultDependencies=no
+
 
 [Service]
 ExecStart=/usr/local/bin/agent-protocol-forwarder -kata-agent-namespace /run/netns/podns -kata-agent-socket /run/kata-containers/agent.sock

--- a/vsphere/image/files/etc/systemd/system/agent-protocol-forwarder.service
+++ b/vsphere/image/files/etc/systemd/system/agent-protocol-forwarder.service
@@ -1,6 +1,9 @@
 [Unit]
 Description=Agent Protocol Forwarder
-After=network.target
+After=cloud-init.target
+Wants=cloud-init.target
+DefaultDependencies=no
+
 
 [Service]
 ExecStart=/usr/local/bin/agent-protocol-forwarder -kata-agent-namespace /run/netns/podns -kata-agent-socket /run/kata-containers/agent.sock


### PR DESCRIPTION
RHEL 9 podvm image is encountering an issue where cloudconfig init hasn't completed before agent-protocol-forwarder starts and it fails because it can't find /peerpods/daemon.json. Restart the service on failure.

Fixes: #388

Suggested-by: Pradipta Banerjee <pradipta.banerjee@gmail.com>
Signed-off-by: Bandan Das <bsd@redhat.com>