### PR TITLE
Add setup steps for the attestation agent to the podvm makefile

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -20,10 +20,20 @@ create create new VPC with public internet access and set also the following env
 export VPC_ID="REPLACE_ME"
 export SUBNET_ID="REPLACE_ME"
 ```
-
+   
 - Create a custom AMI based on Ubuntu 20.04 having kata-agent and other dependencies
-        - **NOTE:** If authentication against container image registries is required copy your JSON format credentials
-        file to [podvm/files/](../podvm/files/)auth.json and add also `USE_SKOPEO=true` before `make image`
+- **Setting up authenticated registry support:** 
+  - If authentication against container image registries is required base64 encode your JSON format credentials file (`auth.json`): `cat auth.json | base64 -w 0`
+  - Then export the base64 encoded version of the file: `export AUTHFILE=<base64 encoded auth.json file>`
+  - Create the necessary resource JSON using the above exported variable in the [podvm/files/etc/](../podvm/files/etc/) directory: 
+  ```
+  cat <<EOF | tee aa-offline_fs_kbc-resources.json
+  {
+    "Credential": "${AUTHFILE}"
+  } 
+  EOF
+  ```
+  - Add `AA_KBC="offline_fs_kbc"` prior to the make image step.
 ```
 cd image
 CLOUD_PROVIDER=aws make image

--- a/podvm/Makefile.inc
+++ b/podvm/Makefile.inc
@@ -32,17 +32,26 @@ endif
 IMAGE_SUFFIX ?= 
 IMAGE_FILE = $(IMAGE_NAME)$(IMAGE_SUFFIX)
 
+LIBC_ARCH := $(shell uname -m)
+LIBC := $(if $(findstring s390x,$(LIBC_ARCH)),gnu,musl)
 
 AGENT_PROTOCOL_FORWARDER = $(FILES_DIR)/usr/local/bin/agent-protocol-forwarder
 KATA_AGENT    = $(FILES_DIR)/usr/local/bin/kata-agent
 PAUSE         = $(FILES_DIR)/$(PAUSE_BUNDLE)/rootfs/pause
 SKOPEO    = $(FILES_DIR)/usr/bin/skopeo
 UMOCI     = $(FILES_DIR)/usr/local/bin/umoci
+ATTESTATION_AGENT = $(FILES_DIR)/usr/local/bin/attestation-agent
 
 BINARIES = $(AGENT_PROTOCOL_FORWARDER) $(KATA_AGENT) $(PAUSE)
 
 ifdef USE_SKOPEO
 BINARIES += $(SKOPEO) $(UMOCI)
+endif
+
+KBC_URI ?= "null"
+ifdef AA_KBC
+BINARIES += $(ATTESTATION_AGENT)
+$(shell sed -i "s/\(aa_kbc_params = \)\"[^\"]*\"/\1\"${AA_KBC}::${KBC_URI}\"/g" $(FILES_DIR)/etc/agent-config.toml)
 endif
 
 AGENT_PROTOCOL_FORWARDER_SRC = ../..
@@ -68,6 +77,10 @@ PAUSE_BUNDLE  = pause_bundle
 STATIC_LIBSECCOMP_BUILDER = ../../../kata-containers/ci/install_libseccomp.sh
 STATIC_LIBSECCOMP_DIR     = $(abspath staticlib)
 STATIC_LIBSECCOMP         = $(STATIC_LIBSECCOMP_DIR)/kata-libseccomp/lib/libseccomp.a
+
+ATTESTATION_AGENT_SRC = ../../../attestation-agent
+ATTESTATION_AGENT_REPO = https://github.com/confidential-containers/attestation-agent
+ATTESTATION_AGENT_BRANCH = main
 
 binaries: $(BINARIES)
 
@@ -108,3 +121,11 @@ $(PAUSE_SRC): $(SKOPEO_SRC)/bin/skopeo
 
 $(PAUSE): | $(PAUSE_SRC) $(UMOCI_SRC)/umoci
 	$(UMOCI_SRC)/umoci unpack --rootless --image "$(PAUSE_SRC):$(PAUSE_VERSION)" "${FILES_DIR}/$(PAUSE_BUNDLE)"
+
+$(ATTESTATION_AGENT_SRC):
+	git clone "$(ATTESTATION_AGENT_REPO)" -b "$(ATTESTATION_AGENT_BRANCH)" "$(ATTESTATION_AGENT_SRC)"
+
+$(ATTESTATION_AGENT): $(ATTESTATION_AGENT_SRC)
+	cd "$(ATTESTATION_AGENT_SRC)" && make KBC="$(AA_KBC)" LIBC="$(LIBC)"
+	mkdir -p "$(@D)"
+	install --compare "$(ATTESTATION_AGENT_SRC)/app/target/$(LIBC_ARCH)-unknown-linux-$(LIBC)/release/attestation-agent" "$@"

--- a/podvm/Makefile.inc
+++ b/podvm/Makefile.inc
@@ -80,7 +80,6 @@ STATIC_LIBSECCOMP         = $(STATIC_LIBSECCOMP_DIR)/kata-libseccomp/lib/libsecc
 
 ATTESTATION_AGENT_SRC = ../../../attestation-agent
 ATTESTATION_AGENT_REPO = https://github.com/confidential-containers/attestation-agent
-ATTESTATION_AGENT_BRANCH = main
 
 binaries: $(BINARIES)
 
@@ -123,7 +122,7 @@ $(PAUSE): | $(PAUSE_SRC) $(UMOCI_SRC)/umoci
 	$(UMOCI_SRC)/umoci unpack --rootless --image "$(PAUSE_SRC):$(PAUSE_VERSION)" "${FILES_DIR}/$(PAUSE_BUNDLE)"
 
 $(ATTESTATION_AGENT_SRC):
-	git clone "$(ATTESTATION_AGENT_REPO)" -b "$(ATTESTATION_AGENT_BRANCH)" "$(ATTESTATION_AGENT_SRC)"
+	git clone "$(ATTESTATION_AGENT_REPO)" "$(ATTESTATION_AGENT_SRC)"
 
 $(ATTESTATION_AGENT): $(ATTESTATION_AGENT_SRC)
 	cd "$(ATTESTATION_AGENT_SRC)" && make KBC="$(AA_KBC)" LIBC="$(LIBC)"

--- a/podvm/files/etc/agent-config.toml
+++ b/podvm/files/etc/agent-config.toml
@@ -5,6 +5,10 @@ enable_signature_verification=false
 # When using the agent-config.toml the KATA_AGENT_SERVER_ADDR env var seems to be ignored, so set it here
 server_addr="unix:///run/kata-containers/agent.sock"
 
+# This field sets up the KBC that attestation agent uses
+# This is replaced in the makefile steps so do not set it manually
+aa_kbc_params = ""
+
 # temp workaround for kata-containers/kata-containers#5590
 [endpoints]
 allowed = [


### PR DESCRIPTION
- Add attestation agent if AA_KBC has been set in the makefile
- Update ibmcloud docs to include steps for setting up the attestation agent with authenticated registry support
- Update AWS docs to remove the skopeo specific steps and replace it with using the attestation agent with authenticated registry support