### PR TITLE
podvm: Add cleanup helper

### DIFF
--- a/podvm/files/etc/systemd/system/kata-agent.service
+++ b/podvm/files/etc/systemd/system/kata-agent.service
@@ -8,6 +8,7 @@ ExecStartPre=-umount /sys/fs/cgroup/misc
 ExecStartPre=ip netns add podns
 ExecStartPre=ip netns exec podns ip link set lo up
 ExecStopPost=ip netns delete podns
+ExecStopPost=/usr/local/bin/kata-agent-clean --config /etc/agent-config.toml
 # Now specified in the agent-config.toml Environment="KATA_AGENT_SERVER_ADDR=unix:///run/kata-containers/agent.sock"
 SyslogIdentifier=kata-agent
 

--- a/podvm/files/usr/local/bin/kata-agent-clean
+++ b/podvm/files/usr/local/bin/kata-agent-clean
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Removes any parts of the kata-agent configuration that
+# maybe left over after shutdown/restarts.
+# List of items currently handled by this are:
+# - ttrpc server sock (e.g. /run/kata-containers/agent.sock)
+#
+
+function usage() {
+    echo "Usage: $0 --config <config path>"
+}
+
+while (( "$#" )); do
+    case "$1" in
+        --config) config_path=$2 ;;
+        --help) usage; exit 0 ;;
+        *)      usage 1>&2; exit 1;;
+    esac
+    shift 2
+done
+
+if [[ -z "${config_path-}" ]]; then
+    usage 1>&2
+    exit 1
+fi
+
+# ttrpc server sock removal
+server_addr_regex='server_addr="unix://([^"]+)"'
+server_addr_line=$(grep "server_addr" "${config_path}")
+[[ $server_addr_line =~ $server_addr_regex ]]
+server_addr="${BASH_REMATCH[1]}"
+if [ -S "$server_addr" ]; then
+    echo "Removing $server_addr"
+    rm -f "$server_addr"
+else
+    echo "Can't remove $server_addr as it doesn't exist"
+fi


### PR DESCRIPTION
- Delete the ttrpc server socket when it stops

This helps handle podvm restarts, including during podvm image creation.

Fixes: #420

Signed-off-by: James Tumber <james.tumber@ibm.com>