### PR TITLE
controller: make spec fields optional

### DIFF
--- a/peer-pod-controller/api/v1alpha1/peerpodconfig_types.go
+++ b/peer-pod-controller/api/v1alpha1/peerpodconfig_types.go
@@ -36,6 +36,7 @@ type PeerPodConfigSpec struct {
 
 	// NodeSelector selects the nodes to which the cca pods, the RuntimeClass and the MachineConfigs we use
 	// to deploy the full peer pod solution.
+	// +optional
 	NodeSelector *metav1.LabelSelector `json:"nodeSelector"`
 
 	// ConfigMapName is the name of the configmap that holds cloud provider specific environment Variables


### PR DESCRIPTION
nodeSelector, configMapName and cloudSecretName should be optional, there's no hard requirement for them in the spec. 

Fixes #425 

Signed-off-by: Jens Freimann <jfreimann@redhat.com>