### PR TITLE
controller: fix typo in environment variable for peerpods namespace

### DIFF
--- a/peer-pod-controller/controllers/peerpodconfig_controller.go
+++ b/peer-pod-controller/controllers/peerpodconfig_controller.go
@@ -169,7 +169,7 @@ func (r *PeerPodConfigReconciler) createCcaDaemonset(cloudProviderName string) *
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dsName,
-			Namespace: os.Getenv("PEERPOD_NAMESPACE"),
+			Namespace: os.Getenv("PEERPODS_NAMESPACE"),
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{


### PR DESCRIPTION
Fix a simple type that led to the cloud-api-adaptor daemon set not being created.

error message:
"Failed setting ControllerReference for cloud-api-adaptor DS"

Fixes #426 

Signed-off-by: Jens Freimann <jfreimann@redhat.com>