### PR TITLE
vsphere: template: workaround ks user bug

### DIFF
--- a/vsphere/image/rhel/data/ks.pkr.hcl
+++ b/vsphere/image/rhel/data/ks.pkr.hcl
@@ -20,7 +20,7 @@ keyboard ${vm_guest_os_keyboard}
 network --bootproto=dhcp --onboot=yes --hostname=${vm_guest_hostname}
 
 ### user with sudo privileges
-user --name=${build_username} --iscrypted --password=${build_password_encrypted} --groups=wheel
+user --name=${build_username} --plaintext --password=${build_password} --groups=wheel
 
 ### firewall is disabled
 firewall --disabled

--- a/vsphere/image/rhel/scripts/createconfig.sh
+++ b/vsphere/image/rhel/scripts/createconfig.sh
@@ -27,6 +27,10 @@ vm_interface_name         = "vmxnet3"
 vm_network_name           = "VM Network"
 vm_hostname		  = "podvm"
 
+// Login
+vm_username = "peerpod"
+vm_password = "peerp0d"
+
 // Removable Media Settings
 iso_url            = "RHEL-9.0.0-20220420.0-x86_64-dvd1.iso"
 iso_checksum_value = "a387f3230acf87ee38707ee90d3c88f44d7bf579e6325492f562f0f1f9449e89"

--- a/vsphere/image/rhel/variables.pkr.hcl
+++ b/vsphere/image/rhel/variables.pkr.hcl
@@ -156,3 +156,15 @@ variable "vm_hostname" {
   description = "name of the podvm guest, by default time is suffixed"
   default = "podvm"
 }
+
+variable "vm_username" {
+  type        = string
+  description = "podvm username"
+  default = "peerpod"
+}
+
+variable "vm_password" {
+  type        = string
+  description = "podvm password"
+  default = "peerp0d"
+}

--- a/vsphere/image/rhel/vsphere-rhel.pkr.hcl
+++ b/vsphere/image/rhel/vsphere-rhel.pkr.hcl
@@ -7,9 +7,8 @@
 locals {
   data_source_content = {
    "/ks.cfg" = templatefile("${abspath(path.root)}/data/ks.pkr.hcl", {
-      build_username           = "peerpod"
-      build_password           = "peerp0d"
-      build_password_encrypted = "$y$j9T$ifwkDEP8Rb9c47stpEGuF1$wT/v1.7ci8lEnD7rLmEqkzFmXuHwpHqhvjg3HQp7hm8"
+      build_username           = "${var.vm_username}"
+      build_password           = "${var.vm_password}"
       vm_guest_os_language     = "${var.vm_guest_os_language}"
       vm_guest_os_keyboard     = "${var.vm_guest_os_keyboard}"
       vm_guest_os_timezone     = "${var.vm_guest_os_timezone}"
@@ -35,8 +34,8 @@ source "vsphere-iso" "rhel" {
   convert_to_template     = "${var.convert_to_template}"
 
 // ssh user/pass to the guest, same as cloudinit data
-  ssh_username            = "peerpod"
-  ssh_password            = "peerp0d"
+  ssh_username            = "${var.vm_username}"
+  ssh_password            = "${var.vm_password}"
   ssh_timeout  		  = "${var.ssh_timeout}"
 
 // VM resources


### PR DESCRIPTION
RHEL8 kickstarts do not seem to recognize the isencrypted flag to user command. Use plaintext instead that works universally. While at it, also make username/password configurable.

Fixes: #429

Signed-off-by: Bandan Das <bsd@redhat.com>