### PR TITLE
vsphere: template: unmount misc cgroup as its not handled by kata

### DIFF
--- a/vsphere/image/files/etc/systemd/system/kata-agent.service
+++ b/vsphere/image/files/etc/systemd/system/kata-agent.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 ExecStart=/usr/local/bin/kata-agent --config /etc/agent-config.toml
+ExecStartPre=-umount /sys/fs/cgroup/misc
 ExecStartPre=ip netns add podns
 ExecStartPre=ip netns exec podns ip link set lo up
 ExecStopPost=ip netns delete podns


### PR DESCRIPTION
Now that we are using legacy cgroups...
https://github.com/kata-containers/kata-containers/issues/4610

Fixes: #431
Signed-off-by: Bandan Das <bsd@redhat.com>