### PR TITLE
ibmcloud: Bump version of go

### DIFF
--- a/ibmcloud/terraform/cluster/ansible/kata-playbook.yml
+++ b/ibmcloud/terraform/cluster/ansible/kata-playbook.yml
@@ -59,7 +59,7 @@
         set -o errexit -o pipefail
         arch="{{ ansible_architecture }}"
         # gover=$(curl -sL 'https://golang.org/VERSION?m=text')
-        gover=go1.18.5
+        gover=go1.19.3
         curl -sL "https://go.dev/dl/$gover.linux-${arch/x86_64/amd64}.tar.gz" | tar -xzf - -C /usr/local
 
         if ! grep -q '^PATH=/usr/local/go/bin:\$PATH$' /root/.bashrc; then


### PR DESCRIPTION
Instal version 1.19.3 of go in the Ansible playbook to match the kata-containers minimum version

Fixes: #440
Signed-off-by: stevenhorsman <steven@uk.ibm.com>