### PR TITLE
controller: add volume to mount auth.json

### DIFF
--- a/peer-pod-controller/controllers/peerpodconfig_controller.go
+++ b/peer-pod-controller/controllers/peerpodconfig_controller.go
@@ -149,10 +149,11 @@ func MountProgagationRef(mode corev1.MountPropagationMode) *corev1.MountPropagat
 */
 func (r *PeerPodConfigReconciler) createCcaDaemonset(cloudProviderName string) *appsv1.DaemonSet {
 	var (
-		runPrivileged           = true
-		runAsUser         int64 = 0
-		defaultMode       int32 = 0600
-		sshSecretOptional       = true
+		runPrivileged                = true
+		runAsUser              int64 = 0
+		defaultMode            int32 = 0600
+		sshSecretOptional            = true
+		authJsonSecretOptional       = true
 	)
 
 	dsName := "peer-pod-controller-cca-daemon"
@@ -222,6 +223,10 @@ func (r *PeerPodConfigReconciler) createCcaDaemonset(cloudProviderName string) *
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
+									Name:      "auth-json-volume",
+									MountPath: "/root/containers/",
+									ReadOnly:  true,
+								}, {
 									Name:      "ssh",
 									MountPath: "/root/.ssh",
 									ReadOnly:  true,
@@ -240,6 +245,15 @@ func (r *PeerPodConfigReconciler) createCcaDaemonset(cloudProviderName string) *
 					},
 					Volumes: []corev1.Volume{
 						{
+							Name: "auth-json-volume",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName:  "auth-json-secret",
+									DefaultMode: &defaultMode,
+									Optional:    &authJsonSecretOptional,
+								},
+							},
+						}, {
 							Name: "ssh",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{


### PR DESCRIPTION
This adds a volume and volumeMount to the cloud-api-adaptor pod definition. cloud-api-adaptor can then inject the auth.json file into the podvm and enable it to pull image from registries that require authentication.

Rename variable sshSecretOptional to be more generic and use it for all optional secrets

Fixes #443

Signed-off-by: Jens Freimann <jfreimann@redhat.com>