### PR TITLE
Ibmcloud: fix guest selinux is enabled in k8s worker

### DIFF
--- a/ibmcloud/terraform/cluster/ansible/kata-playbook.yml
+++ b/ibmcloud/terraform/cluster/ansible/kata-playbook.yml
@@ -240,6 +240,7 @@
           [hypervisor.remote]
           remote_hypervisor_socket = "/run/peerpod/hypervisor.sock"
           remote_hypervisor_timeout = 600
+          disable_guest_selinux = true
           [agent.kata]
           [image]
           service_offload = true


### PR DESCRIPTION
Add disable_guest_selinux = true to the kata configuration on the k8s worker.

With the change in https://github.com/confidential-containers/cloud-api-adaptor/pull/441 this makes setting up the nginx container demo environment using Terraform work again.

