### PR TITLE
controller: set default values for name of config map and secret

### DIFF
--- a/peer-pod-controller/api/v1alpha1/peerpodconfig_types.go
+++ b/peer-pod-controller/api/v1alpha1/peerpodconfig_types.go
@@ -32,6 +32,7 @@ type PeerPodConfigSpec struct {
 	Limit string `json:"limit,omitempty"`
 
 	// CloudSecretName is the name of the secret that holds the credentials for the cloud provider
+	// +kubebuilder:default:=peer-pods-secret
 	CloudSecretName string `json:"cloudSecretName"`
 
 	// NodeSelector selects the nodes to which the cca pods, the RuntimeClass and the MachineConfigs we use
@@ -39,6 +40,7 @@ type PeerPodConfigSpec struct {
 	NodeSelector *metav1.LabelSelector `json:"nodeSelector"`
 
 	// ConfigMapName is the name of the configmap that holds cloud provider specific environment Variables
+	// +kubebuilder:default:=peer-pods-cm
 	ConfigMapName string `json:"configMapName"`
 }
 


### PR DESCRIPTION
use kubebuilder annotations in the API definition. The annotations will be used to set the default names in the PeerPodConfig CRD when it is generated via make manifests.

Fixes #450 

Signed-off-by: Jens Freimann <jfreimann@redhat.com>