### PR TITLE
controller: add labelSelector to PeerPodConfig

### DIFF
--- a/peer-pod-controller/api/v1alpha1/peerpodconfig_types.go
+++ b/peer-pod-controller/api/v1alpha1/peerpodconfig_types.go
@@ -35,9 +35,10 @@ type PeerPodConfigSpec struct {
 	// +kubebuilder:default:=peer-pods-secret
 	CloudSecretName string `json:"cloudSecretName"`
 
-	// NodeSelector selects the nodes to which the cca pods, the RuntimeClass and the MachineConfigs we use
+	// LabelSelector selects the nodes to which the caa pods, the RuntimeClass and the MachineConfigs we use
 	// to deploy the full peer pod solution.
-	NodeSelector *metav1.LabelSelector `json:"nodeSelector"`
+	// +optional
+	LabelSelector *metav1.LabelSelector `json:"labelSelector"`
 
 	// ConfigMapName is the name of the configmap that holds cloud provider specific environment Variables
 	// +kubebuilder:default:=peer-pods-cm

--- a/peer-pod-controller/controllers/peerpodconfig_controller.go
+++ b/peer-pod-controller/controllers/peerpodconfig_controller.go
@@ -154,15 +154,22 @@ func (r *PeerPodConfigReconciler) createCaaDaemonset(cloudProviderName string) *
 		defaultMode            int32 = 0600
 		sshSecretOptional            = true
 		authJsonSecretOptional       = true
+		nodeSelector                 = metav1.LabelSelector{}
 	)
 
 	dsName := "peer-pod-controller-caa-daemon"
 	dsLabelSelectors := map[string]string{
 		"name": dsName,
 	}
-	nodeSelector := map[string]string{
+
+	nodeSelector.MatchLabels = map[string]string{
 		"node-role.kubernetes.io/worker": "",
 	}
+
+	if r.peerPodConfig.Spec.LabelSelector != nil {
+		nodeSelector = *r.peerPodConfig.Spec.LabelSelector
+	}
+
 	return &appsv1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -191,7 +198,7 @@ func (r *PeerPodConfigReconciler) createCaaDaemonset(cloudProviderName string) *
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "default",
-					NodeSelector:       nodeSelector,
+					NodeSelector:       nodeSelector.MatchLabels,
 					HostNetwork:        true,
 					Containers: []corev1.Container{
 						{


### PR DESCRIPTION
This adds an optional field to the PeerPodConfig spec section. It can be used to specify a label that matches the nodes where the cloud-api-adaptor daemonset is supposed to run.

Fixes: #456

Signed-off-by: Jens Freimann <jfreimann@redhat.com>