### PR TITLE
podvm: build rhel image from in a container

### DIFF
--- a/podvm/Dockerfile.podvm.rhel
+++ b/podvm/Dockerfile.podvm.rhel
@@ -1,0 +1,31 @@
+# Copyright Confidential Containers Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Builds pod vm image inside container
+#
+ARG BUILDER_IMG
+
+FROM ${BUILDER_IMG} AS podvm_builder
+
+ARG CLOUD_PROVIDER
+ARG PODVM_DISTRO=rhel
+ARG AA_KBC="offline_fs_kbc"
+
+ARG RHEL_IMAGE_URL="/tmp/rhel.qcow2"
+ARG RHEL_IMAGE_CHECKSUM
+
+# Building binaries separately allows for reuse in case of error
+# with image building step
+RUN cd cloud-api-adaptor/podvm && \
+     CLOUD_PROVIDER=$CLOUD_PROVIDER LIBC=gnu make binaries
+
+# workaround to ensure hashicorp packer is called instead
+# of cracklib packer which is installed by default
+ENV PATH="/usr/bin:${PATH}"
+
+RUN cd cloud-api-adaptor/podvm && \
+     AA_KBC=$AA_KBC CLOUD_PROVIDER=$CLOUD_PROVIDER PODVM_DISTRO=$PODVM_DISTRO LIBC=gnu make image
+
+FROM scratch
+COPY --from=podvm_builder /src/cloud-api-adaptor/podvm/output/*.qcow2 /

--- a/podvm/Dockerfile.podvm_builder.rhel
+++ b/podvm/Dockerfile.podvm_builder.rhel
@@ -5,26 +5,29 @@
 # Creates a builder container image that should be used to build the Pod VM
 # disk inside a container.
 #
-FROM ubuntu:20.04
+FROM registry.access.redhat.com/ubi8/ubi:8.7
 
 ARG GO_VERSION="1.18.7"
 ARG PROTOC_VERSION="3.11.4"
-ARG RUST_VERSION="1.66.0"
+ARG RUST_VERSION="1.62.0"
 
+# This must be running on subscribed RHEL host !!!
+# If you are running a UBI container on a registered and subscribed RHEL host, the main RHEL Server repository is enabled inside the standard UBI container
 
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN apt-get update -y && \
-    apt-get install -y build-essential cloud-image-utils curl git gnupg \
-        libdevmapper-dev libgpgme-dev lsb-release pkg-config qemu-kvm \
-        musl-tools unzip wget git && \
-    curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
-    echo "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee -a /etc/apt/sources.list && \
-    apt-get update && apt-get install -y packer && \
+RUN dnf groupinstall -y 'Development Tools' && \
+    dnf install -y yum-utils gnupg git curl pkg-config libseccomp-devel gpgme-devel \
+        device-mapper-devel qemu-kvm unzip wget libassuan-devel \
+	genisoimage cloud-utils-growpart cloud-init && \
+    yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo && \
+    dnf install -y packer && \
     curl https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz -o go${GO_VERSION}.linux-amd64.tar.gz && \
     rm -rf /usr/local/go && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
     rm -f go${GO_VERSION}.linux-amd64.tar.gz
 
+
+# cloud-utils package is not available for rhel.
+RUN git clone https://github.com/canonical/cloud-utils
+RUN cd cloud-utils && make install
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "${RUST_VERSION}"
 
@@ -32,8 +35,6 @@ ENV PATH "/root/.cargo/bin:/usr/local/go/bin:$PATH"
 
 RUN echo $PATH
 
-RUN rustup target add x86_64-unknown-linux-musl && ln -sf /usr/bin/g++ /bin/musl-g++
-    
 
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip && \
     unzip protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local && rm -f protoc-${PROTOC_VERSION}-linux-x86_64.zip
@@ -52,6 +53,5 @@ RUN echo $CAA_SRC_BRANCH
 
 RUN git clone ${CAA_SRC} -b ${CAA_SRC_BRANCH} cloud-api-adaptor
 RUN git clone ${KATA_SRC} -b ${KATA_SRC_BRANCH} kata-containers
-
 
 ENV GOPATH /src

--- a/podvm/qcow2/rhel/qemu-rhel.pkr.hcl
+++ b/podvm/qcow2/rhel/qemu-rhel.pkr.hcl
@@ -15,6 +15,7 @@ source "qemu" "rhel" {
   ssh_wait_timeout  = "300s"
   vm_name           = "${var.qemu_image_name}"
   shutdown_command  = "sudo shutdown -h now"
+  qemu_binary       = "qemu-kvm"
 }
 
 build {


### PR DESCRIPTION
This has been tested with rhel 8.7 only 

Example:

This must be running on subscribed RHEL host
To build builder rhel container:

$ podman build -t podvm_builder_rhel -f Dockerfile.podvm_builder.rhel 

To build the podvm image:

$ RHEL_IMAGE_URL=<path/to/downloaded/image>
$ RHEL_IMAGE_CHECKSUM=<checksum>
$ podman build -t podvm_rhel_aws --build-arg BUILDER_IMG=localhost/podvm_builder_rhel:latest \
  --build-arg CLOUD_PROVIDER=aws --build-arg RHEL_IMAGE_CHECKSUM=${RHEL_IMAGE_CHECKSUM} \
  -v ${RHEL_IMAGE_URL}:/tmp/rhel.qcow2 -f Dockerfile.podvm.rhel 

Fixes: #472
Depends-on: confidential-containers/cloud-api-adaptor#473
Signed-off-by: Snir Sheriber <ssheribe@redhat.com>

NOTE: it should be possible to build without subscription, it will require to split  binaries build and packer build, which is a bit more complex than seemed, TBD
