### PR TITLE
image: Remove skopeo & umoci

### DIFF
--- a/azure/image/Makefile
+++ b/azure/image/Makefile
@@ -33,14 +33,8 @@ IMAGE_FILE := $(IMAGE_NAME)
 AGENT_PROTOCOL_FORWARDER = $(FILES_DIR)/usr/local/bin/agent-protocol-forwarder
 KATA_AGENT    = $(FILES_DIR)/usr/local/bin/kata-agent
 PAUSE         = $(FILES_DIR)/$(PAUSE_BUNDLE)/rootfs/pause
-SKOPEO    = $(FILES_DIR)/usr/bin/skopeo
-UMOCI     = $(FILES_DIR)/usr/local/bin/umoci
 
 BINARIES = $(AGENT_PROTOCOL_FORWARDER) $(KATA_AGENT) $(PAUSE)
-
-ifdef USE_SKOPEO
-BINARIES += $(SKOPEO) $(UMOCI)
-endif
 
 AGENT_PROTOCOL_FORWARDER_SRC = ../..
 
@@ -99,18 +93,12 @@ $(SKOPEO_SRC):
 $(SKOPEO_SRC)/bin/skopeo: $(SKOPEO_SRC)
 	cd "$(SKOPEO_SRC)" && make bin/skopeo
 
-$(SKOPEO): $(SKOPEO_SRC)/bin/skopeo
-	install -D --compare "$(SKOPEO_SRC)/bin/skopeo" "$@"
-
 # The umoci release page only publishes amd64 binaries. https://github.com/opencontainers/umoci/releases
 $(UMOCI_SRC):
 	git clone -b "v$(UMOCI_VERSION)" "$(UMOCI_REPO)" "$(UMOCI_SRC)"
 
 $(UMOCI_SRC)/umoci: $(UMOCI_SRC)
 	cd "$(UMOCI_SRC)" && make
-
-$(UMOCI): $(UMOCI_SRC)/umoci
-	install -D --compare "$(UMOCI_SRC)/umoci" "$@"
 
 $(PAUSE_SRC): $(SKOPEO_SRC)/bin/skopeo
 	$(SKOPEO_SRC)/bin/skopeo --policy "$(FILES_DIR)/etc/containers/policy.json" copy "$(PAUSE_REPO):$(PAUSE_VERSION)" "oci:$(PAUSE_SRC):$(PAUSE_VERSION)"

--- a/ibmcloud/README.md
+++ b/ibmcloud/README.md
@@ -281,8 +281,6 @@ You need to build a pod VM image for peer pod VMs. A pod VM image contains the f
 
 * Kata agent
 * Agent protocol forwarder
-* skopeo
-* umoci
 
 The build scripts are located in [ibmcloud/image](./image). The prerequisite software to build a pod VM image is already installed in the worker node by [the Ansible playbook](terraform/cluster/ansible/playbook.yml) for convenience.
 

--- a/podvm/Makefile.inc
+++ b/podvm/Makefile.inc
@@ -38,15 +38,9 @@ LIBC ?= $(if $(findstring s390x,$(LIBC_ARCH)),gnu,musl)
 AGENT_PROTOCOL_FORWARDER = $(FILES_DIR)/usr/local/bin/agent-protocol-forwarder
 KATA_AGENT    = $(FILES_DIR)/usr/local/bin/kata-agent
 PAUSE         = $(FILES_DIR)/$(PAUSE_BUNDLE)/rootfs/pause
-SKOPEO    = $(FILES_DIR)/usr/bin/skopeo
-UMOCI     = $(FILES_DIR)/usr/local/bin/umoci
 ATTESTATION_AGENT = $(FILES_DIR)/usr/local/bin/attestation-agent
 
 BINARIES = $(AGENT_PROTOCOL_FORWARDER) $(KATA_AGENT) $(PAUSE)
-
-ifdef USE_SKOPEO
-BINARIES += $(SKOPEO) $(UMOCI)
-endif
 
 KBC_URI ?= "null"
 ifdef AA_KBC
@@ -102,18 +96,12 @@ $(SKOPEO_SRC):
 $(SKOPEO_SRC)/bin/skopeo: $(SKOPEO_SRC)
 	cd "$(SKOPEO_SRC)" && make bin/skopeo
 
-$(SKOPEO): $(SKOPEO_SRC)/bin/skopeo
-	install -D --compare "$(SKOPEO_SRC)/bin/skopeo" "$@"
-
 # The umoci release page only publishes amd64 binaries. https://github.com/opencontainers/umoci/releases
 $(UMOCI_SRC):
 	git clone -b "v$(UMOCI_VERSION)" "$(UMOCI_REPO)" "$(UMOCI_SRC)"
 
 $(UMOCI_SRC)/umoci: $(UMOCI_SRC)
 	cd "$(UMOCI_SRC)" && make
-
-$(UMOCI): $(UMOCI_SRC)/umoci
-	install -D --compare "$(UMOCI_SRC)/umoci" "$@"
 
 $(PAUSE_SRC): $(SKOPEO_SRC)/bin/skopeo
 	$(SKOPEO_SRC)/bin/skopeo --policy "$(FILES_DIR)/etc/containers/policy.json" copy "$(PAUSE_REPO):$(PAUSE_VERSION)" "oci:$(PAUSE_SRC):$(PAUSE_VERSION)"


### PR DESCRIPTION
- Update Makefiles to remove the skopeo and umoci targets that install them into the peer pod image.
- Note: The skopeo and umoci source targets are still needed to copy and unpack the pause image for now.

Fixes: #164
Signed-off-by: stevenhorsman <steven@uk.ibm.com>