### PR TITLE
build: exclude systemd/system dirs from CAA go module

### DIFF
--- a/azure/go.mod
+++ b/azure/go.mod
@@ -1,0 +1,3 @@
+// Empty go.mod file to exclude the run-kata\x2dcontainers.mount file
+// from the cloud-api-adaptor Go module when cloud-api-adaptor is
+// imported by other Go projects

--- a/podvm/go.mod
+++ b/podvm/go.mod
@@ -1,0 +1,3 @@
+// Empty go.mod file to exclude the run-kata\x2dcontainers.mount file
+// from the cloud-api-adaptor Go module when cloud-api-adaptor is
+// imported by other Go projects


### PR DESCRIPTION
When cloud-api-adaptor is required by another Go project as a Go module, ignore the systemd/system directories as they contain a file run-kata\x2dcontainers.mount that breaks Go module imports.

Fixes #483

Signed-off-by: Matthew Arnold <mattarno@uk.ibm.com>