### PR TITLE
podvm: fix rhel's qemu binary path

### DIFF
--- a/podvm/qcow2/rhel/qemu-rhel.pkr.hcl
+++ b/podvm/qcow2/rhel/qemu-rhel.pkr.hcl
@@ -15,7 +15,7 @@ source "qemu" "rhel" {
   ssh_wait_timeout  = "300s"
   vm_name           = "${var.qemu_image_name}"
   shutdown_command  = "sudo shutdown -h now"
-  qemu_binary       = "qemu-kvm"
+  qemu_binary       = "/usr/libexec/qemu-kvm"
 }
 
 build {


### PR DESCRIPTION
to full path as it's not found in $PATH

Fixes: #472
Signed-off-by: Snir Sheriber <ssheribe@redhat.com>