### PR TITLE
qcow2: template: attempt installing open-vm-tools for rhel and centos

### DIFF
--- a/podvm/qcow2/centos/qemu-centos.pkr.hcl
+++ b/podvm/qcow2/centos/qemu-centos.pkr.hcl
@@ -69,6 +69,7 @@ build {
   provisioner "shell" {
     remote_folder = "~"
     inline = [
+      "sudo dnf -y install open-vm-tools || exit 0",
       "sudo bash ~/misc-settings.sh"
     ]
   }

--- a/podvm/qcow2/rhel/qemu-rhel.pkr.hcl
+++ b/podvm/qcow2/rhel/qemu-rhel.pkr.hcl
@@ -69,6 +69,8 @@ build {
   provisioner "shell" {
     remote_folder = "~"
     inline = [
+    # requires subscription
+      "sudo dnf -y install open-vm-tools || exit 0",
       "sudo bash ~/selinux_relabel.sh"
     ]
   }


### PR DESCRIPTION
This is useful if we are repurposing the qcow2 for a ovf.

Fixes: #502
Signed-off-by: Bandan Das <bsd@redhat.com>