### PR TITLE
qcow2: create an install script on the fly

### DIFF
--- a/podvm/qcow2/centos/qemu-centos.pkr.hcl
+++ b/podvm/qcow2/centos/qemu-centos.pkr.hcl
@@ -68,10 +68,12 @@ build {
 
   provisioner "shell" {
     remote_folder = "~"
+    environment_vars = [
+        "CLOUD_PROVIDER=${var.cloud_provider}",
+        "PODVM_DISTRO=${var.podvm_distro}",
+	]
     inline = [
-      "sudo dnf -y install open-vm-tools || exit 0",
-      "sudo bash ~/misc-settings.sh"
+      "sudo -E bash ~/misc-settings.sh"
     ]
   }
-
 }

--- a/podvm/qcow2/centos/variables.pkr.hcl
+++ b/podvm/qcow2/centos/variables.pkr.hcl
@@ -48,3 +48,13 @@ variable "qemu_image_name" {
   type    = string
   default = "peer-pod"
 }
+
+variable "podvm_distro" {
+  type    = string
+  default = env("PODVM_DISTRO")
+}
+
+variable "cloud_provider" {
+  type    = string
+  default = env("CLOUD_PROVIDER")
+}

--- a/podvm/qcow2/misc-settings.sh
+++ b/podvm/qcow2/misc-settings.sh
@@ -11,6 +11,31 @@
 # This ensures machine-id is generated during first boot and a unique
 # dhcp IP is assigned to the VM
 sudo echo -n > /etc/machine-id
-
 #Lock password for the ssh user (peerpod) to disallow logins
 sudo passwd -l peerpod
+
+# install required packages
+if [ "$CLOUD_PROVIDER" == "vsphere" ]
+then
+# Add vsphere specific commands to execute on remote
+    case $PODVM_DISTRO in
+	centos)
+	    #fallthrough
+	    ;&
+	rhel)
+	    (! dnf list --installed | grep open-vm-tools 2>&1 >/dev/null) && \
+		(! dnf -y install open-vm-tools) && \
+		     echo "$PODVM_DISTRO: Error installing package required for cloud provider: $CLOUD_PROVIDER" 1>&2 && exit 1
+	    ;;
+	ubuntu)
+	    (! dpkg -l | grep open-vm-tools 2>&1 > /dev/null) && apt-get update && \
+		(! apt-get -y install open-vm-tools 2>&1 > /dev/null) && \
+		     echo "$PODVM_DISTRO: Error installing package required for cloud provider: $CLOUD_PROVIDER" 1>&2  && exit 1
+	    ;;
+	*)
+	    ;;
+    esac
+# else if...
+#
+fi
+exit 0

--- a/podvm/qcow2/rhel/qemu-rhel.pkr.hcl
+++ b/podvm/qcow2/rhel/qemu-rhel.pkr.hcl
@@ -56,8 +56,12 @@ build {
 
   provisioner "shell" {
     remote_folder = "~"
+    environment_vars = [
+        "CLOUD_PROVIDER=${var.cloud_provider}",
+        "PODVM_DISTRO=${var.podvm_distro}",
+	]
     inline = [
-      "sudo bash ~/misc-settings.sh"
+      "sudo -E bash ~/misc-settings.sh"
     ]
   }
 
@@ -69,8 +73,6 @@ build {
   provisioner "shell" {
     remote_folder = "~"
     inline = [
-    # requires subscription
-      "sudo dnf -y install open-vm-tools || exit 0",
       "sudo bash ~/selinux_relabel.sh"
     ]
   }

--- a/podvm/qcow2/rhel/variables.pkr.hcl
+++ b/podvm/qcow2/rhel/variables.pkr.hcl
@@ -47,3 +47,13 @@ variable "qemu_image_name" {
   type    = string
   default = "peer-pod"
 }
+
+variable "podvm_distro" {
+  type    = string
+  default = env("PODVM_DISTRO")
+}
+
+variable "cloud_provider" {
+  type    = string
+  default = env("CLOUD_PROVIDER")
+}

--- a/podvm/qcow2/ubuntu/qemu-ubuntu.pkr.hcl
+++ b/podvm/qcow2/ubuntu/qemu-ubuntu.pkr.hcl
@@ -55,8 +55,12 @@ build {
 
   provisioner "shell" {
     remote_folder = "~"
+    environment_vars = [
+        "CLOUD_PROVIDER=${var.cloud_provider}",
+        "PODVM_DISTRO=${var.podvm_distro}",
+	]
     inline = [
-      "sudo bash ~/misc-settings.sh"
+      "sudo -E bash ~/misc-settings.sh"
     ]
   }
 

--- a/podvm/qcow2/ubuntu/variables.pkr.hcl
+++ b/podvm/qcow2/ubuntu/variables.pkr.hcl
@@ -47,3 +47,13 @@ variable "qemu_image_name" {
   type    = string
   default = "peer-pod"
 }
+
+variable "podvm_distro" {
+  type    = string
+  default = env("PODVM_DISTRO")
+}
+
+variable "cloud_provider" {
+  type    = string
+  default = env("CLOUD_PROVIDER")
+}


### PR DESCRIPTION
v2: 
  * Remove the shell-local based hack entirely
  * Assign environment vars CLOUD_PROVIDER and PODVM_DISTRO to packer user vars
  * Use environment_vars in the shell provisioner referencing these variables
  * Include logic in misc-settings.sh to install open-vm-tools
  
This script creates a target-script that is to executed on remote but is dependant on local variables. ATM, it is CLOUD_PROVIDER and is used to decide where we should install open-vm-tools but others can be easily added.

The way this works is:
1. Use the shell-local provisioner to create a script based on the value of CLOUD_PROVIDER. We use "generated = true" to make sure Packer does not complain about a failing stat.
2. Copy over as usual so that the shell provisioner can execute it.
3. To keep it simple, if nothing needs to be installed i.e. CLOUD_PROVIDER!=vsphere, we just copy an empty file over.

Fixes: #510
Signed-off-by: Bandan Das <bsd@redhat.com>