### PR TITLE
podvm/github-action: Support building public s390x qcow images 

### DIFF
--- a/.github/workflows/podvm.yaml
+++ b/.github/workflows/podvm.yaml
@@ -24,11 +24,18 @@ jobs:
           - ibmcloud
           - libvirt
           - vsphere
+        arch:
+          - amd64
         include:
           - os: centos
             dockerfile: Dockerfile.podvm.centos
           - os: ubuntu
             dockerfile: Dockerfile.podvm
+          - arch: s390x
+            os: ubuntu
+            provider: ibmcloud
+            dockerfile: Dockerfile.podvm
+            runner: ubuntu-latest
         runner:
           - ubuntu-latest
     steps:
@@ -52,8 +59,8 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         tags: |
-          quay.io/confidential-containers/podvm-${{ matrix.provider }}-${{ matrix.os }}:latest
-          quay.io/confidential-containers/podvm-${{ matrix.provider }}-${{ matrix.os }}:${{ github.sha }}
+          quay.io/confidential-containers/podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ matrix.arch }}:latest
+          quay.io/confidential-containers/podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ matrix.arch }}:${{ github.sha }}
         push: true
         context: podvm
         platforms: linux/amd64
@@ -61,17 +68,19 @@ jobs:
           podvm/${{ matrix.dockerfile }}
         build-args: |
           "CLOUD_PROVIDER=${{ matrix.provider }}"
+          "ARCH=${{ matrix.arch }}"
+          "UBUNTU_IMAGE_URL="
+          "UBUNTU_IMAGE_CHECKSUM="
 
     - name: Extract Asset
       run: |
         UUID=$(cat /proc/sys/kernel/random/uuid | cut -c 1-8)
         CONTAINER_NAME=temp-container-${UUID}
-        CID=$(docker create --name $CONTAINER_NAME quay.io/confidential-containers/podvm-${{ matrix.provider }}-${{ matrix.os }}:${{ github.sha }} /bin/sh)
+        CID=$(docker create --name $CONTAINER_NAME quay.io/confidential-containers/podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ matrix.arch }}:${{ github.sha }} /bin/sh)
         podvm=$(docker export $CID | tar t | grep podvm)
-        docker cp $CONTAINER_NAME:/$podvm podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ github.sha }}.qcow2
+        docker cp $CONTAINER_NAME:/$podvm podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ matrix.arch }}-${{ github.sha }}.qcow2
         docker rm -f $CONTAINER_NAME
     - name: Upload Asset
       uses: softprops/action-gh-release@v1
       with:
-        files: podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ github.sha }}.qcow2
-
+        files: podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ matrix.arch }}-${{ github.sha }}.qcow2

--- a/podvm/Dockerfile.podvm
+++ b/podvm/Dockerfile.podvm
@@ -11,10 +11,16 @@ FROM ${BUILDER_IMG} AS podvm_builder
 ARG CLOUD_PROVIDER=libvirt
 ARG PODVM_DISTRO=ubuntu
 ARG AA_KBC=offline_fs_kbc
+# If not provided, uses system architecture
+ARG ARCH
 
 ENV CLOUD_PROVIDER ${CLOUD_PROVIDER}
 ENV PODVM_DISTRO ${PODVM_DISTRO}
 ENV AA_KBC ${AA_KBC}
+ENV ARCH ${ARCH}
+
+# Installs add-ons for foreign target, if required
+RUN ./cloud-api-adaptor/podvm/hack/cross-build-extras.sh
 
 # Default to Ubuntu Focal amd64 release image. These variables can be overriden as needed
 ARG UBUNTU_IMAGE_URL=https://cloud-images.ubuntu.com/releases/focal/release-20230107/ubuntu-20.04-server-cloudimg-amd64.img

--- a/podvm/Makefile
+++ b/podvm/Makefile
@@ -6,16 +6,19 @@ include Makefile.inc
 
 .PHONY: image clean
 
-UBUNTU_IMAGE_URL  ?= https://cloud-images.ubuntu.com/$(UBUNTU_RELEASE)/current/$(UBUNTU_RELEASE)-server-cloudimg-$(DEB_ARCH).img
-UBUNTU_IMAGE_CHECKSUM ?= $(shell curl -LO  https://cloud-images.ubuntu.com/"$(UBUNTU_RELEASE)"/current/SHA256SUMS && \
+# Check for set but empty or unset URL and CHECKSUM
+UBUNTU_IMAGE_URL := $(or $(UBUNTU_IMAGE_URL),https://cloud-images.ubuntu.com/$(UBUNTU_RELEASE)/current/$(UBUNTU_RELEASE)-server-cloudimg-$(DEB_ARCH).img)
+UBUNTU_IMAGE_CHECKSUM := $(or $(UBUNTU_IMAGE_CHECKSUM),$(shell curl -LO  https://cloud-images.ubuntu.com/"$(UBUNTU_RELEASE)"/current/SHA256SUMS && \
 				grep "$(UBUNTU_RELEASE)"-server-cloudimg-"$(DEB_ARCH)".img SHA256SUMS | awk '{print $$1}' && \
-				rm -f SHA256SUMS)
+				rm -f SHA256SUMS))
 
 IMAGE_SUFFIX := .qcow2
 PODVM_DISTRO ?= ubuntu
 KATA_AGENT_SRC := ../../kata-containers/src/agent
 STATIC_LIBSECCOMP_BUILDER := ../../kata-containers/ci/install_libseccomp.sh
 AGENT_PROTOCOL_FORWARDER_SRC := ../
+
+QEMU_MACHINE_TYPE_s390x := s390-ccw-virtio
 
 image: $(IMAGE_FILE)
 
@@ -24,7 +27,13 @@ ifeq ($(PODVM_DISTRO),ubuntu)
 	@echo defined
 	$(eval OPTS := -var qemu_image_name=${IMAGE_FILE} \
 	-var cloud_image_url=${UBUNTU_IMAGE_URL} \
-	-var cloud_image_checksum=${UBUNTU_IMAGE_CHECKSUM} qcow2/ubuntu)
+	-var cloud_image_checksum=${UBUNTU_IMAGE_CHECKSUM})
+ifneq ($(HOST_ARCH),$(ARCH))
+	$(eval OPTS += -var qemu_binary=qemu-system-${ARCH} \
+	-var machine_type=${QEMU_MACHINE_TYPE_${ARCH}} \
+	-var boot_wait=300s)
+endif
+	$(eval OPTS +=  qcow2/ubuntu)
 else ifeq ($(PODVM_DISTRO),rhel)
 ifndef RHEL_IMAGE_URL
 	$(error "RHEL_IMAGE_URL is not defined")

--- a/podvm/Makefile.inc
+++ b/podvm/Makefile.inc
@@ -15,6 +15,8 @@ IMAGE_PREFIX := podvm
 
 HOST_ARCH   := $(shell uname -m)
 ARCH        ?= $(HOST_ARCH)
+# Normalise x86_64 / amd64 for input ARCH
+ARCH        := $(subst amd64,x86_64,$(ARCH))
 DEB_ARCH    := $(subst x86_64,amd64,$(ARCH))
 LIBC        ?= $(if $(findstring s390x,$(ARCH)),gnu,musl)
 RUST_TARGET := $(ARCH)-unknown-linux-$(LIBC)
@@ -121,6 +123,6 @@ $(ATTESTATION_AGENT_SRC):
 	git clone "$(ATTESTATION_AGENT_REPO)" "$(ATTESTATION_AGENT_SRC)"
 
 $(ATTESTATION_AGENT): $(ATTESTATION_AGENT_SRC)
-	cd "$(ATTESTATION_AGENT_SRC)" && $(RUST_FLAGS) $(MAKE) KBC="$(AA_KBC)" LIBC="$(LIBC)"
+	cd "$(ATTESTATION_AGENT_SRC)" && CC= ARCH=$(ARCH) $(MAKE) KBC="$(AA_KBC)" LIBC="$(LIBC)"
 	mkdir -p "$(@D)"
 	install --compare "$(ATTESTATION_AGENT_SRC)/app/target/$(RUST_TARGET)/release/attestation-agent" "$@"

--- a/podvm/hack/cross-build-extras.sh
+++ b/podvm/hack/cross-build-extras.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# cross-build-extras.sh
+# Install the additional requires for cross-compilation
+# of podvm image binaries
+
+# If ARCH is not set, exit
+[[ -z $ARCH ]] && exit 0
+
+# Normalise ARCH (if input is amd64 use x86_64)
+ARCH=${ARCH/amd64/x86_64}
+
+# If ARCH is equal to HOST, exit
+[[ $ARCH = $(uname -m) ]] && exit 0
+
+# Only gnu is available for s390x
+libc=$([[ $ARCH =~ s390x ]] && echo "gnu" || echo "musl")
+rustTarget="$ARCH-unknown-linux-$libc"
+
+rustup target add "$rustTarget"
+apt install -y "qemu-system-$ARCH"
+apt install -y "gcc-$ARCH-linux-$libc"

--- a/podvm/qcow2/ubuntu/qemu-ubuntu.pkr.hcl
+++ b/podvm/qcow2/ubuntu/qemu-ubuntu.pkr.hcl
@@ -7,14 +7,17 @@ source "qemu" "ubuntu" {
   headless          = true
   iso_checksum      = "${var.cloud_image_checksum}"
   iso_url           = "${var.cloud_image_url}"
-  output_directory  = "output"
-  qemuargs          = [["-m", "${var.memory}"], ["-smp", "cpus=${var.cpus}"], ["-cdrom", "${var.cloud_init_image}"], ["-serial", "mon:stdio"]]
+  output_directory  = "${var.output_directory}"
+  qemuargs          = [["-device", "virtio-blk,drive=virtio-drive,id=virtio-disk0,bootindex=1"], ["-drive", "file=${var.output_directory}/${var.qemu_image_name},if=none,cache=writeback,discard=ignore,format=qcow2,id=virtio-drive"], ["-device", "virtio-scsi"], ["-drive", "file=${var.cloud_init_image},format=raw,if=none,id=c1"], ["-device", "scsi-cd,drive=c1"], ["-m", "${var.memory}"], ["-smp", "cpus=${var.cpus}"], ["-serial", "mon:stdio"]]
   ssh_password      = "${var.ssh_password}"
   ssh_port          = 22
   ssh_username      = "${var.ssh_username}"
   ssh_wait_timeout  = "300s"
+  boot_wait         = "${var.boot_wait}"
   vm_name           = "${var.qemu_image_name}"
-  shutdown_command  = "sudo shutdown -h now" 
+  shutdown_command  = "sudo shutdown -h now"
+  qemu_binary       = "${var.qemu_binary}"
+  machine_type      = "${var.machine_type}"
 }
 
 build {

--- a/podvm/qcow2/ubuntu/variables.pkr.hcl
+++ b/podvm/qcow2/ubuntu/variables.pkr.hcl
@@ -48,6 +48,26 @@ variable "qemu_image_name" {
   default = "peer-pod"
 }
 
+variable "qemu_binary" {
+  type    = string
+  default = "qemu-system-x86_64"
+}
+
+variable "machine_type" {
+  type = string
+  default = "pc"
+}
+
+variable "boot_wait" {
+  type = string
+  default = "10s"
+}
+
+variable "output_directory" {
+  type = string
+  default = "output"
+}
+
 variable "podvm_distro" {
   type    = string
   default = env("PODVM_DISTRO")


### PR DESCRIPTION
The `cd-rom` option for qemu doesn't work for s390x as it can't auto-detect the layout. Uses `virtio-scsi` instead works for both `s390x` and `amd64` for the cloud-init data. Addtionally to make sure it boots from the `qcow2` drive instead of the cloud-init, need to explictly define the device and drive.

Fixes: #512
    
Signed-off-by: James Tumber <james.tumber@ibm.com>