### PR TITLE
podvm: initialize ARCH argument in Dockerfile.podvm

### DIFF
--- a/podvm/Dockerfile.podvm
+++ b/podvm/Dockerfile.podvm
@@ -12,7 +12,7 @@ ARG CLOUD_PROVIDER=libvirt
 ARG PODVM_DISTRO=ubuntu
 ARG AA_KBC=offline_fs_kbc
 # If not provided, uses system architecture
-ARG ARCH
+ARG ARCH=x86_64
 
 ENV CLOUD_PROVIDER ${CLOUD_PROVIDER}
 ENV PODVM_DISTRO ${PODVM_DISTRO}


### PR DESCRIPTION
The ARCH argument to Dockerfile.podvm was introduced in commit 4df1c88d874d1 but it is not proper initialized so that if ARCH is not passed then the libseccomp build fails. This changed the dockerfile to ensure that ARCH is x86_64 by default.

Fixes #536
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>