### PR TITLE
operator: pre-install payload multiarch support

### DIFF
--- a/install/pre-install-payload/Dockerfile
+++ b/install/pre-install-payload/Dockerfile
@@ -1,18 +1,18 @@
-ARG IMAGE
-FROM ${IMAGE:-docker.io/library/centos}:7
+FROM --platform=$BUILDPLATFORM quay.io/centos/centos:stream9-minimal as builder
 
-ARG ARCH
+ARG TARGETARCH
+
+RUN \
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$TARGETARCH/kubectl" && \
+install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
+FROM --platform=$TARGETPLATFORM quay.io/centos/centos:stream9-minimal
+
+COPY --from=builder /usr/local/bin/kubectl /usr/local/bin/kubectl
+
 ARG SYSTEMD_ARTIFACTS=./config/remote-hyp.service
 ARG CAA_ARTIFACTS=./scripts
 ARG DESTINATION=/opt/confidential-containers-pre-install-artifacts
 
 COPY ${SYSTEMD_ARTIFACTS} ${DESTINATION}/etc/systemd/system/
 COPY ${CAA_ARTIFACTS}/* ${DESTINATION}/scripts/
-
-RUN \
-echo "[kubernetes]" >> /etc/yum.repos.d/kubernetes.repo && \
-echo "name=Kubernetes" >> /etc/yum.repos.d/kubernetes.repo && \
-echo "baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-$(uname -m)" >> /etc/yum.repos.d/kubernetes.repo && \
-echo "gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg" >> /etc/yum.repos.d/kubernetes.repo && \
-yum -y install kubectl && \
-yum clean all

--- a/install/pre-install-payload/Makefile
+++ b/install/pre-install-payload/Makefile
@@ -1,2 +1,2 @@
-build: 
+image:
 	hack/build.sh

--- a/install/pre-install-payload/hack/build.sh
+++ b/install/pre-install-payload/hack/build.sh
@@ -6,52 +6,20 @@ set -o nounset
 
 script_dir=$(dirname "$(readlink -f "$0")")
 
-registry="${registry:-quay.io/confidential-containers/peer-pods-pre-install-payload}"
+registry="${registry:-quay.io/confidential-containers}"
+name="peer-pods-pre-install-payload"
+tag=$(date +%Y%m%d%H%M%s)
 
-supported_arches=(
-	"linux/amd64"
-)
-
-function setup_env_for_arch() {
-	case "$1" in
-		"linux/amd64") 
-			image="docker.io/library/centos"
-			kernel_arch="x86_64"
-			;;
-		(*) echo "$1 is not supported" && exit 1
-	esac
-		
-}
+supported_arches="linux/amd64,linux/s390x"
 
 function build_preinstall_payload() {
 	pushd "${script_dir}/.."
 
-	tag=$(date +%Y%m%d%H%M%s)
-
-	for arch in ${supported_arches[@]}; do
-		setup_env_for_arch "${arch}"
-
-		echo "Building payload image for ${arch}"
-		docker buildx build \
-			--build-arg ARCH="${kernel_arch}" \
-			-f Dockerfile \
-			-t "${registry}:${kernel_arch}-${tag}" \
-			--platform="${arch}" \
-			--load \
-			.
-		docker push "${registry}:${kernel_arch}-${tag}"
-	done
-
-	docker manifest create \
-		${registry}:${tag} \
-		--amend ${registry}:x86_64-${tag}
-
-	docker manifest create \
-		${registry}:latest \
-		--amend ${registry}:x86_64-${tag}
-
-	docker manifest push ${registry}:${tag}
-	docker manifest push --purge ${registry}:latest
+	docker buildx build --platform ${supported_arches} \
+		-f Dockerfile \
+		-t "${registry}/${name}:${tag}" \
+		--push \
+		.
 
 	popd
 }


### PR DESCRIPTION
Find test run resulting image [here](https://hub.docker.com/layers/jamesnelson/peer-pods-pre-install-payload/2023011914461674139575/images/sha256-0cab3c4d1823aab8d190ef5f1e201935619c9a2aef447ddc435e969e678de7f8?context=explore)

Switched from centos to ubuntu for base image. CentOS is out of support, but happy to discuss best alternative.

Fixes: #544

Signed-off-by: James Tumber <james.tumber@ibm.com>