### PR TITLE
github-action: Only build s390x image for ibmcloud

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -8,10 +8,13 @@ on:
   push:
     branches:
       - 'staging'
+env:
+  go_version: 1.18
+
 jobs:
   build_push_job:
     name: build and push
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -19,20 +22,20 @@ jobs:
           # Please keep this list in alphabetical order.
           - aws
           - azure
-          - ibmcloud
           - libvirt
           - vsphere
-        runner:
-          - ubuntu-latest
-        go_version:
-          - 1.18
+        arches:
+          - linux/amd64
+        include:
+          - provider: ibmcloud
+            arches: linux/amd64,linux/s390x
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
-      - name: Setup Golang version ${{ matrix.go_version }}
+      - name: Setup Golang version ${{ env.go_version }}
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ matrix.go_version }}
+          go-version: ${{ env.go_version }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Install build dependencies
@@ -48,4 +51,4 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
       - name: Build and push image
         run: |
-          make CLOUD_PROVIDER=${{ matrix.provider }} image
+          ARCHES=${{matrix.arches}} make CLOUD_PROVIDER=${{ matrix.provider }} image

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -10,7 +10,7 @@ registry="${registry:-quay.io/confidential-containers}"
 name="cloud-api-adaptor-${CLOUD_PROVIDER}"
 tag=$(date +%Y%m%d%H%M%s)
 
-supported_arches="linux/amd64,linux/s390x"
+supported_arches=${ARCHES:-"linux/amd64,linux/s390x"}
 
 function build_caa_payload() {
 	pushd "${script_dir}/.."


### PR DESCRIPTION
s390x build doesn't work for libvirt, additionally no other providers can run s390x so enabling it only for ibmcloud makes sense.

Test run: https://github.com/jtumber-ibm/cloud-api-adaptor/actions/runs/3960399170
Test results: 
libvirt https://hub.docker.com/r/jamesnelson/cloud-api-adaptor-libvirt/tags
ibmcloud https://hub.docker.com/r/jamesnelson/cloud-api-adaptor-ibmcloud/tags

I've moved `go_version` and `runs-on` out of the matrix to avoid duplicating them for the separate `ibmcloud` job, hope that is ok.

Fixes: #546

Signed-off-by: James Tumber <james.tumber@ibm.com>