### PR TITLE
podvm: rhel: relabel before running misc-settings.sh

### DIFF
--- a/podvm/qcow2/rhel/qemu-rhel.pkr.hcl
+++ b/podvm/qcow2/rhel/qemu-rhel.pkr.hcl
@@ -49,6 +49,20 @@ build {
     ]
   }
 
+# relabel copied files right after copy-files.sh
+# to prevent other commands from failing
+  provisioner "file" {
+    source      = "qcow2/selinux_relabel.sh"
+    destination = "~/selinux_relabel.sh"
+  }
+
+  provisioner "shell" {
+    remote_folder = "~"
+    inline = [
+      "sudo bash ~/selinux_relabel.sh"
+    ]
+  }
+
   provisioner "file" {
     source      = "qcow2/misc-settings.sh"
     destination = "~/misc-settings.sh"
@@ -62,18 +76,6 @@ build {
 	]
     inline = [
       "sudo -E bash ~/misc-settings.sh"
-    ]
-  }
-
-  provisioner "file" {
-    source      = "qcow2/selinux_relabel.sh"
-    destination = "~/selinux_relabel.sh"
-  }
-
-  provisioner "shell" {
-    remote_folder = "~"
-    inline = [
-      "sudo bash ~/selinux_relabel.sh"
     ]
   }
 }


### PR DESCRIPTION
The relabeling in the provisioner is intended to fix labeling when packer copies over files to the image. It's run at the end during provisioning. However, misc-settings.sh may install packages and configure services to boot at startup. If the labels are not correct, this will fail.

Move labeling to right after we copy our target dir and run misc-settings in the end.

Fixes: #548
Signed-off-by: Bandan Das <bsd@redhat.com>