### PR TITLE
azure: update autogenerated AZURE_VM_NAME

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,7 +40,7 @@ exec cloud-api-adaptor-aws aws \
 }
 
 azure() {
-test_vars AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID
+test_vars AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_VNET_NAME AZURE_SUBNET_NAME AZURE_NSG_NAME
 
 set -x
 exec cloud-api-adaptor-azure azure \
@@ -49,8 +49,8 @@ exec cloud-api-adaptor-azure azure \
   -instance-size "${AZURE_INSTANCE_SIZE}" \
   -resourcegroup "${AZURE_RESOURCE_GROUP}" \
   -vxlan-port 8472 \
-  -subnetid "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP}/providers/Microsoft.Network/virtualNetworks/${AZURE_VM_NAME}VNET/subnets/${AZURE_VM_NAME}Subnet" \
-  -securitygroupid "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP}/providers/Microsoft.Network/networkSecurityGroups/${AZURE_VM_NAME}NSG" \
+  -subnetid "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP}/providers/Microsoft.Network/virtualNetworks/${AZURE_VNET_NAME}VNET/subnets/${AZURE_SUBNET_NAME}Subnet" \
+  -securitygroupid "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP}/providers/Microsoft.Network/networkSecurityGroups/${AZURE_NSG_NAME}NSG" \
   -imageid "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP}/providers/Microsoft.Compute/images/${AZURE_IMAGE}" \
   ${optionals}
 }

--- a/install/overlays/azure/kustomization.yaml
+++ b/install/overlays/azure/kustomization.yaml
@@ -19,7 +19,9 @@ configMapGenerator:
   - AZURE_REGION="eastus" #set
   - AZURE_INSTANCE_SIZE="Standard_D8as_v5" #set
   - AZURE_RESOURCE_GROUP="" #set
-  - AZURE_VM_NAME="" #set
+  - AZURE_VNET_NAME="" #set
+  - AZURE_SUBNET_NAME="" #set
+  - AZURE_NSG_NAME="" #set
   - AZURE_IMAGE="" #set
   #- PAUSE_IMAGE="" # Uncomment and set if you want to use a specific pause image
   #- VXLAN_PORT="" # Uncomment and set if you want to use a specific vxlan port. Defaults to 4789


### PR DESCRIPTION
In a setup where user has a VM different from the default setup then AZURE_VM_NAME won't work, as VNET, SUBNET, NSG name will be different.

Fixes: #551
Signed-off-by: Kautilya Tripathi <ktripathi@microsoft.com>