### PR TITLE
operator: fix cri runtime endpoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CLOUD_PROVIDER=${1:-$CLOUD_PROVIDER}
-CRI_RUNTIME_ENDPOINT=${CRI_RUNTIME_ENDPOINT:-/run/peerpod/cri-runtime.sock}
+CRI_RUNTIME_ENDPOINT=${CRI_RUNTIME_ENDPOINT:-/run/cri-runtime.sock}
 optionals+=""
 
 # Ensure you add a space before the closing quote (") when updating the optionals

--- a/install/overlays/aws/cri_runtime_endpoint.yaml
+++ b/install/overlays/aws/cri_runtime_endpoint.yaml
@@ -11,7 +11,7 @@ spec:
       containers:
       - name: cloud-api-adaptor-con
         volumeMounts:
-        - mountPath: /run/peerpod/cri-runtime.sock # in-container CRI_RUNTIME_ENDPOINT default
+        - mountPath: /run/cri-runtime.sock # in-container CRI_RUNTIME_ENDPOINT default
           name: cri-runtime-endpoint
       volumes:
       - name: cri-runtime-endpoint

--- a/install/overlays/azure/cri_runtime_endpoint.yaml
+++ b/install/overlays/azure/cri_runtime_endpoint.yaml
@@ -11,7 +11,7 @@ spec:
       containers:
       - name: cloud-api-adaptor-con
         volumeMounts:
-        - mountPath: /run/peerpod/cri-runtime.sock # in-container CRI_RUNTIME_ENDPOINT default
+        - mountPath: /run/cri-runtime.sock # in-container CRI_RUNTIME_ENDPOINT default
           name: cri-runtime-endpoint
       volumes:
       - name: cri-runtime-endpoint

--- a/install/overlays/ibmcloud/cri_runtime_endpoint.yaml
+++ b/install/overlays/ibmcloud/cri_runtime_endpoint.yaml
@@ -11,7 +11,7 @@ spec:
       containers:
       - name: cloud-api-adaptor-con
         volumeMounts:
-        - mountPath: /run/peerpod/cri-runtime.sock # in-container CRI_RUNTIME_ENDPOINT default
+        - mountPath: /run/cri-runtime.sock # in-container CRI_RUNTIME_ENDPOINT default
           name: cri-runtime-endpoint
       volumes:
       - name: cri-runtime-endpoint

--- a/install/overlays/libvirt/cri_runtime_endpoint.yaml
+++ b/install/overlays/libvirt/cri_runtime_endpoint.yaml
@@ -11,7 +11,7 @@ spec:
       containers:
       - name: cloud-api-adaptor-con
         volumeMounts:
-        - mountPath: /run/peerpod/cri-runtime.sock # in-container CRI_RUNTIME_ENDPOINT default
+        - mountPath: /run/cri-runtime.sock # in-container CRI_RUNTIME_ENDPOINT default
           name: cri-runtime-endpoint
       volumes:
       - name: cri-runtime-endpoint

--- a/install/overlays/vsphere/cri_runtime_endpoint.yaml
+++ b/install/overlays/vsphere/cri_runtime_endpoint.yaml
@@ -11,7 +11,7 @@ spec:
       containers:
       - name: cloud-api-adaptor-con
         volumeMounts:
-        - mountPath: /run/peerpod/cri-runtime.sock # in-container CRI_RUNTIME_ENDPOINT default
+        - mountPath: /run/cri-runtime.sock # in-container CRI_RUNTIME_ENDPOINT default
           name: cri-runtime-endpoint
       volumes:
       - name: cri-runtime-endpoint


### PR DESCRIPTION
The operator install for a kubernetes cluster using IBM Cloud VPC Infrastructure requires the following cri_runtime_endpoint.yaml to work.

Fixes: #530

Signed-off-by: Matthew Arnold <mattarno@uk.ibm.com>