### PR TITLE
ibmcloud: create ibmcloud self-managed cluster

### DIFF
--- a/ibmcloud/cluster/.gitignore
+++ b/ibmcloud/cluster/.gitignore
@@ -1,0 +1,5 @@
+.terraform*
+terraform.tfvars
+terraform.tfstate*
+/ansible/inventory
+/config

--- a/ibmcloud/cluster/README.md
+++ b/ibmcloud/cluster/README.md
@@ -1,3 +1,165 @@
-This Terraform script creates a cluster of n workers using ibmcloud infrastructure.
+# Setup procedure for an IBM Cloud self-managed cluster
 
-It can be used as a basis for testing the cloud-api-adaptor and peerpods.
+This Terraform script creates an *n*-node self-managed Kubernetes cluster using ibmcloud infrastructure.
+This can then be used to test the cloud-api adaptor and peer-pods.
+
+## Prerequisites
+
+To create the Kubernetes cluster, you need to install terraform, Ansible and the IBM Cloud CLI on your 
+'development machine'. To manage the cluster you will need to install `kubectl`.
+Please follow the the official installation guides:
+
+* [Install Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+
+> **Tip:** If you are using Ubuntu linux, you can run follow commands simply:
+> ```bash
+> $ sudo apt-get update && sudo apt-get install -y gnupg software-properties-common curl
+> $ curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+> $ sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+> $ sudo apt-get install terraform -y
+> ```
+
+* [Install Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
+
+> **Tip:** If you are using Ubuntu linux, you can run follow commands simply:
+> ```bash
+> $ sudo apt-get install -y python3
+> $ sudo ln -s /usr/bin/python3 /usr/bin/python
+> $ sudo add-apt-repository --yes --update ppa:ansible/ansible
+> $ sudo apt-get install ansible -y
+> ```
+
+* [Installing the stand-alone IBM Cloud CLI](https://cloud.ibm.com/docs/cli?topic=cli-install-ibmcloud-cli)
+
+> **Tips**
+> - If you are using Ubuntu linux, you can run follow commands simply:
+>     ```bash
+>     $ curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
+>     $ ibmcloud plugin install vpc-infrastructure
+>     $ ibmcloud plugin install cloud-object-storage
+>     ```
+> - You can use the [IBM Cloud Web UI](https://cloud.ibm.com/vpc-ext/overview) for most of the operations of IBM Cloud.
+And please make sure that you are selecting the correct region in the Web UI.
+> 
+
+* You need IBM Cloud API key. You can create your own API key at [https://cloud.ibm.com/iam/apikeys](https://cloud.ibm.com/iam/apikeys).
+
+* [Install `kubectl` to run commands against the Kubernetes cluster](https://kubernetes.io/docs/tasks/tools/)
+
+## Create an IBM Cloud Virtual Private Cloud (VPC) and 'self-managed' Kubernetes Cluster -
+
+The Terraform configuration supports building the cluster on both the x86 (Intel) and s390x (IBM Z) architectures.
+
+To use the Terraform configuration, you need to create a file `terraform.tfvars` to specify parameters for the
+Terraform configuration. The `terraform.tfvars` file with all mandatory parameters looks like this:
+
+```
+ibmcloud_api_key = "<your API key>"
+ssh_key_name = "<name of your IBM Cloud create SSH key>"
+```
+
+There are also a number of optional fields:
+```
+cluster_name = "<name of your cluster>
+region_name = "<name of an IBM Cloud region>"
+zone_name = "<name of a zone in your IBM Cloud zone region>"
+ssh_pub_key = "<your SSH public key - this results in the ssh_key being created on IBM Cloud>"
+node_image = "<name of the image to use for the Kubernetes nodes"
+node_profile = "<name of the instance profile to use for the Kubernetes nodes>"
+nodes = <number of nodes created in the cluster>
+containerd_version = "<the version of containerd installed on the Kubernetes nodes>"
+```
+
+#### Parameters
+
+> **Notes:**
+> - `ibmcloud_api_key` is your IBM Cloud API key that you created at 
+[https://cloud.ibm.com/iam/apikeys](https://cloud.ibm.com/iam/apikeys).
+> - `ssh_key_name` is the name of your SSH key registered in IBM Cloud or the name of a new SSH key if a public key is
+also provided using the optional `ssh_pub_key` parameter. You can add your SSH key at 
+[https://cloud.ibm.com/vpc-ext/compute/sshKeys](https://cloud.ibm.com/vpc-ext/compute/sshKeys). For more information
+about SSH keys see [managing SSH Keys](https://cloud.ibm.com/docs/vpc?topic=vpc-ssh-keys). The SSH key will be 
+installed on the Kubernetes control plane and worker nodes and is used to access them from your 'development machine' and for terraform to perform the cluster set up.
+> - `cluster_name` (optional) is a name of a Kubernetes cluster. This name is used for the prefix of the names of 
+Kubernetes node virtual server instances, the VPC and the subnet. If not set it defaults to `caa-cluster`.
+> - `region_name` (optional) is the IBM Cloud region Terraform will create the demo environment in. If not set it
+defaults to `jp-tok`.
+> - `zone_name` (optional) is the zone in the region Terraform will create the demo environment in. If not set it
+defaults to `jp-tok-2`.
+> - `ssh_pub_key` (optional) is an variable for a SSH public key which has **not** been registered in IBM Cloud in the
+targeted region. Terraform will manage this key instead. You cannot register the same SSH public key in the same region
+twice under different SSHs key names. This key needs to be password-less and on the 'developer machine' running the terraform in order to perform the cluster set up.
+> - `node_image` (optional) is a name of IBM Cloud infrastructure image. This name is used to create virtual server
+ instances for the Kubernetes control plane and worker. For more information, about VPC custom images, see 
+ [IBM Cloud Importing and managing custom images](https://cloud.ibm.com/docs/vpc?topic=vpc-managing-images).
+  If not set it defaults to `ibm-ubuntu-20-04-2-minimal-s390x-1` for **`s390x`** architecture.
+> - `node_profile` (optional) is a name of IBM Cloud virtual server instance profile. This name is used to create virtual server instances for the Kubernetes control plane and worker. For more information, about virtual server instance profile, see [instance profiles](https://cloud.ibm.com/docs/vpc?topic=vpc-profiles). If not set it defaults to `bz2-2x8`, which uses the `s390x` architecture, has 2 vCPUs and 8 GB memory.
+> - `nodes` (optional) is the number of VSIs created to be used as Kubernetes nodes. There will be a single control 
+plane node and the rest will be worker nodes. If not set it defaults to `2`.
+> - `containerd_version` (optional) is the version of containerd installed on the Kubernetes nodes. If not set it 
+defaults to `1.7.0-beta.3`.
+ <!-- TODO #570 once we've fixed pre-install of containerd note that this might be overriden?-->
+
+> **Hint:** In order to create a cluster based on a different type of VSI image you can use the `instance_profile_name`
+and `image_name` parameters. E.g., to create an **x86** architecture based cluster, include the following two lines in
+the `terraform.tfvars` file
+>
+>     node_profile = "bx2-2x8"
+>     node_image = "ibm-ubuntu-20-04-3-minimal-amd64-1"
+>
+
+After writing you `terraform.tfvars` file you can create your VPC by executing the following commands on your
+'development machine`':
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+The following IBM Cloud resources will be created when running the end-to-end Terraform configuration:
+* VPC
+* Security groups
+* Subnets
+* Public gateway
+* Floating IP for the public gateway
+* Virtual server instances for the Kubernetes nodes
+* Floating IPs for the Kubernetes control plane and worker virtual server instances
+* SSH key, if you specified the optional `ssh_pub_key` variable
+
+## Connect to the cluster and test it
+
+Once the terraform process has completed, the IBM Cloud VPC resources will have been created and it will have created
+a file `config` which is the
+[kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
+for the cluster. 
+
+To create a quick nginx pod to test the cluster, you can run the follow steps:
+- From within the `cloud-api-adaptor/ibmcloud/cluster` directory, run `export KUBECONFIG="$(pwd)/config"` to let the
+system know to use the `config` file for Kubernetes. Alternatively add the `--kubeconfig config` option to all
+`kubectl` commands.
+- Create an nginx deployment with:
+```
+$ kubectl create -f https://k8s.io/examples/application/deployment.yaml
+```
+- Check the pods were created successfully with:
+```
+$ kubectl get pods
+```
+This should result in something like:
+```
+NAME                                READY   STATUS    RESTARTS   AGE
+nginx-deployment-85996f8dbd-26kls   1/1     Running   0          8s
+nginx-deployment-85996f8dbd-m555l   1/1     Running   0          8s
+```
+- The deployment can be removed by running:
+```
+$ kubectl delete -f https://k8s.io/examples/application/deployment.yaml
+```
+
+## Delete the cluster
+
+Once you are finished with the cluster and ready to free up the IBM Cloud resources, from your 'development machine'
+navigate to the `cloud-api-adaptor/ibmcloud/cluster` repository directory and delete the VPC Kubernetes cluster with:
+```bash
+$ terraform destroy
+```

--- a/ibmcloud/cluster/README.md
+++ b/ibmcloud/cluster/README.md
@@ -1,0 +1,3 @@
+This Terraform script creates a cluster of n workers using ibmcloud infrastructure.
+
+It can be used as a basis for testing the cloud-api-adaptor and peerpods.

--- a/ibmcloud/cluster/ansible/containerd.yaml
+++ b/ibmcloud/cluster/ansible/containerd.yaml
@@ -1,0 +1,42 @@
+#
+# (C) Copyright IBM Corp. 2023.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+---
+- hosts: all
+  become: true
+  tasks:
+    - include_tasks: tasks/bootstrap.yaml
+    - include_tasks: tasks/k8s.yaml
+    - include_tasks: tasks/binaries.yaml
+
+    - name: "Create a directory for containerd config"
+      file: path=/etc/containerd state=directory
+
+    - name: Load kernel modules
+      modprobe:
+        name: "{{ item }}"
+      with_items:
+        - br_netfilter
+
+    - name: Set sysctl parameters for Kubernetes
+      sysctl:
+        name: "{{ item.name }}"
+        value: "{{ item.value }}"
+        reload: yes
+      with_items:
+        - { name: net.ipv4.ip_forward, value: 1 }
+        - { name: net.bridge.bridge-nf-call-ip6tables, value: 1 }
+        - { name: net.bridge.bridge-nf-call-iptables, value: 1 }
+
+    - name: "Create a directory for systemd service"
+      file: path=/usr/local/lib/systemd/system state=directory
+
+    - name: "Get containerd.service"
+      ansible.builtin.get_url:
+        url: "https://raw.githubusercontent.com/containerd/containerd/main/containerd.service"
+        dest: /usr/local/lib/systemd/system/containerd.service
+
+    - name: "Start Containerd"
+      systemd: name=containerd daemon_reload=yes state=started enabled=yes

--- a/ibmcloud/cluster/ansible/inventory.tmpl
+++ b/ibmcloud/cluster/ansible/inventory.tmpl
@@ -1,0 +1,7 @@
+[cluster]
+%{ for addr in ip_addrs ~}
+${addr}
+%{ endfor ~}
+
+[cluster:vars]
+ansible_ssh_common_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'

--- a/ibmcloud/cluster/ansible/tasks/binaries.yaml
+++ b/ibmcloud/cluster/ansible/tasks/binaries.yaml
@@ -1,0 +1,23 @@
+#
+# (C) Copyright IBM Corp. 2023.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+---
+- name: "Get containerd binary"
+  unarchive:
+    src: "https://github.com/containerd/containerd/releases/download/v{{ containerd_release_version }}/containerd-{{ containerd_release_version }}-linux-{{ ansible_architecture }}.tar.gz"
+    dest: "/usr/local"
+    remote_src: yes
+
+- name: "Get runc binary"
+  ansible.builtin.get_url:
+    url: "https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.{{ ansible_architecture }}"
+    dest: /usr/local/sbin/runc
+    mode: '0555'
+
+- name: "Get cni plugin"
+  unarchive:
+    src: "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-{{ ansible_architecture }}-v1.2.0.tgz"
+    dest: "/opt/cni/bin"
+    remote_src: yes

--- a/ibmcloud/cluster/ansible/tasks/bootstrap.yaml
+++ b/ibmcloud/cluster/ansible/tasks/bootstrap.yaml
@@ -1,0 +1,18 @@
+#
+# (C) Copyright IBM Corp. 2023.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+---
+- name: "Install required packages on Ubuntu"
+  apt:
+    update_cache: true
+    name: "{{ item }}"
+    state: latest
+  with_items:
+      - unzip
+      - tar
+      - apt-transport-https
+      - libbtrfs-dev
+      - libseccomp2
+      - util-linux

--- a/ibmcloud/cluster/ansible/tasks/k8s.yaml
+++ b/ibmcloud/cluster/ansible/tasks/k8s.yaml
@@ -1,0 +1,29 @@
+#
+# (C) Copyright IBM Corp. 2023.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+---
+- name: "Add gpg key "
+  apt_key:
+    url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+    state: present
+
+- name: "Add kubernetes source list "
+  apt_repository:
+    repo: "deb http://packages.cloud.google.com/apt/ kubernetes-xenial main"
+    state: present
+    filename: "kubernetes"
+
+- name: "Update the repository cache "
+  apt:
+    update_cache: yes
+
+- name: "Install kubelet, kubeadm, kubectl "
+  apt: name={{item}} state=present
+  with_items:
+    - kubelet
+    - kubeadm
+    - kubectl
+    - kubernetes-cni
+    - cri-tools

--- a/ibmcloud/cluster/kube-init.sh
+++ b/ibmcloud/cluster/kube-init.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Copyright (c) 2023 IBM
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+error() {
+    echo "$1"
+    exit 1
+}
+
+inventory=./ansible/inventory
+ssh_options="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+[ -f "$inventory" ] || error "$inventory: file does not exist"
+
+ips=()
+start="[cluster]"
+end=""
+capture="false"
+while read line; do
+    if [ "$line" = "$end" ]; then
+        capture="false"
+    fi
+    if [ $capture = "true" ]; then
+        ips+=($line)
+    fi
+    if [ "$line" = "$start" ]; then
+        capture="true"
+    fi
+done <$inventory
+
+control_plane_lan_ip="$1"
+control_plane_wan_ip="${ips[0]}"
+control_plane_execute(){
+    ssh $ssh_options "root@$control_plane_wan_ip" "$1"
+}
+control_plane_execute "kubeadm init --apiserver-advertise-address=$control_plane_lan_ip --apiserver-cert-extra-sans=$control_plane_wan_ip --pod-network-cidr=172.20.0.0/16"
+control_plane_execute "mkdir -p /root/.kube"
+control_plane_execute "cp -f /etc/kubernetes/admin.conf /root/.kube/config"
+control_plane_execute "curl -sL -o /tmp/kube-flannel.yml https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml"
+control_plane_execute "sed -i 's|\"10.244.0.0/16\"|\"172.20.0.0/16\"|' /tmp/kube-flannel.yml"
+control_plane_execute "kubectl apply -f /tmp/kube-flannel.yml"
+
+join_command=$(ssh $ssh_options "root@$control_plane_wan_ip" "/bin/bash -c 'kubeadm token create --print-join-command'")
+
+for ip in "${ips[@]:1}"; do
+    ssh $ssh_options "root@$ip" "/bin/bash -c '$join_command'"
+done
+
+scp $ssh_options root@$control_plane_wan_ip:/root/.kube/config config
+sed -E -i "s|(\s+server: https://).*(:[0-9]+)|\1$control_plane_wan_ip\2|" config

--- a/ibmcloud/cluster/main.tf
+++ b/ibmcloud/cluster/main.tf
@@ -1,0 +1,78 @@
+#
+# (C) Copyright IBM Corp. 2022.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+module "vpc" {
+  source       = "./vpc"
+  cluster_name = var.cluster_name
+  zone         = var.zone
+}
+
+data "ibm_is_image" "node_image" {
+  name = var.node_image
+}
+
+resource "ibm_is_ssh_key" "created_ssh_key" {
+  # Create the ssh key only if the public key is set
+  count      = var.ssh_pub_key == "" ? 0 : 1
+  name       = var.ssh_key_name
+  public_key = var.ssh_pub_key
+}
+
+data "ibm_is_ssh_key" "ssh_key" {
+  # Wait if the key needs creating first
+  depends_on = [ibm_is_ssh_key.created_ssh_key]
+  name       = var.ssh_key_name
+}
+
+
+resource "ibm_is_instance_template" "node_template" {
+  name    = "${var.cluster_name}-node-template"
+  image   = data.ibm_is_image.node_image.id
+  profile = var.node_profile
+  vpc     = module.vpc.vpc_id
+  zone    = var.zone
+  keys    = [data.ibm_is_ssh_key.ssh_key.id]
+
+  primary_network_interface {
+    subnet          = module.vpc.subnet_id
+    security_groups = [module.vpc.security_group_id]
+  }
+}
+
+module "nodes" {
+  source                      = "./node"
+  count                       = var.nodes
+  node_name                 = "${var.cluster_name}-node-${count.index}"
+  node_instance_template_id = ibm_is_instance_template.node_template.id
+}
+
+resource "local_file" "inventory" {
+  content = templatefile("${path.module}/ansible/inventory.tmpl",
+    {
+      ip_addrs = [for k, w in module.nodes : w.public_ip],
+    }
+  )
+  filename = "${path.module}/ansible/inventory"
+}
+
+
+resource "null_resource" "ansible" {
+  triggers = {
+    inventory = resource.local_file.inventory.content
+  }
+  provisioner "local-exec" {
+    working_dir = "./ansible"
+    command     = "ansible-playbook -i inventory -u root containerd.yaml -e containerd_release_version=${var.containerd_version}"
+  }
+}
+
+resource "null_resource" "kubeadm" {
+  depends_on = [
+    null_resource.ansible
+  ]
+  provisioner "local-exec" {
+    command = "./kube-init.sh ${module.nodes[0].private_ip}"
+  }
+}

--- a/ibmcloud/cluster/node/main.tf
+++ b/ibmcloud/cluster/node/main.tf
@@ -1,0 +1,14 @@
+#
+# (C) Copyright IBM Corp. 2023.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+resource "ibm_is_instance" "node" {
+  name              = var.node_name
+  instance_template = var.node_instance_template_id
+}
+
+resource "ibm_is_floating_ip" "node" {
+  name   = "${var.node_name}-ip"
+  target = ibm_is_instance.node.primary_network_interface[0].id
+}

--- a/ibmcloud/cluster/node/outputs.tf
+++ b/ibmcloud/cluster/node/outputs.tf
@@ -1,0 +1,11 @@
+#
+# (C) Copyright IBM Corp. 2023.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+output "public_ip" {
+  value = ibm_is_floating_ip.node.address
+}
+output "private_ip" {
+  value = ibm_is_instance.node.primary_network_interface.0.primary_ip.0.address
+}

--- a/ibmcloud/cluster/node/variables.tf
+++ b/ibmcloud/cluster/node/variables.tf
@@ -1,0 +1,8 @@
+#
+# (C) Copyright IBM Corp. 2023.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+variable "node_instance_template_id" {}
+
+variable "node_name" {}

--- a/ibmcloud/cluster/node/version.tf
+++ b/ibmcloud/cluster/node/version.tf
@@ -1,0 +1,13 @@
+#
+# (C) Copyright IBM Corp. 2023.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+terraform {
+    required_providers {
+        ibm = {
+            source = "IBM-Cloud/ibm"
+            version = "~> 1.50.0"
+        }
+    }
+}

--- a/ibmcloud/cluster/provider.tf
+++ b/ibmcloud/cluster/provider.tf
@@ -1,0 +1,9 @@
+#
+# (C) Copyright IBM Corp. 2023.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+provider "ibm" {
+    ibmcloud_api_key = var.ibmcloud_api_key
+    region = var.region
+}

--- a/ibmcloud/cluster/variables.tf
+++ b/ibmcloud/cluster/variables.tf
@@ -1,0 +1,47 @@
+#
+# (C) Copyright IBM Corp. 2023.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+variable "ibmcloud_api_key" {
+    sensitive = true
+}
+
+variable "cluster_name" {
+    default = "caa-cluster"
+}
+
+variable "ssh_key_name" {}
+
+variable "ssh_pub_key" {
+    default = ""
+}
+
+# amd64: ibm-ubuntu-20-04-3-minimal-amd64-1
+# s390x: ibm-ubuntu-20-04-2-minimal-s390x-1
+variable "node_image" {
+    default = "ibm-ubuntu-20-04-2-minimal-s390x-1"
+}
+
+# amd64: bx2-2x8
+# s390x: bz2-2x8
+variable "node_profile" {
+    default = "bz2-2x8"
+}
+
+variable "nodes" {
+    type = number
+    default = 2
+}
+
+variable "region" {
+    default = "jp-tok"
+}
+
+variable "zone" {
+    default = "jp-tok-2"
+}
+
+variable "containerd_version" {
+    default = "1.7.0-beta.3"
+}

--- a/ibmcloud/cluster/version.tf
+++ b/ibmcloud/cluster/version.tf
@@ -1,0 +1,13 @@
+#
+# (C) Copyright IBM Corp. 2023.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+terraform {
+    required_providers {
+        ibm = {
+            source = "IBM-Cloud/ibm"
+            version = "~> 1.50.0"
+        }
+    }
+}

--- a/ibmcloud/cluster/vpc/main.tf
+++ b/ibmcloud/cluster/vpc/main.tf
@@ -1,0 +1,80 @@
+#
+# (C) Copyright IBM Corp. 2023.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+resource "ibm_is_vpc" "vpc" {
+  name = "${var.cluster_name}-vpc"
+}
+
+resource "ibm_is_floating_ip" "gateway" {
+    name = "${var.cluster_name}-gateway-ip"
+    zone = var.zone
+}
+
+resource "ibm_is_public_gateway" "gateway" {
+  name        = "${var.cluster_name}-gateway"
+  vpc         = ibm_is_vpc.vpc.id
+  zone        = var.zone
+  floating_ip = {
+    id = ibm_is_floating_ip.gateway.id
+  }
+}
+
+resource "ibm_is_subnet" "primary" {
+  name                     = "${var.cluster_name}-subnet"
+  vpc                      = ibm_is_vpc.vpc.id
+  zone                     = var.zone
+  total_ipv4_address_count = 256
+  public_gateway           = ibm_is_public_gateway.gateway.id
+}
+
+resource "ibm_is_security_group" "primary" {
+  name = "${var.cluster_name}-security-group"
+  vpc  = ibm_is_vpc.vpc.id
+}
+
+resource "ibm_is_security_group_rule" "primary_outbound" {
+  group      = ibm_is_security_group.primary.id
+  direction  = "outbound"
+  remote     = "0.0.0.0/0"
+}
+
+resource "ibm_is_security_group_rule" "primary_inbound" {
+  group      = ibm_is_security_group.primary.id
+  direction  = "inbound"
+  remote     = ibm_is_security_group.primary.id
+}
+
+resource "ibm_is_security_group_rule" "primary_ssh" {
+  group      = ibm_is_security_group.primary.id
+  direction  = "inbound"
+  remote     = "0.0.0.0/0"
+
+  tcp {
+    port_min = 22
+    port_max = 22
+  }
+}
+
+resource "ibm_is_security_group_rule" "primary_ping" {
+  group      = ibm_is_security_group.primary.id
+  direction  = "inbound"
+  remote     = "0.0.0.0/0"
+
+  icmp {
+    code = 0
+    type = 8
+  }
+}
+
+resource "ibm_is_security_group_rule" "primary_api_server" {
+  group      = ibm_is_security_group.primary.id
+  direction  = "inbound"
+  remote     = "0.0.0.0/0"
+
+  tcp {
+    port_min = 6443
+    port_max = 6443
+  }
+}

--- a/ibmcloud/cluster/vpc/outputs.tf
+++ b/ibmcloud/cluster/vpc/outputs.tf
@@ -1,0 +1,16 @@
+#
+# (C) Copyright IBM Corp. 2023.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+output "vpc_id" {
+  value = ibm_is_vpc.vpc.id
+}
+
+output "subnet_id" {
+  value = ibm_is_subnet.primary.id
+}
+
+output "security_group_id" {
+  value = ibm_is_security_group.primary.id
+}

--- a/ibmcloud/cluster/vpc/variables.tf
+++ b/ibmcloud/cluster/vpc/variables.tf
@@ -1,0 +1,7 @@
+#
+# (C) Copyright IBM Corp. 2023.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+variable "cluster_name" {}
+variable "zone" {}

--- a/ibmcloud/cluster/vpc/version.tf
+++ b/ibmcloud/cluster/vpc/version.tf
@@ -1,0 +1,13 @@
+#
+# (C) Copyright IBM Corp. 2023.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+terraform {
+    required_providers {
+        ibm = {
+            source = "IBM-Cloud/ibm"
+            version = "~> 1.50.0"
+        }
+    }
+}


### PR DESCRIPTION
To phase out the existing demo in favour of operator, we need
to split out the cluster creation from the cloud-api-adaptor
configuration.

Fixes: https://github.com/confidential-containers/cloud-api-adaptor/issues/589

Signed-off-by: James Tumber <james.tumber@ibm.com>
Signed-off-by: stevenhorsman <steven@uk.ibm.com>