### PR TITLE
pkg/adaptor: Add Teardown() to cloud.Provider

### DIFF
--- a/pkg/adaptor/cloud/aws/provider.go
+++ b/pkg/adaptor/cloud/aws/provider.go
@@ -169,3 +169,7 @@ func (p *awsProvider) DeleteInstance(ctx context.Context, instanceID string) err
 	return nil
 
 }
+
+func (p *awsProvider) Teardown() error {
+	return nil
+}

--- a/pkg/adaptor/cloud/azure/provider.go
+++ b/pkg/adaptor/cloud/azure/provider.go
@@ -264,3 +264,7 @@ func (p *azureProvider) DeleteInstance(ctx context.Context, instanceID string) e
 
 	return nil
 }
+
+func (p *azureProvider) Teardown() error {
+	return nil
+}

--- a/pkg/adaptor/cloud/cloud.go
+++ b/pkg/adaptor/cloud/cloud.go
@@ -35,6 +35,7 @@ var logger = log.New(log.Writer(), "[adaptor/cloud] ", log.LstdFlags|log.Lmsgpre
 type Provider interface {
 	CreateInstance(ctx context.Context, podName, sandboxID string, cloudConfig cloudinit.CloudConfigGenerator) (instance *Instance, err error)
 	DeleteInstance(ctx context.Context, instanceID string) error
+	Teardown() error
 }
 
 type Instance struct {
@@ -46,6 +47,7 @@ type Instance struct {
 type Service interface {
 	pb.HypervisorService
 	GetInstanceID(ctx context.Context, podNamespace, podName string, wait bool) (string, error)
+	Teardown() error
 }
 
 type cloudService struct {
@@ -124,6 +126,10 @@ func NewService(provider Provider, proxyFactory proxy.Factory, workerNode podnet
 	s.cond = sync.NewCond(&s.mutex)
 
 	return s
+}
+
+func (s *cloudService) Teardown() error {
+	return s.provider.Teardown()
 }
 
 func (s *cloudService) setInstance(sid sandboxID, instanceID, instanceName string) error {

--- a/pkg/adaptor/cloud/cloud_test.go
+++ b/pkg/adaptor/cloud/cloud_test.go
@@ -37,6 +37,10 @@ func (p *mockProvider) DeleteInstance(ctx context.Context, instanceID string) er
 	return nil
 }
 
+func (p *mockProvider) Teardown() error {
+	return nil
+}
+
 type mockProxy struct {
 	socketPath string
 	readyCh    chan struct{}

--- a/pkg/adaptor/cloud/ibmcloud/provider.go
+++ b/pkg/adaptor/cloud/ibmcloud/provider.go
@@ -206,3 +206,7 @@ func (p *ibmcloudProvider) DeleteInstance(ctx context.Context, instanceID string
 	logger.Printf("deleted an instance %s", instanceID)
 	return nil
 }
+
+func (p *ibmcloudProvider) Teardown() error {
+	return nil
+}

--- a/pkg/adaptor/cloud/libvirt/provider.go
+++ b/pkg/adaptor/cloud/libvirt/provider.go
@@ -93,3 +93,7 @@ func (p *libvirtProvider) DeleteInstance(ctx context.Context, instanceID string)
 	return nil
 
 }
+
+func (p *libvirtProvider) Teardown() error {
+	return nil
+}

--- a/pkg/adaptor/cloud/vsphere/provider.go
+++ b/pkg/adaptor/cloud/vsphere/provider.go
@@ -293,3 +293,7 @@ func (p *vsphereProvider) DeleteInstance(ctx context.Context, instanceID string)
 
 	return nil
 }
+
+func (p *vsphereProvider) Teardown() error {
+	return nil
+}

--- a/pkg/adaptor/server.go
+++ b/pkg/adaptor/server.go
@@ -129,7 +129,8 @@ func (s *server) Shutdown() error {
 	s.stopOnce.Do(func() {
 		close(s.stopCh)
 	})
-	return nil
+
+	return s.cloudService.Teardown()
 }
 
 func (s *server) Ready() chan struct{} {

--- a/pkg/adaptor/server_test.go
+++ b/pkg/adaptor/server_test.go
@@ -232,3 +232,7 @@ func (p *mockProvider) CreateInstance(ctx context.Context, podName, sandboxID st
 func (p *mockProvider) DeleteInstance(ctx context.Context, instanceID string) error {
 	return nil
 }
+
+func (p *mockProvider) Teardown() error {
+	return nil
+}


### PR DESCRIPTION
This patch adds a hook to clean up a cloud provider.

Fixes #593

