### PR TITLE
 test/e2e: Introduce a e2e framework for testing - part 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ BINARIES    := cloud-api-adaptor agent-protocol-forwarder
 SOURCEDIRS  := ./cmd ./pkg
 PACKAGES    := $(shell go list $(addsuffix /...,$(SOURCEDIRS)))
 SOURCES     := $(shell find $(SOURCEDIRS) -name '*.go' -print)
+# End-to-end tests overall run timeout.
+TEST_E2E_TIMEOUT ?= 20m
 
 all: build
 build: $(BINARIES)
@@ -72,7 +74,7 @@ test: ## Run tests.
 
 .PHONY: test-e2e
 test-e2e: ## Run end-to-end tests.
-	go test -v $(GOFLAGS) -count=1 ./test/e2e
+	go test -v $(GOFLAGS) -timeout $(TEST_E2E_TIMEOUT) -count=1 ./test/e2e
 
 .PHONY: check
 check: fmt vet ## Run go vet and go vet against the code.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -26,6 +26,8 @@ The `TEST_E2E_PODVM_IMAGE` is an optional variable which specifies the path to t
 $ TEST_E2E_PROVISION=yes TEST_E2E_PODVM_IMAGE="path/to/podvm-base.qcow2" CLOUD_PROVIDER=libvirt make test-e2e
 ```
 
+By default it is given 20 minutes for the entire e2e execution to complete, otherwise the process is preempted. If you need to extend that timeout then export the `TEST_E2E_TIMEOUT` variable. For example, `TEST_E2E_TIMEOUT=30m` set the timeout to 30 minutes. See `-timeout` in [go test flags](https://pkg.go.dev/cmd/go#hdr-Testing_flags) for the values accepted.
+
 # Adding support for a new cloud provider
 
 In order to add a test pipeline for a new cloud provider, you will need to implement some

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -28,6 +28,8 @@ $ TEST_E2E_PROVISION=yes TEST_E2E_PODVM_IMAGE="path/to/podvm-base.qcow2" CLOUD_P
 
 By default it is given 20 minutes for the entire e2e execution to complete, otherwise the process is preempted. If you need to extend that timeout then export the `TEST_E2E_TIMEOUT` variable. For example, `TEST_E2E_TIMEOUT=30m` set the timeout to 30 minutes. See `-timeout` in [go test flags](https://pkg.go.dev/cmd/go#hdr-Testing_flags) for the values accepted.
 
+To leave the cluster untouched by the execution finish you should export `TEST_E2E_TEARDOWN=no`, otherwise the framework will attempt to wipe out any resources created. For example, if `TEST_E2E_PROVISION=yes` is used to create a VPC and cluster for testing and `TEST_E2E_TEARDOWN=no` not specified, then at the end of the test the provisioned cluster and VPC, will both be deleted.
+
 # Adding support for a new cloud provider
 
 In order to add a test pipeline for a new cloud provider, you will need to implement some

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -32,6 +32,12 @@ func TestMain(m *testing.M) {
 	// unless it is running with an in-cluster configuration.
 	testEnv = env.New()
 
+	// TEST_E2E_TEARDOWN is an option variable which specifies whether the teardown code path
+	// should run or not.
+	shouldTeardown := true
+	if os.Getenv("TEST_E2E_TEARDOWN") == "no" {
+		shouldTeardown = false
+	}
 	// In case TEST_E2E_PROVISION is exported then it will try to provision the test environment
 	// in the cloud provider. Otherwise, assume the developer did setup the environment and it will
 	// look for a suitable kubeconfig file.
@@ -98,6 +104,9 @@ func TestMain(m *testing.M) {
 
 	// Run *once* after the tests.
 	testEnv.Finish(func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+		if !shouldTeardown {
+			return ctx, nil
+		}
 		if shouldProvisionCluster {
 			if err = provisioner.DeleteCluster(ctx, cfg); err != nil {
 				return ctx, err

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -15,6 +15,7 @@ var (
 	testEnv       env.Environment
 	cloudProvider string
 	provisioner   CloudProvision
+	peerPods      *PeerPods
 )
 
 func TestMain(m *testing.M) {
@@ -87,7 +88,7 @@ func TestMain(m *testing.M) {
 			}
 		}
 
-		peerPods := NewPeerPods(cloudProvider)
+		peerPods = NewPeerPods(cloudProvider)
 		fmt.Println("Deploy Peer Pods")
 		if err = peerPods.Deploy(ctx, cfg); err != nil {
 			return ctx, err
@@ -106,8 +107,10 @@ func TestMain(m *testing.M) {
 				return ctx, nil
 			}
 		} else {
-			// TODO: if cluster is not provisioned then we should remove the CAA installation.
-			fmt.Println("Remove CAA installation manually")
+			fmt.Println("Delete the peer pods installation")
+			if err = peerPods.Delete(ctx, cfg); err != nil {
+				return ctx, err
+			}
 		}
 
 		return ctx, nil

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 var (
-	testEnv       env.Environment
-	cloudProvider string
-	provisioner   CloudProvision
-	peerPods      *PeerPods
+	testEnv         env.Environment
+	cloudProvider   string
+	provisioner     CloudProvision
+	cloudAPIAdaptor *CloudAPIAdaptor
 )
 
 func TestMain(m *testing.M) {
@@ -94,9 +94,9 @@ func TestMain(m *testing.M) {
 			}
 		}
 
-		peerPods = NewPeerPods(cloudProvider)
-		fmt.Println("Deploy Peer Pods")
-		if err = peerPods.Deploy(ctx, cfg); err != nil {
+		cloudAPIAdaptor = NewCloudAPIAdaptor(cloudProvider)
+		fmt.Println("Deploy the Cloud API Adaptor")
+		if err = cloudAPIAdaptor.Deploy(ctx, cfg); err != nil {
 			return ctx, err
 		}
 		return ctx, nil
@@ -116,8 +116,8 @@ func TestMain(m *testing.M) {
 				return ctx, nil
 			}
 		} else {
-			fmt.Println("Delete the peer pods installation")
-			if err = peerPods.Delete(ctx, cfg); err != nil {
+			fmt.Println("Delete the Cloud API Adaptor installation")
+			if err = cloudAPIAdaptor.Delete(ctx, cfg); err != nil {
 				return ctx, err
 			}
 		}

--- a/test/e2e/provision.go
+++ b/test/e2e/provision.go
@@ -31,7 +31,7 @@ type CloudProvision interface {
 	UploadPodvm(imagePath string, ctx context.Context, cfg *envconf.Config) error
 }
 
-type PeerPods struct {
+type CloudAPIAdaptor struct {
 	caaDaemonSet         *appsv1.DaemonSet    // Represents the cloud-api-adaptor daemonset
 	ccDaemonSet          *appsv1.DaemonSet    // Represents the CoCo installer daemonset
 	cloudProvider        string               // Cloud provider
@@ -41,11 +41,11 @@ type PeerPods struct {
 	runtimeClass         *nodev1.RuntimeClass // The Kata Containers runtimeclass
 }
 
-func NewPeerPods(provider string) (p *PeerPods) {
+func NewCloudAPIAdaptor(provider string) (p *CloudAPIAdaptor) {
 	namespace := "confidential-containers-system"
 	overlayDir := path.Join("../../install/overlays", provider)
 
-	return &PeerPods{
+	return &CloudAPIAdaptor{
 		caaDaemonSet:         &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "cloud-api-adaptor-daemonset-" + provider, Namespace: namespace}},
 		ccDaemonSet:          &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "cc-operator-daemon-install", Namespace: namespace}},
 		cloudProvider:        provider,
@@ -57,7 +57,7 @@ func NewPeerPods(provider string) (p *PeerPods) {
 }
 
 // Deletes the peer pods installation including the controller manager.
-func (p *PeerPods) Delete(ctx context.Context, cfg *envconf.Config) error {
+func (p *CloudAPIAdaptor) Delete(ctx context.Context, cfg *envconf.Config) error {
 	client, err := cfg.NewClient()
 	if err != nil {
 		return err
@@ -105,7 +105,7 @@ func (p *PeerPods) Delete(ctx context.Context, cfg *envconf.Config) error {
 }
 
 // Deploy installs Peer Pods on the cluster.
-func (p *PeerPods) Deploy(ctx context.Context, cfg *envconf.Config) error {
+func (p *CloudAPIAdaptor) Deploy(ctx context.Context, cfg *envconf.Config) error {
 	client, err := cfg.NewClient()
 	if err != nil {
 		return err
@@ -167,7 +167,7 @@ func (p *PeerPods) Deploy(ctx context.Context, cfg *envconf.Config) error {
 	return nil
 }
 
-func (p *PeerPods) DoKustomize(ctx context.Context, cfg *envconf.Config) {
+func (p *CloudAPIAdaptor) DoKustomize(ctx context.Context, cfg *envconf.Config) {
 }
 
 // TODO: convert this into a klient/wait/conditions

--- a/test/e2e/provision.go
+++ b/test/e2e/provision.go
@@ -141,7 +141,8 @@ func (p *PeerPods) Deploy(ctx context.Context, cfg *envconf.Config) error {
 
 		if err = wait.For(conditions.New(resources).ResourceMatch(ds, func(object k8s.Object) bool {
 			ds = object.(*appsv1.DaemonSet)
-			return ds.Status.NumberAvailable > 0
+
+			return ds.Status.CurrentNumberScheduled > 0
 		}), wait.WithTimeout(time.Second*20)); err != nil {
 			return err
 		}

--- a/test/e2e/provision.go
+++ b/test/e2e/provision.go
@@ -158,8 +158,9 @@ func (p *PeerPods) Deploy(ctx context.Context, cfg *envconf.Config) error {
 		}
 	}
 
-	fmt.Printf("Check the %s runtimeclass exists\n", p.runtimeClass.GetName())
-	if err = resources.Get(context.TODO(), p.runtimeClass.GetName(), p.runtimeClass.GetNamespace(), p.runtimeClass); err != nil {
+	fmt.Printf("Wait for the %s runtimeclass be created\n", p.runtimeClass.GetName())
+	if err = wait.For(conditions.New(resources).ResourcesFound(&nodev1.RuntimeClassList{Items: []nodev1.RuntimeClass{*p.runtimeClass}}),
+		wait.WithTimeout(time.Second*20)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR contains some fixes and features missed in the https://github.com/confidential-containers/cloud-api-adaptor/pull/386 that introduced the e2e framework.

