### PR TITLE
vshpere: Add vshpere back to the command help

### DIFF
--- a/cmd/cloud-api-adaptor/main.go
+++ b/cmd/cloud-api-adaptor/main.go
@@ -35,7 +35,7 @@ type networkConfig struct {
 func (cfg *daemonConfig) Setup() (cmd.Starter, error) {
 
 	if len(os.Args) < 2 {
-		fmt.Printf("%s \n<aws|azure|ibmcloud|libvirt|version> [options]\n", os.Args[0])
+		fmt.Printf("%s \n<aws|azure|ibmcloud|libvirt|vsphere|version> [options]\n", os.Args[0])
 		cmd.Exit(1)
 	}
 


### PR DESCRIPTION
Re-add vshpere to the print,
Fixes: https://github.com/confidential-containers/cloud-api-adaptor/issues/477
Signed-off-by: Jordan Jackson <jordan.jackson@ibm.com>