### PR TITLE
[RFC] github-actions: add common e2e workflow

### DIFF
--- a/.github/workflows/test_e2e.yaml
+++ b/.github/workflows/test_e2e.yaml
@@ -1,0 +1,147 @@
+name: test-e2e
+on: [pull_request]
+
+jobs:
+  # Build and push the podvm builder image for each OS.
+  #
+  podvm_builder:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          # Please keep this list in alphabetical order.
+          #- centos
+          - ubuntu
+        include:
+          #- os: centos
+          #  dockerfile: Dockerfile.podvm_builder.centos
+          - os: ubuntu
+            dockerfile: Dockerfile.podvm_builder
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to Github container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build the podvm builder
+      uses: docker/build-push-action@v3
+      with:
+        tags: |
+          ghcr.io/${{ github.repository_owner }}/ci-podvm-builder-${{ matrix.os }}:pr${{ github.event.number  }}
+        push: true
+        context: podvm
+        platforms: linux/amd64
+        file: |
+          podvm/${{ matrix.dockerfile }}
+        build-args: |
+          "CAA_SRC=https://github.com/${{ github.repository }}.git"
+          "CAA_SRC_REF=${{ github.ref }}"
+  # Build the podvm image and extract the qcow2 for each os/provider combination.
+  podvm:
+    needs: podvm_builder
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          # Please keep this list in alphabetical order.
+          #- centos
+          - ubuntu
+        provider:
+          - generic
+        include:
+          #- os: centos
+          #  dockerfile: Dockerfile.podvm.centos
+          - os: ubuntu
+            dockerfile: Dockerfile.podvm
+    env:
+      builder_image: ghcr.io/${{ github.repository_owner }}/ci-podvm-builder-${{ matrix.os }}:pr${{ github.event.number }}
+      podvm_image: podvm-${{ matrix.provider }}-${{ matrix.os }}:pr${{ github.event.number }}
+      qcow2: podvm-${{ matrix.provider }}-${{ matrix.os }}.qcow2
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build the podvm image
+      uses: docker/build-push-action@v3
+      with:
+        tags: |
+          "${{ env.podvm_image }}"
+        push: false
+        load: true
+        context: podvm
+        platforms: linux/amd64
+        file: |
+          podvm/${{ matrix.dockerfile }}
+        build-args: |
+          "CLOUD_PROVIDER=${{ matrix.provider }}"
+          "BUILDER_IMG=${{ env.builder_image }}"
+
+    - name: Extract the podvm qcow2
+      run: ./hack/download-image.sh ${{ env.podvm_image }} . -o ${{ env.qcow2 }}
+      working-directory: podvm
+
+    - name: Cache the qcow2 file
+      uses: actions/cache/save@v3
+      env:
+        qcow2_path: podvm/${{ env.qcow2 }}
+      with:
+        path: |
+          ${{ env.qcow2_path }}
+        key: ${{ env.qcow2}}-${{ hashFiles(env.qcow2_path) }}
+  # TODO: This almost identical to image.yaml. Let's use shared workflows to avoid duplication.
+  caa-build-dev:
+    runs-on: ubuntu-latest
+    env:
+      go_version: 1.18
+    strategy:
+      fail-fast: false
+      matrix:
+        arches:
+          - linux/amd64
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v3
+
+    - name: Setup Golang version ${{ env.go_version }}
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ env.go_version }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y libvirt-dev
+
+    - name: Login to Github container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push the cloud-api-adaptor image
+      uses: docker/build-push-action@v3
+      with:
+        tags: |
+          ghcr.io/${{ github.repository_owner }}/ci-cloud-api-adaptor-dev:pr${{ github.event.number  }}
+        push: true
+        context: .
+        platforms: ${{ matrix.arches }}
+        file: Dockerfile
+

--- a/.github/workflows/test_e2e.yaml
+++ b/.github/workflows/test_e2e.yaml
@@ -144,4 +144,37 @@ jobs:
         context: .
         platforms: ${{ matrix.arches }}
         file: Dockerfile
+  test:
+    needs: [podvm, caa-build-dev]
+    env:
+      go_version: 1.18
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        provider:
+          - libvirt
+        include:
+          - provider: libvirt
+            runner: ubuntu-latest
+            os: ubuntu
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v3
 
+    - name: Setup Golang version ${{ env.go_version }}
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ env.go_version }}
+
+    - name: Update the CAA image
+      run: |
+        # install kustomize
+        # kustomize -e cloud-api-adaptor
+        # quay.io/confidential-containers/cloud-api-adaptor
+        #ghcr.io/${{ github.repository_owner }}/ci-cloud-api-adaptor-dev:pr${{ github.event.number  }}
+        curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+        pushd install/overlays/${{ matrix.provider }}
+        ../../../kustomize edit set image cloud-api-adaptor=ghcr.io/${{ github.repository_owner }}/ci-cloud-api-adaptor-dev:pr${{ github.event.number  }}
+        cat kustomization.yaml
+        popd

--- a/podvm/Dockerfile.podvm_builder
+++ b/podvm/Dockerfile.podvm_builder
@@ -47,6 +47,7 @@ WORKDIR /src
 
 ARG CAA_SRC="https://github.com/confidential-containers/cloud-api-adaptor"
 ARG CAA_SRC_BRANCH="staging"
+ARG CAA_SRC_REF=""
 
 ARG KATA_SRC="https://github.com/kata-containers/kata-containers"
 ARG KATA_SRC_BRANCH="CCv0"
@@ -55,7 +56,15 @@ RUN echo $CAA_SRC
 
 RUN echo $CAA_SRC_BRANCH
 
-RUN git clone ${CAA_SRC} -b ${CAA_SRC_BRANCH} cloud-api-adaptor
+RUN echo $CAA_SRC_REF
+
+RUN if [ -z "${CAA_SRC_REF}" ]; then \
+      git clone ${CAA_SRC} -b ${CAA_SRC_BRANCH} cloud-api-adaptor ;\
+    else \
+      git clone ${CAA_SRC} cloud-api-adaptor && cd cloud-api-adaptor && \
+      git fetch origin ${CAA_SRC_REF} && \
+      git checkout FETCH_HEAD -b ${CAA_SRC_REF} ;\
+    fi
 RUN git clone ${KATA_SRC} -b ${KATA_SRC_BRANCH} kata-containers
 
 

--- a/podvm/Dockerfile.podvm_builder.centos
+++ b/podvm/Dockerfile.podvm_builder.centos
@@ -50,6 +50,7 @@ WORKDIR /src
 
 ARG CAA_SRC="https://github.com/confidential-containers/cloud-api-adaptor"
 ARG CAA_SRC_BRANCH="staging"
+ARG CAA_SRC_REF=""
 
 ARG KATA_SRC="https://github.com/kata-containers/kata-containers"
 ARG KATA_SRC_BRANCH="CCv0"
@@ -58,7 +59,15 @@ RUN echo $CAA_SRC
 
 RUN echo $CAA_SRC_BRANCH
 
-RUN git clone ${CAA_SRC} -b ${CAA_SRC_BRANCH} cloud-api-adaptor
+ARG echo $CAA_SRC_REF
+
+RUN if [ -z "${CAA_SRC_REF}" ]; then \
+      git clone ${CAA_SRC} -b ${CAA_SRC_BRANCH} cloud-api-adaptor ;\
+    else \
+      git clone ${CAA_SRC} cloud-api-adaptor && cd cloud-api-adaptor && \
+      git fetch origin ${CAA_SRC_REF} && \
+      git checkout FETCH_HEAD -b ${CAA_SRC_REF} ;\
+    fi
 RUN git clone ${KATA_SRC} -b ${KATA_SRC_BRANCH} kata-containers
 
 ENV GOPATH /src

--- a/podvm/Dockerfile.podvm_builder.rhel
+++ b/podvm/Dockerfile.podvm_builder.rhel
@@ -46,6 +46,7 @@ WORKDIR /src
 
 ARG CAA_SRC="https://github.com/confidential-containers/cloud-api-adaptor"
 ARG CAA_SRC_BRANCH="staging"
+ARG CAA_SRC_REF=""
 
 ARG KATA_SRC="https://github.com/kata-containers/kata-containers"
 ARG KATA_SRC_BRANCH="CCv0"
@@ -54,7 +55,15 @@ RUN echo $CAA_SRC
 
 RUN echo $CAA_SRC_BRANCH
 
-RUN git clone ${CAA_SRC} -b ${CAA_SRC_BRANCH} cloud-api-adaptor
+RUN $CAA_SRC_REF
+
+RUN if [ -z "${CAA_SRC_REF}" ]; then \
+      git clone ${CAA_SRC} -b ${CAA_SRC_BRANCH} cloud-api-adaptor ;\
+    else \
+      git clone ${CAA_SRC} cloud-api-adaptor && cd cloud-api-adaptor && \
+      git fetch origin ${CAA_SRC_REF} && \
+      git checkout FETCH_HEAD -b ${CAA_SRC_REF} ;\
+    fi
 RUN git clone ${KATA_SRC} -b ${KATA_SRC_BRANCH} kata-containers
 
 ENV GOPATH /src

--- a/podvm/README.md
+++ b/podvm/README.md
@@ -54,6 +54,7 @@ currently accepted:
 |--------|-------------|-----------|
 |CAA\_SRC |https://github.com/confidential-containers/cloud-api-adaptor | The cloud-api-adaptor source repository |
 |CAA\_SRC\_BRANCH|staging| cloud-api-adaptor repository branch |
+|CAA\_SRC\_REF|""| cloud-api-adaptor repository refspec. When set it takes precedence over CAA\_SRC\_BRANCH|
 |KATA\_SRC | https://github.com/kata-containers/kata-containers | The Kata Containers source repository |
 |KATA\_SRC\_BRANCH | CCv0 | The Kata Containers repository branch |
 |GO\_VERSION | 1.18.7 | Go version |


### PR DESCRIPTION
**Description**

As we already have a simple but yet working [e2e testing framework](https://github.com/confidential-containers/cloud-api-adaptor/tree/staging/test/e2e), I began to work on the other pieces to implement the CI for libvirt.

This PR implements a workflow that can be common to all cloud e2e jobs. It does build the components that will be used to deploy peer pods:
  - build the podvm builder
  - build the podvm image
  - extract the qcow2 & save in a cache
  - build the cloud-api-adaptor image

As is, the implemented jobs on this PR are useful to check the deployment components can be built. But I envision each cloud should implement at least one additional job to effectively execute the tests on their testing environments.  

**Implementation**

* This depends on PR 608: [podvm: allow the builder to checkout a refspec](https://github.com/confidential-containers/cloud-api-adaptor/pull/608). That PR has got some interesting idea that will likely cascade in changes to this one
* Images are pushed to Github's images registry. I tried to use a local started registry but `docker buildx` fails to connect. In the end I think that using github's registry is better than a local registry  because it is public and so allows fetching the cloud-api-adaptor image by the operator from within any cloud provider. Besides the fact that devels will be able to fetch the images to debug failed e2e jobs
   * Because images are pushed for each PR it might hit the storage limit at some point in time. We could have an automation to delete the images when the PR is closed
 * The `docker buildx` action allow for caching components. I didn't explore that, it can be done on a follow up
 * So far the jobs build an Ubuntu podvm for libvirt to ease my life. I should enable it to more os/providers combinations as I get the first reviews for this PR.