### PR TITLE
libvirt: remove non-essential libvirt build tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,6 @@ jobs:
         with:
           go-version: ${{ matrix.go_version }}
       - name: Install build dependencies
-        if: ${{ matrix.provider == 'libvirt' }}
         run: |
           sudo apt-get update -y
           sudo apt-get install -y libvirt-dev

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -50,7 +50,6 @@ jobs:
         with:
           go-version: 1.18
       - name: Install build dependencies
-        if: ${{ matrix.provider == 'libvirt' }}
         run: |
           sudo apt-get update -y
           sudo apt-get install -y libvirt-dev

--- a/Makefile
+++ b/Makefile
@@ -45,22 +45,17 @@ help: ## Display this help.
 	@printf "$$(git rev-parse HEAD 2>/dev/null)" >$@
 	@test -n "$$(git status --porcelain --untracked-files=no)" && echo -dirty >>$@ || true
 
-$(BINARIES): .git-commit $(SOURCES)
-ifeq ($(CLOUD_PROVIDER),libvirt)
-	$(GOOPTIONS) go build $(GOFLAGS) -ldflags="-X 'github.com/confidential-containers/cloud-api-adaptor/cmd.VERSION=$(shell echo "unknown")' -X 'github.com/confidential-containers/cloud-api-adaptor/cmd.COMMIT=$(shell cat .git-commit)'" -o "$@" "cmd/$@/main.go"
-else
+agent-protocol-forwarder: .git-commit $(SOURCES)
 	$(GOOPTIONS) CGO_ENABLED=0 go build $(GOFLAGS) -ldflags="-X 'github.com/confidential-containers/cloud-api-adaptor/cmd.VERSION=$(shell echo "unknown")' -X 'github.com/confidential-containers/cloud-api-adaptor/cmd.COMMIT=$(shell cat .git-commit)'" -o "$@" "cmd/$@/main.go"
-endif
+
+cloud-api-adaptor: .git-commit $(SOURCES)
+	$(GOOPTIONS) go build $(GOFLAGS) -ldflags="-X 'github.com/confidential-containers/cloud-api-adaptor/cmd.VERSION=$(shell echo "unknown")' -X 'github.com/confidential-containers/cloud-api-adaptor/cmd.COMMIT=$(shell cat .git-commit)'" -o "$@" "cmd/$@/main.go"
 
 ##@ Development
 
 .PHONY: escapes
 escapes: ## golang memeory escapes check
-ifeq ($(CLOUD_PROVIDER),libvirt)
 	go build $(GOFLAGS) -gcflags="-m -l" ./... 2>&1 | grep "escapes to heap" 1>&2 || true
-else
-	CGO_ENABLED=0 go build $(GOFLAGS) -gcflags="-m -l" ./... 2>&1 | grep "escapes to heap" 1>&2 || true
-endif
 
 .PHONY: test
 test: ## Run tests.

--- a/pkg/adaptor/cloud/libvirt/image.go
+++ b/pkg/adaptor/cloud/libvirt/image.go
@@ -1,4 +1,4 @@
-//go:build libvirt
+//go:build cgo
 
 // (C) Copyright Confidential Containers Contributors
 // SPDX-License-Identifier: Apache-2.0

--- a/pkg/adaptor/cloud/libvirt/libvirt.go
+++ b/pkg/adaptor/cloud/libvirt/libvirt.go
@@ -1,4 +1,4 @@
-//go:build libvirt
+//go:build cgo
 
 // (C) Copyright Confidential Containers Contributors
 // SPDX-License-Identifier: Apache-2.0

--- a/pkg/adaptor/cloud/libvirt/provider.go
+++ b/pkg/adaptor/cloud/libvirt/provider.go
@@ -1,4 +1,4 @@
-//go:build libvirt
+//go:build cgo
 
 // (C) Copyright Confidential Containers Contributors
 // SPDX-License-Identifier: Apache-2.0

--- a/pkg/adaptor/cloud/libvirt/stream.go
+++ b/pkg/adaptor/cloud/libvirt/stream.go
@@ -1,4 +1,4 @@
-//go:build libvirt
+//go:build cgo
 
 // (C) Copyright Confidential Containers Contributors
 // SPDX-License-Identifier: Apache-2.0

--- a/pkg/adaptor/cloud/libvirt/types.go
+++ b/pkg/adaptor/cloud/libvirt/types.go
@@ -1,4 +1,4 @@
-//go:build libvirt
+//go:build cgo
 
 // (C) Copyright Confidential Containers Contributors
 // SPDX-License-Identifier: Apache-2.0

--- a/pkg/adaptor/cloud/libvirt/volume.go
+++ b/pkg/adaptor/cloud/libvirt/volume.go
@@ -1,4 +1,4 @@
-//go:build libvirt
+//go:build cgo
 
 // (C) Copyright Confidential Containers Contributors
 // SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
to allow easy importing of the pkg

Fixes: #617