### PR TITLE
all: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/libvirt/README.md
+++ b/libvirt/README.md
@@ -124,7 +124,7 @@ cc-operator-controller-manager-5df7584679-5dbmr   2/2     Running   0          3
 cloud-api-adaptor-daemonset-libvirt-vgj2s         1/1     Running   0          3m57s
 $ kubectl logs pod/cloud-api-adaptor-daemonset-libvirt-vgj2s -n confidential-containers-system
 + exec cloud-api-adaptor-libvirt libvirt -uri 'qemu+ssh://wmoschet@192.168.122.1/system?no_verify=1' -data-dir /opt/data-dir -pods-dir /run/peerpod/pods -network-name default -pool-name default -socket /run/peerpod/hypervisor.sock
-2022/11/09 18:18:00 [helper/hypervisor] hypervisor config {/run/peerpod/hypervisor.sock  k8s.gcr.io/pause:3.7 /run/peerpod/pods libvirt}
+2022/11/09 18:18:00 [helper/hypervisor] hypervisor config {/run/peerpod/hypervisor.sock  registry.k8s.io/pause:3.7 /run/peerpod/pods libvirt}
 2022/11/09 18:18:00 [helper/hypervisor] cloud config {qemu+ssh://wmoschet@192.168.122.1/system?no_verify=1 default default /opt/data-dir}
 2022/11/09 18:18:00 [helper/hypervisor] service config &{qemu+ssh://wmoschet@192.168.122.1/system?no_verify=1 default default /opt/data-dir}
 ```

--- a/pkg/adaptor/proxy/service.go
+++ b/pkg/adaptor/proxy/service.go
@@ -24,7 +24,7 @@ type proxyService struct {
 	pauseImage string
 }
 
-const defaultPauseImage = "k8s.gcr.io/pause:3.7"
+const defaultPauseImage = "registry.k8s.io/pause:3.7"
 
 func newProxyService(dialer func(context.Context) (net.Conn, error), criClient *criClient, pauseImage string) *proxyService {
 

--- a/podvm/Makefile.inc
+++ b/podvm/Makefile.inc
@@ -73,7 +73,7 @@ UMOCI_REPO  = https://github.com/opencontainers/umoci
 # Embed the pause container image
 # https://github.com/arronwy/kata-containers/commit/75b9f3fa3caaae62f49b4733f65cbab0cc87dbee
 PAUSE_SRC     = pause
-PAUSE_REPO    = docker://k8s.gcr.io/pause
+PAUSE_REPO    = docker://registry.k8s.io/pause
 PAUSE_VERSION = 3.6
 PAUSE_BUNDLE  = pause_bundle
 

--- a/volumes/csi-wrapper/hack/ibm/ibm-vpc-block-csi-driver.patch
+++ b/volumes/csi-wrapper/hack/ibm/ibm-vpc-block-csi-driver.patch
@@ -36,13 +36,13 @@ index 1d9fd58..cc5a29e 100644
 --- a/deploy/kubernetes/driver/kubernetes/overlays/stage/controller-server-images.yaml
 +++ b/deploy/kubernetes/driver/kubernetes/overlays/stage/controller-server-images.yaml
 @@ -14,6 +14,6 @@ spec:
-           image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
+           image: registry.k8s.io/sig-storage/livenessprobe:v2.3.0
          - name: iks-vpc-block-driver
            imagePullPolicy: Always
 -          image: gcr.io/k8s-staging-cloud-provider-ibm/ibm-vpc-block-csi-driver:master
 +          image: gcr.io/k8s-staging-cloud-provider-ibm/ibm-vpc-block-csi-driver:v4.3.1
          - name: csi-resizer
-           image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
+           image: registry.k8s.io/sig-storage/csi-resizer:v1.2.0
 diff --git a/deploy/kubernetes/driver/kubernetes/overlays/stage/node-server-images.yaml b/deploy/kubernetes/driver/kubernetes/overlays/stage/node-server-images.yaml
 index 8900848..a29a012 100644
 --- a/deploy/kubernetes/driver/kubernetes/overlays/stage/node-server-images.yaml
@@ -54,7 +54,7 @@ index 8900848..a29a012 100644
 -          image: gcr.io/k8s-staging-cloud-provider-ibm/ibm-vpc-block-csi-driver:master
 +          image: gcr.io/k8s-staging-cloud-provider-ibm/ibm-vpc-block-csi-driver:v4.3.1
          - name: csi-driver-registrar
-           image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+           image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0
          - name: liveness-probe
 diff --git a/scripts/apply-required-setup.sh b/scripts/apply-required-setup.sh
 index 674739e..9e39f0c 100644


### PR DESCRIPTION
This fix is a part of an umbrella issue https://github.com/kubernetes/k8s.io/issues/4780