### PR TITLE
update golangci-lint version

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.46.2
+          version: v1.47.3
 
   go_check:
     strategy:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -229,7 +229,6 @@ linters:
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - typecheck
     - unused
     - varcheck


### PR DESCRIPTION
This PR updates the version of golangci-lint to 1.47.3. It also remove the deprecated linter - `structcheck`.

Fixes:#631