### PR TITLE
ibmcloud: build caa with release build set

### DIFF
--- a/ibmcloud/terraform/cluster/ansible/kata-playbook.yml
+++ b/ibmcloud/terraform/cluster/ansible/kata-playbook.yml
@@ -246,6 +246,8 @@
           service_offload = true
 
     - name: Install cloud-api-adaptor
+      environment:
+        RELEASE_BUILD: "true"
       shell: |
         set -o errexit
         cd /root/cloud-api-adaptor


### PR DESCRIPTION
Build CAA with RELEASE_BUILD=true to exclude the libvirt provider.

Fixes: #636