### PR TITLE
gh-action: build dev and release images for every PR merge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ clean: ## Remove binaries.
 
 .PHONY: image
 image: ## Build and push docker image to $registry
-	hack/build.sh
+	hack/build.sh $(shell cat .git-commit)
 
 ##@ Deployment
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -8,21 +8,26 @@ script_dir=$(dirname "$(readlink -f "$0")")
 
 registry="${registry:-quay.io/confidential-containers}"
 name="cloud-api-adaptor"
-tag=$(date +%Y%m%d%H%M%s)
+commit_id=${1:-$(git rev-parse HEAD)}
 
 supported_arches=${ARCHES:-"linux/amd64"}
 
 function build_caa_payload() {
 	pushd "${script_dir}/.."
 
+	local tag_string="-t ${registry}/${name}:latest -t ${registry}/${name}:dev-${commit_id}"
+
+	if [[ "$RELEASE_BUILD" == "true" ]]; then
+		tag_string="-t ${registry}/${name}:${commit_id}"
+	fi
+
+
 	docker buildx build --platform "${supported_arches}" \
 		--build-arg RELEASE_BUILD="${RELEASE_BUILD}" \
 		-f Dockerfile \
-		-t "${registry}/${name}:${tag}" \
-		-t "${registry}/${name}:latest" \
+		${tag_string} \
 		--push \
 		.
-
 	popd
 }
 


### PR DESCRIPTION
Fixes: #637

@jtumber-ibm @stevenhorsman @snir911 PTAL.

The PR will ensure both dev and release builds for every PR merged and use `dev-$timestamp` and `release-$timestamp` as tags. Also the `latest` tag will be only for dev release.

Hope this approach will be able to meet the requirements for multi-arch as well.