### PR TITLE
test/e2e: implement the GetCloudProvisioner() factory

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -42,7 +42,7 @@ Create a new Go file (.go) named `provision_<CLOUD_PROVIDER>`.go (e.g., `provisi
 that should be tagged with `//go:build <CLOUD_PROVIDER>`. That file should have the implementation
 of the `CloudProvision` interface (see its definition in [provision.go](./provision.go)).
 
-Apart from that, it should implement the `func GetCloudProvisioner() (CloudProvision, error)` factory function.
+Apart from that, it should be added an entry to the `GetCloudProvisioner()` factory function in [provision.go](./provision.go).
 
 ## Create the test suite
 

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -19,10 +19,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 )
 
-var (
-	group *resources.Group
-)
-
 func initResourceGroup() (*resources.Group, error) {
 	/*
 		Set following environment variables to verify identity.

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -6,17 +6,17 @@
 package e2e
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"testing"
-	"context"
-	"net/http"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
-    	"github.com/Azure/go-autorest/autorest"
-    	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
 )
 
 var (
@@ -43,7 +43,7 @@ func initResourceGroup() (*resources.Group, error) {
 		return nil, errors.New("RESOURCE_GROUP was not set")
 	}
 
-	if ((len(os.Getenv("AZURE_CLIENT_ID")) <= 0) || (len(os.Getenv("AZURE_CLIENT_SECRET")) <= 0) || (len(os.Getenv("AZURE_TENANT_ID")) <= 0))  {
+	if (len(os.Getenv("AZURE_CLIENT_ID")) <= 0) || (len(os.Getenv("AZURE_CLIENT_SECRET")) <= 0) || (len(os.Getenv("AZURE_TENANT_ID")) <= 0) {
 		return nil, errors.New("Please set all the env variables mentioned")
 	}
 
@@ -98,10 +98,10 @@ func (c AzureCloudAssert) HasPodVM(t *testing.T, id string) {
 	vm, err := vmClient.Get(context.Background(), *c.group.Name, id, "")
 	if err != nil {
 		if vmNotFound, ok := err.(autorest.DetailedError); ok && vmNotFound.StatusCode == http.StatusNotFound {
-            		fmt.Printf("Virtual machine '%s' not found in resource group '\n", id)
-        	} else {
-            		t.Fatal(err)
-        	}
+			fmt.Printf("Virtual machine '%s' not found in resource group '\n", id)
+		} else {
+			t.Fatal(err)
+		}
 	}
 
 	fmt.Printf("VM name: %s\n", *vm.Name)

--- a/test/e2e/common_suite.go
+++ b/test/e2e/common_suite.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-const WAIT_POD_RUNNING_TIMEOUT = time.Second*180
+const WAIT_POD_RUNNING_TIMEOUT = time.Second * 180
 
 // doTestCreateSimplePod tests a simple peer-pod can be created.
 func doTestCreateSimplePod(t *testing.T, assert CloudAssert) {

--- a/test/e2e/ibmcloud_test.go
+++ b/test/e2e/ibmcloud_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	mu sync.Mutex
+	mu  sync.Mutex
 	vpc *vpcv1.VpcV1
 )
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -53,7 +53,7 @@ func TestMain(m *testing.M) {
 
 	if shouldProvisionCluster || podvmImage != "" {
 		// Get an provisioner instance for the cloud provider.
-		provisioner, err = GetCloudProvisioner()
+		provisioner, err = GetCloudProvisioner(cloudProvider)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/test/e2e/provision.go
+++ b/test/e2e/provision.go
@@ -56,6 +56,27 @@ func NewCloudAPIAdaptor(provider string) (p *CloudAPIAdaptor) {
 	}
 }
 
+//GetCloudProvisioner returns a CloudProvision implementation
+func GetCloudProvisioner(provider string) (CloudProvision, error) {
+	var (
+		err         error
+		provisioner CloudProvision
+	)
+
+	switch provider {
+	case "azure":
+		provisioner, err = NewAzureCloudProvisioner("default", "default")
+	case "libvirt":
+		provisioner, err = NewLibvirtProvisioner("default", "default")
+	case "ibmcloud":
+		provisioner, err = NewIBMCloudProvisioner("default", "default")
+	default:
+		return nil, fmt.Errorf("Not implemented provisioner for %s\n", provider)
+	}
+
+	return provisioner, err
+}
+
 // Deletes the peer pods installation including the controller manager.
 func (p *CloudAPIAdaptor) Delete(ctx context.Context, cfg *envconf.Config) error {
 	client, err := cfg.NewClient()

--- a/test/e2e/provision_azure.go
+++ b/test/e2e/provision_azure.go
@@ -37,8 +37,3 @@ func (l *AzureCloudProvisioner) DeleteVPC(ctx context.Context, cfg *envconf.Conf
 func (l *AzureCloudProvisioner) UploadPodvm(imagePath string, ctx context.Context, cfg *envconf.Config) error {
 	return nil
 }
-
-//nolint:typecheck
-func GetCloudProvisioner() (CloudProvision, error) {
-	return NewAzureCloudProvisioner("default", "default")
-}

--- a/test/e2e/provision_ibmcloud.go
+++ b/test/e2e/provision_ibmcloud.go
@@ -37,8 +37,3 @@ func (l *IBMCloudProvisioner) DeleteVPC(ctx context.Context, cfg *envconf.Config
 func (l *IBMCloudProvisioner) UploadPodvm(imagePath string, ctx context.Context, cfg *envconf.Config) error {
 	return nil
 }
-
-//nolint:typecheck
-func GetCloudProvisioner() (CloudProvision, error) {
-	return NewIBMCloudProvisioner("default", "default")
-}

--- a/test/e2e/provision_libvirt.go
+++ b/test/e2e/provision_libvirt.go
@@ -175,8 +175,3 @@ func (l *LibvirtProvisioner) GetStoragePool() (*libvirt.StoragePool, error) {
 
 	return sp, nil
 }
-
-//nolint:typecheck
-func GetCloudProvisioner() (CloudProvision, error) {
-	return NewLibvirtProvisioner("default", "default")
-}


### PR DESCRIPTION
Since commit 54ce74374be8a it has been passed all cloud providers in the golang -tags option because now it built a single cloud-api-adaptor.

That broke the e2e tests as the compiler find multiple implementations of GetCloudProvisioner(). In order to solve, it is added the `GetCloudProvisioner(provider)` function that returns an implementation based on `provider`.

Fixes: #573