### PR TITLE
pkg: use io or os package instead of deprecated io/ioutil

### DIFF
--- a/pkg/adaptor/cloud/azure/provider.go
+++ b/pkg/adaptor/cloud/azure/provider.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -169,7 +168,7 @@ func (p *azureProvider) CreateInstance(ctx context.Context, podName, sandboxID s
 	sshPublicKeyPath := os.ExpandEnv(p.serviceConfig.SSHKeyPath)
 	var sshBytes []byte
 	if _, err := os.Stat(sshPublicKeyPath); err == nil {
-		sshBytes, err = ioutil.ReadFile(sshPublicKeyPath)
+		sshBytes, err = os.ReadFile(sshPublicKeyPath)
 		if err != nil {
 			err = fmt.Errorf("reading ssh public key file: %w", err)
 			logger.Printf("%v", err)

--- a/pkg/adaptor/server_test.go
+++ b/pkg/adaptor/server_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -82,7 +81,7 @@ func TestCreateStartAndStop(t *testing.T) {
 }
 
 func testServerStart(t *testing.T, ctx context.Context) (Server, string, string, pb.HypervisorService, chan error) {
-	dir, err := ioutil.TempDir("", "helper")
+	dir, err := os.MkdirTemp("", "helper")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/podnetwork/tuntest/util.go
+++ b/pkg/podnetwork/tuntest/util.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -236,7 +236,7 @@ func ConnectToHTTPServer(t *testing.T, ns *netops.NS, addr, localAddr string) {
 		if err != nil {
 			return fmt.Errorf("failed to get an http response at %s from http://%s : %v", ns.Name, addr, err)
 		}
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			return fmt.Errorf("failed to read an http response at %s from http://%s:: %v", ns.Name, addr, err)
 		}


### PR DESCRIPTION
Some functions in package `io/ioutil` are deprecated as of go 1.16 and 1.17. Move to using functions from package `io` or `os`.

Fixes:#646