### PR TITLE
test/e2e: read provision properties from file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v66.0.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.27
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.11
+	github.com/BurntSushi/toml v1.2.0
 	github.com/avast/retry-go/v4 v4.3.2
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.6
 	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20220913141151-9b49a6ddc6fd

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/BurntSushi/toml v1.2.0 h1:Rt8g24XnyGTyglgET/PRUNlrUeu9F5L+7FilkXfZgs0=
 github.com/BurntSushi/toml v1.2.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -20,6 +20,20 @@ You can instruct the tool to provision a test environment though, as shown below
 $ TEST_E2E_PROVISION=yes CLOUD_PROVIDER=libvirt make test-e2e
 ```
 
+Each provider must have a provisioner implementation so that the framework is able to perform operations on the cluster. The provisioner will likely to need additional information (e.g. login credentials), and those are passed via a properties file with the following format:
+
+```
+key1 = "value1"
+key2 = "value2"
+...
+```
+
+You should use the `TEST_E2E_PROVISION_FILE` variable to specify the properties file path, as shown below:
+
+```
+$ TEST_E2E_PROVISION=yes TEST_E2E_PROVISION_FILE=/path/to/libvirt.properties CLOUD_PROVIDER=libvirt make test-e2e
+```
+
 The `TEST_E2E_PODVM_IMAGE` is an optional variable which specifies the path to the podvm qcow2 image. If it is set then the image should be uploaded to the VPC storage. The following command, as an example, instructs the tool to upload `path/to/podvm-base.qcow2` after the provisioning of the test environment:
 
 ```

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -51,9 +51,16 @@ func TestMain(m *testing.M) {
 	// the VPC images storage.
 	podvmImage := os.Getenv("TEST_E2E_PODVM_IMAGE")
 
+	// The TEST_E2E_PROVISION_FILE is an optional variable which specifies the path
+	// to the provision properties file. The file must have the format:
+	//
+	//  key1 = "value1"
+	//  key2 = "value2"
+	provisionPropsFile := os.Getenv("TEST_E2E_PROVISION_FILE")
+
 	if shouldProvisionCluster || podvmImage != "" {
 		// Get an provisioner instance for the cloud provider.
-		provisioner, err = GetCloudProvisioner(cloudProvider)
+		provisioner, err = GetCloudProvisioner(cloudProvider, provisionPropsFile)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/test/e2e/provision_libvirt.go
+++ b/test/e2e/provision_libvirt.go
@@ -26,10 +26,20 @@ type LibvirtProvisioner struct {
 	volumeName string           // Podvm volume name
 }
 
-func NewLibvirtProvisioner(network string, storage string) (*LibvirtProvisioner, error) {
+func NewLibvirtProvisioner(properties map[string]string) (*LibvirtProvisioner, error) {
 	wd, err := filepath.Abs(path.Join("..", "..", "libvirt"))
 	if err != nil {
 		return nil, err
+	}
+
+	network := "default"
+	if properties["libvirt_network"] != "" {
+		network = properties["libvirt_network"]
+	}
+
+	storage := "default"
+	if properties["libvirt_storage"] != "" {
+		storage = properties["libvirt_storage"]
 	}
 
 	// TODO: accept a different URI.


### PR DESCRIPTION
This allow passing properties to the provisioner via a file which path should be specified in the TEST_E2E_PROVISION_FILE variable.

Fixes #592
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>