### PR TITLE
makefile: Parameterize built-in cloud providers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Build
         run: |
           # Build each provider separately
-          make GOFLAGS="-tags=${{ matrix.provider }}" build
+          make BUILTIN_CLOUD_PROVIDERS="${{ matrix.provider }}" build
       - name: Test
         run: |
           go install github.com/jstemmer/go-junit-report@v1.0.0

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -55,12 +55,12 @@ You can also build specific providers as per your requirement.
 
 For example, run the following command to build only the `aws` provider:
 ```
-GOFLAGS="-tags=aws" make
+BUILTIN_CLOUD_PROVIDERS="aws" make
 ```
 
 For example, run the following command to build the `aws`, `azure` and `ibmcloud` providers:
 ```
-GOFLAGS="-tags=aws,azure,ibmcloud" make
+BUILTIN_CLOUD_PROVIDERS="aws azure ibmcloud" make
 ```
 
 ## Build Kata runtime and agent


### PR DESCRIPTION
This PR introduces the BUILTIN_CLOUD_PROVIDERS variable in Makefile to specify cloud providers that to be built into the cloud-api-adaptor binary.

This patch also refactors Makefile to simplify the rules to derive build tags and CGO_ENABLED.

Fixes #653