### PR TITLE
github: remove provider specific podvm builds

### DIFF
--- a/.github/workflows/podvm.yaml
+++ b/.github/workflows/podvm.yaml
@@ -2,42 +2,27 @@ name: Create Pod VM Image
 on:
   workflow_run:
     workflows: ["Create Pod VM Builder Image"]
-    types: 
+    types:
       - completed
 
 jobs:
   build:
     name: Create pod vm image
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os:
-          # Please keep this list in alphabetical order.
-          - centos
-          - ubuntu
-        provider:
-          # Please keep this list in alphabetical order.
-          - aws
-          - azure
-          - ibmcloud
-          - libvirt
-          - vsphere
-        arch:
-          - amd64
-        include:
+        os: [centos, ubuntu]
+        arch: [amd64, s390x]
+        provider: [generic, vsphere]
+        exclude:
           - os: centos
-            dockerfile: Dockerfile.podvm.centos
-          - os: ubuntu
-            dockerfile: Dockerfile.podvm
-          - arch: s390x
-            os: ubuntu
-            provider: ibmcloud
-            dockerfile: Dockerfile.podvm
-            runner: ubuntu-latest
-        runner:
-          - ubuntu-latest
+            arch: s390x
+          - provider: vsphere
+            arch: s390x
+          - provider: vsphere
+            os: centos
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3

--- a/.github/workflows/podvm.yaml
+++ b/.github/workflows/podvm.yaml
@@ -16,6 +16,11 @@ jobs:
         os: [centos, ubuntu]
         arch: [amd64, s390x]
         provider: [generic, vsphere]
+        include:
+          - os: centos
+            dockerfile: Dockerfile.podvm.centos
+          - os: ubuntu
+            dockerfile: Dockerfile.podvm
         exclude:
           - os: centos
             arch: s390x


### PR DESCRIPTION
Keeping vsphere in for `open-vm-tools`.

Tested matrix logic using `act`

```
act -n -j build -W .github/workflows/podvm.yaml | grep Matrix
*DRYRUN* [Create Pod VM Image/Create pod vm image-3] 🧪  Matrix: map[arch:amd64 os:ubuntu provider:vsphere]
*DRYRUN* [Create Pod VM Image/Create pod vm image-1] 🧪  Matrix: map[arch:amd64 os:centos provider:generic]
*DRYRUN* [Create Pod VM Image/Create pod vm image-4] 🧪  Matrix: map[arch:s390x os:ubuntu provider:generic]
*DRYRUN* [Create Pod VM Image/Create pod vm image-2] 🧪  Matrix: map[arch:amd64 os:ubuntu provider:generic]
```

Will result in 4 images

- podvm-vsphere-ubuntu-amd64
- podvm-generic-centos-amd64
- podvm-generic-ubuntu-amd64
- podvm-generic-ubuntu-s390x

A more appropriate name than `generic` for the providers other than `vsphere` might be clearer.

Fixes: #630