### PR TITLE
install: add kind and apiVersion to kustomization files

### DIFF
--- a/install/overlays/aws/kustomization.yaml
+++ b/install/overlays/aws/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 bases:
 - ../../yamls
 nameSuffix: -aws

--- a/install/overlays/azure/kustomization.yaml
+++ b/install/overlays/azure/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 bases:
 - ../../yamls
 nameSuffix: -azure

--- a/install/overlays/ibmcloud/kustomization.yaml
+++ b/install/overlays/ibmcloud/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 bases:
 - ../../yamls
 nameSuffix: -ibmcloud

--- a/install/overlays/libvirt/kustomization.yaml
+++ b/install/overlays/libvirt/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 bases:
 - ../../yamls
 nameSuffix: -libvirt

--- a/install/overlays/vsphere/kustomization.yaml
+++ b/install/overlays/vsphere/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 bases:
 - ../../yamls
 nameSuffix: -vsphere


### PR DESCRIPTION
Added the missing kind and apiVersion fields to all install/overlays/*/kustomization.yaml

Fixes #666
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>