### PR TITLE
e2e: remove build tags in provision_*.go files

### DIFF
--- a/test/e2e/libvirt_test.go
+++ b/test/e2e/libvirt_test.go
@@ -1,4 +1,4 @@
-//go:build libvirt
+//go:build libvirt && cgo
 
 package e2e
 

--- a/test/provisioner/provision_azure.go
+++ b/test/provisioner/provision_azure.go
@@ -1,5 +1,3 @@
-//go:build azure
-
 // (C) Copyright Confidential Containers Contributors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/provisioner/provision_ibmcloud.go
+++ b/test/provisioner/provision_ibmcloud.go
@@ -1,5 +1,3 @@
-//go:build ibmcloud
-
 // (C) Copyright Confidential Containers Contributors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/provisioner/provision_libvirt.go
+++ b/test/provisioner/provision_libvirt.go
@@ -1,4 +1,4 @@
-//go:build libvirt
+//go:build cgo
 
 // (C) Copyright Confidential Containers Contributors
 // SPDX-License-Identifier: Apache-2.0

--- a/test/provisioner/provision_libvirt_nocgo.go
+++ b/test/provisioner/provision_libvirt_nocgo.go
@@ -1,0 +1,10 @@
+//go:build !cgo
+
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package provisioner
+
+func NewLibvirtProvisioner(properties map[string]string) (CloudProvisioner, error) {
+	panic("CGO is not enabled")
+}


### PR DESCRIPTION
Avoid compile error when using tag to filter tests 
Add CGO constraint for libvirt

Fixes #658

Signed-off-by: Lei Li [genjuro214@gmail.com](mailto:genjuro214@gmail.com)