### PR TITLE
gh-action: add peerpod controller workflow

### DIFF
--- a/.github/workflows/controller.yaml
+++ b/.github/workflows/controller.yaml
@@ -1,0 +1,35 @@
+# Copyright Confidential Containers Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run tests for peer-pod controller.
+---
+name: controller
+on: [pull_request]
+jobs:
+  controller_job:
+    name: peer-pod-controller
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: peer-pod-controller
+    strategy:
+      matrix:
+        go_version:
+          - 1.19
+    steps:
+      - name: Checkout the pull request code
+        uses: actions/checkout@v3
+      - name: Setup Golang version ${{ matrix.go_version }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go_version }}
+      - name: Verify go modules
+        run: make verify-modules
+      - name: Verify go generated code
+        run: make verify-gen
+      - name: Build the controller manager
+        run: make build
+      - name: Run unit tests
+        run: make test
+      - name: Build the controller image
+        run: make docker-build


### PR DESCRIPTION
Add a new github workflow to run required checks for peerpod controller

This PR depend on: #675 

Fixes: #665