### PR TITLE
ibmcloud: remove go1.18.x from terraform build

### DIFF
--- a/ibmcloud/terraform/cluster/ansible/kube-playbook.yml
+++ b/ibmcloud/terraform/cluster/ansible/kube-playbook.yml
@@ -126,7 +126,7 @@
         set -o errexit -o pipefail
         arch="{{ ansible_architecture }}"
         #gover=$(curl -sL 'https://golang.org/VERSION?m=text')
-        gover=go1.18.5
+        gover=go1.19.3
         curl -sL "https://go.dev/dl/$gover.linux-${arch/x86_64/amd64}.tar.gz" | tar -xzf - -C /usr/local
 
         if ! grep -q '^PATH=/usr/local/go/bin:\$PATH$' /root/.bashrc; then


### PR DESCRIPTION
Fixes: #678