### PR TITLE
build: Fix unbound variable error of hack/build.sh

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -9,6 +9,7 @@ script_dir=$(dirname "$(readlink -f "$0")")
 registry="${registry:-quay.io/confidential-containers}"
 name="cloud-api-adaptor"
 commit_id=${1:-$(git rev-parse HEAD)}
+release_build=${RELEASE_BUILD:-false}
 
 supported_arches=${ARCHES:-"linux/amd64"}
 
@@ -17,13 +18,13 @@ function build_caa_payload() {
 
 	local tag_string="-t ${registry}/${name}:latest -t ${registry}/${name}:dev-${commit_id}"
 
-	if [[ "$RELEASE_BUILD" == "true" ]]; then
+	if [[ "$release_build" == "true" ]]; then
 		tag_string="-t ${registry}/${name}:${commit_id}"
 	fi
 
 
 	docker buildx build --platform "${supported_arches}" \
-		--build-arg RELEASE_BUILD="${RELEASE_BUILD}" \
+		--build-arg RELEASE_BUILD="${release_build}" \
 		-f Dockerfile \
 		${tag_string} \
 		--push \


### PR DESCRIPTION
This patch fixes the problem that hack/build.sh fails due to unbound variable error when RELEASE_BUILD is not set.

Fixes #690
