### PR TITLE
e2e: fix error to run tests with shouldProvisionCluster false

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -60,13 +60,11 @@ func TestMain(m *testing.M) {
 	//  key2 = "value2"
 	provisionPropsFile := os.Getenv("TEST_E2E_PROVISION_FILE")
 
-	if shouldProvisionCluster || podvmImage != "" {
-		// Get an provisioner instance for the cloud provider.
-		provisioner, err = pv.GetCloudProvisioner(cloudProvider, provisionPropsFile)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+	// Get an provisioner instance for the cloud provider.
+	provisioner, err = pv.GetCloudProvisioner(cloudProvider, provisionPropsFile)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
 
 	if !shouldProvisionCluster {

--- a/test/provisioner/provision_ibmcloud_initializer.go
+++ b/test/provisioner/provision_ibmcloud_initializer.go
@@ -149,7 +149,7 @@ func initProperties(properties map[string]string) error {
 	}
 
 	podvmImage := os.Getenv("TEST_E2E_PODVM_IMAGE")
-	if len(podvmImage) >= 0 {
+	if len(podvmImage) > 0 {
 		if len(IBMCloudProps.CosApiKey) <= 0 {
 			return errors.New("COS_APIKEY was not set.")
 		}


### PR DESCRIPTION
Fixes #693

I tried a solution by invoking `pv.GetCloudProvisioner`, regardless of whether `shouldProvisionCluster` is true or false.

Set TEST_E2E_PROVISION_FILE like:
```
APIKEY="xxx"
IAM_SERVICE_URL="https://iam.test.cloud.ibm.com/identity/token"
VPC_SERVICE_URL="https://us-south-stage01.iaasdev.cloud.ibm.com/v1"
```