### PR TITLE
controller: fix namespace variable name to match implementation

### DIFF
--- a/peer-pod-controller/config/manager/manager.yaml
+++ b/peer-pod-controller/config/manager/manager.yaml
@@ -57,7 +57,7 @@ spec:
             cpu: 10m
             memory: 64Mi
         env:
-        - name: PEERPOD_NAMESPACE
+        - name: PEERPODS_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace


### PR DESCRIPTION
otherwise controller will fail to get namespace correctly

Fixes: #706

Related also to: https://github.com/confidential-containers/cloud-api-adaptor/issues/708 