### PR TITLE
cloud: set the instance name correctly

### DIFF
--- a/pkg/adaptor/cloud/cloud.go
+++ b/pkg/adaptor/cloud/cloud.go
@@ -143,7 +143,7 @@ func (s *cloudService) setInstance(sid sandboxID, instanceID, instanceName strin
 	}
 
 	sandbox.instanceID = instanceID
-	sandbox.instanceName = instanceID
+	sandbox.instanceName = instanceName
 
 	s.cond.Broadcast()
 


### PR DESCRIPTION
While setting instance details for the sandbox, `instanceID` is assigned to `instanceName`. Fix it.

Fixes: #718