### PR TITLE
podvm: Enable uefi for qemu builder

### DIFF
--- a/podvm/Makefile
+++ b/podvm/Makefile
@@ -20,6 +20,9 @@ AGENT_PROTOCOL_FORWARDER_SRC := ../
 
 QEMU_MACHINE_TYPE_s390x := s390-ccw-virtio
 
+UEFI  ?= false
+UEFI_FIRMWARE_LOCATION ?=
+
 image: $(IMAGE_FILE)
 
 setopts:
@@ -66,6 +69,15 @@ endif
 ifdef QEMU_BINARY
 	$(eval OPTS += -var qemu_binary=${QEMU_BINARY} )
 endif
+
+# UEFI is enabled for x86_64 only
+ifeq ($(UEFI),true)
+	$(eval OPTS += -var is_uefi=true -var os_arch="x86_64" )
+ifdef UEFI_FIRMWARE_LOCATION
+	$(eval OPTS += -var uefi_firmware=${UEFI_FIRMWARE_LOCATION} )
+endif
+endif
+
 
 $(IMAGE_FILE): $(BINARIES) $(FILES) setopts
 	rm -fr output

--- a/podvm/qcow2/centos/qemu-centos.pkr.hcl
+++ b/podvm/qcow2/centos/qemu-centos.pkr.hcl
@@ -1,3 +1,9 @@
+locals {
+   machine_type = "${var.os_arch}" == "x86_64" && "${var.is_uefi}" ? "q35" : "${var.machine_type}"
+   use_pflash = "${var.os_arch}" == "x86_64" && "${var.is_uefi}" ? "true" : "false"
+   firmware = "${var.os_arch}" == "x86_64" && "${var.is_uefi}" ? "${var.uefi_firmware}"  : ""
+}
+
 source "qemu" "centos" {
   boot_command      = ["<enter>"]
   disk_compression  = true
@@ -14,7 +20,10 @@ source "qemu" "centos" {
   ssh_username      = "${var.ssh_username}"
   ssh_wait_timeout  = "300s"
   vm_name           = "${var.qemu_image_name}"
-  shutdown_command  = "sudo shutdown -h now" 
+  shutdown_command  = "sudo shutdown -h now"
+  machine_type      = "${local.machine_type}"
+  use_pflash        = "${local.use_pflash}"
+  firmware          = "${local.firmware}"
 }
 
 build {

--- a/podvm/qcow2/centos/variables.pkr.hcl
+++ b/podvm/qcow2/centos/variables.pkr.hcl
@@ -58,3 +58,24 @@ variable "cloud_provider" {
   type    = string
   default = env("CLOUD_PROVIDER")
 }
+
+variable "machine_type" {
+  type = string
+  default = "pc"
+}
+
+variable "os_arch" {
+  type    = string
+  default = "x86_64"
+}
+
+variable "is_uefi" {
+  type        = bool
+  default     = false
+}
+
+variable "uefi_firmware" {
+  type    = string
+  default = "/usr/share/edk2/ovmf/OVMF_CODE.cc.fd"
+}
+

--- a/podvm/qcow2/rhel/qemu-rhel.pkr.hcl
+++ b/podvm/qcow2/rhel/qemu-rhel.pkr.hcl
@@ -1,3 +1,9 @@
+locals {
+   machine_type = "${var.os_arch}" == "x86_64" && "${var.is_uefi}" ? "q35" : "${var.machine_type}"
+   use_pflash = "${var.os_arch}" == "x86_64" && "${var.is_uefi}" ? "true" : "false"
+   firmware = "${var.os_arch}" == "x86_64" && "${var.is_uefi}" ? "${var.uefi_firmware}"  : ""
+}
+
 source "qemu" "rhel" {
   boot_command      = ["<enter>"]
   disk_compression  = true
@@ -15,6 +21,9 @@ source "qemu" "rhel" {
   ssh_wait_timeout  = "300s"
   vm_name           = "${var.qemu_image_name}"
   shutdown_command  = "sudo shutdown -h now"
+  machine_type      = "${local.machine_type}"
+  use_pflash        = "${local.use_pflash}"
+  firmware          = "${local.firmware}"
 }
 
 build {

--- a/podvm/qcow2/rhel/variables.pkr.hcl
+++ b/podvm/qcow2/rhel/variables.pkr.hcl
@@ -57,3 +57,23 @@ variable "cloud_provider" {
   type    = string
   default = env("CLOUD_PROVIDER")
 }
+
+variable "machine_type" {
+  type = string
+  default = "pc"
+}
+
+variable "os_arch" {
+  type    = string
+  default = "x86_64"
+}
+
+variable "is_uefi" {
+  type        = bool
+  default     = false
+}
+
+variable "uefi_firmware" {
+  type    = string
+  default = "/usr/share/edk2/ovmf/OVMF_CODE.cc.fd"
+}

--- a/podvm/qcow2/ubuntu/variables.pkr.hcl
+++ b/podvm/qcow2/ubuntu/variables.pkr.hcl
@@ -77,3 +77,18 @@ variable "cloud_provider" {
   type    = string
   default = env("CLOUD_PROVIDER")
 }
+
+variable "os_arch" {
+  type    = string
+  default = "x86_64"
+}
+
+variable "is_uefi" {
+  type        = bool
+  default     = false
+}
+
+variable "uefi_firmware" {
+  type    = string
+  default = "/usr/share/OVMF/OVMF_CODE.fd"
+}


### PR DESCRIPTION
Confidential VM images are UEFI based and in order to customise them, we need qemu builder to support UEFI

Fixes: #721