### PR TITLE
e2e: make tests pass for ibmcloud with TEST_E2E_PROVISION=no

### DIFF
--- a/test/provisioner/provision_ibmcloud.properties
+++ b/test/provisioner/provision_ibmcloud.properties
@@ -21,6 +21,8 @@ REGION="jp-tok"
 RESOURCE_GROUP_ID="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 # The ssh key with name ${SSH_KEY_NAME} will be created in VPC as contents from ${SSH_PUBLIC_KEY_CONTENT}
 SSH_KEY_NAME="my-ssh-key-123"
+# optional, existing ssh key id if using existing VPC and cluster for testing
+SSH_KEY_ID=""
 # Public part of a ssh key generated from ssh-keygen, for example: contents from file id_rsa.pub
 SSH_PUBLIC_KEY_CONTENT="${public part of a ssh key generated from ssh-keygen}"
 WORKER_FLAVOR="bx2.2x8"
@@ -32,5 +34,11 @@ ZONE="jp-tok-1"
 PODVM_IMAGE_ID=""
 # optional, it'll be set as ${CLUSTER_NAME}-vpc-subnet if not provided
 VPC_SUBNET_NAME=""
+# optional, existing subnet id if using existing VPC and cluster for testing
+VPC_SUBNET_ID=""
+# optional, existing security group id if using existing VPC and cluster for testing
+VPC_SECURITY_GROUP_ID=""
 # optional, it'll be set as ${CLUSTER_NAME}-vpc if not provided
 VPC_NAME=""
+# optional, existing VPC id if using existing VPC and cluster for testing
+VPC_ID=""

--- a/test/provisioner/provision_ibmcloud_initializer.go
+++ b/test/provisioner/provision_ibmcloud_initializer.go
@@ -79,6 +79,10 @@ func initProperties(properties map[string]string) error {
 		WorkerFlavor:    properties["WORKER_FLAVOR"],
 		WorkerOS:        properties["WORKER_OPERATION_SYSTEM"],
 		Zone:            properties["ZONE"],
+		SshKeyID:        properties["SSH_KEY_ID"],
+		SubnetID:        properties["VPC_SUBNET_ID"],
+		SecurityGroupID: properties["VPC_SECURITY_GROUP_ID"],
+		VpcID:           properties["VPC_ID"],
 	}
 
 	if len(IBMCloudProps.ClusterName) <= 0 {
@@ -118,14 +122,11 @@ func initProperties(properties map[string]string) error {
 	if len(IBMCloudProps.ApiKey) <= 0 {
 		return errors.New("APIKEY was not set.")
 	}
-	if len(IBMCloudProps.Region) <= 0 {
-		return errors.New("REGION was not set.")
+	if len(IBMCloudProps.ResourceGroupID) <= 0 {
+		return errors.New("RESOURCE_GROUP_ID was not set.")
 	}
-	if len(IBMCloudProps.KubeVersion) <= 0 {
-		return errors.New("KUBE_VERSION was not set, get it via command: ibmcloud cs versions")
-	}
-	if len(IBMCloudProps.WorkerOS) <= 0 {
-		return errors.New("WORKER_OPERATION_SYSTEM was not set, set it like: UBUNTU_20_64, UBUNTU_18_S390X")
+	if len(IBMCloudProps.Zone) <= 0 {
+		return errors.New("ZONE was not set.")
 	}
 
 	// IAM_SERVICE_URL can overwrite default IamServiceURL, for example: IAM_SERVICE_URL="https://iam.test.cloud.ibm.com/identity/token"
@@ -142,15 +143,34 @@ func initProperties(properties map[string]string) error {
 
 	needProvisionStr := os.Getenv("TEST_E2E_PROVISION")
 	if strings.EqualFold(needProvisionStr, "yes") || strings.EqualFold(needProvisionStr, "true") {
-		if len(IBMCloudProps.ResourceGroupID) <= 0 {
-			return errors.New("RESOURCE_GROUP_ID was not set.")
+		if len(IBMCloudProps.Region) <= 0 {
+			return errors.New("REGION was not set.")
 		}
-		if len(IBMCloudProps.Zone) <= 0 {
-			return errors.New("ZONE was not set.")
+		if len(IBMCloudProps.KubeVersion) <= 0 {
+			return errors.New("KUBE_VERSION was not set, get it via command: ibmcloud cs versions")
+		}
+		if len(IBMCloudProps.WorkerOS) <= 0 {
+			return errors.New("WORKER_OPERATION_SYSTEM was not set, set it like: UBUNTU_20_64, UBUNTU_18_S390X")
 		}
 
 		if err := initClustersAPI(); err != nil {
 			return err
+		}
+	} else {
+		if len(IBMCloudProps.PodvmImageID) <= 0 {
+			return errors.New("PODVM_IMAGE_ID was not set, set it with existing custom image id in VPC")
+		}
+		if len(IBMCloudProps.SshKeyID) <= 0 {
+			return errors.New("SSH_KEY_ID was not set, set it with existing SSH key id in VPC")
+		}
+		if len(IBMCloudProps.SubnetID) <= 0 {
+			return errors.New("VPC_SUBNET_ID was not set, set it with existing subnet id in VPC")
+		}
+		if len(IBMCloudProps.SecurityGroupID) <= 0 {
+			return errors.New("VPC_SECURITY_GROUP_ID was not set, set it with existing security group id in VPC")
+		}
+		if len(IBMCloudProps.VpcID) <= 0 {
+			return errors.New("VPC_ID was not set, set it with existing VPC id")
 		}
 	}
 


### PR DESCRIPTION
If `TEST_E2E_PROVISION=no`, some properties should be initialized in `initProperties()` from the properties file.

Also adjust the properties check according to TEST_E2E_PROVISION value

Fixes #730

Signed-off-by: Lei Li <genjuro214@gmail.com>
Signed-off-by: Lei Li <cdlleili@cn.ibm.com>