### PR TITLE
cmd: Notify systemd about service state changes

### DIFF
--- a/cmd/starter.go
+++ b/cmd/starter.go
@@ -19,6 +19,7 @@ type Starter interface {
 }
 type Service interface {
 	Start(context.Context) error
+	Ready() chan struct{}
 }
 
 type Config interface {
@@ -31,6 +32,7 @@ type starter struct {
 type starterService struct {
 	Service
 	errorCh chan error
+	readyCh chan struct{}
 }
 
 func NewStarter(services ...Service) Starter {
@@ -80,6 +82,8 @@ func (s *starter) Start(ctx context.Context) error {
 				service.errorCh <- err
 			}
 		}()
+
+		service.readyCh = service.Ready()
 	}
 
 	<-ctx.Done()

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/IBM/ibm-cos-sdk-go v1.9.4
 	github.com/avast/retry-go/v4 v4.3.2
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.6
+	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
 	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20220913141151-9b49a6ddc6fd
 	github.com/sirupsen/logrus v1.9.0
 	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2

--- a/go.sum
+++ b/go.sum
@@ -473,6 +473,7 @@ github.com/coreos/go-systemd v0.0.0-20161114122254-48702e0da86b/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190620071333-e64a0ec8b42a/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f h1:JOrtw2xFKzlg+cbHpyrpLDmnN1HqhBfnX7WDiW7eG2c=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -47,6 +47,7 @@ type Config struct {
 type Daemon interface {
 	Start(ctx context.Context) error
 	Shutdown() error
+	Ready() chan struct{}
 	Addr() string
 }
 
@@ -171,6 +172,10 @@ func (d *daemon) Shutdown() error {
 		close(d.stopCh)
 	})
 	return nil
+}
+
+func (d *daemon) Ready() chan struct{} {
+	return d.readyCh
 }
 
 func (d *daemon) Addr() string {

--- a/podvm/files/etc/systemd/system/agent-protocol-forwarder.service
+++ b/podvm/files/etc/systemd/system/agent-protocol-forwarder.service
@@ -1,11 +1,12 @@
 [Unit]
 Description=Agent Protocol Forwarder
-After=cloud-init.target
-Wants=cloud-init.target
+After=cloud-init.target kata-agent.service
+Wants=cloud-init.target kata-agent.service
 DefaultDependencies=no
 
 
 [Service]
+Type=notify
 EnvironmentFile=-/etc/default/agent-protocol-forwarder
 ExecStart=/usr/local/bin/agent-protocol-forwarder -kata-agent-namespace /run/netns/podns -kata-agent-socket /run/kata-containers/agent.sock $TLS_OPTIONS
 Restart=on-failure


### PR DESCRIPTION
This patch enables notification to systemd using the sd_notify protocol.  When the program is running as a systemd service with type=notify, and becomes ready for serving requests, systemd gets notified.

Fixes #735
