### PR TITLE
terraform: remove deprecated attributes

### DIFF
--- a/ibmcloud/terraform/cluster/main.tf
+++ b/ibmcloud/terraform/cluster/main.tf
@@ -9,8 +9,8 @@ locals {
   controlplane_floating_ip_name = "${local.controlplane_name}-ip"
   worker_name = "${var.cluster_name}-worker"
   worker_floating_ip_name = "${local.worker_name}-ip"
-  controlplane_ip = resource.ibm_is_instance.controlplane.primary_network_interface[0].primary_ipv4_address
-  worker_ip = resource.ibm_is_instance.worker.primary_network_interface[0].primary_ipv4_address
+  controlplane_ip = resource.ibm_is_instance.controlplane.primary_network_interface[0].primary_ip[0].address
+  worker_ip = resource.ibm_is_instance.worker.primary_network_interface[0].primary_ip[0].address
   bastion_ip = resource.ibm_is_floating_ip.worker.address
   vpc_id = var.vpc_name != null ? data.ibm_is_vpc.vpc[0].id : var.vpc_id
   primary_security_group_id = var.primary_security_group_name != null ? data.ibm_is_security_group.primary[0].id : var.primary_security_group_id

--- a/ibmcloud/terraform/cluster/outputs.tf
+++ b/ibmcloud/terraform/cluster/outputs.tf
@@ -8,7 +8,7 @@ output "cluster_name" {
 }
 
 output "worker_ip" {
-  value = data.ibm_is_instance.provisioned_worker.primary_network_interface[0].primary_ipv4_address
+  value = data.ibm_is_instance.provisioned_worker.primary_network_interface[0].primary_ip[0].address
 }
 
 output "bastion_ip" {

--- a/ibmcloud/terraform/run-nginx-demo/main.tf
+++ b/ibmcloud/terraform/run-nginx-demo/main.tf
@@ -6,7 +6,7 @@
 locals {
   worker_name = var.cluster_name != null ? "${var.cluster_name}-worker" : null
   worker_floating_ip_name = local.worker_name != null ? "${local.worker_name}-ip" : null
-  worker_ip = local.worker_name != null ? data.ibm_is_instance.worker[0].primary_network_interface[0].primary_ipv4_address : var.worker_ip
+  worker_ip = local.worker_name != null ? data.ibm_is_instance.worker[0].primary_network_interface[0].primary_ip[0].address : var.worker_ip
   bastion_ip = local.worker_floating_ip_name != null ? data.ibm_is_floating_ip.worker[0].address : var.bastion_ip
   vpc_id = var.vpc_name != null ? data.ibm_is_vpc.vpc[0].id : var.vpc_id
   podvm_image_id = var.podvm_image_name != null ? data.ibm_is_image.podvm_image[0].id : var.podvm_image_id

--- a/ibmcloud/terraform/start-cloud-api-adaptor/main.tf
+++ b/ibmcloud/terraform/start-cloud-api-adaptor/main.tf
@@ -7,7 +7,7 @@ locals {
   worker_name = var.cluster_name != null ? "${var.cluster_name}-worker" : null
   worker_floating_ip_name = local.worker_name != null ? "${local.worker_name}-ip" : null
   podvm_image_id = var.podvm_image_name != null ? data.ibm_is_image.podvm_image[0].id : var.podvm_image_id
-  worker_ip = local.worker_name != null ? data.ibm_is_instance.worker[0].primary_network_interface[0].primary_ipv4_address : var.worker_ip
+  worker_ip = local.worker_name != null ? data.ibm_is_instance.worker[0].primary_network_interface[0].primary_ip[0].address : var.worker_ip
   bastion_ip = local.worker_floating_ip_name != null ? data.ibm_is_floating_ip.worker[0].address : var.bastion_ip
   zone_name = data.ibm_is_subnet.primary_subnet_by_id.zone
   vpc_id = var.vpc_name != null ? data.ibm_is_vpc.vpc[0].id : var.vpc_id


### PR DESCRIPTION
The attribute `primary_ipv4_address` is deprecated. Instead, use `primary_ip.address`.

Fixes: #743