### PR TITLE
go: Use valid go.mod format in the podvm directory

### DIFF
--- a/azure/go.mod
+++ b/azure/go.mod
@@ -1,3 +1,0 @@
-// Empty go.mod file to exclude the run-kata\x2dcontainers.mount file
-// from the cloud-api-adaptor Go module when cloud-api-adaptor is
-// imported by other Go projects

--- a/podvm/go.mod
+++ b/podvm/go.mod
@@ -1,3 +1,7 @@
 // Empty go.mod file to exclude the run-kata\x2dcontainers.mount file
 // from the cloud-api-adaptor Go module when cloud-api-adaptor is
 // imported by other Go projects
+
+module github.com/confidential-containers/cloud-api-adaptor/podvm
+
+go 1.19


### PR DESCRIPTION
The `go.mod` file in the `podvm` directory is empty to void the issue addressed by #500. But, empty `go.mod` file causes errors when we run some go commands as described in #747.

This PR keeps the go.mod file, but changes the file to use a valid go.mod file format. I confirmed that referencing `cloud-api-adaptor` repo as a go module from another go program still works after this change is introduced.

This PR also removes `azure/go.sum`, since this file is no longer necessary, as #538 has removed the files that caused the problem.
