### PR TITLE
proxy: add new flag for number of proxy retries

### DIFF
--- a/cmd/cloud-api-adaptor/main.go
+++ b/cmd/cloud-api-adaptor/main.go
@@ -71,6 +71,7 @@ func (cfg *daemonConfig) Setup() (cmd.Starter, error) {
 			flags.StringVar(&tlsConfig.KeyFile, "cert-key", "", "cert key")
 			flags.BoolVar(&tlsConfig.SkipVerify, "tls-skip-verify", false, "Skip TLS certificate verification - use it only for testing")
 			flags.BoolVar(&disableTLS, "disable-tls", false, "Disable TLS encryption - use it only for testing")
+			flags.IntVar(&cfg.serverConfig.ProxyRetries, "proxy-retries", 20, "Number of retries for establishing agent proxy connection")
 
 			flags.StringVar(&cfg.networkConfig.TunnelType, "tunnel-type", podnetwork.DefaultTunnelType, "Tunnel provider")
 			flags.StringVar(&cfg.networkConfig.HostInterface, "host-interface", "", "Host Interface")

--- a/pkg/adaptor/proxy/factory.go
+++ b/pkg/adaptor/proxy/factory.go
@@ -14,9 +14,10 @@ type factory struct {
 	criSocketPath string
 	tlsConfig     *tlsutil.TLSConfig
 	caService     tlsutil.CAService
+	proxyRetries  int
 }
 
-func NewFactory(pauseImage, criSocketPath string, tlsConfig *tlsutil.TLSConfig) Factory {
+func NewFactory(pauseImage, criSocketPath string, tlsConfig *tlsutil.TLSConfig, proxyRetries int) Factory {
 
 	if tlsConfig != nil && !tlsConfig.HasCertAuth() {
 
@@ -45,10 +46,11 @@ func NewFactory(pauseImage, criSocketPath string, tlsConfig *tlsutil.TLSConfig) 
 		criSocketPath: criSocketPath,
 		tlsConfig:     tlsConfig,
 		caService:     caService,
+		proxyRetries:  proxyRetries,
 	}
 }
 
 func (f *factory) New(serverName, socketPath string) AgentProxy {
 
-	return NewAgentProxy(serverName, socketPath, f.criSocketPath, f.pauseImage, f.tlsConfig, f.caService)
+	return NewAgentProxy(serverName, socketPath, f.criSocketPath, f.pauseImage, f.tlsConfig, f.caService, f.proxyRetries)
 }

--- a/pkg/adaptor/proxy/proxy.go
+++ b/pkg/adaptor/proxy/proxy.go
@@ -27,7 +27,6 @@ import (
 const (
 	SocketName = "agent.ttrpc"
 
-	defaultMaxRetries    = 20
 	defaultRetryInterval = 10 * time.Second
 	defaultCriTimeout    = 1 * time.Second
 
@@ -65,7 +64,7 @@ type agentProxy struct {
 	stopOnce      sync.Once
 }
 
-func NewAgentProxy(serverName, socketPath, criSocketPath string, pauseImage string, tlsConfig *tlsutil.TLSConfig, caService tlsutil.CAService) AgentProxy {
+func NewAgentProxy(serverName, socketPath, criSocketPath string, pauseImage string, tlsConfig *tlsutil.TLSConfig, caService tlsutil.CAService, proxyRetries int) AgentProxy {
 
 	return &agentProxy{
 		serverName:    serverName,
@@ -73,7 +72,7 @@ func NewAgentProxy(serverName, socketPath, criSocketPath string, pauseImage stri
 		criSocketPath: criSocketPath,
 		readyCh:       make(chan struct{}),
 		stopCh:        make(chan struct{}),
-		maxRetries:    defaultMaxRetries,
+		maxRetries:    proxyRetries,
 		retryInterval: defaultRetryInterval,
 		criTimeout:    defaultCriTimeout,
 		pauseImage:    pauseImage,
@@ -117,7 +116,7 @@ func (p *agentProxy) dial(ctx context.Context, address string) (net.Conn, error)
 		dialer = &net.Dialer{}
 	}
 
-	maxRetries := defaultMaxRetries
+	maxRetries := p.maxRetries
 	count := 1
 	for {
 		var err error

--- a/pkg/adaptor/proxy/proxy_test.go
+++ b/pkg/adaptor/proxy/proxy_test.go
@@ -25,7 +25,7 @@ func TestNewAgentProxy(t *testing.T) {
 
 	socketPath := "/run/dummy.sock"
 
-	proxy := NewAgentProxy("podvm", socketPath, "", "", nil, nil)
+	proxy := NewAgentProxy("podvm", socketPath, "", "", nil, nil, 0)
 	p, ok := proxy.(*agentProxy)
 	if !ok {
 		t.Fatalf("expect %T, got %T", &agentProxy{}, proxy)
@@ -82,7 +82,7 @@ func TestStartStop(t *testing.T) {
 		Host:   agentListener.Addr().String(),
 	}
 
-	proxy := NewAgentProxy("podvm", socketPath, "", "", nil, nil)
+	proxy := NewAgentProxy("podvm", socketPath, "", "", nil, nil, 0)
 	p, ok := proxy.(*agentProxy)
 	if !ok {
 		t.Fatalf("expect %T, got %T", &agentProxy{}, proxy)

--- a/pkg/adaptor/server.go
+++ b/pkg/adaptor/server.go
@@ -36,6 +36,7 @@ type ServerConfig struct {
 	PauseImage    string
 	PodsDir       string
 	ForwarderPort string
+	ProxyRetries  int
 }
 
 type Server interface {
@@ -59,7 +60,7 @@ func NewServer(provider cloud.Provider, cfg *ServerConfig, workerNode podnetwork
 
 	logger.Printf("server config: %#v", cfg)
 
-	agentFactory := proxy.NewFactory(cfg.PauseImage, cfg.CriSocketPath, cfg.TLSConfig)
+	agentFactory := proxy.NewFactory(cfg.PauseImage, cfg.CriSocketPath, cfg.TLSConfig, cfg.ProxyRetries)
 	cloudService := cloud.NewService(provider, agentFactory, workerNode, cfg.PodsDir, cfg.ForwarderPort)
 	vmInfoService := vminfo.NewService(cloudService)
 


### PR DESCRIPTION
A new flag proxy-retries has been introduced to customize the number of retries needed for establishing agent proxy connection.

Fixes: #751