### PR TITLE
pkg: enhance retry logic for establishing connections

### DIFF
--- a/cmd/cloud-api-adaptor/main.go
+++ b/cmd/cloud-api-adaptor/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/confidential-containers/cloud-api-adaptor/cmd"
 	"github.com/confidential-containers/cloud-api-adaptor/cmd/cloud-api-adaptor/cloudmgr"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor"
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/proxy"
 	daemon "github.com/confidential-containers/cloud-api-adaptor/pkg/forwarder"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork/tunneler/vxlan"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/util/tlsutil"
@@ -71,6 +72,7 @@ func (cfg *daemonConfig) Setup() (cmd.Starter, error) {
 			flags.StringVar(&tlsConfig.KeyFile, "cert-key", "", "cert key")
 			flags.BoolVar(&tlsConfig.SkipVerify, "tls-skip-verify", false, "Skip TLS certificate verification - use it only for testing")
 			flags.BoolVar(&disableTLS, "disable-tls", false, "Disable TLS encryption - use it only for testing")
+			flags.DurationVar(&cfg.serverConfig.ProxyTimeout, "proxy-timeout", proxy.DefaultProxyTimeout, "Maximum timeout in minutes for establishing agent proxy connection")
 
 			flags.StringVar(&cfg.networkConfig.TunnelType, "tunnel-type", podnetwork.DefaultTunnelType, "Tunnel provider")
 			flags.StringVar(&cfg.networkConfig.HostInterface, "host-interface", "", "Host Interface")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,7 @@ optionals+=""
 [[ "${CACERT_FILE}" ]] && optionals+="-ca-cert-file ${CACERT_FILE} "
 [[ "${CERT_FILE}" ]] && [[ "${CERT_KEY}" ]] && optionals+="-cert-file ${CERT_FILE} -cert-key ${CERT_KEY} "
 [[ "${TLS_SKIP_VERIFY}" ]] && optionals+="-tls-skip-verify "
+[[ "${PROXY_TIMEOUT}" ]] && optionals+="-proxy-timeout ${PROXY_TIMEOUT} "
 
 test_vars() {
         for i in "$@"; do

--- a/pkg/adaptor/proxy/factory.go
+++ b/pkg/adaptor/proxy/factory.go
@@ -3,7 +3,11 @@
 
 package proxy
 
-import "github.com/confidential-containers/cloud-api-adaptor/pkg/util/tlsutil"
+import (
+	"time"
+
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/util/tlsutil"
+)
 
 type Factory interface {
 	New(serverName, socketPath string) AgentProxy
@@ -14,9 +18,10 @@ type factory struct {
 	criSocketPath string
 	tlsConfig     *tlsutil.TLSConfig
 	caService     tlsutil.CAService
+	proxyTimeout  time.Duration
 }
 
-func NewFactory(pauseImage, criSocketPath string, tlsConfig *tlsutil.TLSConfig) Factory {
+func NewFactory(pauseImage, criSocketPath string, tlsConfig *tlsutil.TLSConfig, proxyTimeout time.Duration) Factory {
 
 	if tlsConfig != nil && !tlsConfig.HasCertAuth() {
 
@@ -45,10 +50,11 @@ func NewFactory(pauseImage, criSocketPath string, tlsConfig *tlsutil.TLSConfig) 
 		criSocketPath: criSocketPath,
 		tlsConfig:     tlsConfig,
 		caService:     caService,
+		proxyTimeout:  proxyTimeout,
 	}
 }
 
 func (f *factory) New(serverName, socketPath string) AgentProxy {
 
-	return NewAgentProxy(serverName, socketPath, f.criSocketPath, f.pauseImage, f.tlsConfig, f.caService)
+	return NewAgentProxy(serverName, socketPath, f.criSocketPath, f.pauseImage, f.tlsConfig, f.caService, f.proxyTimeout)
 }

--- a/pkg/adaptor/proxy/proxy_test.go
+++ b/pkg/adaptor/proxy/proxy_test.go
@@ -25,7 +25,7 @@ func TestNewAgentProxy(t *testing.T) {
 
 	socketPath := "/run/dummy.sock"
 
-	proxy := NewAgentProxy("podvm", socketPath, "", "", nil, nil)
+	proxy := NewAgentProxy("podvm", socketPath, "", "", nil, nil, 0)
 	p, ok := proxy.(*agentProxy)
 	if !ok {
 		t.Fatalf("expect %T, got %T", &agentProxy{}, proxy)
@@ -82,7 +82,7 @@ func TestStartStop(t *testing.T) {
 		Host:   agentListener.Addr().String(),
 	}
 
-	proxy := NewAgentProxy("podvm", socketPath, "", "", nil, nil)
+	proxy := NewAgentProxy("podvm", socketPath, "", "", nil, nil, 5*time.Second)
 	p, ok := proxy.(*agentProxy)
 	if !ok {
 		t.Fatalf("expect %T, got %T", &agentProxy{}, proxy)
@@ -156,8 +156,7 @@ func TestStartStop(t *testing.T) {
 
 func TestDialerSuccess(t *testing.T) {
 	p := &agentProxy{
-		maxRetries:    20,
-		retryInterval: 100 * time.Millisecond,
+		proxyTimeout: 5 * time.Second,
 	}
 
 	for {
@@ -209,8 +208,7 @@ func TestDialerSuccess(t *testing.T) {
 
 func TestDialerFailure(t *testing.T) {
 	p := &agentProxy{
-		maxRetries:    5,
-		retryInterval: 100 * time.Millisecond,
+		proxyTimeout: 5 * time.Second,
 	}
 
 	address := "0.0.0.0:0"
@@ -220,7 +218,7 @@ func TestDialerFailure(t *testing.T) {
 		t.Fatal("expect error, got nil")
 	}
 
-	if e, a := "reaches max retry count", err.Error(); !strings.Contains(a, e) {
+	if e, a := "All attempts fail", err.Error(); !strings.Contains(a, e) {
 		t.Fatalf("expect %q, got %q", e, a)
 	}
 }

--- a/pkg/adaptor/server.go
+++ b/pkg/adaptor/server.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/containerd/ttrpc"
 	pbHypervisor "github.com/kata-containers/kata-containers/src/runtime/protocols/hypervisor"
@@ -36,6 +37,7 @@ type ServerConfig struct {
 	PauseImage    string
 	PodsDir       string
 	ForwarderPort string
+	ProxyTimeout  time.Duration
 }
 
 type Server interface {
@@ -59,7 +61,7 @@ func NewServer(provider cloud.Provider, cfg *ServerConfig, workerNode podnetwork
 
 	logger.Printf("server config: %#v", cfg)
 
-	agentFactory := proxy.NewFactory(cfg.PauseImage, cfg.CriSocketPath, cfg.TLSConfig)
+	agentFactory := proxy.NewFactory(cfg.PauseImage, cfg.CriSocketPath, cfg.TLSConfig, cfg.ProxyTimeout)
 	cloudService := cloud.NewService(provider, agentFactory, workerNode, cfg.PodsDir, cfg.ForwarderPort)
 	vmInfoService := vminfo.NewService(cloudService)
 

--- a/pkg/adaptor/server_test.go
+++ b/pkg/adaptor/server_test.go
@@ -155,6 +155,7 @@ func newServer(t *testing.T, socketPath, podsDir string) Server {
 			SocketPath:    socketPath,
 			PodsDir:       podsDir,
 			ForwarderPort: port,
+			ProxyTimeout:  5 * time.Second,
 		}
 		srv := NewServer(provider, serverConfig, &mockWorkerNode{})
 		return srv

--- a/pkg/adaptor/shim_test.go
+++ b/pkg/adaptor/shim_test.go
@@ -90,6 +90,7 @@ func TestShim(t *testing.T) {
 		SocketPath:    helperSocketPath,
 		PodsDir:       podsDir,
 		ForwarderPort: port,
+		ProxyTimeout:  5 * time.Second,
 	}
 
 	provider := &mockProvider{primaryIP: primaryIP, secondaryIP: secondaryIP}


### PR DESCRIPTION
This PR introduces a new flag `proxy-timeout` which represents the maximum time in minutes for establishing agent proxy connection. It also refactors the retry logic for establshing connection between agent proxy and `agent-protocol-forwarder` on peer pod VM and between `agent-protocol-forwarder` and kata agent.

Fixes: #754