### PR TITLE
ibmcloud: Add the ability to import to staging

### DIFF
--- a/ibmcloud/IMPORT_PODVM_TO_VPC.md
+++ b/ibmcloud/IMPORT_PODVM_TO_VPC.md
@@ -32,9 +32,12 @@ The later options:
 - `instance`: the cos instance name. Required if the cli has not been configured with the cos instance before
 - `bucket`: name of the bucket to use. Will use an available bucket if not specified
 - `region`: name of the region the bucket is in. Only required if that region is different from the VPC region
+- `endpoint`: the COS endpoint to upload to. Optional, but required if using staging, where the endpoint can be found in the 'Configuration' tab in the COS bucket page of the IBM Cloud UI.
 - `os`: name of the operating-system for the image, will default to `ubuntu-20-04-<< image-suffix >>` e.g. `ubuntu-20-04-s390x`. The HyperProtect OS is `hyper-protect-1-0-s390x`.
 
 The script will sanitise `.` and `_` into `-` and lowercase the image name. Only lowercase alphanumeric characters and hyphens only (without spaces) are allowed for image names. If your image file name contains other special characters please rename it before attempting to import.
+
+> **Note:** If uploading to IBM Cloud staging, you will first need to set the API endpoint with `export IBMCLOUD_API_ENDPOINT=https://test.cloud.ibm.com`.
 
 ### Examples
 

--- a/ibmcloud/image/import.sh
+++ b/ibmcloud/image/import.sh
@@ -21,7 +21,7 @@ bucket=
 bucket_region=$region
 instance=
 endpoint=
-api=https://cloud.ibm.com
+api=${IBMCLOUD_API_ENDPOINT-https://cloud.ibm.com}
 operating_system=
 
 shift 2


### PR DESCRIPTION
- Add the ability to create the VPC image to staging, like push.sh does, by allowing the api endpoint to be overridden

Fixes: #774