### PR TITLE
podvm: Start Attestation Agent process in podns namespace

### DIFF
--- a/docs/runtime-key-release.md
+++ b/docs/runtime-key-release.md
@@ -1,0 +1,21 @@
+# Secure Key Release at Runtime
+
+To request a key at runtime a Pod can invoke a local Key Broker Client (KBC) implemented in [Attestation Agent](https://github.com/confidential-containers/attestation-agent) (AA). An instance of AA is available as gRPC endpoint in the Pod's network namespace on port `50001`. Depending on the KBC implementation this might trigger a remote attestation exchange with an external [Key Broker Service](https://github.com/confidential-containers/kbs) (KBS).
+
+
+## Example
+
+The following code is supposed to run in a Peer Pod. It downloads a grpcurl binary, the respective proto files for the gRPC service, and triggers a request to retrieve a key. The example below is using an external KBS via the `cc_kbc` KBC implementation.
+
+```bash
+wget https://github.com/fullstorydev/grpcurl/releases/download/v1.8.7/grpcurl_1.8.7_linux_x86_64.tar.gz -O grpcurl.tar.gz
+tar -xvf grpcurl.tar.gz
+wget https://raw.githubusercontent.com/confidential-containers/attestation-agent/main/protos/getresource.proto -O aa.proto
+./grpcurl -proto aa.proto -plaintext -d @ localhost:50001 getresource.GetResourceService.GetResource <<EOM
+{
+  "ResourcePath": "/my_repo/resource_type/123abc",
+  "KbcName":"cc_kbc",
+  "KbsUri": "https://some-kbs.com"
+}
+EOM
+```

--- a/podvm/Makefile.inc
+++ b/podvm/Makefile.inc
@@ -21,6 +21,8 @@ ARCH        := $(subst amd64,x86_64,$(ARCH))
 DEB_ARCH    := $(subst x86_64,amd64,$(ARCH))
 LIBC        ?= $(if $(findstring s390x,$(ARCH)),gnu,musl)
 RUST_TARGET := $(ARCH)-unknown-linux-$(LIBC)
+AA_KBC      ?= offline_fs_kbc
+KBC_URI     ?= null
 
 ifneq ($(HOST_ARCH),$(ARCH))
     ifeq ($(CC),cc)
@@ -55,11 +57,8 @@ ATTESTATION_AGENT = $(FILES_DIR)/usr/local/bin/attestation-agent
 # Allow BINARIES to be overriden externally
 BINARIES ?= $(AGENT_PROTOCOL_FORWARDER) $(KATA_AGENT) $(PAUSE)
 
-KBC_URI ?= "null"
-ifdef AA_KBC
 BINARIES += $(ATTESTATION_AGENT)
 $(shell sed -i "s/\(aa_kbc_params = \)\"[^\"]*\"/\1\"${AA_KBC}::${KBC_URI}\"/g" $(FILES_DIR)/etc/agent-config.toml)
-endif
 
 AGENT_PROTOCOL_FORWARDER_SRC = ../..
 

--- a/podvm/files/etc/systemd/system/attestation-agent.service
+++ b/podvm/files/etc/systemd/system/attestation-agent.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Attestation Agent Service
+BindsTo=netns@podns.service
+After=network.target kata-agent.service netns@podns.service
+
+[Service]
+Type=simple
+NetworkNamespacePath=/run/netns/podns
+ExecStart=/usr/local/bin/attestation-agent --getresource_sock 127.0.0.1:50001
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/podvm/files/etc/systemd/system/kata-agent.service
+++ b/podvm/files/etc/systemd/system/kata-agent.service
@@ -1,13 +1,11 @@
 [Unit]
 Description=Kata Agent
-After=network.target
+BindsTo=netns@podns.service
+After=network.target netns@podns.service
 
 [Service]
 ExecStart=/usr/local/bin/kata-agent --config /etc/agent-config.toml
 ExecStartPre=-umount /sys/fs/cgroup/misc
-ExecStartPre=ip netns add podns
-ExecStartPre=ip netns exec podns ip link set lo up
-ExecStopPost=ip netns delete podns
 ExecStopPost=/usr/local/bin/kata-agent-clean --config /etc/agent-config.toml
 # Now specified in the agent-config.toml Environment="KATA_AGENT_SERVER_ADDR=unix:///run/kata-containers/agent.sock"
 SyslogIdentifier=kata-agent

--- a/podvm/files/etc/systemd/system/multi-user.target.wants/attestation-agent.service
+++ b/podvm/files/etc/systemd/system/multi-user.target.wants/attestation-agent.service
@@ -1,0 +1,1 @@
+../attestation-agent.service

--- a/podvm/files/etc/systemd/system/netns@.service
+++ b/podvm/files/etc/systemd/system/netns@.service
@@ -1,0 +1,6 @@
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=ip netns add %I
+ExecStart=ip netns exec %I ip link set lo up
+ExecStop=ip netns del %I


### PR DESCRIPTION
Discussion about the preceding draft PR concluded that we do want to keep isolating the pod's network from the peerpod vm. So we propose starting AA as a discrete systemd service in the `podns` namespace. Pods will be able to talk to a grpc service exposed on port `50001` similar to a non-peerpod CoCo deployment. 

Note: we only expose AA's `GetResourceService` to the Pod. `KeyProviderService` is meant for image layer decryption which is not in the scope of the Pod.

fixes #773