### PR TITLE
test/e2e: Add support for oidc

### DIFF
--- a/test/provisioner/provision.go
+++ b/test/provisioner/provision.go
@@ -16,6 +16,7 @@ import (
 	nodev1 "k8s.io/api/node/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"sigs.k8s.io/e2e-framework/klient/decoder"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/klient/wait"


### PR DESCRIPTION
Import oidc to prevent error
```
time="2023-03-31T06:56:01-07:00" level=trace msg="start of Deploy &{<nil> /root/.kube/config  <nil> <nil> map[] <nil> map[] <nil> false false false false}"
F0331 06:56:01.646445  114195 env.go:360] Setup failure: envconfig: client failed: no Auth Provider found for name "oidc"
```
Fixes: #777