### PR TITLE
cmd: cloud-api-adaptor correctly shows builtin cloud provider names

### DIFF
--- a/cmd/cloud-api-adaptor/cloudmgr/manager.go
+++ b/cmd/cloud-api-adaptor/cloudmgr/manager.go
@@ -22,6 +22,17 @@ func Get(name string) Cloud {
 	return cloudTable[name]
 }
 
+func List() []string {
+
+	var list []string
+
+	for name := range cloudTable {
+		list = append(list, name)
+	}
+
+	return list
+}
+
 func defaultToEnv(field *string, env string, fallback ...string) {
 	if *field == "" {
 		*field = os.Getenv(env)

--- a/cmd/cloud-api-adaptor/main.go
+++ b/cmd/cloud-api-adaptor/main.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/confidential-containers/cloud-api-adaptor/cmd"
@@ -34,73 +35,103 @@ type networkConfig struct {
 	VXLANMinID    int
 }
 
+func printHelp(out io.Writer) {
+	fmt.Fprintf(out, "Usage: %s <provider-name> [options] | help | version\n", programName)
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Supported cloud providers are:")
+
+	for _, name := range cloudmgr.List() {
+		fmt.Fprintf(out, "\t%s\n", name)
+	}
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "Use \"%s <provider-name> -help\" to show options for a cloud provider\n", programName)
+}
+
 func (cfg *daemonConfig) Setup() (cmd.Starter, error) {
 
 	if len(os.Args) < 2 {
-		fmt.Printf("%s <provider_name> [options] | version\n", os.Args[0])
-		fmt.Printf("   The <provider_name> should be one of aws|azure|ibmcloud|libvirt|vsphere>\n")
+		printHelp(os.Stderr)
 		cmd.Exit(1)
-	}
-
-	if os.Args[1] == "version" {
-		cmd.ShowVersion(programName)
-		cmd.Exit(0)
 	}
 
 	//TODO: transition to better CLI library
 
 	cloudName := os.Args[1]
 
-	if cloud := cloudmgr.Get(cloudName); cloud != nil {
-
-		fmt.Printf("%s: starting Cloud API Adaptor daemon for %q\n", programName, cloudName)
-
-		var (
-			disableTLS bool
-			tlsConfig  tlsutil.TLSConfig
-		)
-
-		cmd.Parse(programName, os.Args[1:], func(flags *flag.FlagSet) {
-
-			flags.StringVar(&cfg.serverConfig.SocketPath, "socket", adaptor.DefaultSocketPath, "Unix domain socket path of remote hypervisor service")
-			flags.StringVar(&cfg.serverConfig.PodsDir, "pods-dir", adaptor.DefaultPodsDir, "base directory for pod directories")
-			flags.StringVar(&cfg.serverConfig.CriSocketPath, "cri-runtime-endpoint", "", "cri runtime uds endpoint")
-			flags.StringVar(&cfg.serverConfig.PauseImage, "pause-image", "", "pause image to be used for the pods")
-			flags.StringVar(&cfg.serverConfig.ForwarderPort, "forwarder-port", daemon.DefaultListenPort, "port number of agent protocol forwarder")
-			flags.StringVar(&tlsConfig.CAFile, "ca-cert-file", "", "CA cert file")
-			flags.StringVar(&tlsConfig.CertFile, "cert-file", "", "cert file")
-			flags.StringVar(&tlsConfig.KeyFile, "cert-key", "", "cert key")
-			flags.BoolVar(&tlsConfig.SkipVerify, "tls-skip-verify", false, "Skip TLS certificate verification - use it only for testing")
-			flags.BoolVar(&disableTLS, "disable-tls", false, "Disable TLS encryption - use it only for testing")
-			flags.DurationVar(&cfg.serverConfig.ProxyTimeout, "proxy-timeout", proxy.DefaultProxyTimeout, "Maximum timeout in minutes for establishing agent proxy connection")
-
-			flags.StringVar(&cfg.networkConfig.TunnelType, "tunnel-type", podnetwork.DefaultTunnelType, "Tunnel provider")
-			flags.StringVar(&cfg.networkConfig.HostInterface, "host-interface", "", "Host Interface")
-			flags.IntVar(&cfg.networkConfig.VXLANPort, "vxlan-port", vxlan.DefaultVXLANPort, "VXLAN UDP port number (VXLAN tunnel mode only")
-			flags.IntVar(&cfg.networkConfig.VXLANMinID, "vxlan-min-id", vxlan.DefaultVXLANMinID, "Minimum VXLAN ID (VXLAN tunnel mode only")
-
-			cloud.ParseCmd(flags)
-		})
-
-		if !disableTLS {
-			cfg.serverConfig.TLSConfig = &tlsConfig
-		}
-
-		cloud.LoadEnv()
-
-		workerNode := podnetwork.NewWorkerNode(cfg.TunnelType, cfg.HostInterface, cfg.VXLANPort, cfg.VXLANMinID)
-
-		provider, err := cloud.NewProvider()
-		if err != nil {
-			return nil, err
-		}
-
-		server := adaptor.NewServer(provider, &cfg.serverConfig, workerNode)
-
-		return cmd.NewStarter(server), nil
+	switch cloudName {
+	case "version":
+		cmd.ShowVersion(programName)
+		cmd.Exit(0)
+	case "help":
+		printHelp(os.Stdout)
+		cmd.Exit(0)
 	}
 
-	return nil, fmt.Errorf("Unsupported cloud provider: %s", cloudName)
+	if len(cloudName) == 0 || cloudName[0] == '-' {
+		fmt.Fprintf(os.Stderr, "%s: Unknown option: %q\n\n", programName, cloudName)
+		printHelp(os.Stderr)
+		cmd.Exit(1)
+	}
+
+	cloud := cloudmgr.Get(cloudName)
+
+	if cloud == nil {
+		fmt.Fprintf(os.Stderr, "%s: Unsupported cloud provider: %s\n\n", programName, cloudName)
+		printHelp(os.Stderr)
+		cmd.Exit(1)
+	}
+
+	var (
+		disableTLS bool
+		tlsConfig  tlsutil.TLSConfig
+	)
+
+	cmd.Parse(programName, os.Args[1:], func(flags *flag.FlagSet) {
+
+		flags.Usage = func() {
+			fmt.Fprintf(flags.Output(), "Usage: %s %s [options]\n\n", programName, cloudName)
+			fmt.Fprintf(flags.Output(), "The options for %q are:\n", cloudName)
+			flags.PrintDefaults()
+		}
+
+		flags.StringVar(&cfg.serverConfig.SocketPath, "socket", adaptor.DefaultSocketPath, "Unix domain socket path of remote hypervisor service")
+		flags.StringVar(&cfg.serverConfig.PodsDir, "pods-dir", adaptor.DefaultPodsDir, "base directory for pod directories")
+		flags.StringVar(&cfg.serverConfig.CriSocketPath, "cri-runtime-endpoint", "", "cri runtime uds endpoint")
+		flags.StringVar(&cfg.serverConfig.PauseImage, "pause-image", "", "pause image to be used for the pods")
+		flags.StringVar(&cfg.serverConfig.ForwarderPort, "forwarder-port", daemon.DefaultListenPort, "port number of agent protocol forwarder")
+		flags.StringVar(&tlsConfig.CAFile, "ca-cert-file", "", "CA cert file")
+		flags.StringVar(&tlsConfig.CertFile, "cert-file", "", "cert file")
+		flags.StringVar(&tlsConfig.KeyFile, "cert-key", "", "cert key")
+		flags.BoolVar(&tlsConfig.SkipVerify, "tls-skip-verify", false, "Skip TLS certificate verification - use it only for testing")
+		flags.BoolVar(&disableTLS, "disable-tls", false, "Disable TLS encryption - use it only for testing")
+		flags.DurationVar(&cfg.serverConfig.ProxyTimeout, "proxy-timeout", proxy.DefaultProxyTimeout, "Maximum timeout in minutes for establishing agent proxy connection")
+
+		flags.StringVar(&cfg.networkConfig.TunnelType, "tunnel-type", podnetwork.DefaultTunnelType, "Tunnel provider")
+		flags.StringVar(&cfg.networkConfig.HostInterface, "host-interface", "", "Host Interface")
+		flags.IntVar(&cfg.networkConfig.VXLANPort, "vxlan-port", vxlan.DefaultVXLANPort, "VXLAN UDP port number (VXLAN tunnel mode only")
+		flags.IntVar(&cfg.networkConfig.VXLANMinID, "vxlan-min-id", vxlan.DefaultVXLANMinID, "Minimum VXLAN ID (VXLAN tunnel mode only")
+
+		cloud.ParseCmd(flags)
+	})
+
+	fmt.Printf("%s: starting Cloud API Adaptor daemon for %q\n", programName, cloudName)
+
+	if !disableTLS {
+		cfg.serverConfig.TLSConfig = &tlsConfig
+	}
+
+	cloud.LoadEnv()
+
+	workerNode := podnetwork.NewWorkerNode(cfg.TunnelType, cfg.HostInterface, cfg.VXLANPort, cfg.VXLANMinID)
+
+	provider, err := cloud.NewProvider()
+	if err != nil {
+		return nil, err
+	}
+
+	server := adaptor.NewServer(provider, &cfg.serverConfig, workerNode)
+
+	return cmd.NewStarter(server), nil
 }
 
 var config cmd.Config = &daemonConfig{}

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -1,4 +1,4 @@
-// (C) Copyright IBM Corp. 2022.
+// (C) Copyright Confidential Containers Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd
@@ -15,7 +15,7 @@ func Parse(programName string, args []string, fn func(flags *flag.FlagSet)) {
 	fn(flags)
 
 	if len(args) == 1 {
-		flags.PrintDefaults()
+		flags.Usage()
 		Exit(1)
 	}
 


### PR DESCRIPTION
This PR makes `cloud-api-adaptor` shows a list of supported cloud providers that are actually built into the binary, instead of names hard-coded in the source code.

This PR also improves the command help message.

 Fixes #787