### PR TITLE
peerpod-ctrl: build azure by default

### DIFF
--- a/peerpod-ctrl/Makefile
+++ b/peerpod-ctrl/Makefile
@@ -63,7 +63,7 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
-BUILTIN_CLOUD_PROVIDERS ?= aws libvirt
+BUILTIN_CLOUD_PROVIDERS ?= aws azure libvirt
 # Build tags required to build cloud-api-adaptor are derived from BUILTIN_CLOUD_PROVIDERS.
 # When libvirt is specified, CGO_ENABLED is set to 1.
 space := $() $()

--- a/pkg/adaptor/cloud/azure/manager.go
+++ b/pkg/adaptor/cloud/azure/manager.go
@@ -32,7 +32,8 @@ func (_ *Manager) LoadEnv() {
 	cloud.DefaultToEnv(&azurecfg.ClientId, "AZURE_CLIENT_ID", "")
 	cloud.DefaultToEnv(&azurecfg.ClientSecret, "AZURE_CLIENT_SECRET", "")
 	cloud.DefaultToEnv(&azurecfg.TenantId, "AZURE_TENANT_ID", "")
-
+	cloud.DefaultToEnv(&azurecfg.SubscriptionId, "AZURE_SUBSCRIPTION_ID", "")
+	cloud.DefaultToEnv(&azurecfg.Region, "AZURE_REGION", "")
 }
 
 func (_ *Manager) NewProvider() (cloud.Provider, error) {


### PR DESCRIPTION
This add the necessary bits for azure support by the peerpod-ctrl, however:

WIP as I don't have access to azure required testing:
the [following](https://github.com/snir911/cloud-api-adaptor/tree/375merged_azure) is hacked branch that can be tested:
use `quay.io/snir/cloud-api-adaptor:test `for the caa pod
& deploy controller with `cd peerpod-ctrl && make docker-build docker-push IMG=quay.io/snir/osc-operator:rename`

**after merging this will require to update go.mod in peerpod-ctrl**