### PR TITLE
powervs: add podvm image documentation for IBM Cloud PowerVS provider

### DIFF
--- a/ibmcloud-powervs/README.md
+++ b/ibmcloud-powervs/README.md
@@ -1,0 +1,78 @@
+# Setup instructions
+## Prerequisites
+- golang
+- pvsadm tool
+- IBM Cloud account
+
+> Note: You can only run the below image build instructions on `ppc64le`(CentOS/RHEL). This would additionally require `qemu-img` to be installed.
+
+#### Intall pvsadm
+
+We will be using the tool `pvsadm` to customise and build the VM image. Download or install it using the below instructions.
+
+1. You can download the binary from Github releases [here](https://github.com/ppc64le-cloud/pvsadm/releases)
+   
+2. To install from source
+   ```
+   cd $GOPATH/src/github.com/
+   git clone https://github.com/ppc64le-cloud/pvsadm.git
+   cd pvsadm && make build
+   ```
+
+3. For MacOS, refer [here](https://github.com/ppc64le-cloud/pvsadm#homebrew)
+
+## Image Build
+
+1. Customise the image preparation
+```
+pvsadm image qcow2ova --prep-template-default > image-prep.template
+```
+
+Add the following snippet to `image-prep.template`
+```
+yum install -y gcc gcc-c++ git make
+git clone -b CCv0 https://github.com/kata-containers/kata-containers.git
+git clone -b staging https://github.com/confidential-containers/cloud-api-adaptor.git
+cd cloud-api-adaptor/ibmcloud-powervs/image
+make build
+```
+
+> If you intend to use DHCP network type for creating peer pod VMs with
+> PowerVS provider, you need to additionally add this to `image-prep.template`
+> ```
+> mkdir -p /etc/cloud/cloud.cfg.d
+> cat <<EOF >> /etc/cloud/cloud.cfg.d/99-custom-networking.cfg
+> network: {config: disabled}
+> EOF
+> ```
+
+2. Download the qcow2 image and converts into ova type
+```
+pvsadm image qcow2ova --image-name <name> --image-dist centos --image-url https://cloud.centos.org/centos/8-stream/ppc64le/images/CentOS-Stream-GenericCloud-8-latest.ppc64le.qcow2 --prep-template image-prep.template
+```
+
+
+> Qcow2 CentOS images for ppc64le can be found [here](https://cloud.centos.org/centos/8-stream/ppc64le/images/)
+
+## Import image to PowerVS
+
+> You can export IBMCLOUD_API_KEY or pass it as a flag (`-k` or `--api-key`) to the below commads.
+
+1. First, we need to upload the ova image to a COS bucket
+```
+pvsadm image upload -b <bucket-name> -f <file-name> -r <region> --accesskey <access-key-value> --secretkey <secret-key-value>
+```
+
+2. Import the ova image to a PowerVS service instance
+```
+pvsadm image import -n <service-instance-name> -b <bucket-name> -o <file-name> -r <region> --accesskey <access-key-value> --secretkey <secret-key-value> --pvs-image-name <final-image-name>
+```
+> The access key and secret key can be fetched from the IBM Cloud UI. For more details, refer [here](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-service-credentials)
+
+## Running cloud-api-adaptor
+
+1. Setup necessary cloud resources such as PowerVS Service instance, network, API Key etc..
+
+2. Update [kustomization.yaml](../install/overlays/aws/kustomization.yaml) with the required details
+ 
+3. Deploy Cloud API Adaptor by following the [install](../install/README.md) guide

--- a/ibmcloud-powervs/image/Makefile
+++ b/ibmcloud-powervs/image/Makefile
@@ -1,0 +1,26 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+SKOPEO_SRC =
+SKOPEO_BIN = /usr/bin/skopeo
+
+include ../../podvm/Makefile.inc
+
+export PATH := $(PATH):/usr/local/go/bin:$(HOME)/.cargo/bin
+
+.PHONY: build clean
+
+prerequisites: ## Install dependencies
+	./prereq.sh
+
+build: prerequisites $(BINARIES)
+	./copy-files.sh
+
+clean:
+	rm -f $(BINARIES)
+	rm -rf "$(UMOCI_SRC)" "$(PAUSE_SRC)" "$(FILES_DIR)/$(PAUSE_BUNDLE)"
+	yum remove -y skopeo
+
+.PHONY: force
+force:

--- a/ibmcloud-powervs/image/copy-files.sh
+++ b/ibmcloud-powervs/image/copy-files.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# copy-files.sh is used to copy required files into
+# the correct location on the podvm image
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
+PODVM_DIR=${REPO_ROOT}/podvm
+
+sudo mkdir -p /etc/containers
+sudo cp ${PODVM_DIR}/files/etc/agent-config.toml /etc/agent-config.toml
+sudo cp -a ${PODVM_DIR}/files/etc/containers/* /etc/containers/
+sudo cp -a ${PODVM_DIR}/files/etc/systemd/* /etc/systemd/
+if [ -e ${PODVM_DIR}/files/etc/aa-offline_fs_kbc-resources.json ]; then
+	sudo cp ${PODVM_DIR}/files/etc/aa-offline_fs_kbc-resources.json /etc/aa-offline_fs_kbc-resources.json
+fi
+
+
+sudo mkdir -p /usr/local/bin
+sudo cp -a ${PODVM_DIR}/files/usr/* /usr/
+
+sudo cp -a ${PODVM_DIR}/files/pause_bundle /
+
+if [ -e ${PODVM_DIR}/files/auth.json ]; then
+       sudo mkdir -p /root/.config/containers/
+       sudo cp -a ${PODVM_DIR}/files/auth.json /root/.config/containers/auth.json
+fi

--- a/ibmcloud-powervs/image/prereq.sh
+++ b/ibmcloud-powervs/image/prereq.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+GO_VERSION="1.19.6"
+RUST_VERSION="1.66.0"
+SKOPEO_VERSION="1.5.0"
+
+# Install dependencies
+yum install -y curl protobuf-compiler libseccomp-devel openssl openssl-devel skopeo-${SKOPEO_VERSION}
+
+# Install Golang
+curl https://dl.google.com/go/go${GO_VERSION}.linux-ppc64le.tar.gz -o go${GO_VERSION}.linux-ppc64le.tar.gz && \
+rm -rf /usr/local/go && tar -C /usr/local -xzf go${GO_VERSION}.linux-ppc64le.tar.gz && \
+rm -f go${GO_VERSION}.linux-ppc64le.tar.gz
+
+# Install Rust
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_VERSION}
+rustup target add powerpc64le-unknown-linux-gnu

--- a/podvm/Makefile.inc
+++ b/podvm/Makefile.inc
@@ -19,10 +19,11 @@ ARCH        ?= $(HOST_ARCH)
 # Normalise x86_64 / amd64 for input ARCH
 ARCH        := $(subst amd64,x86_64,$(ARCH))
 DEB_ARCH    := $(subst x86_64,amd64,$(ARCH))
-LIBC        ?= $(if $(findstring s390x,$(ARCH)),gnu,musl)
-RUST_TARGET := $(ARCH)-unknown-linux-$(LIBC)
 AA_KBC      ?= offline_fs_kbc
 KBC_URI     ?= null
+LIBC        ?= $(if $(filter $(ARCH),s390x ppc64le),gnu,musl)
+RUST_ARCH   ?= $(subst ppc64le,powerpc64le,$(ARCH))
+RUST_TARGET := $(RUST_ARCH)-unknown-linux-$(LIBC)
 
 ifneq ($(HOST_ARCH),$(ARCH))
     ifeq ($(CC),cc)
@@ -65,8 +66,9 @@ AGENT_PROTOCOL_FORWARDER_SRC = ../..
 KATA_AGENT_SRC = ../../../kata-containers/src/agent
 KATA_AGENT_BUILD_TYPE = release
 
-SKOPEO_SRC  = skopeo
+SKOPEO_SRC ?= skopeo
 SKOPEO_REPO = https://github.com/containers/skopeo
+SKOPEO_BIN ?= $(SKOPEO_SRC)/bin/skopeo
 
 UMOCI_SRC   = umoci
 UMOCI_REPO  = https://github.com/opencontainers/umoci
@@ -101,11 +103,11 @@ $(KATA_AGENT): force $(STATIC_LIBSECCOMP)
 $(STATIC_LIBSECCOMP):
 	$(RUST_FLAGS) $(STATIC_LIBSECCOMP_BUILDER) $(STATIC_LIBSECCOMP_DIR)/kata-libseccomp $(STATIC_LIBSECCOMP_DIR)/kata-gperf
 
-# Skoepo package packages are available in RHEL/CentOS 8 or later and Ubuntu 20.10 or later
+# Skopeo package packages are available in RHEL/CentOS 8 or later and Ubuntu 20.10 or later
 $(SKOPEO_SRC):
 	git clone -b "v$(SKOPEO_VERSION)" "$(SKOPEO_REPO)" "$(SKOPEO_SRC)"
 
-$(SKOPEO_SRC)/bin/skopeo: $(SKOPEO_SRC)
+$(SKOPEO_BIN): $(SKOPEO_SRC)
 	cd "$(SKOPEO_SRC)" && CC= $(MAKE) bin/skopeo
 
 # The umoci release page only publishes amd64 binaries. https://github.com/opencontainers/umoci/releases
@@ -115,8 +117,8 @@ $(UMOCI_SRC):
 $(UMOCI_SRC)/umoci: $(UMOCI_SRC)
 	cd "$(UMOCI_SRC)" && CC= $(MAKE)
 
-$(PAUSE_SRC): $(SKOPEO_SRC)/bin/skopeo
-	$(SKOPEO_SRC)/bin/skopeo --override-arch $(DEB_ARCH) --policy "$(FILES_DIR)/etc/containers/policy.json" copy "$(PAUSE_REPO):$(PAUSE_VERSION)" "oci:$(PAUSE_SRC):$(PAUSE_VERSION)"
+$(PAUSE_SRC): $(SKOPEO_BIN)
+	$(SKOPEO_BIN) --override-arch $(DEB_ARCH) --policy "$(FILES_DIR)/etc/containers/policy.json" copy "$(PAUSE_REPO):$(PAUSE_VERSION)" "oci:$(PAUSE_SRC):$(PAUSE_VERSION)"
 
 $(PAUSE): | $(PAUSE_SRC) $(UMOCI_SRC)/umoci
 	$(UMOCI_SRC)/umoci unpack --rootless --image "$(PAUSE_SRC):$(PAUSE_VERSION)" "${FILES_DIR}/$(PAUSE_BUNDLE)"


### PR DESCRIPTION
This PR adds the instructions to build a pod VM image to be used with IBM Cloud PowerVS provider.

Fixes: #785