### PR TITLE
powervs: deploy ibmcloud-powervs provider as a pod

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -22,7 +22,7 @@ jobs:
           - type: dev
             arches: linux/amd64
           - type: release
-            arches: linux/amd64,linux/s390x
+            arches: linux/amd64,linux/s390x,linux/ppc64le
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -81,6 +81,27 @@ exec cloud-api-adaptor ibmcloud \
         -socket /run/peerpod/hypervisor.sock
 }
 
+
+ibmcloud_powervs() {
+test_vars IBMCLOUD_API_KEY
+
+[[ "${POWERVS_MEMORY}" ]] && optionals+="-memory ${POWERVS_MEMORY} "
+[[ "${POWERVS_PROCESSORS}" ]] && optionals+="-cpu ${POWERVS_PROCESSORS} "
+[[ "${POWERVS_PROCESSOR_TYPE}" ]] && optionals+="-proc-type ${POWERVS_PROCESSOR_TYPE} "
+[[ "${POWERVS_SYSTEM_TYPE}" ]] && optionals+="-sys-type ${POWERVS_SYSTEM_TYPE} "
+
+set -x
+exec cloud-api-adaptor ibmcloud-powervs \
+        -service-instance-id ${POWERVS_SERVICE_INSTANCE_ID} \
+        -zone ${POWERVS_ZONE} \
+        -image-id ${POWERVS_IMAGE_ID} \
+        -network-id ${POWERVS_NETWORK_ID} \
+        -ssh-key ${POWERVS_SSH_KEY_NAME}
+        -pods-dir /run/peerpod/pods \
+ 	${optionals} \
+ 	-socket /run/peerpod/hypervisor.sock
+}
+
 libvirt() {
 test_vars LIBVIRT_URI
 
@@ -116,9 +137,9 @@ exec cloud-api-adaptor vsphere \
 help_msg() {
 	cat <<EOF
 Usage:
-	CLOUD_PROVIDER=aws|azure|ibmcloud|libvirt|vsphere $0
+	CLOUD_PROVIDER=aws|azure|ibmcloud|ibmcloud-powervs|libvirt|vsphere $0
 or
-	$0 aws|azure|ibmcloud|libvirt|vsphere
+	$0 aws|azure|ibmcloud|ibmcloud-powervs|libvirt|vsphere
 in addition all cloud provider specific env variables must be set and valid
 (CLOUD_PROVIDER is currently set to "$CLOUD_PROVIDER")
 EOF
@@ -130,6 +151,8 @@ elif [[ "$CLOUD_PROVIDER" == "azure" ]]; then
 	azure
 elif [[ "$CLOUD_PROVIDER" == "ibmcloud" ]]; then
 	ibmcloud
+elif [[ "$CLOUD_PROVIDER" == "ibmcloud-powervs" ]]; then
+ 	ibmcloud_powervs
 elif [[ "$CLOUD_PROVIDER" == "libvirt" ]]; then
 	libvirt
 elif [[ "$CLOUD_PROVIDER" == "vsphere" ]]; then

--- a/install/overlays/ibmcloud-powervs/cri_runtime_endpoint.yaml
+++ b/install/overlays/ibmcloud-powervs/cri_runtime_endpoint.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cloud-api-adaptor-daemonset
+  namespace: confidential-containers-system
+  labels:
+    app: cloud-api-adaptor
+spec:
+  template:
+    spec:
+      containers:
+      - name: cloud-api-adaptor-con
+        volumeMounts:
+        - mountPath: /run/cri-runtime # in-container CRI_RUNTIME_ENDPOINT default
+          name: cri-runtime-endpoint
+      volumes:
+      - name: cri-runtime-endpoint
+        hostPath:
+          path: /run/containerd # SET! (crio's default: /var/run/crio/crio.sock)
+          type: Directory
+
+# to apply this uncomment the patchesStrategicMerge of this file in kustomization.yaml

--- a/install/overlays/ibmcloud-powervs/kustomization.yaml
+++ b/install/overlays/ibmcloud-powervs/kustomization.yaml
@@ -1,0 +1,63 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- ../../yamls
+
+images:
+- name: cloud-api-adaptor
+  newName: quay.io/confidential-containers/cloud-api-adaptor # change image if needed
+  newTag: latest
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+- name: peer-pods-cm
+  namespace: confidential-containers-system
+  literals:
+  - CLOUD_PROVIDER="ibmcloud-powervs"
+  - POWERVS_SERVICE_INSTANCE_ID="" #set
+  - POWERVS_NETWORK_ID="" #set
+  - POWERVS_SSH_KEY_NAME="" #set
+  - POWERVS_IMAGE_ID="" #set
+  - POWERVS_ZONE="" #set
+  - CRI_RUNTIME_ENDPOINT="/run/cri-runtime/containerd.sock"
+  #- POWERVS_MEMORY="" # Uncomment and set if you want to use a specific amount of memory
+  #- POWERVS_PROCESSORS="" # Uncomment and set if you want to use a specific number of CPUs
+  #- POWERVS_PROCESSOR_TYPE="" # Uncomment and set if you want to use a specific processor type
+  #- POWERVS_SYSTEM_TYPE="" # Uncomment and set if you want to use a specific system type
+  #- PAUSE_IMAGE="" # Uncomment and set if you want to use a specific pause image
+  #- VXLAN_PORT="" # Uncomment and set if you want to use a specific vxlan port. Defaults to 4789
+  #- PROXY_TIMEOUT="" # Uncomment and set if you want to pass a specific timeout. Defaults to 5m
+##TLS_SETTINGS
+  #- CACERT_FILE="/etc/certificates/ca.crt" # for TLS
+  #- CERT_FILE="/etc/certificates/client.crt" # for TLS
+  #- CERT_KEY="/etc/certificates/client.key" # for TLS
+  #- TLS_SKIP_VERIFY="" # for testing only
+##TLS_SETTINGS
+
+secretGenerator:
+- name: auth-json-secret
+  namespace: confidential-containers-system
+  files:
+  #- auth.json # set - path to auth.json pull credentials file
+- name: peer-pods-secret
+  namespace: confidential-containers-system
+  literals:
+  - IBMCLOUD_API_KEY="" # set
+
+##TLS_SETTINGS
+#- name: certs-for-tls
+#  namespace: confidential-containers-system
+#  files:
+#  - <path_to_ca.crt> # set - path to ca.crt
+#  - <path_to_client.crt> # set - path to client.crt
+#  - <path_to_client.key> # set - path to client.key
+##TLS_SETTINGS
+
+patchesStrategicMerge:
+  - cri_runtime_endpoint.yaml # set (modify host's runtime cri socket path in the file, default is /run/containerd/containerd.sock)
+##TLS_SETTINGS
+  #- tls_certs_volume_mount.yaml # set (for tls)
+##TLS_SETTINGS

--- a/install/overlays/ibmcloud-powervs/tls_certs_volume_mount.yaml
+++ b/install/overlays/ibmcloud-powervs/tls_certs_volume_mount.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cloud-api-adaptor-daemonset
+  namespace: confidential-containers-system
+  labels:
+    app: cloud-api-adaptor
+spec:
+  template:
+    spec:
+      containers:
+      - name: cloud-api-adaptor-con
+        volumeMounts:
+        - mountPath: /etc/certificates
+          name: certs
+      volumes:
+      - name: certs
+        secret:
+          secretName: certs-for-tls
+
+# to apply this uncomment the patchesStrategicMerge of this file in kustomization.yaml


### PR DESCRIPTION
With the IBM Cloud PowerVS provider support being added, this PR aims at adding the necessary changes to deploy cloud-api-adaptor as a pod running with powervs provider. It also adds support for building cloud-api-adaptor image for ppc64le platform.

Fixes: #801