### PR TITLE
Use new pkg path of cloudmgr in peerpod-ctrl

### DIFF
--- a/peerpod-ctrl/go.sum
+++ b/peerpod-ctrl/go.sum
@@ -326,8 +326,6 @@ github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/confidential-containers/cloud-api-adaptor v0.5.0-alpha h1:ShEX+d01eLaLv6o9j5yxW/F2iGAZnefFf02yEMZH+IA=
-github.com/confidential-containers/cloud-api-adaptor v0.5.0-alpha/go.mod h1:4809SseMTdYou/4+m5IGaCwqG628e+VPfkEleKtbzr8=
 github.com/confidential-containers/cloud-api-adaptor v0.5.0 h1:CwbGKUzu13s27N1NiYeeqD+Odb3kDJnVpHQGAdu9a2c=
 github.com/confidential-containers/cloud-api-adaptor v0.5.0/go.mod h1:4809SseMTdYou/4+m5IGaCwqG628e+VPfkEleKtbzr8=
 github.com/container-orchestrated-devices/container-device-interface v0.4.0/go.mod h1:E1zcucIkq9P3eyNmY+68dBQsTcsXJh9cgRo2IVNScKQ=

--- a/peerpod-ctrl/main.go
+++ b/peerpod-ctrl/main.go
@@ -32,10 +32,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	"github.com/confidential-containers/cloud-api-adaptor/cmd/cloud-api-adaptor/cloudmgr"
 	confidentialcontainersorgv1alpha1 "github.com/confidential-containers/cloud-api-adaptor/peerpod-ctrl/api/v1alpha1"
 	"github.com/confidential-containers/cloud-api-adaptor/peerpod-ctrl/controllers"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/cloud"
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/cloud/cloudmgr"
 	//+kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
This is the follow-on PR of #786.

The location of `cmd/cloud-api-adaptor/cloudmgr` has been moved to `pkg/adaptor/cloud`. This PR updates its pacakge path in peerpod-ctrl. We need a separated PR, since peerpod-ctrl is an independent Go module that references the main module as a remote module.

Fixes #830
