### PR TITLE
test/e2e: Enable configmap and secret tests to Libvirt

### DIFF
--- a/test/e2e/libvirt_test.go
+++ b/test/e2e/libvirt_test.go
@@ -13,6 +13,16 @@ func TestLibvirtCreateSimplePod(t *testing.T) {
 	doTestCreateSimplePod(t, assert)
 }
 
+func TestLibvirtCreatePodWithConfigMap(t *testing.T) {
+	assert := LibvirtAssert{}
+	doTestCreatePodWithConfigMap(t, assert)
+}
+
+func TestLibvirtCreatePodWithSecret(t *testing.T) {
+	assert := LibvirtAssert{}
+	doTestCreatePodWithSecret(t, assert)
+}
+
 // LibvirtAssert implements the CloudAssert interface for Libvirt.
 type LibvirtAssert struct {
 	// TODO: create the connection once on the initializer.


### PR DESCRIPTION
The configmap and secret tests were introduced on commit ee4eef6df380a7a but only enabled to ibmcloud. Let's run them as part of the libvirt e2e suite as well.

Fixes #807
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>