### PR TITLE
Fix a flaky test in pkg/adaptor/server_test.go

### DIFF
--- a/pkg/adaptor/server_test.go
+++ b/pkg/adaptor/server_test.go
@@ -93,7 +93,9 @@ func testServerStart(t *testing.T, ctx context.Context) (Server, string, string,
 			serverErrCh <- err
 		}
 	}()
-	time.Sleep(1 * time.Millisecond)
+
+	<-s.Ready()
+
 	select {
 	case err := <-serverErrCh:
 		t.Fatal(err)


### PR DESCRIPTION
This PR changes the test code to wait for the server to become ready by using a channel instead of sleep.

This PR also removes some leftover code in the test code.

Fixes #837