### PR TITLE
test/e2e: Enable configmap and secret tests to azure

### DIFF
--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -22,6 +22,20 @@ func TestCreateSimplePodAzure(t *testing.T) {
 	doTestCreateSimplePod(t, assert)
 }
 
+func TestCreatePodWithConfigMapAzure(t *testing.T) {
+	assert := AzureCloudAssert{
+		group: pv.AzureProps.ResourceGroup,
+	}
+	doTestCreatePodWithConfigMap(t, assert)
+}
+
+func TestCreatePodWithSecretAzure(t *testing.T) {
+	assert := AzureCloudAssert{
+		group: pv.AzureProps.ResourceGroup,
+	}
+	doTestCreatePodWithSecret(t, assert)
+}
+
 // AzureCloudAssert implements the CloudAssert interface for azure.
 type AzureCloudAssert struct {
 	group *resources.Group


### PR DESCRIPTION
Enable configmap and secret tests for azure

Fixes #807
Signed-off-by: Kartik Joshi <kartikjoshi@microsoft.com>