### PR TITLE
ibmcloud: Testcases for peer pod container with external IP access

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -20,6 +20,19 @@ func newPod(namespace string, name string, containerName string, runtimeclass st
 	}
 }
 
+// newPod returns a new Pod object.
+func newBusyboxPod(namespace string, name string, containerName string, runtimeclass string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: corev1.PodSpec{
+			Containers:       []corev1.Container{{Name: containerName, Image: "quay.io/prometheus/busybox:latest", Command: []string{"/bin/sh", "-c", "sleep 3600"}}},
+			DNSPolicy:        "ClusterFirst",
+			RuntimeClassName: &runtimeclass,
+			RestartPolicy:    corev1.RestartPolicyAlways,
+		},
+	}
+}
+
 func newPodWithConfigMap(namespace string, name string, containerName string, runtimeclass string, configmapname string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},

--- a/test/e2e/ibmcloud_test.go
+++ b/test/e2e/ibmcloud_test.go
@@ -33,6 +33,12 @@ func TestCreatePodWithSecret(t *testing.T) {
 	}
 	doTestCreatePodWithSecret(t, assert)
 }
+func TestCreatePeerPodContainerWithExternalIPAccess(t *testing.T) {
+	assert := IBMCloudAssert{
+		vpc: pv.IBMCloudProps.VPC,
+	}
+	doTestCreatePeerPodContainerWithExternalIPAccess(t, assert)
+}
 
 // IBMCloudAssert implements the CloudAssert interface for ibmcloud.
 type IBMCloudAssert struct {


### PR DESCRIPTION
Added Testcases for peer pod container with external IP access in ibmcloud

Fixes: #847