### PR TITLE
csi-wrapper: Fix lint errors and enable lint checks in CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,5 @@
-# (C) Copyright Red Hat 2022.
-# SPDX-License-Identifier: Apache-2.0
+# (C) Copyright Confidential Containers Contributors
+# # SPDX-License-Identifier: Apache-2.0
 #
 # Run linting tools on the sources of the project.
 ---
@@ -20,6 +20,7 @@ jobs:
           - .
           - peerpod-ctrl
           - peerpodconfig-ctrl
+          - volumes/csi-wrapper
           - webhook
     steps:
       - name: Checkout the pull request code
@@ -38,7 +39,7 @@ jobs:
           working-directory: ${{ matrix.workdir }}
           args: --path-prefix=${{ matrix.workdir }}
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.51.1
+          version: v1.52.2
 
   go_check:
     runs-on: ubuntu-latest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -270,7 +270,7 @@ issues:
     - 'declaration of "(err|ctx)" shadows declaration at'
 
   # Excluding configuration per-path, per-linter, per-text and per-source
-  #exclude-rules:
+  exclude-rules:
     # Exclude some linters from running on tests files.
     #- path: _test\.go
     #  linters:
@@ -295,6 +295,12 @@ issues:
     #- linters:
     #    - lll
     #  source: "^//go:generate "
+
+    # "github.com/container-storage-interface/spec/lib/go/csi" still uses
+    # "github.com/golang/protobuf", which is the deprecated protobuf V1.
+    - path: ^volumes/csi-wrapper/pkg/wrapper/
+      linters: [staticcheck]
+      text: 'SA1019: "github.com/golang/protobuf/jsonpb" is deprecated: Use the "google.golang.org/protobuf/encoding/protojson" package instead.'
 
   # Independently of option `exclude` we use default exclude patterns,
   # it can be disabled by this option.

--- a/volumes/csi-wrapper/cmd/csi-node-wrapper/main.go
+++ b/volumes/csi-wrapper/cmd/csi-node-wrapper/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 func init() {
-	flag.Set("logtostderr", "true")
+	_ = flag.Set("logtostderr", "true") // TODO: error check
 }
 
 func main() {
@@ -35,7 +35,7 @@ func main() {
 
 	k8sconfig, err := clientcmd.BuildConfigFromFlags("", "")
 	if err != nil {
-		glog.Fatalf("Build kubeconfig failed: %w", err)
+		glog.Fatalf("Build kubeconfig failed: %v", err)
 	}
 	peerPodVolumeClient := peerpodvolumeV1alpha1.NewForConfigOrDie(k8sconfig)
 
@@ -49,11 +49,11 @@ func main() {
 		nodeService.DeleteFunction,
 	)
 	if err != nil {
-		glog.Fatalf("Initialize peer pod Volume Node monitor failed: %w", err)
+		glog.Fatalf("Initialize peer pod Volume Node monitor failed: %v", err)
 	}
 	go func() {
 		if err := podVolumeMonitor.Start(context.Background()); err != nil {
-			glog.Fatalf("Running peer pod Volume Node monitor failed: %w", err)
+			glog.Fatalf("Running peer pod Volume Node monitor failed: %v", err)
 		}
 	}()
 

--- a/volumes/csi-wrapper/cmd/csi-podvm-wrapper/main.go
+++ b/volumes/csi-wrapper/cmd/csi-podvm-wrapper/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 func init() {
-	flag.Set("logtostderr", "true")
+	_ = flag.Set("logtostderr", "true") // TODO: error check
 }
 
 func main() {
@@ -46,7 +46,7 @@ func main() {
 
 	k8sconfig, err := clientcmd.BuildConfigFromFlags("", "")
 	if err != nil {
-		glog.Fatalf("Build kubeconfig failed: %w", err)
+		glog.Fatalf("Build kubeconfig failed: %v", err)
 	}
 	peerPodVolumeClient := peerpodvolumeV1alpha1.NewForConfigOrDie(k8sconfig)
 
@@ -60,11 +60,11 @@ func main() {
 		podvmService.DeleteFunction,
 	)
 	if err != nil {
-		glog.Fatalf("Initialize peer pod Volume Node monitor failed: %w", err)
+		glog.Fatalf("Initialize peer pod Volume Node monitor failed: %v", err)
 	}
 	go func() {
 		if err := podVolumeMonitor.Start(context.Background()); err != nil {
-			glog.Fatalf("Running peer pod Volume Node monitor failed: %w", err)
+			glog.Fatalf("Running peer pod Volume Node monitor failed: %v", err)
 		}
 	}()
 
@@ -74,10 +74,10 @@ func main() {
 	}
 	peerpodVolumes, err := peerPodVolumeClient.PeerpodV1alpha1().PeerpodVolumes(cfg.Namespace).List(context.Background(), options)
 	if err != nil {
-		glog.Fatalf("Failed to get peerpodVolume crd object by podUid: %v, err: %w", podUid, err)
+		glog.Fatalf("Failed to get peerpodVolume crd object by podUid: %v, err: %v", podUid, err)
 	}
 	if len(peerpodVolumes.Items) != 1 {
-		glog.Fatalf("Only one peerpodVolume crd object is expected but got: %w", len(peerpodVolumes.Items))
+		glog.Fatalf("Only one peerpodVolume crd object is expected but got: %v", len(peerpodVolumes.Items))
 	}
 	savedPeerpodvolume := peerpodVolumes.Items[0]
 	savedPeerpodvolume.Spec.PodName = podName

--- a/volumes/csi-wrapper/pkg/peerpodvolume/monitor.go
+++ b/volumes/csi-wrapper/pkg/peerpodvolume/monitor.go
@@ -2,7 +2,6 @@ package peerpodvolume
 
 import (
 	"context"
-	"log"
 	"sync"
 	"time"
 
@@ -11,7 +10,7 @@ import (
 	informers "github.com/confidential-containers/cloud-api-adaptor/volumes/csi-wrapper/pkg/generated/peerpodvolume/informers/externalversions"
 )
 
-var logger = log.New(log.Writer(), "[peerpodvolume/monitor] ", log.LstdFlags|log.Lmsgprefix)
+// var logger = log.New(log.Writer(), "[peerpodvolume/monitor] ", log.LstdFlags|log.Lmsgprefix)
 
 type CsiPodVolumeMonitor interface {
 	Start(context.Context) error
@@ -65,7 +64,7 @@ func (m *csiPodVolumeMonitor) Start(ctx context.Context) error {
 
 	select {
 	case <-ctx.Done():
-		m.Shutdown()
+		_ = m.Shutdown() // TODO: error check
 	case <-m.stopCh:
 	}
 

--- a/volumes/csi-wrapper/pkg/wrapper/identityservice.go
+++ b/volumes/csi-wrapper/pkg/wrapper/identityservice.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 type IdentityService struct {
@@ -22,7 +23,7 @@ func NewIdentityService(targetEndpoint string) *IdentityService {
 }
 
 func (s *IdentityService) redirect(ctx context.Context, req interface{}, fn func(context.Context, csi.IdentityClient)) error {
-	conn, err := grpc.Dial(s.TargetEndpoint, grpc.WithInsecure(), grpc.WithBlock())
+	conn, err := grpc.Dial(s.TargetEndpoint, grpc.WithBlock(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return err
 	}

--- a/volumes/csi-wrapper/pkg/wrapper/server.go
+++ b/volumes/csi-wrapper/pkg/wrapper/server.go
@@ -38,8 +38,6 @@ func (s *nonBlockingGRPCServer) Start(endpoint string, ids csi.IdentityServer, c
 	s.wg.Add(1)
 
 	go s.serve(endpoint, ids, cs, ns)
-
-	return
 }
 
 func (s *nonBlockingGRPCServer) Wait() {
@@ -81,7 +79,7 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, c
 		csi.RegisterNodeServer(server, ns)
 	}
 
-	server.Serve(listener)
+	_ = server.Serve(listener) // TODO: error check
 }
 
 func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {


### PR DESCRIPTION
This PR fixes the errors reported by golangci-lint in the csi-wrapper module.

I only refactored the code to supress lint errors, and I only added TODO comments at the locations where
errors are reported like this.
```
Error return value of `func` is not checked (errcheck)
```

This PR also bumps the version of golangci-lint to v1.52.2, since  the old version has a bug in processing the --prefix-path option, which is necessary to run the lint tool in sub modules.
