### PR TITLE
cmd: Show version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,16 +46,18 @@ help: ## Display this help.
 # Targets that depend on .gits-commit can use $(shell cat .git-commit) to get a
 # git revision string.  They will only be rebuilt if the revision string
 # actually changes.
-# TODO When a release is created change these steps to use: git describe --abbrev=0 --tags to pull the latest release tag on a specific branch.
 .PHONY: .git-commit.tmp
 .git-commit: .git-commit.tmp
 	@cmp $< $@ >/dev/null 2>&1 || cp $< $@
 .git-commit.tmp:
-	@printf "$$(git rev-parse HEAD 2>/dev/null)" >$@
+	@printf "$$(git rev-parse HEAD 2>/dev/null || echo unknown)" >$@
 	@test -n "$$(git status --porcelain --untracked-files=no)" && echo -dirty >>$@ || true
 
-GOFLAGS += -ldflags="-X 'github.com/confidential-containers/cloud-api-adaptor/cmd.VERSION=$(shell echo "unknown")' \
-                     -X 'github.com/confidential-containers/cloud-api-adaptor/cmd.COMMIT=$(shell cat .git-commit)'"
+version = $(shell git describe --match "v[0-9]*" --abbrev=0 --tags --dirty=-dev || echo unknown)
+commit  = $(shell cat .git-commit)
+
+GOFLAGS += -ldflags="-X 'github.com/confidential-containers/cloud-api-adaptor/cmd.VERSION=$(version)' \
+                     -X 'github.com/confidential-containers/cloud-api-adaptor/cmd.COMMIT=$(commit)'"
 
 # Build tags required to build cloud-api-adaptor are derived from BUILTIN_CLOUD_PROVIDERS.
 # When libvirt is specified, CGO_ENABLED is set to 1.

--- a/cmd/agent-protocol-forwarder/main.go
+++ b/cmd/agent-protocol-forwarder/main.go
@@ -46,11 +46,13 @@ func load(path string, obj interface{}) error {
 func (cfg *Config) Setup() (cmd.Starter, error) {
 
 	var (
-		disableTLS bool
-		tlsConfig  tlsutil.TLSConfig
+		showVersion bool
+		disableTLS  bool
+		tlsConfig   tlsutil.TLSConfig
 	)
 
 	cmd.Parse(programName, os.Args, func(flags *flag.FlagSet) {
+		flags.BoolVar(&showVersion, "version", false, "Show version")
 		flags.StringVar(&cfg.configPath, "config", daemon.DefaultConfigPath, "Path to a deamon config file")
 		flags.StringVar(&cfg.listenAddr, "listen", daemon.DefaultListenAddr, "Listen address")
 		flags.StringVar(&cfg.kataAgentSocketPath, "kata-agent-socket", daemon.DefaultKataAgentSocketPath, "Path to a kata agent socket")
@@ -65,6 +67,12 @@ func (cfg *Config) Setup() (cmd.Starter, error) {
 
 	if !disableTLS {
 		cfg.tlsConfig = &tlsConfig
+	}
+
+	cmd.ShowVersion(programName)
+
+	if showVersion {
+		cmd.Exit(0)
 	}
 
 	for path, obj := range map[string]interface{}{

--- a/cmd/cloud-api-adaptor/main.go
+++ b/cmd/cloud-api-adaptor/main.go
@@ -114,6 +114,8 @@ func (cfg *daemonConfig) Setup() (cmd.Starter, error) {
 		cloud.ParseCmd(flags)
 	})
 
+	cmd.ShowVersion(programName)
+
 	fmt.Printf("%s: starting Cloud API Adaptor daemon for %q\n", programName, cloudName)
 
 	if !disableTLS {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,4 +1,4 @@
-// (C) Copyright IBM Corp. 2022.
+// Copyright Confidential Containers Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd
@@ -14,7 +14,7 @@ var (
 )
 
 func ShowVersion(programName string) {
-	fmt.Printf("%s, version: %s, commit: %v\n", programName, VERSION, COMMIT)
-
-	fmt.Printf("go: %s\n", runtime.Version())
+	fmt.Printf("%s version %s\n", programName, VERSION)
+	fmt.Printf("  commit: %s\n", COMMIT)
+	fmt.Printf("  go: %s\n", runtime.Version())
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -46,7 +46,7 @@ func TestShowVersion(t *testing.T) {
 		ShowVersion(programName)
 	})
 
-	if e, a := fmt.Sprintf("test, version: %s, commit: %s\ngo: %s\n", VERSION, COMMIT, runtime.Version()), output; e != a {
+	if e, a := fmt.Sprintf("test version %s\n  commit: %s\n  go: %s\n", VERSION, COMMIT, runtime.Version()), output; e != a {
 		t.Fatalf("Expect %q, got %q", e, a)
 	}
 
@@ -54,7 +54,7 @@ func TestShowVersion(t *testing.T) {
 		ShowVersion(programName)
 	})
 
-	if e, a := fmt.Sprintf("test, version: %s, commit: %s\ngo: %s\n", VERSION, COMMIT, runtime.Version()), output; e != a {
+	if e, a := fmt.Sprintf("test version %s\n  commit: %s\n  go: %s\n", VERSION, COMMIT, runtime.Version()), output; e != a {
 		t.Fatalf("Expect %q, got %q", e, a)
 	}
 }


### PR DESCRIPTION
This patch updates Makefile to derive version information from the latest git release tag, and embed it in binaries.

The version information is also shown in the begging of log messages from the commands.

Fixes #850 

A version information is shown like this
```
cloud-api-adaptor version v0.5.0-dev
  commit: f3f604e9cd8be01a1922b8c84e95bd4afd4b0bad-dirty
  go: go1.19.4
```