### PR TITLE
Fetch git tags when buliding container images in CI

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Setup Golang version ${{ env.go_version }}
         uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
This PR changes the GitHub workflow job ([image.yaml](https://github.com/confidential-containers/cloud-api-adaptor/blob/078b6d3f1fb513b3230ea0d54b40cd9b44572b0a/.github/workflows/image.yaml)) to clone the repository to fetch Git tags, which are necessary to derive a correct version string.

Fetching all commits and tags are somewhat inefficient, but there is no other way to generate a version string. In the future, we may introduce a VERSION file like this one. https://github.com/kata-containers/kata-containers/blob/CCv0/VERSION

Fixes #878 