### PR TITLE
Revert "podvm: skip download ubuntu checksum during build"

### DIFF
--- a/podvm/Makefile
+++ b/podvm/Makefile
@@ -6,6 +6,12 @@ include Makefile.inc
 
 .PHONY: image clean clean_sources
 
+# Check for set but empty or unset URL and CHECKSUM
+UBUNTU_IMAGE_URL := $(or $(UBUNTU_IMAGE_URL),https://cloud-images.ubuntu.com/$(UBUNTU_RELEASE)/current/$(UBUNTU_RELEASE)-server-cloudimg-$(DEB_ARCH).img)
+UBUNTU_IMAGE_CHECKSUM := $(or $(UBUNTU_IMAGE_CHECKSUM),$(shell curl -LO  https://cloud-images.ubuntu.com/"$(UBUNTU_RELEASE)"/current/SHA256SUMS && \
+				grep "$(UBUNTU_RELEASE)"-server-cloudimg-"$(DEB_ARCH)".img SHA256SUMS | awk '{print $$1}' && \
+				rm -f SHA256SUMS))
+
 IMAGE_SUFFIX := .qcow2
 PODVM_DISTRO ?= ubuntu
 KATA_AGENT_SRC := ../../kata-containers/src/agent
@@ -25,13 +31,6 @@ image: $(IMAGE_FILE)
 setopts:
 ifeq ($(PODVM_DISTRO),ubuntu)
 	@echo defined
-
-	# Check for set but empty or unset URL and CHECKSUM
-	UBUNTU_IMAGE_URL := $(or $(UBUNTU_IMAGE_URL),https://cloud-images.ubuntu.com/$(UBUNTU_RELEASE)/current/$(UBUNTU_RELEASE)-server-cloudimg-$(DEB_ARCH).img)
-	UBUNTU_IMAGE_CHECKSUM := $(or $(UBUNTU_IMAGE_CHECKSUM),$(shell curl -LO  https://cloud-images.ubuntu.com/"$(UBUNTU_RELEASE)"/current/SHA256SUMS && \
-				grep "$(UBUNTU_RELEASE)"-server-cloudimg-"$(DEB_ARCH)".img SHA256SUMS | awk '{print $$1}' && \
-				rm -f SHA256SUMS))
-
 	$(eval OPTS := -var qemu_image_name=${IMAGE_FILE} \
 	-var cloud_image_url=${UBUNTU_IMAGE_URL} \
 	-var cloud_image_checksum=${UBUNTU_IMAGE_CHECKSUM})


### PR DESCRIPTION
Reverts confidential-containers/cloud-api-adaptor#890

You can't set variables in a Makefile recipe

Errors with 

```
make: UBUNTU_IMAGE_URL: Command not found
make: *** [Makefile:29: setopts] Error 127
```