### PR TITLE
azure: resource group is essential for deletion

### DIFF
--- a/pkg/adaptor/cloud/azure/manager.go
+++ b/pkg/adaptor/cloud/azure/manager.go
@@ -35,6 +35,7 @@ func (_ *Manager) LoadEnv() {
 	cloud.DefaultToEnv(&azurecfg.TenantId, "AZURE_TENANT_ID", "")
 	cloud.DefaultToEnv(&azurecfg.SubscriptionId, "AZURE_SUBSCRIPTION_ID", "")
 	cloud.DefaultToEnv(&azurecfg.Region, "AZURE_REGION", "")
+	cloud.DefaultToEnv(&azurecfg.ResourceGroupName, "AZURE_RESOURCE_GROUP", "")
 }
 
 func (_ *Manager) NewProvider() (cloud.Provider, error) {


### PR DESCRIPTION
fetch it from also environment for peerpod-ctrl usage

Fixes: #881