### PR TITLE
Update runtime payload runtimeclassname

### DIFF
--- a/install/runtime-payload/scripts/kata-deploy.sh
+++ b/install/runtime-payload/scripts/kata-deploy.sh
@@ -131,7 +131,7 @@ function cleanup_different_shims_base() {
 }
 
 function configure_crio_runtime() {
-	local runtime="kata"
+	local runtime="kata-remote"
 	local configuration="configuration"
 	if [ -n "${1-}" ]; then
 		runtime+="-$1"
@@ -172,7 +172,7 @@ function configure_crio() {
 }
 
 function configure_containerd_runtime() {
-	local runtime="kata"
+	local runtime="kata-remote"
 	local configuration="configuration"
 	if [ -n "${1-}" ]; then
 		runtime+="-$1"

--- a/install/yamls/ccruntime-peer-pods.yaml
+++ b/install/yamls/ccruntime-peer-pods.yaml
@@ -23,9 +23,9 @@ spec:
         name: containerd-conf
       - mountPath: /opt/confidential-containers/
         name: kata-artifacts
-      - mountPath: /var/run/dbus
+      - mountPath: /var/run/dbus/system_bus_socket
         name: dbus
-      - mountPath: /run/systemd
+      - mountPath: /run/systemd/system
         name: systemd
       - mountPath: /usr/local/bin/
         name: local-bin
@@ -43,11 +43,11 @@ spec:
           type: DirectoryOrCreate
         name: kata-artifacts
       - hostPath:
-          path: /var/run/dbus
+          path: /var/run/dbus/system_bus_socket
           type: ""
         name: dbus
       - hostPath:
-          path: /run/systemd
+          path: /run/systemd/system
           type: ""
         name: systemd
       - hostPath:
@@ -64,9 +64,9 @@ spec:
           name: confidential-containers-artifacts
         - mountPath: /etc/systemd/system/
           name: etc-systemd-system
-        - mountPath: /var/run/dbus
+        - mountPath: /var/run/dbus/system_bus_socket
           name: dbus
-        - mountPath: /run/systemd
+        - mountPath: /run/systemd/system
           name: systemd
       volumes:
         - hostPath:
@@ -78,11 +78,11 @@ spec:
             type: ""
           name: etc-systemd-system
         - hostPath:
-            path: /var/run/dbus
+            path: /var/run/dbus/system_bus_socket
             type: ""
           name: dbus
         - hostPath:
-            path: /run/systemd
+            path: /run/systemd/system
             type: ""
           name: systemd
     preInstall:
@@ -92,9 +92,9 @@ spec:
           name: confidential-containers-artifacts
         - mountPath: /etc/systemd/system/
           name: etc-systemd-system
-        - mountPath: /var/run/dbus
+        - mountPath: /var/run/dbus/system_bus_socket
           name: dbus
-        - mountPath: /run/systemd
+        - mountPath: /run/systemd/system
           name: systemd
         - mountPath: /run/hyp.env
           name: hyp-env
@@ -108,11 +108,11 @@ spec:
             type: ""
           name: etc-systemd-system
         - hostPath:
-            path: /var/run/dbus
+            path: /var/run/dbus/system_bus_socket
             type: ""
           name: dbus
         - hostPath:
-            path: /run/systemd
+            path: /run/systemd/system
             type: ""
           name: systemd
         - hostPath:

--- a/install/yamls/deploy.yaml
+++ b/install/yamls/deploy.yaml
@@ -5669,6 +5669,12 @@ spec:
                           type: object
                         type: array
                     type: object
+                  runtimeClassNames:
+                    description: This specifies the RuntimeClasses that needs to be
+                      created
+                    items:
+                      type: string
+                    type: array
                   runtimeImage:
                     description: This specifies the location of the container image
                       containing the Cc runtime binaries If both payloadImage and

--- a/install/yamls/kustomization.yaml
+++ b/install/yamls/kustomization.yaml
@@ -13,3 +13,6 @@ patchesJSON6902:
       path: /spec/config/preInstall
     - op: remove
       path: /spec/config/postUninstall
+    - op: replace
+      path: /spec/config/runtimeClassNames
+      value: ["kata-remote"]


### PR DESCRIPTION
This PR updates the peer pod fork of the runtime payload to install to the `kata-remote` runtime class.
This is in prep for us switching over to the upstream coco operator rather than using our own fork.

I don't think there is any automation for building the payload image, so this is fairly safe to merge, but then we will need to build the runtime-payload manually and follow up with the doc, webhook and e2e compatible fixes in #904 