### PR TITLE
Update runtimeclassname in docs/tests/webhook

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -348,14 +348,12 @@ Verify that the runtime class is created after deploying CAA:
 kubectl get runtimeclass
 ```
 
-Once you can find a runtimeclass named `kata` then you can be sure that the deployment was successful. Successful deployment will look like this:
+Once you can find a runtimeclass named `kata-remote` then you can be sure that the deployment was successful. Successful deployment will look like this:
 
 ```console
 $ kubectl get runtimeclass
-NAME        HANDLER     AGE
-kata        kata        7s
-kata-clh    kata-clh    7s
-kata-qemu   kata-qemu   7s
+NAME          HANDLER       AGE
+kata-remote   kata-remote   7m18s
 ```
 
 ### Deploy Workload
@@ -379,7 +377,7 @@ spec:
       labels:
         app: nginx
     spec:
-      runtimeClassName: kata
+      runtimeClassName: kata-remote
       containers:
       - name: nginx
         image: bitnami/nginx:1.14

--- a/ibmcloud/demo/nginx.yaml
+++ b/ibmcloud/demo/nginx.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: nginx
 spec:
-  runtimeClassName: kata
+  runtimeClassName: kata-remote
   containers:
     - name: nginx
       image: nginx

--- a/ibmcloud/demo/runtime-class.yaml
+++ b/ibmcloud/demo/runtime-class.yaml
@@ -1,7 +1,7 @@
 apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
-  name: kata
-handler: kata
+  name: kata-remote
+handler: kata-remote
 scheduling:
   nodeSelector:

--- a/install/README.md
+++ b/install/README.md
@@ -66,12 +66,10 @@
     ```
     kubectl get runtimeclass
     ```
-  A successful install should show `kata` related `RuntimeClasses`
+  A successful install should show `kata-remote` related `RuntimeClasses`
     ```
-    NAME        HANDLER     AGE
-    kata        kata        6m7s
-    kata-clh    kata-clh    6m7s
-    kata-qemu   kata-qemu   6m7s
+    NAME          HANDLER       AGE
+    kata-remote   kata-remote   7m18s
     ```
 
 * View cloud-api-adaptor logs

--- a/libvirt/README.md
+++ b/libvirt/README.md
@@ -134,10 +134,8 @@ were created on the cluster, as for example:
 
 ```
 $ kubectl get runtimeclass
-NAME        HANDLER     AGE
-kata        kata        7m41s
-kata-clh    kata-clh    7m41s
-kata-qemu   kata-qemu   7m41s
+NAME          HANDLER       AGE
+kata-remote   kata-remote   7m18s
 ```
 
 ## Create a sample peer-pods pod
@@ -169,7 +167,7 @@ spec:
     resources: {}
   dnsPolicy: ClusterFirst
   restartPolicy: Never
-  runtimeClassName: kata
+  runtimeClassName: kata-remote
 ```
 
 And create the Pod:

--- a/test/e2e/common_suite_test.go
+++ b/test/e2e/common_suite_test.go
@@ -24,7 +24,7 @@ func doTestCreateSimplePod(t *testing.T, assert CloudAssert) {
 	// TODO: generate me.
 	namespace := "default"
 	name := "simple-peer-pod"
-	pod := newPod(namespace, name, "nginx", "kata")
+	pod := newPod(namespace, name, "nginx", "kata-remote")
 
 	simplePodFeature := features.New("Simple Peer Pod").
 		WithSetup("Create pod", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -66,7 +66,7 @@ func doTestCreatePodWithConfigMap(t *testing.T, assert CloudAssert) {
 	configmapname := "nginx-config"
 	configmapData := map[string]string{"example.txt": "Hello, world"}
 	containerName := "nginx"
-	pod := newPodWithConfigMap(namespace, name, containerName, "kata", configmapname)
+	pod := newPodWithConfigMap(namespace, name, containerName, "kata-remote", configmapname)
 	configmap := newConfigMap(namespace, configmapname, configmapData)
 	nginxPodFeature := features.New("Configmap Pod").
 		WithSetup("Create pod", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -134,7 +134,7 @@ func doTestCreatePodWithSecret(t *testing.T, assert CloudAssert) {
 	secretname := "nginx-secret"
 	containerName := "nginx"
 	secretData := map[string][]byte{"password": []byte("123456"), "username": []byte("admin")}
-	pod := newPodWithSecret(namespace, name, containerName, "kata", secretname)
+	pod := newPodWithSecret(namespace, name, containerName, "kata-remote", secretname)
 	secret := newSecret(namespace, secretname, secretData)
 	nginxPodFeature := features.New("Secret Pod").
 		WithSetup("Create pod", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -204,7 +204,7 @@ func doTestCreatePodWithSecret(t *testing.T, assert CloudAssert) {
 func doTestCreatePeerPodContainerWithExternalIPAccess(t *testing.T, assert CloudAssert) {
 	namespace := envconf.RandomName("default", 7)
 	podname := "busy-box-pod"
-	pod := newBusyboxPod(namespace, podname, "busybox", "kata")
+	pod := newBusyboxPod(namespace, podname, "busybox", "kata-remote")
 	PublicpodFeature := features.New("Peer Pod Container").
 		WithSetup("Create pod", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			client, err := cfg.NewClient()

--- a/test/provisioner/provision.go
+++ b/test/provisioner/provision.go
@@ -77,7 +77,7 @@ func NewCloudAPIAdaptor(provider string) (*CloudAPIAdaptor, error) {
 		controllerDeployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "cc-operator-controller-manager", Namespace: namespace}},
 		namespace:            namespace,
 		installOverlay:       overlay,
-		runtimeClass:         &nodev1.RuntimeClass{ObjectMeta: metav1.ObjectMeta{Name: "kata", Namespace: ""}},
+		runtimeClass:         &nodev1.RuntimeClass{ObjectMeta: metav1.ObjectMeta{Name: "kata-remote", Namespace: ""}},
 	}, nil
 }
 

--- a/volumes/csi-wrapper/hack/ibm/nginx-kata-with-my-pvc-and-csi-wrapper.yaml
+++ b/volumes/csi-wrapper/hack/ibm/nginx-kata-with-my-pvc-and-csi-wrapper.yaml
@@ -6,7 +6,7 @@ metadata:
     app: nginx
   namespace: kube-system
 spec:
-  runtimeClassName: kata
+  runtimeClassName: kata-remote
   containers:
     - name: ibm-vpc-block-podvm-node-driver
       env:

--- a/webhook/config/manager/manager.yaml
+++ b/webhook/config/manager/manager.yaml
@@ -35,7 +35,7 @@ spec:
         name: manager
         env:
         - name: TARGET_RUNTIMECLASS
-          value: kata-remote-cc
+          value: kata-remote
         - name: POD_VM_INSTANCE_TYPE
           value: t2.small
         - name: POD_VM_EXTENDED_RESOURCE

--- a/webhook/docs/INSTALL.md
+++ b/webhook/docs/INSTALL.md
@@ -55,7 +55,7 @@ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.9
 kubectl apply -f hack/webhook-deploy.yaml
 ```
 
-The default `RuntimeClass` that the webhook monitors is `kata-remote-cc`. 
+The default `RuntimeClass` that the webhook monitors is `kata-remote`. 
 The default `RuntimeClass` can be changed by modifying the `TARGET_RUNTIMECLASS` environment variable.
 For example, executing the following command changes it to `kata`
 

--- a/webhook/hack/deploy.yaml
+++ b/webhook/hack/deploy.yaml
@@ -14,7 +14,7 @@ spec:
       labels:
         app: nginx
     spec:
-      runtimeClassName: kata-remote-cc
+      runtimeClassName: kata-remote
       containers:
       - name: nginx
         image: bitnami/nginx

--- a/webhook/hack/pod.yaml
+++ b/webhook/hack/pod.yaml
@@ -15,4 +15,4 @@ spec:
       limits:
         cpu: 1
         memory: 2Gi
-  runtimeClassName: kata-remote-cc
+  runtimeClassName: kata-remote

--- a/webhook/hack/rc.yaml
+++ b/webhook/hack/rc.yaml
@@ -1,8 +1,8 @@
 apiVersion: node.k8s.io/v1
-handler: kata-remote-cc
+handler: kata-remote
 kind: RuntimeClass
 metadata:
-  name: kata-remote-cc
+  name: kata-remote
 overhead:
   podFixed:
     memory: "120Mi"

--- a/webhook/hack/webhook-deploy.yaml
+++ b/webhook/hack/webhook-deploy.yaml
@@ -255,7 +255,7 @@ spec:
             memory: 64Mi
         env:
         - name: TARGET_RUNTIMECLASS
-          value: kata-remote-cc
+          value: kata-remote
         - name: POD_VM_INSTANCE_TYPE
           value: t2.small
         - name: POD_VM_EXTENDED_RESOURCE

--- a/webhook/pkg/mutating_webhook/remove-resourcespec.go
+++ b/webhook/pkg/mutating_webhook/remove-resourcespec.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	RUNTIME_CLASS_NAME_DEFAULT       = "kata-remote-cc"
+	RUNTIME_CLASS_NAME_DEFAULT       = "kata-remote"
 	POD_VM_ANNOTATION_INSTANCE_TYPE  = "kata.peerpods.io/instance_type"
 	POD_VM_INSTANCE_TYPE_DEFAULT     = "t2.small"
 	POD_VM_EXTENDED_RESOURCE_DEFAULT = "kata.peerpods.io/vm"


### PR DESCRIPTION
This code depends on #903 and contains the e2e, doc and webhook changes to move us to use `kata-remote` as our peer pods runtime class in prep for switching to use the upstream operator to install the runtime payload.