### PR TITLE
test/e2e: Refactor kata e2e tests

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -7,63 +7,72 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// newPod returns a new Pod object.
-func newPod(namespace string, name string, containerName string, runtimeclass string) *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Spec: corev1.PodSpec{
-			Containers:       []corev1.Container{{Name: containerName, Image: "nginx"}},
-			DNSPolicy:        "ClusterFirst",
-			RestartPolicy:    "Never",
-			RuntimeClassName: &runtimeclass,
-		},
+type podOption func(*corev1.Pod)
+
+func withRestartPolicy(restartPolicy corev1.RestartPolicy) podOption {
+	return func(p *corev1.Pod) {
+		p.Spec.RestartPolicy = restartPolicy
 	}
 }
 
-// newPod returns a new Pod object.
-func newBusyboxPod(namespace string, name string, containerName string, runtimeclass string) *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Spec: corev1.PodSpec{
-			Containers:       []corev1.Container{{Name: containerName, Image: "quay.io/prometheus/busybox:latest", Command: []string{"/bin/sh", "-c", "sleep 3600"}}},
-			DNSPolicy:        "ClusterFirst",
-			RuntimeClassName: &runtimeclass,
-			RestartPolicy:    corev1.RestartPolicyAlways,
-		},
+func withCommand(command []string) podOption {
+	return func(p *corev1.Pod) {
+		p.Spec.Containers[0].Command = command
 	}
 }
 
-func newPodWithConfigMap(namespace string, name string, containerName string, runtimeclass string, configmapname string) *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Spec: corev1.PodSpec{
-			Containers:       []corev1.Container{{Name: containerName, Image: "nginx", VolumeMounts: []corev1.VolumeMount{{Name: "config-volume", MountPath: "/etc/config"}}}},
-			DNSPolicy:        "ClusterFirst",
-			RestartPolicy:    "Never",
-			RuntimeClassName: &runtimeclass,
-			Volumes:          []corev1.Volume{{Name: "config-volume", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: configmapname}}}}},
-		},
+func withConfigMapBinding(mountPath string, configMapName string) podOption {
+	return func(p *corev1.Pod) {
+		p.Spec.Containers[0].VolumeMounts = append(p.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{Name: "config-volume", MountPath: mountPath})
+		p.Spec.Volumes = append(p.Spec.Volumes, corev1.Volume{Name: "config-volume", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: configMapName}}}})
 	}
 }
-func newPodWithSecret(namespace string, name string, containerName string, runtimeclass string, secretname string) *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+
+func withSecretBinding(mountPath string, secretName string) podOption {
+	return func(p *corev1.Pod) {
+		p.Spec.Containers[0].VolumeMounts = append(p.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{Name: "secret-volume", MountPath: mountPath})
+		p.Spec.Volumes = append(p.Spec.Volumes, corev1.Volume{Name: "secret-volume", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: secretName}}})
+	}
+}
+
+func newPod(namespace string, podName string, containerName string, imageName string, options ...podOption) *corev1.Pod {
+	runtimeClassName := "kata-remote"
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: namespace},
 		Spec: corev1.PodSpec{
-			Containers:       []corev1.Container{{Name: containerName, Image: "nginx", VolumeMounts: []corev1.VolumeMount{{Name: "secret-volume", MountPath: "/etc/secret"}}}},
-			DNSPolicy:        "ClusterFirst",
-			RestartPolicy:    "Never",
-			RuntimeClassName: &runtimeclass,
-			Volumes:          []corev1.Volume{{Name: "secret-volume", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: secretname}}}},
+			Containers:       []corev1.Container{{Name: containerName, Image: imageName}},
+			RuntimeClassName: &runtimeClassName,
 		},
 	}
+
+	for _, option := range options {
+		option(pod)
+	}
+
+	return pod
+}
+
+func newNginxPod(namespace string) *corev1.Pod {
+	return newPod(namespace, "nginx", "nginx", "nginx", withRestartPolicy(corev1.RestartPolicyNever))
+}
+
+func newBusyboxPod(namespace string) *corev1.Pod {
+	return newPod(namespace, "busybox-pod", "busybox", "quay.io/prometheus/busybox:latest", withCommand([]string{"/bin/sh", "-c", "sleep 3600"}))
+}
+
+func newNginxPodWithConfigMap(namespace string, configMapName string) *corev1.Pod {
+	return newPod(namespace, "nginx-configmap-pod", "nginx-configmap", "nginx", withRestartPolicy(corev1.RestartPolicyNever), withConfigMapBinding("/etc/config", configMapName))
+}
+
+func newNginxPodWithSecret(namespace string, secretName string) *corev1.Pod {
+	return newPod(namespace, "nginx-secret-pod", "nginx-secret", "nginx", withRestartPolicy(corev1.RestartPolicyNever), withSecretBinding("/etc/secret", secretName))
 }
 
 // newConfigMap returns a new config map object.
-func newConfigMap(namespace string, name string, configmapData map[string]string) *corev1.ConfigMap {
-
+func newConfigMap(namespace string, name string, configMapData map[string]string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Data:       configmapData,
+		Data:       configMapData,
 	}
 }
 

--- a/test/e2e/common_suite_test.go
+++ b/test/e2e/common_suite_test.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -19,30 +20,95 @@ import (
 
 const WAIT_POD_RUNNING_TIMEOUT = time.Second * 300
 
-// doTestCreateSimplePod tests a simple peer-pod can be created.
-func doTestCreateSimplePod(t *testing.T, assert CloudAssert) {
-	// TODO: generate me.
-	namespace := "default"
-	name := "simple-peer-pod"
-	pod := newPod(namespace, name, "nginx", "kata-remote")
+// testCommand is a list of commands to execute inside the pod container,
+// each with a function to test if the command outputs the value the test
+// expects it to on the stdout stream
+type testCommand struct {
+	command             []string
+	testCommandStdoutFn func(stdout bytes.Buffer) bool
+	containerName       string
+}
 
-	simplePodFeature := features.New("Simple Peer Pod").
+type testCase struct {
+	testing       *testing.T
+	assert        CloudAssert
+	assessMessage string
+	pod           *v1.Pod
+	configMap     *v1.ConfigMap
+	secret        *v1.Secret
+	testCommands  []testCommand
+}
+
+func (tc *testCase) withConfigMap(configMap *v1.ConfigMap) *testCase {
+	tc.configMap = configMap
+	return tc
+}
+
+func (tc *testCase) withSecret(secret *v1.Secret) *testCase {
+	tc.secret = secret
+	return tc
+}
+
+func (tc *testCase) withTestCommands(testCommands []testCommand) *testCase {
+	tc.testCommands = testCommands
+	return tc
+}
+
+func (tc *testCase) run() {
+	podFeature := features.New(fmt.Sprintf("%s Pod", tc.pod.Name)).
 		WithSetup("Create pod", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			client, err := cfg.NewClient()
 			if err != nil {
 				t.Fatal(err)
 			}
-			if err = client.Resources().Create(ctx, pod); err != nil {
+
+			if tc.configMap != nil {
+				if err = client.Resources().Create(ctx, tc.configMap); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if tc.secret != nil {
+				if err = client.Resources().Create(ctx, tc.secret); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if err = client.Resources().Create(ctx, tc.pod); err != nil {
 				t.Fatal(err)
 			}
-			if err = wait.For(conditions.New(client.Resources()).PodRunning(pod), wait.WithTimeout(WAIT_POD_RUNNING_TIMEOUT)); err != nil {
+
+			if err = wait.For(conditions.New(client.Resources()).PodRunning(tc.pod), wait.WithTimeout(WAIT_POD_RUNNING_TIMEOUT)); err != nil {
 				t.Fatal(err)
 			}
 
 			return ctx
 		}).
-		Assess("PodVM is created", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			assert.HasPodVM(t, name)
+		Assess(tc.assessMessage, func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			tc.assert.HasPodVM(t, tc.pod.Name)
+
+			var podlist v1.PodList
+
+			if err := cfg.Client().Resources(tc.pod.Namespace).List(context.TODO(), &podlist); err != nil {
+				t.Fatal(err)
+			}
+
+			for _, testCommand := range tc.testCommands {
+				var stdout, stderr bytes.Buffer
+
+				for _, podItem := range podlist.Items {
+					if podItem.ObjectMeta.Name == tc.pod.Name {
+						if err := cfg.Client().Resources(tc.pod.Namespace).ExecInPod(ctx, tc.pod.Namespace, tc.pod.Name, testCommand.containerName, testCommand.command, &stdout, &stderr); err != nil {
+							t.Log(stderr.String())
+							t.Fatal(err)
+						}
+
+						if !testCommand.testCommandStdoutFn(stdout) {
+							t.Fatal(fmt.Errorf("Command %v running in container %s produced unexpected output on stdout: %s", testCommand.command, testCommand.containerName, stdout.String()))
+						}
+					}
+				}
+			}
 
 			return ctx
 		}).
@@ -51,208 +117,145 @@ func doTestCreateSimplePod(t *testing.T, assert CloudAssert) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if err = client.Resources().Delete(ctx, pod); err != nil {
+
+			if err = client.Resources().Delete(ctx, tc.pod); err != nil {
 				t.Fatal(err)
+			}
+
+			log.Infof("Deleting pod... %s", tc.pod.Name)
+
+			if tc.configMap != nil {
+				if err = client.Resources().Delete(ctx, tc.configMap); err != nil {
+					t.Fatal(err)
+				}
+
+				log.Infof("Deleting Configmap... %s", tc.configMap.Name)
+			}
+
+			if tc.secret != nil {
+				if err = client.Resources().Delete(ctx, tc.secret); err != nil {
+					t.Fatal(err)
+				} else {
+					log.Infof("Deleting Secret... %s", tc.secret.Name)
+				}
 			}
 
 			return ctx
 		}).Feature()
-	testEnv.Test(t, simplePodFeature)
+	testEnv.Test(tc.testing, podFeature)
+}
+
+func newTestCase(t *testing.T, assert CloudAssert, assessMessage string, pod *v1.Pod) *testCase {
+	testCase := &testCase{
+		testing:       t,
+		assert:        assert,
+		assessMessage: assessMessage,
+		pod:           pod,
+	}
+
+	return testCase
+}
+
+// doTestCreateSimplePod tests a simple peer-pod can be created.
+func doTestCreateSimplePod(t *testing.T, assert CloudAssert) {
+	namespace := envconf.RandomName("default", 7)
+	pod := newNginxPod(namespace)
+	newTestCase(t, assert, "PodVM is created", pod).run()
 }
 
 func doTestCreatePodWithConfigMap(t *testing.T, assert CloudAssert) {
 	namespace := envconf.RandomName("default", 7)
-	name := "configmap-pod"
-	configmapname := "nginx-config"
-	configmapData := map[string]string{"example.txt": "Hello, world"}
-	containerName := "nginx"
-	pod := newPodWithConfigMap(namespace, name, containerName, "kata-remote", configmapname)
-	configmap := newConfigMap(namespace, configmapname, configmapData)
-	nginxPodFeature := features.New("Configmap Pod").
-		WithSetup("Create pod", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			client, err := cfg.NewClient()
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if err = client.Resources().Create(ctx, configmap); err != nil {
-				t.Fatal(err)
-			}
-			if err = client.Resources().Create(ctx, pod); err != nil {
-				t.Fatal(err)
-			}
-			if err = wait.For(conditions.New(client.Resources()).PodRunning(pod), wait.WithTimeout(WAIT_POD_RUNNING_TIMEOUT)); err != nil {
-				t.Fatal(err)
-			}
-
-			return ctx
-		}).
-		Assess("Configmap is created and contains data", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			var podlist v1.PodList
-			var stdout, stderr bytes.Buffer
-			if err := cfg.Client().Resources(namespace).List(context.TODO(), &podlist); err != nil {
-				t.Fatal(err)
-			}
-			for _, i := range podlist.Items {
-				if i.ObjectMeta.Name == name {
-					if err := cfg.Client().Resources(namespace).ExecInPod(ctx, namespace, name, containerName, []string{"cat", "/etc/config/example.txt"}, &stdout, &stderr); err != nil {
-						t.Log(stderr.String())
-						t.Fatal(err)
-					}
+	configMapName := "nginx-config"
+	configMapFileName := "example.txt"
+	configMapPath := "/etc/config/" + configMapFileName
+	configMapContents := "Hello, world"
+	configMapData := map[string]string{configMapFileName: configMapContents}
+	pod := newNginxPodWithConfigMap(namespace, configMapName)
+	configMap := newConfigMap(namespace, configMapName, configMapData)
+	testCommands := []testCommand{
+		{
+			command:       []string{"cat", configMapPath},
+			containerName: pod.Spec.Containers[0].Name,
+			testCommandStdoutFn: func(stdout bytes.Buffer) bool {
+				if stdout.String() == configMapContents {
+					log.Infof("Data Inside Configmap: %s", stdout.String())
+					return true
+				} else {
+					log.Errorf("Configmap has invalid Data: %s", stdout.String())
+					return false
 				}
-			}
-			if stdout.String() == "Hello, world" {
-				log.Infof("Data Inside Configmap: %s", stdout.String())
-			} else {
-				t.Errorf("Configmap with invalid Data: %s", stdout.String())
-			}
-			return ctx
-		}).
-		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			client, err := cfg.NewClient()
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err = client.Resources().Delete(ctx, pod); err != nil {
-				t.Fatal(err)
-			} else {
-				log.Infof("Deleting pod... %s", name)
-			}
-			if err = client.Resources().Delete(ctx, configmap); err != nil {
-				t.Fatal(err)
-			} else {
-				log.Infof("Deleting Configmap... %s", configmapname)
-			}
+			},
+		},
+	}
 
-			return ctx
-		}).Feature()
-	testEnv.Test(t, nginxPodFeature)
+	newTestCase(t, assert, "Configmap is created and contains data", pod).withConfigMap(configMap).withTestCommands(testCommands).run()
 }
+
 func doTestCreatePodWithSecret(t *testing.T, assert CloudAssert) {
+	//doTestCreatePod(t, assert, "Secret is created and contains data", pod)
 	namespace := envconf.RandomName("default", 7)
-	name := "secret-pod"
-	secretname := "nginx-secret"
-	containerName := "nginx"
-	secretData := map[string][]byte{"password": []byte("123456"), "username": []byte("admin")}
-	pod := newPodWithSecret(namespace, name, containerName, "kata-remote", secretname)
-	secret := newSecret(namespace, secretname, secretData)
-	nginxPodFeature := features.New("Secret Pod").
-		WithSetup("Create pod", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			client, err := cfg.NewClient()
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err = client.Resources().Create(ctx, secret); err != nil {
-				t.Fatal(err)
-			}
-			if err = client.Resources().Create(ctx, pod); err != nil {
-				t.Fatal(err)
-			}
+	secretName := "nginx-secret"
+	podKubeSecretsDir := "/etc/secret/"
+	usernameFileName := "username"
+	username := "admin"
+	usernamePath := podKubeSecretsDir + usernameFileName
+	passwordFileName := "password"
+	password := "password"
+	passwordPath := podKubeSecretsDir + passwordFileName
+	secretData := map[string][]byte{passwordFileName: []byte(password), usernameFileName: []byte(username)}
+	pod := newNginxPodWithSecret(namespace, secretName)
+	secret := newSecret(namespace, secretName, secretData)
 
-			if err = wait.For(conditions.New(client.Resources()).PodRunning(pod), wait.WithTimeout(WAIT_POD_RUNNING_TIMEOUT)); err != nil {
-				t.Fatal(err)
-			}
-
-			return ctx
-		}).
-		Assess("Secret is created and contains data", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			var podlist v1.PodList
-			var usernameStdOut, passwordStdOut, usernameStdErr, passwordStdErr bytes.Buffer
-			if err := cfg.Client().Resources(namespace).List(context.TODO(), &podlist); err != nil {
-				t.Fatal(err)
-			}
-			for _, i := range podlist.Items {
-				if i.ObjectMeta.Name == name {
-					if err := cfg.Client().Resources(namespace).ExecInPod(ctx, namespace, name, containerName, []string{"cat", "/etc/secret/username"}, &usernameStdOut, &usernameStdErr); err != nil {
-						t.Log(usernameStdErr.String())
-						t.Fatal(err)
-					}
-					if err := cfg.Client().Resources(namespace).ExecInPod(ctx, namespace, name, containerName, []string{"cat", "/etc/secret/password"}, &passwordStdOut, &passwordStdErr); err != nil {
-						t.Log(passwordStdErr.String())
-						t.Fatal(err)
-					}
+	testCommands := []testCommand{
+		{
+			command:       []string{"cat", usernamePath},
+			containerName: pod.Spec.Containers[0].Name,
+			testCommandStdoutFn: func(stdout bytes.Buffer) bool {
+				if stdout.String() == username {
+					log.Infof("Username from secret inside pod: %s", stdout.String())
+					return true
+				} else {
+					log.Errorf("Username value from secret inside pod unexpected. Expected %s, got %s", username, stdout.String())
+					return false
 				}
-			}
-			if usernameStdOut.String() == "admin" && passwordStdOut.String() == "123456" {
-				log.Infof("Username inside volume: %s", usernameStdOut.String())
-				log.Infof("Password inside volume: %s", passwordStdOut.String())
-			} else {
-				t.Errorf("Secret with Invalid user: %s and password: %s", usernameStdOut.String(), passwordStdOut.String())
-			}
-			return ctx
-		}).
-		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			client, err := cfg.NewClient()
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err = client.Resources().Delete(ctx, pod); err != nil {
-				t.Fatal(err)
-			} else {
-				log.Infof("Deleting pod... %s", name)
-			}
-			if err = client.Resources().Delete(ctx, secret); err != nil {
-				t.Fatal(err)
-			} else {
-				log.Infof("Deleting Secret... %s", secretname)
-			}
+			},
+		},
+		{
+			command:       []string{"cat", passwordPath},
+			containerName: pod.Spec.Containers[0].Name,
+			testCommandStdoutFn: func(stdout bytes.Buffer) bool {
+				if stdout.String() == password {
+					log.Infof("Password from secret inside pod: %s", stdout.String())
+					return true
+				} else {
+					log.Errorf("Password value from secret inside pod unexpected. Expected %s, got %s", password, stdout.String())
+					return false
+				}
+			},
+		},
+	}
 
-			return ctx
-		}).Feature()
-	testEnv.Test(t, nginxPodFeature)
+	newTestCase(t, assert, "Secret has been created and contains data", pod).withSecret(secret).withTestCommands(testCommands).run()
 }
+
 func doTestCreatePeerPodContainerWithExternalIPAccess(t *testing.T, assert CloudAssert) {
 	namespace := envconf.RandomName("default", 7)
-	podname := "busy-box-pod"
-	pod := newBusyboxPod(namespace, podname, "busybox", "kata-remote")
-	PublicpodFeature := features.New("Peer Pod Container").
-		WithSetup("Create pod", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			client, err := cfg.NewClient()
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err = client.Resources(namespace).Create(ctx, pod); err != nil {
-				t.Fatal(err)
-			}
-			if err = wait.For(conditions.New(client.Resources()).PodRunning(pod), wait.WithTimeout(WAIT_POD_RUNNING_TIMEOUT)); err != nil {
-				t.Fatal(err)
-			}
-			return ctx
-		}).
-		Assess("Peer Pod Container Connected to External IP", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			var podlist v1.PodList
-			var pingstdout, pingstderr bytes.Buffer
-			if err := cfg.Client().Resources(namespace).List(ctx, &podlist); err != nil {
-				t.Fatal(err)
-			}
-			for _, i := range podlist.Items {
-				if i.ObjectMeta.Name == podname {
-					if err := cfg.Client().Resources(namespace).ExecInPod(ctx, namespace, podname, "busybox", []string{"ping", "-c", "1", "www.google.com"}, &pingstdout, &pingstderr); err != nil {
-						log.Println(pingstderr.String())
-						t.Fatal(err)
-					} else {
-						log.Println("Pinging www.google.com ...")
-					}
+	pod := newBusyboxPod(namespace)
+	testCommands := []testCommand{
+		{
+			command:       []string{"ping", "-c", "1", "www.google.com"},
+			containerName: pod.Spec.Containers[0].Name,
+			testCommandStdoutFn: func(stdout bytes.Buffer) bool {
+				if stdout.String() != "" {
+					log.Infof("Output of ping command in busybox : %s", stdout.String())
+					return true
+				} else {
+					log.Info("No output from ping command")
+					return false
 				}
-			}
-			if pingstdout.String() != "" {
-				log.Printf("Output of ping command in busybox : %s", pingstdout.String())
+			},
+		},
+	}
 
-			} else {
-				t.Errorf("No output from ping command")
-			}
-			return ctx
-		}).
-		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			client, err := cfg.NewClient()
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err = client.Resources().Delete(ctx, pod); err != nil {
-				t.Fatal(err)
-			}
-
-			return ctx
-		}).Feature()
-	testEnv.Test(t, PublicpodFeature)
+	newTestCase(t, assert, "Peer Pod Container Connected to External IP", pod).withTestCommands(testCommands).run()
 }


### PR DESCRIPTION
Refactor provider-common e2e tests so we have common methods for creating pod objects that all the test cases use.

Fixes: #918