### PR TITLE
ibmcloud: update runtime handler to kata-remote

### DIFF
--- a/ibmcloud/terraform/cluster/ansible/kata-playbook.yml
+++ b/ibmcloud/terraform/cluster/ansible/kata-playbook.yml
@@ -116,7 +116,7 @@
                 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
                   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
                     runtime_type = "io.containerd.runc.v2"
-                  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
+                  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-remote]
                     runtime_type = "io.containerd.kata.v2"
                     cri_handler = "cc"
 

--- a/ibmcloud/terraform/cluster/ansible/kube-playbook.yml
+++ b/ibmcloud/terraform/cluster/ansible/kube-playbook.yml
@@ -189,7 +189,7 @@
                 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
                   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
                     runtime_type = "io.containerd.runc.v2"
-                  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
+                  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-remote]
                     runtime_type = "io.containerd.kata.v2"
                     cri_handler = "cc"
 


### PR DESCRIPTION
Update runtime handler to kata-remote in containerd config.

Fixes: #933