### PR TITLE
podnetwork: Refactor to use the new type net/netip package

### DIFF
--- a/pkg/adaptor/cloud/aws/provider.go
+++ b/pkg/adaptor/cloud/aws/provider.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"net"
+	"net/netip"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -72,9 +72,9 @@ func NewProvider(config *Config) (cloud.Provider, error) {
 	return provider, nil
 }
 
-func getIPs(instance types.Instance) ([]net.IP, error) {
+func getIPs(instance types.Instance) ([]netip.Addr, error) {
 
-	var podNodeIPs []net.IP
+	var podNodeIPs []netip.Addr
 	for i, nic := range instance.NetworkInterfaces {
 		addr := nic.PrivateIpAddress
 
@@ -82,9 +82,9 @@ func getIPs(instance types.Instance) ([]net.IP, error) {
 			return nil, errNotReady
 		}
 
-		ip := net.ParseIP(*addr)
-		if ip == nil {
-			return nil, fmt.Errorf("failed to parse pod node IP %q", *addr)
+		ip, err := netip.ParseAddr(*addr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse pod node IP %q: %w", *addr, err)
 		}
 		podNodeIPs = append(podNodeIPs, ip)
 

--- a/pkg/adaptor/cloud/aws/provider_test.go
+++ b/pkg/adaptor/cloud/aws/provider_test.go
@@ -6,7 +6,7 @@ package aws
 import (
 	"context"
 	"fmt"
-	"net"
+	"net/netip"
 	"reflect"
 	"testing"
 
@@ -190,7 +190,7 @@ func TestCreateInstance(t *testing.T) {
 			want: &cloud.Instance{
 				ID:   "i-1234567890abcdef0",
 				Name: "podvm-podtest-123",
-				IPs:  []net.IP{net.ParseIP("10.0.0.2")},
+				IPs:  []netip.Addr{netip.MustParseAddr("10.0.0.2")},
 			},
 			// Test should not return an error
 			wantErr: false,
@@ -257,7 +257,7 @@ func TestCreateInstance(t *testing.T) {
 			want: &cloud.Instance{
 				ID:   "i-1234567890abcdef0",
 				Name: "podvm-podemptyinstance-123",
-				IPs:  []net.IP{net.ParseIP("10.0.0.2")},
+				IPs:  []netip.Addr{netip.MustParseAddr("10.0.0.2")},
 			},
 			// Test should not return an error
 			wantErr: false,
@@ -283,7 +283,7 @@ func TestCreateInstance(t *testing.T) {
 			want: &cloud.Instance{
 				ID:   "i-1234567890abcdef0",
 				Name: "podvm-podemptyinstance-123",
-				IPs:  []net.IP{net.ParseIP("10.0.0.2")},
+				IPs:  []netip.Addr{netip.MustParseAddr("10.0.0.2")},
 			},
 			// Test should not return an error
 			wantErr: false,

--- a/pkg/adaptor/cloud/azure/provider.go
+++ b/pkg/adaptor/cloud/azure/provider.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"net"
+	"net/netip"
 	"os"
 	"regexp"
 
@@ -57,8 +57,8 @@ func NewProvider(config *Config) (cloud.Provider, error) {
 	return provider, nil
 }
 
-func getIPs(nic *armnetwork.Interface) ([]net.IP, error) {
-	var podNodeIPs []net.IP
+func getIPs(nic *armnetwork.Interface) ([]netip.Addr, error) {
+	var podNodeIPs []netip.Addr
 
 	for i, ipc := range nic.Properties.IPConfigurations {
 		addr := ipc.Properties.PrivateIPAddress
@@ -67,9 +67,9 @@ func getIPs(nic *armnetwork.Interface) ([]net.IP, error) {
 			return nil, errNotReady
 		}
 
-		ip := net.ParseIP(*addr)
-		if ip == nil {
-			return nil, fmt.Errorf("parsing pod node IP %q", *addr)
+		ip, err := netip.ParseAddr(*addr)
+		if err == nil {
+			return nil, fmt.Errorf("parsing pod node IP %q: %w", *addr, err)
 		}
 
 		podNodeIPs = append(podNodeIPs, ip)

--- a/pkg/adaptor/cloud/cloud_test.go
+++ b/pkg/adaptor/cloud/cloud_test.go
@@ -6,7 +6,7 @@ package cloud
 import (
 	"context"
 	"fmt"
-	"net"
+	"net/netip"
 	"net/url"
 	"reflect"
 	"testing"
@@ -29,8 +29,8 @@ func (p *mockProvider) CreateInstance(ctx context.Context, podName, sandboxID st
 	return &Instance{
 		Name: "abc",
 		ID:   fmt.Sprintf("%s-%.8s", podName, sandboxID),
-		IPs: []net.IP{
-			net.ParseIP("192.0.2.1"),
+		IPs: []netip.Addr{
+			netip.MustParseAddr("192.0.2.1"),
 		},
 	}, nil
 }
@@ -94,7 +94,7 @@ func (n mockWorkerNode) Inspect(nsPath string) (*tunneler.Config, error) {
 	return nil, nil
 }
 
-func (n *mockWorkerNode) Setup(nsPath string, podNodeIPs []net.IP, config *tunneler.Config) error {
+func (n *mockWorkerNode) Setup(nsPath string, podNodeIPs []netip.Addr, config *tunneler.Config) error {
 	return nil
 }
 

--- a/pkg/adaptor/cloud/libvirt/libvirt.go
+++ b/pkg/adaptor/cloud/libvirt/libvirt.go
@@ -10,7 +10,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"net"
+	"net/netip"
 	"os"
 	"os/exec"
 	"strconv"
@@ -268,7 +268,11 @@ func CreateDomain(ctx context.Context, libvirtClient *libvirtClient, v *vmConfig
 	if len(domInterface) > 0 {
 		// TBD: ability to handle multiple interfaces and ips
 		logger.Printf("VM IP %s", domInterface[0].Addrs[0].Addr)
-		v.ips = append(v.ips, net.ParseIP(domInterface[0].Addrs[0].Addr))
+		addr, err := netip.ParseAddr(domInterface[0].Addrs[0].Addr)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse address: %s", err)
+		}
+		v.ips = append(v.ips, addr)
 		logger.Printf("VM IP list %v", v.ips)
 	}
 

--- a/pkg/adaptor/cloud/libvirt/provider.go
+++ b/pkg/adaptor/cloud/libvirt/provider.go
@@ -8,7 +8,7 @@ package libvirt
 import (
 	"context"
 	"log"
-	"net"
+	"net/netip"
 
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/cloud"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/util"
@@ -42,7 +42,7 @@ func NewProvider(config *Config) (cloud.Provider, error) {
 	return provider, nil
 }
 
-func getIPs(instance *vmConfig) ([]net.IP, error) {
+func getIPs(instance *vmConfig) ([]netip.Addr, error) {
 	return instance.ips, nil
 }
 

--- a/pkg/adaptor/cloud/libvirt/types.go
+++ b/pkg/adaptor/cloud/libvirt/types.go
@@ -6,7 +6,7 @@
 package libvirt
 
 import (
-	"net"
+	"net/netip"
 
 	libvirt "libvirt.org/go/libvirt"
 )
@@ -25,7 +25,7 @@ type vmConfig struct {
 	rootDiskSize uint64
 	userData     string
 	metaData     string
-	ips          []net.IP
+	ips          []netip.Addr
 	instanceId   string //keeping it consistent with sandbox.vsi
 }
 

--- a/pkg/adaptor/cloud/types.go
+++ b/pkg/adaptor/cloud/types.go
@@ -5,7 +5,7 @@ package cloud
 
 import (
 	"context"
-	"net"
+	"net/netip"
 	"sync"
 
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/k8sops"
@@ -25,7 +25,7 @@ type Provider interface {
 type Instance struct {
 	ID   string
 	Name string
-	IPs  []net.IP
+	IPs  []netip.Addr
 }
 
 type Service interface {

--- a/pkg/adaptor/cloud/vsphere/provider.go
+++ b/pkg/adaptor/cloud/vsphere/provider.go
@@ -8,7 +8,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
-	"net"
+	"net/netip"
 	"path"
 	"strings"
 	"time"
@@ -312,8 +312,8 @@ func (p *vsphereProvider) CreateInstance(ctx context.Context, podName, sandboxID
 	return instance, nil
 }
 
-func getIPs(vm *object.VirtualMachine) ([]net.IP, error) { // TODO Fix to get all ips
-	var podNodeIPs []net.IP
+func getIPs(vm *object.VirtualMachine) ([]netip.Addr, error) { // TODO Fix to get all ips
+	var podNodeIPs []netip.Addr
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(600*time.Second))
 	defer cancel()
@@ -325,9 +325,9 @@ func getIPs(vm *object.VirtualMachine) ([]net.IP, error) { // TODO Fix to get al
 	}
 
 	logger.Printf("VM IP = %s", ip)
-	ip_item := net.ParseIP(ip)
-	if ip_item == nil {
-		return nil, fmt.Errorf("failed to parse pod node IP %q", ip)
+	ip_item, err := netip.ParseAddr(ip)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse pod node IP %q: %w", ip, err)
 	}
 	podNodeIPs = append(podNodeIPs, ip_item)
 

--- a/pkg/adaptor/server_test.go
+++ b/pkg/adaptor/server_test.go
@@ -6,8 +6,8 @@ package adaptor
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"testing"
@@ -181,7 +181,7 @@ func (n *mockWorkerNode) Inspect(nsPath string) (*tunneler.Config, error) {
 	return &tunneler.Config{}, nil
 }
 
-func (n *mockWorkerNode) Setup(nsPath string, podNodeIPs []net.IP, config *tunneler.Config) error {
+func (n *mockWorkerNode) Setup(nsPath string, podNodeIPs []netip.Addr, config *tunneler.Config) error {
 	return nil
 }
 
@@ -206,13 +206,9 @@ func (p *mockProvider) CreateInstance(ctx context.Context, podName, sandboxID st
 		secondaryIP = "127.0.0.1"
 	}
 
-	ips := make([]net.IP, 2)
-	ips[0] = net.ParseIP(primaryIP)
-	ips[1] = net.ParseIP(secondaryIP)
-
-	if ips[0] == nil || ips[1] == nil {
-		return nil, fmt.Errorf("Could not parse IPs: primary IP %s and secondary IP %s", primaryIP, secondaryIP)
-	}
+	ips := make([]netip.Addr, 2)
+	ips[0] = netip.MustParseAddr(primaryIP)
+	ips[1] = netip.MustParseAddr(secondaryIP)
 
 	instance := &cloud.Instance{
 		ID:   "mock",

--- a/pkg/podnetwork/tunneler/routing/common.go
+++ b/pkg/podnetwork/tunneler/routing/common.go
@@ -5,7 +5,7 @@ package routing
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 	"strings"
 
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/util/netops"
@@ -18,11 +18,8 @@ const (
 	podTablePriority           = 0
 )
 
-func mask32(ip net.IP) *net.IPNet {
-	return &net.IPNet{
-		IP:   ip,
-		Mask: net.CIDRMask(8*net.IPv4len, 8*net.IPv4len),
-	}
+func mask32(ip netip.Prefix) netip.Prefix {
+	return netip.PrefixFrom(ip.Addr(), ip.Addr().BitLen())
 }
 
 func sysctlSet(ns netops.Namespace, key string, val string) error {
@@ -36,7 +33,7 @@ func sysctlSet(ns netops.Namespace, key string, val string) error {
 	return err
 }
 
-func findLinkByAddr(ns netops.Namespace, ip net.IP) (netops.Link, error) {
+func findLinkByAddr(ns netops.Namespace, addr netip.Addr) (netops.Link, error) {
 
 	links, err := ns.LinkList()
 	if err != nil {
@@ -44,12 +41,12 @@ func findLinkByAddr(ns netops.Namespace, ip net.IP) (netops.Link, error) {
 	}
 	var foundLinks []netops.Link
 	for _, link := range links {
-		ipNets, err := link.GetAddr()
+		ips, err := link.GetAddr()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get IP addresses assigned to %q on netns %s", link.Name(), ns.Path())
 		}
-		for _, ipNet := range ipNets {
-			if ipNet.IP.Equal(ip) {
+		for _, ip := range ips {
+			if ip.Addr() == addr {
 				foundLinks = append(foundLinks, link)
 				break
 			}
@@ -57,14 +54,14 @@ func findLinkByAddr(ns netops.Namespace, ip net.IP) (netops.Link, error) {
 	}
 
 	if len(foundLinks) == 0 {
-		return nil, fmt.Errorf("failed to find interface that has %s on netns %s", ip.String(), ns.Path())
+		return nil, fmt.Errorf("failed to find interface that has %s on netns %s", addr.String(), ns.Path())
 	}
 	if len(foundLinks) > 1 {
 		var names []string
 		for _, link := range foundLinks {
 			names = append(names, link.Name())
 		}
-		return nil, fmt.Errorf("multiple interfaces have %s on netns %s: %s", ip.String(), ns.Path(), strings.Join(names, ", "))
+		return nil, fmt.Errorf("multiple interfaces have %s on netns %s: %s", addr.String(), ns.Path(), strings.Join(names, ", "))
 	}
 
 	return foundLinks[0], nil

--- a/pkg/podnetwork/tunneler/tunneler.go
+++ b/pkg/podnetwork/tunneler/tunneler.go
@@ -5,31 +5,31 @@ package tunneler
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 )
 
 type Tunneler interface {
-	Setup(nsPath string, podNodeIPs []net.IP, config *Config) error
+	Setup(nsPath string, podNodeIPs []netip.Addr, config *Config) error
 	Teardown(nsPath, hostInterface string, config *Config) error
 }
 
 type Config struct {
-	PodIP         string   `json:"podip"`
-	PodHwAddr     string   `json:"pod-hw-addr"`
-	InterfaceName string   `json:"interface"`
-	WorkerNodeIP  string   `json:"worker-node-ip"`
-	TunnelType    string   `json:"tunnel-type"`
-	Routes        []*Route `json:"routes"`
-	MTU           int      `json:"mtu"`
-	Index         int      `json:"index"`
-	VXLANPort     int      `json:"vxlan-port,omitempty"`
-	VXLANID       int      `json:"vxlan-id,omitempty"`
-	Dedicated     bool     `json:"dedicated"`
+	PodIP         netip.Prefix `json:"podip"`
+	PodHwAddr     string       `json:"pod-hw-addr"`
+	InterfaceName string       `json:"interface"`
+	WorkerNodeIP  netip.Prefix `json:"worker-node-ip"`
+	TunnelType    string       `json:"tunnel-type"`
+	Routes        []*Route     `json:"routes"`
+	MTU           int          `json:"mtu"`
+	Index         int          `json:"index"`
+	VXLANPort     int          `json:"vxlan-port,omitempty"`
+	VXLANID       int          `json:"vxlan-id,omitempty"`
+	Dedicated     bool         `json:"dedicated"`
 }
 
 type Route struct {
-	Dst string
-	GW  string
+	Dst netip.Prefix
+	GW  netip.Addr
 	Dev string
 }
 

--- a/pkg/podnetwork/tunneler/vxlan/workernode.go
+++ b/pkg/podnetwork/tunneler/vxlan/workernode.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"net"
+	"net/netip"
 	"os"
 
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork/tunneler"
@@ -30,9 +30,9 @@ func NewWorkerNodeTunneler() tunneler.Tunneler {
 	return &workerNodeTunneler{}
 }
 
-func (t *workerNodeTunneler) Setup(nsPath string, podNodeIPs []net.IP, config *tunneler.Config) error {
+func (t *workerNodeTunneler) Setup(nsPath string, podNodeIPs []netip.Addr, config *tunneler.Config) error {
 
-	var dstAddr net.IP
+	var dstAddr netip.Addr
 
 	if config.Dedicated {
 		dstAddr = podNodeIPs[1]


### PR DESCRIPTION
This is a follow-on PR to #947.

Go 1.18 introduces the new net/netip package to define a new IP address type netip.Addr. The new type is comparable, immutable, and lightweight compared to the old type net.IP.

Fixes https://github.com/confidential-containers/cloud-api-adaptor/issues/953

**References**

- https://tip.golang.org/doc/go1.18#netip
- https://djosephsen.github.io//posts/ipnet/
