### PR TITLE
ibmcloud: upload se-podvm image with correct osName

### DIFF
--- a/ibmcloud/SECURE_EXECUTION.md
+++ b/ibmcloud/SECURE_EXECUTION.md
@@ -131,7 +131,7 @@ $ kubectl get pods -n confidential-containers-system --watch
 ## Test
 
 You can follow guide [Validating the set-up](./README.md#validating-the-set-up) to deploy a nginx pod.
-- Verify the Peer Pod VM is created with the SE enabled custom image.
+- Verify the Peer Pod VM is created with the Secure Execution enabled custom image.
 ```bash
 $ ibmcloud is ins
 Listing instances in all resource groups and region eu-gb under account DaLi Liu's Account as user liudali@cn.ibm.com...
@@ -141,3 +141,13 @@ ID                                          Name                   Status    Res
 > **Note**
 > - `Profile` should be `bz2e-2x8`.
 > - `Image` should be match `<image-name>` from the previous step.
+- Verify the Secure Execution feature is enabled inside the container.
+```bash
+$ kubectl exec nginx -- grep facilities /proc/cpuinfo | grep 158
+```
+> **Note** If the command displays any output, the CPU is compatible with Secure Execution.
+- Verify the kernel includes support for Secure Execution inside the container
+```bash
+$ kubectl exec nginx -- cat /sys/firmware/uv/prot_virt_guest
+```
+> **Note** If the command output is `1`, the kernel supports Secure Execution.

--- a/test/provisioner/provision_ibmcloud.go
+++ b/test/provisioner/provision_ibmcloud.go
@@ -883,7 +883,11 @@ func (p *IBMCloudProvisioner) UploadPodvm(imagePath string, ctx context.Context,
 
 	var osNames []string
 	if strings.EqualFold("s390x", IBMCloudProps.PodvmImageArch) {
-		osNames = []string{"ubuntu-20-04-s390x"}
+		if strings.Contains(IBMCloudProps.InstanceProfile, "e-") {
+			osNames = []string{"hyper-protect-1-0-s390x"}
+		} else {
+			osNames = []string{"ubuntu-20-04-s390x"}
+		}
 	} else {
 		osNames = []string{"ubuntu-20-04-amd64"}
 

--- a/test/provisioner/provision_ibmcloud.properties
+++ b/test/provisioner/provision_ibmcloud.properties
@@ -11,7 +11,7 @@ COS_SERVICE_URL="s3.jp-tok.cloud-object-storage.appdomain.cloud"
 # Resource list -> storage -> a cos service -> instances -> an cos service instance -> service credentials -> apikey
 COS_APIKEY="${MY_COS_SERVICE_APIKEY}"
 IS_SELF_MANAGED_CLUSTER="no"
-# bz2-2x8 | bx2-2x8
+# bz2-2x8 | bx2-2x8 | bz2e-2x8
 INSTANCE_PROFILE_NAME="bz2-2x8"
 # ibmcloud cs versions
 KUBE_VERSION="1.26.1"


### PR DESCRIPTION
- How to verify one container is SE enabled
- Use correct osName when create image base on se-podvm image

fixes: #959