### PR TITLE
peerpodconfig-ctrl: rename CAA_IMAGE env var

### DIFF
--- a/peerpodconfig-ctrl/config/manager/manager.yaml
+++ b/peerpodconfig-ctrl/config/manager/manager.yaml
@@ -61,7 +61,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: CAA_IMAGE
+        - name: RELATED_IMAGE_CAA
           value: "quay.io/confidential-containers/cloud-api-adaptor"
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/peerpodconfig-ctrl/controllers/peerpodconfig_controller.go
+++ b/peerpodconfig-ctrl/controllers/peerpodconfig_controller.go
@@ -45,7 +45,7 @@ import (
 
 const (
 	// Name of env var containing the cloud-api-adaptor image name
-	CloudApiAdaptorImageEnvName = "CAA_IMAGE"
+	CloudApiAdaptorImageEnvName = "RELATED_IMAGE_CAA"
 	DefaultCloudApiAdaptorImage = "quay.io/confidential-containers/cloud-api-adaptor"
 	defaultNodeSelectorLabel    = "node-role.kubernetes.io/worker"
 )


### PR DESCRIPTION
rename it to RELATED_IMAGE_ENV_VAR so that we can include it as a related image in the CSV and by that enable automatic digest pinning in tools like OSBS
(https://osbs.readthedocs.io/en/latest/users.html#creating-the-relatedimages-section)

Fixes: https://github.com/confidential-containers/cloud-api-adaptor/issues/962