### PR TITLE
azure-packer: Allow user to use local credentials

### DIFF
--- a/azure/image/centos/azure-centos.pkr.hcl
+++ b/azure/image/centos/azure-centos.pkr.hcl
@@ -6,10 +6,11 @@ source "azure-arm" "centos" {
     plan_publisher = "${var.plan_publisher}"
   }
 
-  client_id       = "${var.client_id}"
-  client_secret   = "${var.client_secret}"
-  subscription_id = "${var.subscription_id}"
-  tenant_id       = "${var.tenant_id}"
+  use_azure_cli_auth = "${var.use_azure_cli_auth}"
+  client_id          = "${var.client_id}"
+  client_secret      = "${var.client_secret}"
+  subscription_id    = "${var.subscription_id}"
+  tenant_id          = "${var.tenant_id}"
 
   vm_size                           = "${var.vm_size}"
   os_type                           = "Linux"
@@ -61,8 +62,8 @@ build {
     ]
   }
 
-# relabel copied files right after copy-files.sh
-# to prevent other commands from failing
+  # relabel copied files right after copy-files.sh
+  # to prevent other commands from failing
   provisioner "file" {
     source      = "selinux_relabel.sh"
     destination = "~/selinux_relabel.sh"
@@ -83,9 +84,9 @@ build {
   provisioner "shell" {
     remote_folder = "~"
     environment_vars = [
-        "CLOUD_PROVIDER=${var.cloud_provider}",
-        "PODVM_DISTRO=${var.podvm_distro}",
-        ]
+      "CLOUD_PROVIDER=${var.cloud_provider}",
+      "PODVM_DISTRO=${var.podvm_distro}",
+    ]
     inline = [
       "sudo -E bash ~/misc-settings.sh"
     ]

--- a/azure/image/centos/variables.pkr.hcl
+++ b/azure/image/centos/variables.pkr.hcl
@@ -19,19 +19,28 @@ variable "resource_group" {
 }
 
 variable "client_id" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "client_secret" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "subscription_id" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "tenant_id" {
-  type = string
+  type    = string
+  default = ""
+}
+
+variable "use_azure_cli_auth" {
+  type    = bool
+  default = false
 }
 
 variable "ssh_username" {

--- a/azure/image/rhel/azure-rhel.pkr.hcl
+++ b/azure/image/rhel/azure-rhel.pkr.hcl
@@ -6,10 +6,11 @@ source "azure-arm" "rhel" {
     plan_publisher = "${var.plan_publisher}"
   }
 
-  client_id       = "${var.client_id}"
-  client_secret   = "${var.client_secret}"
-  subscription_id = "${var.subscription_id}"
-  tenant_id       = "${var.tenant_id}"
+  use_azure_cli_auth = "${var.use_azure_cli_auth}"
+  client_id          = "${var.client_id}"
+  client_secret      = "${var.client_secret}"
+  subscription_id    = "${var.subscription_id}"
+  tenant_id          = "${var.tenant_id}"
 
   vm_size                           = "${var.vm_size}"
   os_type                           = "Linux"
@@ -61,8 +62,8 @@ build {
     ]
   }
 
-# relabel copied files right after copy-files.sh
-# to prevent other commands from failing
+  # relabel copied files right after copy-files.sh
+  # to prevent other commands from failing
   provisioner "file" {
     source      = "selinux_relabel.sh"
     destination = "~/selinux_relabel.sh"
@@ -83,9 +84,9 @@ build {
   provisioner "shell" {
     remote_folder = "~"
     environment_vars = [
-        "CLOUD_PROVIDER=${var.cloud_provider}",
-        "PODVM_DISTRO=${var.podvm_distro}",
-        ]
+      "CLOUD_PROVIDER=${var.cloud_provider}",
+      "PODVM_DISTRO=${var.podvm_distro}",
+    ]
     inline = [
       "sudo -E bash ~/misc-settings.sh"
     ]

--- a/azure/image/rhel/variables.pkr.hcl
+++ b/azure/image/rhel/variables.pkr.hcl
@@ -19,19 +19,28 @@ variable "resource_group" {
 }
 
 variable "client_id" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "client_secret" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "subscription_id" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "tenant_id" {
-  type = string
+  type    = string
+  default = ""
+}
+
+variable "use_azure_cli_auth" {
+  type    = bool
+  default = false
 }
 
 variable "ssh_username" {

--- a/azure/image/ubuntu/azure-ubuntu.pkr.hcl
+++ b/azure/image/ubuntu/azure-ubuntu.pkr.hcl
@@ -1,8 +1,9 @@
 source "azure-arm" "ubuntu" {
-  client_id       = "${var.client_id}"
-  client_secret   = "${var.client_secret}"
-  subscription_id = "${var.subscription_id}"
-  tenant_id       = "${var.tenant_id}"
+  use_azure_cli_auth = "${var.use_azure_cli_auth}"
+  client_id          = "${var.client_id}"
+  client_secret      = "${var.client_secret}"
+  subscription_id    = "${var.subscription_id}"
+  tenant_id          = "${var.tenant_id}"
 
   vm_size                           = "${var.vm_size}"
   os_type                           = "Linux"

--- a/azure/image/ubuntu/variables.pkr.hcl
+++ b/azure/image/ubuntu/variables.pkr.hcl
@@ -37,19 +37,28 @@ variable "resource_group" {
 }
 
 variable "client_id" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "client_secret" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "subscription_id" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "tenant_id" {
-  type = string
+  type    = string
+  default = ""
+}
+
+variable "use_azure_cli_auth" {
+  type    = bool
+  default = false
 }
 
 variable "ssh_username" {


### PR DESCRIPTION
Fixes: #972

---

## Testing Done

Follow all the steps before https://github.com/confidential-containers/cloud-api-adaptor/tree/staging/azure#build-pod-vm-image.

- Test the feature in this PR:

```bash
az login

cd image
export PKR_VAR_use_azure_cli_auth=true
export PKR_VAR_resource_group="${AZURE_RESOURCE_GROUP}"
export PKR_VAR_subscription_id="${AZURE_SUBSCRIPTION_ID}"
export PKR_VAR_az_gallery_name="${GALLERY_NAME}"
export PKR_VAR_az_gallery_image_name="${GALLERY_IMAGE_DEF_NAME}"

export CLOUD_PROVIDER=azure
PODVM_DISTRO=ubuntu make image && cd -

```

- The default method should work as is:


```bash
az logout 

cd image
# This is the default value but if you have previous env var then it should be overridden.
export PKR_VAR_use_azure_cli_auth=false 
export PKR_VAR_resource_group="${AZURE_RESOURCE_GROUP}"
export PKR_VAR_subscription_id="${AZURE_SUBSCRIPTION_ID}"
export PKR_VAR_client_id="${AZURE_CLIENT_ID}"
export PKR_VAR_client_secret="${AZURE_CLIENT_SECRET}"
export PKR_VAR_tenant_id="${AZURE_TENANT_ID}"
export PKR_VAR_az_gallery_name="${GALLERY_NAME}"
export PKR_VAR_az_gallery_image_name="${GALLERY_IMAGE_DEF_NAME}"
export PKR_VAR_az_image_name="newimg"
export PKR_VAR_az_gallery_image_version=0.0.2

export CLOUD_PROVIDER=azure
PODVM_DISTRO=ubuntu make image && cd -
```