### PR TITLE
podvm: Disable VNC of Packer QEMU Builder

### DIFF
--- a/podvm/Makefile
+++ b/podvm/Makefile
@@ -26,7 +26,7 @@ UEFI_FIRMWARE_LOCATION ?=
 SE_BOOT ?= 0
 
 # Env variable for default qemu builder options across distros/arch
-PACKER_DEFAULT_OPTS ?= -var boot_wait=300s
+PACKER_DEFAULT_OPTS ?=
 
 image: $(IMAGE_FILE)
 
@@ -37,9 +37,6 @@ ifeq ($(PODVM_DISTRO),ubuntu)
 	-var cloud_image_url=${UBUNTU_IMAGE_URL} \
 	-var cloud_image_checksum=${UBUNTU_IMAGE_CHECKSUM} \
 	-var se_boot=${SE_BOOT})
-ifeq ($(ARCH),s390x)
-	$(eval PACKER_DEFAULT_OPTS = -var boot_wait=600s )
-endif
 ifneq ($(HOST_ARCH),$(ARCH))
 	$(eval OPTS += -var machine_type=${QEMU_MACHINE_TYPE_${ARCH}})
 ifndef QEMU_BINARY

--- a/podvm/qcow2/centos/qemu-centos.pkr.hcl
+++ b/podvm/qcow2/centos/qemu-centos.pkr.hcl
@@ -5,7 +5,7 @@ locals {
 }
 
 source "qemu" "centos" {
-  boot_command      = ["<enter>"]
+  disable_vnc       = true
   disk_compression  = true
   disk_image        = true
   disk_size         = "${var.disk_size}"
@@ -18,7 +18,7 @@ source "qemu" "centos" {
   ssh_password      = "${var.ssh_password}"
   ssh_port          = 22
   ssh_username      = "${var.ssh_username}"
-  ssh_wait_timeout  = "300s"
+  ssh_timeout       = "${var.ssh_timeout}"
   boot_wait         = "${var.boot_wait}"
   vm_name           = "${var.qemu_image_name}"
   shutdown_command  = "sudo shutdown -h now"

--- a/podvm/qcow2/centos/variables.pkr.hcl
+++ b/podvm/qcow2/centos/variables.pkr.hcl
@@ -44,6 +44,11 @@ variable "ssh_username" {
   default = "peerpod"
 }
 
+variable "ssh_timeout" {
+  type = string
+  default = "15m"
+}
+
 variable "qemu_image_name" {
   type    = string
   default = "peer-pod"

--- a/podvm/qcow2/rhel/qemu-rhel.pkr.hcl
+++ b/podvm/qcow2/rhel/qemu-rhel.pkr.hcl
@@ -5,7 +5,7 @@ locals {
 }
 
 source "qemu" "rhel" {
-  boot_command      = ["<enter>"]
+  disable_vnc       = true
   disk_compression  = true
   disk_image        = true
   disk_size         = "${var.disk_size}"
@@ -18,7 +18,7 @@ source "qemu" "rhel" {
   ssh_password      = "${var.ssh_password}"
   ssh_port          = 22
   ssh_username      = "${var.ssh_username}"
-  ssh_wait_timeout  = "300s"
+  ssh_timeout       = "${var.ssh_timeout}"
   boot_wait         = "${var.boot_wait}"
   vm_name           = "${var.qemu_image_name}"
   shutdown_command  = "sudo shutdown -h now"

--- a/podvm/qcow2/rhel/variables.pkr.hcl
+++ b/podvm/qcow2/rhel/variables.pkr.hcl
@@ -43,6 +43,11 @@ variable "ssh_username" {
   default = "peerpod"
 }
 
+variable "ssh_timeout" {
+  type = string
+  default = "15m"
+}
+
 variable "qemu_image_name" {
   type    = string
   default = "peer-pod"

--- a/podvm/qcow2/ubuntu/qemu-ubuntu.pkr.hcl
+++ b/podvm/qcow2/ubuntu/qemu-ubuntu.pkr.hcl
@@ -29,7 +29,7 @@ locals {
 }
 
 source "qemu" "ubuntu" {
-  boot_command     = ["<enter>"]
+  disable_vnc      = true
   disk_compression = true
   disk_image       = true
   disk_size        = "${var.disk_size}"
@@ -42,7 +42,7 @@ source "qemu" "ubuntu" {
   ssh_password     = "${var.ssh_password}"
   ssh_port         = 22
   ssh_username     = "${var.ssh_username}"
-  ssh_wait_timeout = "300s"
+  ssh_timeout      = "${var.ssh_timeout}"
   boot_wait        = "${var.boot_wait}"
   vm_name          = "${var.qemu_image_name}"
   shutdown_command = "sudo shutdown -h now"

--- a/podvm/qcow2/ubuntu/variables.pkr.hcl
+++ b/podvm/qcow2/ubuntu/variables.pkr.hcl
@@ -43,6 +43,11 @@ variable "ssh_username" {
   default = "peerpod"
 }
 
+variable "ssh_timeout" {
+  type = string
+  default = "15m"
+}
+
 variable "qemu_image_name" {
   type    = string
   default = "peer-pod"


### PR DESCRIPTION
Currently, the `boot_wait` option is specified to packer. This option is necessary, because `boot_command` is specified and sent to the started VM via VNC. We are using public cloud VM images, and we do not need to send boot commands via VNC to start up VM.

This patch removes the `boot_command` option, and adds the `disable_vnc` option. This change makes `packer` wait using SSH instead of VNC for VM startup.

Fixes #981

The `ssh_wait_timeout` option is deprecated, and the `ssh_timeout` option is used instead.
https://github.com/hashicorp/packer-plugin-sdk/blob/8331daf9a68be731b67b59621179cd3909458986/communicator/config.go#L125-L131

`packer` proceeds to the next step, immediately after  it successfully connects to a started VM via SSH, so we can specify a large enough value to the `ssh_timeout` option.
https://github.com/hashicorp/packer-plugin-sdk/blob/8331daf9a68be731b67b59621179cd3909458986/communicator/step_connect_ssh.go#L45-L87



