### PR TITLE
ci: increase golangci-lint timeout

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,7 +9,7 @@ run:
 
   # Timeout for analysis, e.g. 30s, 5m.
   # Default: 1m
-  timeout: 5m
+  timeout: 10m
 
   # Exit code when at least one issue was found.
   # Default: 1


### PR DESCRIPTION
As the the check is currently failing from time to time due to timeout, increasing it to 10 minutes.

Fixes: #988