### PR TITLE
ibmcloud: Support Container Auth with IAM Profiles

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,6 +24,13 @@ test_vars() {
         [[ -n $EXT ]] && exit 1
 }
 
+one_of() {
+        for i in "$@"; do
+                [ -n "${!i}" ] && echo "\$$i is SET" && EXIST=1
+        done
+        [[ -z $EXIST ]] && echo "At least one of these must be SET: $@" && exit 1
+}
+
 aws() {
 test_vars AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
 
@@ -63,7 +70,7 @@ exec cloud-api-adaptor azure \
 }
 
 ibmcloud() {
-test_vars IBMCLOUD_API_KEY
+one_of IBMCLOUD_API_KEY IBMCLOUD_IAM_PROFILE_ID
 
 set -x
 exec cloud-api-adaptor ibmcloud \

--- a/install/overlays/ibmcloud/cr_token_projection.yaml
+++ b/install/overlays/ibmcloud/cr_token_projection.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cloud-api-adaptor-daemonset
+  namespace: confidential-containers-system
+  labels:
+    app: cloud-api-adaptor
+spec:
+  template:
+    spec:
+      containers:
+      - name: cloud-api-adaptor-con
+        volumeMounts:
+        - mountPath: /var/run/secrets/tokens
+          name: vault-token
+      volumes:
+        - name: vault-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: vault-token
+                expirationSeconds: 3600
+                audience: iam

--- a/install/overlays/ibmcloud/kustomization.yaml
+++ b/install/overlays/ibmcloud/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-- ../../yamls
+resources:
+  - ../../yamls
 
 images:
 - name: cloud-api-adaptor
@@ -44,7 +44,10 @@ secretGenerator:
 - name: peer-pods-secret
   namespace: confidential-containers-system
   literals:
-  - IBMCLOUD_API_KEY="" # set
+##IAM PROFILE SETTINGS
+# - IBMCLOUD_IAM_PROFILE_ID="" # set
+##/IAM PROFILE SETTINGS
+  - IBMCLOUD_API_KEY="" # set if not using IAM profile ID
   - IBMCLOUD_IAM_ENDPOINT="" #set
   - IBMCLOUD_ZONE="" #set
 ##TLS_SETTINGS
@@ -56,8 +59,11 @@ secretGenerator:
 #  - <path_to_client.key> # set - path to client.key
 ##TLS_SETTINGS
 
-patchesStrategicMerge:
-  - cri_runtime_endpoint.yaml # set (modify host's runtime cri socket path in the file, default is /run/containerd/containerd.sock)
+patches:
+  - path: cri_runtime_endpoint.yaml # set (modify host's runtime cri socket path in the file, default is /run/containerd/containerd.sock)
+##IAM PROFILE SETTINGS
+# - path: cr_token_projection.yaml
+##/IAM PROFILE SETTINGS
 ##TLS_SETTINGS
-  #- tls_certs_volume_mount.yaml # set (for tls)
+# - path: tls_certs_volume_mount.yaml # set (for tls)
 ##TLS_SETTINGS

--- a/pkg/adaptor/cloud/ibmcloud/manager.go
+++ b/pkg/adaptor/cloud/ibmcloud/manager.go
@@ -13,9 +13,11 @@ var ibmcloudVPCConfig Config
 
 type Manager struct{}
 
-func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
+func (*Manager) ParseCmd(flags *flag.FlagSet) {
 
 	flags.StringVar(&ibmcloudVPCConfig.ApiKey, "api-key", "", "IBM Cloud API key, defaults to `IBMCLOUD_API_KEY`")
+	flags.StringVar(&ibmcloudVPCConfig.IAMProfileID, "iam-profile-id", "", "IBM IAM Profile ID, defaults to `IBMCLOUD_IAM_PROFILE_ID`")
+	flags.StringVar(&ibmcloudVPCConfig.CRTokenFileName, "cr-token-filename", "/var/run/secrets/tokens/vault-token", "Projected service account token")
 	flags.StringVar(&ibmcloudVPCConfig.IamServiceURL, "iam-service-url", "https://iam.cloud.ibm.com/identity/token", "IBM Cloud IAM Service URL")
 	flags.StringVar(&ibmcloudVPCConfig.VpcServiceURL, "vpc-service-url", "https://jp-tok.iaas.cloud.ibm.com/v1", "IBM Cloud VPC Service URL")
 	flags.StringVar(&ibmcloudVPCConfig.ResourceGroupID, "resource-group-id", "", "Resource Group ID")
@@ -31,10 +33,11 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 
 }
 
-func (_ *Manager) LoadEnv() {
+func (*Manager) LoadEnv() {
 	cloud.DefaultToEnv(&ibmcloudVPCConfig.ApiKey, "IBMCLOUD_API_KEY", "")
+	cloud.DefaultToEnv(&ibmcloudVPCConfig.IAMProfileID, "IBMCLOUD_IAM_PROFILE_ID", "")
 }
 
-func (_ *Manager) NewProvider() (cloud.Provider, error) {
+func (*Manager) NewProvider() (cloud.Provider, error) {
 	return NewProvider(&ibmcloudVPCConfig)
 }

--- a/pkg/adaptor/cloud/ibmcloud/types.go
+++ b/pkg/adaptor/cloud/ibmcloud/types.go
@@ -7,6 +7,8 @@ import "github.com/confidential-containers/cloud-api-adaptor/pkg/util"
 
 type Config struct {
 	ApiKey                   string
+	IAMProfileID             string
+	CRTokenFileName          string
 	IamServiceURL            string
 	VpcServiceURL            string
 	ResourceGroupID          string


### PR DESCRIPTION
Remove the need to pass around apikeys when deploying to an IKS cluster by using a [Trusted Profile ](https://www.ibm.com/cloud/blog/introducing-trusted-profiles-for-kubernetes-service-accounts?mhsrc=ibmsearch_a&mhq=trusted%20IAM) in IBM Cloud.

To test this you will need to create a [Trusted Profile](https://cloud.ibm.com/iam/trusted-profiles) in cloud.ibm. This must have the VPC access required to create the peer pod vsi. And you can limit it to the cloud-api-adaptor pod in various ways. I just used the namespace condition for testing.

When setting up the kustomizations, uncomment the IAM PROFILE ID sections (including the patch to mount the volume), and don't set the APIKEY.