### PR TITLE
Azure: Default to docker based podvm image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,14 +4,6 @@ cloud-api-adaptor
 cluster-provisioner
 kata-agent
 
-aws/
-docs/
-install/
-ibmcloud/
-libvirt/
-peerpod-ctrl/
-peerpodconfig-ctrl/
-volumes/
 webwook/
 
 **/*.qcow2

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,17 +5,14 @@ cluster-provisioner
 kata-agent
 
 aws/
-azure/
 docs/
 install/
 ibmcloud/
 libvirt/
 peerpod-ctrl/
 peerpodconfig-ctrl/
-podvm/
 volumes/
 webwook/
 
-.git*
 **/*.qcow2
 **/*.img

--- a/azure/image/.gitignore
+++ b/azure/image/.gitignore
@@ -2,3 +2,4 @@ agent-protocol-forwarder
 kata-agent
 skopeo
 umoci
+*/variables.pkrvars.hcl

--- a/azure/image/Dockerfile
+++ b/azure/image/Dockerfile
@@ -33,4 +33,4 @@ RUN tar xvf /src/cloud-api-adaptor/podvm/files/podvm-binaries.tar.gz -C /src/clo
     rm /src/cloud-api-adaptor/podvm/files/pause-bundle.tar.gz
 
 RUN cd /src/cloud-api-adaptor/azure/image && \
-    BINARIES= PAUSE_BUNDLE= CLOUD_PROVIDER=azure PODVM_DISTRO=$PODVM_DISTRO make image
+    BINARIES= PAUSE_BUNDLE= CLOUD_PROVIDER=azure PODVM_DISTRO=$PODVM_DISTRO make image-build-in-docker

--- a/azure/image/Dockerfile
+++ b/azure/image/Dockerfile
@@ -15,21 +15,14 @@ ARG CLOUD_PROVIDER=azure
 ARG PODVM_DISTRO=ubuntu
 # If not provided, uses system architecture
 ARG ARCH=x86_64
-ARG CAA_SRC=""
-ARG CAA_SRC_REF=""
 
 ENV CLOUD_PROVIDER ${CLOUD_PROVIDER}
 ENV PODVM_DISTRO ${PODVM_DISTRO}
 
-RUN if [ -n "${CAA_SRC}" ]; then \
-      rm -rf cloud-api-adaptor && \
-      git clone ${CAA_SRC} cloud-api-adaptor;\
-    fi && \
-    if [ -n "${CAA_SRC_REF}" ]; then \
-      cd cloud-api-adaptor && \
-      git fetch origin ${CAA_SRC_REF} && \
-      git checkout FETCH_HEAD -b ${CAA_SRC_REF} ;\
-    fi
+# Copy the local source code of cloud api adaptor.
+RUN rm -rf /src/cloud-api-adaptor
+COPY . /src/cloud-api-adaptor
+RUN mkdir -p /src/cloud-api-adaptor/podvm/files
 
 # Copy the binaries to podvm/files folder
 COPY --from=podvm_binaries /podvm-binaries.tar.gz /src/cloud-api-adaptor/podvm/files

--- a/azure/image/Dockerfile
+++ b/azure/image/Dockerfile
@@ -11,13 +11,11 @@ ARG BINARIES_IMG="quay.io/confidential-containers/podvm-binaries-ubuntu-amd64"
 FROM ${BINARIES_IMG} AS podvm_binaries
 FROM ${BUILDER_IMG} AS podvm_builder
 
-ARG CLOUD_PROVIDER=azure
 ARG PODVM_DISTRO=ubuntu
+ENV PODVM_DISTRO ${PODVM_DISTRO}
+
 # If not provided, uses system architecture
 ARG ARCH=x86_64
-
-ENV CLOUD_PROVIDER ${CLOUD_PROVIDER}
-ENV PODVM_DISTRO ${PODVM_DISTRO}
 
 # Copy the local source code of cloud api adaptor.
 RUN rm -rf /src/cloud-api-adaptor
@@ -26,60 +24,13 @@ RUN mkdir -p /src/cloud-api-adaptor/podvm/files
 
 # Copy the binaries to podvm/files folder
 COPY --from=podvm_binaries /podvm-binaries.tar.gz /src/cloud-api-adaptor/podvm/files
-RUN tar xvf /src/cloud-api-adaptor/podvm/files/podvm-binaries.tar.gz -C /src/cloud-api-adaptor/podvm/files
+COPY --from=podvm_binaries /pause-bundle.tar.gz /src/cloud-api-adaptor/podvm/files
 
 # Copy the pause_bundle to podvm/files folder
-COPY --from=podvm_binaries /pause-bundle.tar.gz /src/cloud-api-adaptor/podvm/files
-RUN tar xvf /src/cloud-api-adaptor/podvm/files/pause-bundle.tar.gz -C /src/cloud-api-adaptor/podvm/files
+RUN tar xvf /src/cloud-api-adaptor/podvm/files/podvm-binaries.tar.gz -C /src/cloud-api-adaptor/podvm/files && \
+    rm /src/cloud-api-adaptor/podvm/files/podvm-binaries.tar.gz && \
+    tar xvf /src/cloud-api-adaptor/podvm/files/pause-bundle.tar.gz -C /src/cloud-api-adaptor/podvm/files && \
+    rm /src/cloud-api-adaptor/podvm/files/pause-bundle.tar.gz
 
-ARG VM_SIZE=Standard_D2as_v5
-ARG AZURE_RESOURCE_GROUP
-ARG IMAGE_NAME=peer-pod-vmimage
-ARG GALLERY_NAME=caaubntcvmsGallery
-ARG GALLERY_IMAGE_DEF_NAME=cc-image
-ARG SSH_USERNAME=peerpod
-ARG PUBLISHER=Canonical
-ARG OFFER=0001-com-ubuntu-confidential-vm-jammy
-ARG SKU=22_04-lts-cvm
-ARG PLAN_NAME
-ARG PLAN_PRODUCT
-ARG PLAN_PUBLISHER
-
-ENV AZURE_RESOURCE_GROUP ${AZURE_RESOURCE_GROUP}
-ENV VM_SIZE ${VM_SIZE}
-ENV IMAGE_NAME ${IMAGE_NAME}
-ENV GALLERY_NAME ${GALLERY_NAME}
-ENV GALLERY_IMAGE_DEF_NAME ${GALLERY_IMAGE_DEF_NAME}
-ENV PUBLISHER ${PUBLISHER}
-ENV OFFER ${OFFER}
-ENV SKU ${SKU}
-ENV PLAN_NAME ${PLAN_NAME}
-ENV PLAN_PRODUCT ${PLAN_PRODUCT}
-ENV PLAN_PUBLISHER ${PLAN_PUBLISHER}
-
-RUN --mount=type=secret,id=AZURE_SUBSCRIPTION_ID \
-    --mount=type=secret,id=AZURE_CLIENT_ID \
-    --mount=type=secret,id=AZURE_CLIENT_SECRET \
-    --mount=type=secret,id=AZURE_TENANT_ID \
-    export AZURE_SUBSCRIPTION_ID=$(cat /run/secrets/AZURE_SUBSCRIPTION_ID) && \
-    export AZURE_CLIENT_ID=$(cat /run/secrets/AZURE_CLIENT_ID) && \
-    export AZURE_CLIENT_SECRET=$(cat /run/secrets/AZURE_CLIENT_SECRET) && \
-    export AZURE_TENANT_ID=$(cat /run/secrets/AZURE_TENANT_ID) && \
-    export PKR_VAR_client_id=${AZURE_CLIENT_ID} && \
-    export PKR_VAR_client_secret=${AZURE_CLIENT_SECRET} && \
-    export PKR_VAR_subscription_id=${AZURE_SUBSCRIPTION_ID} && \
-    export PKR_VAR_tenant_id=${AZURE_TENANT_ID} && \
-    export PKR_VAR_resource_group=${AZURE_RESOURCE_GROUP} && \
-    export PKR_VAR_az_image_name=${IMAGE_NAME} && \
-    export PKR_VAR_az_gallery_name=${GALLERY_NAME} && \
-    export PKR_VAR_az_gallery_image_name=${GALLERY_IMAGE_DEF_NAME} && \
-    export PKR_VAR_vm_size=${VM_SIZE} && \
-    export PKR_VAR_ssh_username=${SSH_USERNAME} && \
-    export PKR_VAR_publisher=${PUBLISHER} && \
-    export PKR_VAR_offer=${OFFER} && \
-    export PKR_VAR_sku=${SKU} && \
-    export PKR_VAR_plan_name=${PLAN_NAME} && \
-    export PKR_VAR_plan_product=${PLAN_PRODUCT} && \
-    export PKR_VAR_plan_publisher=${PLAN_PUBLISHER} && \
-    cd cloud-api-adaptor/azure/image && \
+RUN cd /src/cloud-api-adaptor/azure/image && \
     BINARIES= PAUSE_BUNDLE= CLOUD_PROVIDER=azure PODVM_DISTRO=$PODVM_DISTRO make image

--- a/azure/image/Makefile
+++ b/azure/image/Makefile
@@ -10,19 +10,6 @@ image: $(IMAGE_FILE)
 
 $(IMAGE_FILE): $(BINARIES) $(FILES)
 	mkdir -p toupload
-	# export the required packer variables as PKR_VAR_<var_name>
-	# export PKR_VAR_client_id="${AZURE_CLIENT_ID}"
-	# export PKR_VAR_client_secret="${AZURE_CLIENT_SECRET:%=REDACTED}"
-	# export PKR_VAR_subscription_id="${AZURE_SUBSCRIPTION_ID}"
-	# export PKR_VAR_tenant_id="${AZURE_TENANT_ID}"
-	# export PKR_VAR_resource_group="${AZURE_RESOURCE_GROUP}"
-	# export PKR_VAR_az_image_name="${IMAGE_NAME}"
-	# export PKR_VAR_vm_size="${VM_SIZE}"
-	# export PKR_VAR_ssh_username="${SSH_USERNAME}"
-	# export PKR_VAR_az_gallery_name="${GALLERY_NAME}"
-	# export PKR_VAR_az_gallery_image_name="${GALLERY_IMAGE_NAME}"
-	# export PKR_VAR_az_gallery_image_version="${GALLERY_IMAGE_VERSION}"
-
 	packer build ./${PODVM_DISTRO}/
 	rm -fr toupload
 

--- a/azure/image/Makefile
+++ b/azure/image/Makefile
@@ -8,9 +8,14 @@ include ../../podvm/Makefile.inc
 
 image: $(IMAGE_FILE)
 
-$(IMAGE_FILE): $(BINARIES) $(FILES)
+$(IMAGE_FILE): $(BINARIES) $(FILES) packer-build
+
+# When doing a packer build we already have dependencies built. We don't need to build things like kata-agent, etc.
+image-build-in-docker: packer-build
+
+packer-build:
 	mkdir -p toupload
-	packer build ./${PODVM_DISTRO}/
+	packer build -var-file=./${PODVM_DISTRO}/variables.pkrvars.hcl ./${PODVM_DISTRO}/
 	rm -fr toupload
 
 clean:

--- a/azure/image/centos/variables.pkrvars.hcl.example
+++ b/azure/image/centos/variables.pkrvars.hcl.example
@@ -1,0 +1,24 @@
+resource_group        = "${AZURE_RESOURCE_GROUP}"
+subscription_id       = "${AZURE_SUBSCRIPTION_ID}"
+az_gallery_name       = "${GALLERY_NAME}"
+az_gallery_image_name = "${GALLERY_IMAGE_DEF_NAME}"
+podvm_distro          = "${PODVM_DISTRO}"
+
+# If you set this true then don't provide client_id, client_secret & tenant_id.
+# use_azure_cli_auth  = "false"
+client_id             = "${AZURE_CLIENT_ID}"
+client_secret         = "${AZURE_CLIENT_SECRET}"
+tenant_id             = "${AZURE_TENANT_ID}"
+
+# az_gallery_image_version = "0.0.1"
+# az_image_name            = "peer-pod-vmimage"
+# # We cannot use the confidential machine type while building the image because packer fails with the following error:
+# # The VM size 'Standard_DC2as_v5' is not supported for creation of VMs and Virtual Machine Scale Set with 'NULL' security type.
+# vm_size                  = "Standard_D2as_v5"
+# ssh_username             = "peerpod"
+# publisher                = ""
+# offer                    = ""
+# sku                      = ""
+# plan_name                = ""
+# plan_product             = ""
+# plan_publisher           = ""

--- a/azure/image/rhel/variables.pkrvars.hcl.example
+++ b/azure/image/rhel/variables.pkrvars.hcl.example
@@ -1,0 +1,18 @@
+resource_group        = "${AZURE_RESOURCE_GROUP}"
+subscription_id       = "${AZURE_SUBSCRIPTION_ID}"
+az_gallery_name       = "${GALLERY_NAME}"
+az_gallery_image_name = "${GALLERY_IMAGE_DEF_NAME}"
+podvm_distro          = "${PODVM_DISTRO}"
+
+# If you set this true then don't provide client_id, client_secret & tenant_id.
+# use_azure_cli_auth  = "false"
+client_id             = "${AZURE_CLIENT_ID}"
+client_secret         = "${AZURE_CLIENT_SECRET}"
+tenant_id             = "${AZURE_TENANT_ID}"
+
+# az_gallery_image_version = "0.0.1"
+# az_image_name            = "peer-pod-vmimage"
+# # We cannot use the confidential machine type while building the image because packer fails with the following error:
+# # The VM size 'Standard_DC2as_v5' is not supported for creation of VMs and Virtual Machine Scale Set with 'NULL' security type.
+# vm_size                  = "Standard_D2as_v5"
+# ssh_username             = "peerpod"

--- a/azure/image/ubuntu/variables.pkrvars.hcl.example
+++ b/azure/image/ubuntu/variables.pkrvars.hcl.example
@@ -1,0 +1,18 @@
+resource_group        = "${AZURE_RESOURCE_GROUP}"
+subscription_id       = "${AZURE_SUBSCRIPTION_ID}"
+az_gallery_name       = "${GALLERY_NAME}"
+az_gallery_image_name = "${GALLERY_IMAGE_DEF_NAME}"
+podvm_distro          = "${PODVM_DISTRO}"
+
+# If you set this true then don't provide client_id, client_secret & tenant_id.
+# use_azure_cli_auth  = "false"
+client_id             = "${AZURE_CLIENT_ID}"
+client_secret         = "${AZURE_CLIENT_SECRET}"
+tenant_id             = "${AZURE_TENANT_ID}"
+
+# az_gallery_image_version = "0.0.1"
+# az_image_name            = "peer-pod-vmimage"
+# # We cannot use the confidential machine type while building the image because packer fails with the following error:
+# # The VM size 'Standard_DC2as_v5' is not supported for creation of VMs and Virtual Machine Scale Set with 'NULL' security type.
+# vm_size                  = "Standard_D2as_v5"
+# ssh_username             = "peerpod"


### PR DESCRIPTION
- Remove the need to use packer locally.
- Create three sections of image build for each distro viz. Ubuntu,
  Centos and RHEL.
- Use packer variables file instead of convoluted environment variables
  passing from local environment to docker environment to packer.
- Add a new target in the `azure/image/Makefile` to skip building
  dependencies like kata-agent, etc. and rely on the dependencies
  present in the builder and binaries images.
- Add support to build the local CAA code.
- Add defaults to the RHEL and CentOS packer-variable files for
  publisher, offer and sku.
- Remove the relative path of the `toupload` directory from the
  respective packer configs.

  Fixes: #987