### PR TITLE
add e2e test case to verify SE pod vm

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -56,6 +56,10 @@ func newNginxPod(namespace string) *corev1.Pod {
 	return newPod(namespace, "nginx", "nginx", "nginx", withRestartPolicy(corev1.RestartPolicyNever))
 }
 
+func newNginxPodWithName(namespace string, podName string) *corev1.Pod {
+	return newPod(namespace, podName, "nginx", "nginx", withRestartPolicy(corev1.RestartPolicyNever))
+}
+
 func newBusyboxPod(namespace string) *corev1.Pod {
 	return newPod(namespace, "busybox-pod", "busybox", "quay.io/prometheus/busybox:latest", withCommand([]string{"/bin/sh", "-c", "sleep 3600"}))
 }

--- a/test/e2e/common_suite_test.go
+++ b/test/e2e/common_suite_test.go
@@ -259,3 +259,13 @@ func doTestCreatePeerPodContainerWithExternalIPAccess(t *testing.T, assert Cloud
 
 	newTestCase(t, assert, "Peer Pod Container Connected to External IP", pod).withTestCommands(testCommands).run()
 }
+
+// doTestCreateConfidentialPod verify a confidential peer-pod can be created.
+func doTestCreateConfidentialPod(t *testing.T, assert CloudAssert, testCommands []testCommand) {
+	namespace := envconf.RandomName("default", 7)
+	pod := newNginxPodWithName(namespace, "confidential-pod-nginx")
+	for i := 0; i < len(testCommands); i++ {
+		testCommands[i].containerName = pod.Spec.Containers[0].Name
+	}
+	newTestCase(t, assert, "Confidential PodVM is created", pod).withTestCommands(testCommands).run()
+}


### PR DESCRIPTION
- This added a test case to create SE pod VM in ibmcloud and verify it's SE pod instead of simple pod.

fixes: https://github.com/confidential-containers/cloud-api-adaptor/issues/1014

Signed-off-by: yuanyuanwang <wyuany@cn.ibm.com>