### PR TITLE
doc: Fix typo

### DIFF
--- a/test/tools/README.md
+++ b/test/tools/README.md
@@ -27,7 +27,7 @@ export CLOUD_PROVIDER=${CLOUD_PROVIDER}
 export TEST_PROVISION_FILE=${PROPERTIES_FILE_PATH}
 export TEST_PROVISION="yes"
 export INSTALL_DIR="../../install"
-./caa-provisioner-cli -actions=${ACTION}
+./caa-provisioner-cli -action=${ACTION}
 ```
 `ACTION` supports `provision`, `deprovision`, `install`, `uninstall` and `uploadimage`.
 


### PR DESCRIPTION
- Swap `actions`, for `action` to match the code

Fixes: #1033