### PR TITLE
ibmcloud: e2e Test cases for ibmcloud to check Peer Pod Logs Working Directory from container

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -42,7 +42,7 @@ func newPod(namespace string, podName string, containerName string, imageName st
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: namespace},
 		Spec: corev1.PodSpec{
-			Containers:       []corev1.Container{{Name: containerName, Image: imageName}},
+			Containers:       []corev1.Container{{Name: containerName, Image: imageName, ImagePullPolicy: corev1.PullAlways}},
 			RuntimeClassName: &runtimeClassName,
 		},
 	}

--- a/test/e2e/common_suite_test.go
+++ b/test/e2e/common_suite_test.go
@@ -481,5 +481,15 @@ func doTestCreateConfidentialPod(t *testing.T, assert CloudAssert, testCommands 
 	for i := 0; i < len(testCommands); i++ {
 		testCommands[i].containerName = pod.Spec.Containers[0].Name
 	}
+
 	newTestCase(t, "ConfidentialPodVM", assert, "Confidential PodVM is created").withPod(pod).withTestCommands(testCommands).run()
+}
+
+func doTestCreatePeerPodAndCheckWorkDirLogs(t *testing.T, assert CloudAssert) {
+	namespace := envconf.RandomName("default", 7)
+	podName := "workdirpod"
+	imageName := "quay.io/confidential-containers/test-images:testworkdir"
+	pod := newPod(namespace, podName, podName, imageName, withRestartPolicy(v1.RestartPolicyNever))
+	expectedPodLogString := "/other"
+	newTestCase(t, "WorkDirPeerPod", assert, "Peer pod with work directory has been created").withPod(pod).withExpectedPodLogString(expectedPodLogString).withCustomPodState(v1.PodSucceeded).run()
 }

--- a/test/e2e/fixtures/Dockerfile.testworkdir
+++ b/test/e2e/fixtures/Dockerfile.testworkdir
@@ -1,0 +1,4 @@
+FROM --platform="${TARGETPLATFORM}" alpine:latest AS testworkdir
+RUN mkdir -p /other
+WORKDIR /other/
+ENTRYPOINT [ "/bin/sh", "-c", "pwd" ]

--- a/test/e2e/ibmcloud_test.go
+++ b/test/e2e/ibmcloud_test.go
@@ -99,6 +99,13 @@ func TestCreatePeerPodAndCheckUserLogs(t *testing.T) {
 	doTestCreatePeerPodAndCheckUserLogs(t, assert)
 }
 
+func TestCreatePeerPodAndCheckWorkDirLogs(t *testing.T) {
+	assert := IBMCloudAssert{
+		vpc: pv.IBMCloudProps.VPC,
+	}
+	doTestCreatePeerPodAndCheckWorkDirLogs(t, assert)
+}
+
 // IBMCloudAssert implements the CloudAssert interface for ibmcloud.
 type IBMCloudAssert struct {
 	vpc *vpcv1.VpcV1


### PR DESCRIPTION
Added test cases to check whether peer pod logs work directory while created using a custom dockerfile in ibmcloud cloud-provider

Fixes: #1045 
