### PR TITLE
libvirt: add LIBVIRT_VOL_NAME environment variable

### DIFF
--- a/install/overlays/libvirt/kustomization.yaml
+++ b/install/overlays/libvirt/kustomization.yaml
@@ -20,6 +20,7 @@ configMapGenerator:
   - LIBVIRT_URI="qemu+ssh://root@192.168.122.1/system?no_verify=1" #set
   - LIBVIRT_NET="default" # set
   - LIBVIRT_POOL="default" # set
+  #- LIBVIRT_VOL_NAME="" # Uncomment and set if you want to use a specific volume name. Defaults to podvm-base.qcow2
   #- PAUSE_IMAGE="" # Uncomment and set if you want to use a specific pause image
   #- VXLAN_PORT="" # Uncomment and set if you want to use a specific vxlan port. Defaults to 4789
 ##TLS_SETTINGS

--- a/pkg/adaptor/cloud/libvirt/libvirt.go
+++ b/pkg/adaptor/cloud/libvirt/libvirt.go
@@ -20,12 +20,6 @@ import (
 	libvirtxml "libvirt.org/go/libvirtxml"
 )
 
-// Create a base volume
-// Create qcow2 image with prerequisites
-// virsh vol-create-as --pool default --name podvm-base.qcow2 --capacity 107374182400 --allocation 2361393152 --prealloc-metadata --format qcow2
-// virsh vol-upload --vol podvm-base.qcow2 ./podvm.qcow2 --pool default --sparse
-const podBaseVolName = "podvm-base.qcow2"
-
 func createCloudInitISO(v *vmConfig, libvirtClient *libvirtClient) string {
 	logger.Printf("Create cloudInit iso\n")
 	cloudInitIso := libvirtClient.dataDir + "/" + v.name + "-cloudinit.iso"
@@ -140,7 +134,7 @@ func CreateDomain(ctx context.Context, libvirtClient *libvirtClient, v *vmConfig
 	}
 
 	rootVolName := v.name + "-root.qcow2"
-	err = createVolume(rootVolName, v.rootDiskSize, podBaseVolName, libvirtClient)
+	err = createVolume(rootVolName, v.rootDiskSize, libvirtClient.volName, libvirtClient)
 	if err != nil {
 		return nil, fmt.Errorf("Error in creating volume: %s", err)
 	}
@@ -384,6 +378,7 @@ func NewLibvirtClient(libvirtCfg Config) (*libvirtClient, error) {
 		poolName:    libvirtCfg.PoolName,
 		networkName: libvirtCfg.NetworkName,
 		dataDir:     libvirtCfg.DataDir,
+		volName:     libvirtCfg.VolName,
 	}, nil
 }
 

--- a/pkg/adaptor/cloud/libvirt/manager.go
+++ b/pkg/adaptor/cloud/libvirt/manager.go
@@ -20,6 +20,7 @@ const (
 	defaultPoolName    = "default"
 	defaultNetworkName = "default"
 	defaultDataDir     = "/var/lib/libvirt/images"
+	defaultVolName     = "podvm-base.qcow2"
 )
 
 func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
@@ -35,6 +36,7 @@ func (_ *Manager) LoadEnv() {
 	cloud.DefaultToEnv(&libvirtcfg.URI, "LIBVIRT_URI", defaultURI)
 	cloud.DefaultToEnv(&libvirtcfg.PoolName, "LIBVIRT_POOL", defaultPoolName)
 	cloud.DefaultToEnv(&libvirtcfg.NetworkName, "LIBVIRT_NET", defaultNetworkName)
+	cloud.DefaultToEnv(&libvirtcfg.VolName, "LIBVIRT_VOL_NAME", defaultVolName)
 }
 
 func (_ *Manager) NewProvider() (cloud.Provider, error) {

--- a/pkg/adaptor/cloud/libvirt/types.go
+++ b/pkg/adaptor/cloud/libvirt/types.go
@@ -16,6 +16,7 @@ type Config struct {
 	PoolName    string
 	NetworkName string
 	DataDir     string
+	VolName     string
 }
 
 type vmConfig struct {
@@ -45,4 +46,6 @@ type libvirtClient struct {
 	networkName string
 
 	dataDir string
+
+	volName string
 }

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -59,6 +59,7 @@ Use the properties on the table below for Libvirt:
 |libvirt_network|Libvirt Network|"default"|
 |libvirt_storage|Libvirt storage pool|"default"|
 |libvirt_url|Libvirt connection URI|"qemu+ssh://root@192.168.122.1/system?no_verify=1"|
+|libvirt_vol_name|Volume name|"podvm-base.qcow2"|
 |libvirt_ssh_key_file|Path to SSH private key||
 |pause_image|k8s pause image||
 |vxlan_port| VXLAN port number||

--- a/test/provisioner/provision_libvirt.go
+++ b/test/provisioner/provision_libvirt.go
@@ -65,6 +65,11 @@ func NewLibvirtProvisioner(properties map[string]string) (CloudProvisioner, erro
 		uri = properties["libvirt_uri"]
 	}
 
+	vol_name := "podvm-base.qcow2"
+	if properties["libvirt_vol_name"] != "" {
+		vol_name = properties["libvirt_vol_name"]
+	}
+
 	// TODO: accept a different URI.
 	conn, err := libvirt.NewConnect("qemu:///system")
 	if err != nil {
@@ -79,7 +84,7 @@ func NewLibvirtProvisioner(properties map[string]string) (CloudProvisioner, erro
 		storage:      storage,
 		uri:          uri,
 		wd:           wd,
-		volumeName:   "podvm-base.qcow2",
+		volumeName:   vol_name,
 	}, nil
 }
 
@@ -246,11 +251,12 @@ func (lio *LibvirtInstallOverlay) Edit(ctx context.Context, cfg *envconf.Config,
 
 	// Mapping the internal properties to ConfigMapGenerator properties and their default values.
 	mapProps := map[string][2]string{
-		"network":     {"default", "LIBVIRT_NET"},
-		"storage":     {"default", "LIBVIRT_POOL"},
-		"pause_image": {"", "PAUSE_IMAGE"},
-		"uri":         {"qemu+ssh://root@192.168.122.1/system?no_verify=1", "LIBVIRT_URI"},
-		"vxlan_port":  {"", "VXLAN_PORT"},
+		"network":      {"default", "LIBVIRT_NET"},
+		"storage":      {"default", "LIBVIRT_POOL"},
+		"pause_image":  {"", "PAUSE_IMAGE"},
+		"podvm_volume": {"", "LIBVIRT_VOL_NAME"},
+		"uri":          {"qemu+ssh://root@192.168.122.1/system?no_verify=1", "LIBVIRT_URI"},
+		"vxlan_port":   {"", "VXLAN_PORT"},
 	}
 
 	for k, v := range mapProps {


### PR DESCRIPTION
It is not too convinient to always hardcode the image used by libvirt to podvm-base.qcow2. Use LIBVIRT_VOL_NAME to specify a custom qcow2 image to use.