### PR TITLE
volume/csi-wrapper: make sure CSI target path has been mounted before…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/confidential-containers/cloud-api-adaptor/peerpod-ctrl v0.0.0-20230329054732-0d6eda047e81
 	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
 	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20230606170044-338e18e4fd46
+	github.com/moby/sys/mountinfo v0.6.2
 	github.com/sirupsen/logrus v1.9.0
 	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
 	k8s.io/api v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -1371,6 +1371,7 @@ github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2J
 github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/mountinfo v0.5.0/go.mod h1:3bMD3Rg+zkqx8MRYPi7Pyb0Ie97QEBmdxbhnCLlSvSU=
 github.com/moby/sys/mountinfo v0.6.1/go.mod h1:3bMD3Rg+zkqx8MRYPi7Pyb0Ie97QEBmdxbhnCLlSvSU=
+github.com/moby/sys/mountinfo v0.6.2 h1:BzJjoreD5BMFNmD9Rus6gdd1pLuecOFPt8wC+Vygl78=
 github.com/moby/sys/mountinfo v0.6.2/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
 github.com/moby/sys/signal v0.6.0/go.mod h1:GQ6ObYZfqacOwTtlXvcmh9A26dVRul/hbOZn88Kg8Tg=
 github.com/moby/sys/symlink v0.1.0/go.mod h1:GGDODQmbFOjFsXvfLVn3+ZRxkch54RkSiGqsZeMYowQ=

--- a/install/overlays/ibmcloud/kata_direct_volumes_mount.yaml
+++ b/install/overlays/ibmcloud/kata_direct_volumes_mount.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cloud-api-adaptor-daemonset
+  namespace: confidential-containers-system
+  labels:
+    app: cloud-api-adaptor
+spec:
+  template:
+    spec:
+      containers:
+      - name: cloud-api-adaptor-con
+        volumeMounts:
+        - mountPath: /run/kata-containers/shared/direct-volumes
+          name: kata-direct-volumes-dir
+      volumes:
+      - name: kata-direct-volumes-dir
+        hostPath:
+          path: /run/kata-containers/shared/direct-volumes
+          type: DirectoryOrCreate
+

--- a/install/overlays/ibmcloud/kustomization.yaml
+++ b/install/overlays/ibmcloud/kustomization.yaml
@@ -61,6 +61,7 @@ secretGenerator:
 
 patchesStrategicMerge:
   - cri_runtime_endpoint.yaml # set (modify host's runtime cri socket path in the file, default is /run/containerd/containerd.sock)
+  - kata_direct_volumes_mount.yaml # set (for volumes/csi-wrapper)
 ##IAM PROFILE SETTINGS
 # - cr_token_projection.yaml
 ##/IAM PROFILE SETTINGS

--- a/pkg/adaptor/proxy/service_test.go
+++ b/pkg/adaptor/proxy/service_test.go
@@ -1,0 +1,73 @@
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	b64 "encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsNodePublishVolumeTargetPath(t *testing.T) {
+	volumePath := "/var/lib/kubelet/pods/abc/volumes/kubernetes.io~csi/pvc123/mount"
+	directVolumesDir := t.TempDir()
+
+	t.Run("Empty direct-volumes dir", func(t *testing.T) {
+		assert.False(t, isNodePublishVolumeTargetPath(volumePath, directVolumesDir))
+	})
+
+	t.Run("Good path", func(t *testing.T) {
+		err := prepareVolumeDir(directVolumesDir, volumePath)
+		if err != nil {
+			t.Errorf("Failed to add volume dir: %v", err)
+		}
+
+		assert.True(t, isNodePublishVolumeTargetPath(volumePath, directVolumesDir))
+	})
+
+	t.Run("Not CSI path", func(t *testing.T) {
+		volumePath = "/var/lib/kubelet"
+
+		err := prepareVolumeDir(directVolumesDir, volumePath)
+		if err != nil {
+			t.Errorf("Failed to add volume dir: %v", err)
+		}
+
+		assert.False(t, isNodePublishVolumeTargetPath(volumePath, directVolumesDir))
+	})
+
+	t.Run("Not much volumes/kubernetes.io~csi", func(t *testing.T) {
+		volumePath = "/var/lib/kubelet/kubernetes.io~csi/12345/mount"
+
+		err := prepareVolumeDir(directVolumesDir, volumePath)
+		if err != nil {
+			t.Errorf("Failed to add volume dir: %v", err)
+		}
+
+		assert.False(t, isNodePublishVolumeTargetPath(volumePath, directVolumesDir))
+	})
+}
+
+func prepareVolumeDir(directVolumesDir, volumePath string) error {
+	volumeDir := filepath.Join(directVolumesDir, b64.URLEncoding.EncodeToString([]byte(volumePath)))
+	stat, err := os.Stat(volumeDir)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if err := os.MkdirAll(volumeDir, 0700); err != nil {
+			return err
+		}
+	}
+	if stat != nil && !stat.IsDir() {
+		return fmt.Errorf("%s should be a directory", volumeDir)
+	}
+
+	return nil
+}

--- a/pkg/forwarder/interceptor/interceptor_test.go
+++ b/pkg/forwarder/interceptor/interceptor_test.go
@@ -5,6 +5,8 @@ package interceptor
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewInterceptor(t *testing.T) {
@@ -15,4 +17,13 @@ func TestNewInterceptor(t *testing.T) {
 	if i == nil {
 		t.Fatal("Expect non nil, got nil")
 	}
+}
+
+func TestIsTargetPath(t *testing.T) {
+	path := "/path/to/target"
+
+	assert.False(t, isTargetPath(path, ""))
+	assert.False(t, isTargetPath("", ""))
+	assert.False(t, isTargetPath(path, "mock path"))
+	assert.True(t, isTargetPath(path, "/path/to/target"))
 }


### PR DESCRIPTION
… creating workload container

- in adaptor proxy, identify the target path and add it to OCI annotations
- In forworder interceptor, get the target path from OCI annotations
- wait for device is mounted to the target path, and then redirect CreateContainerRequest to kata-agent

fixes #1068