### PR TITLE
ibmcloud: Automatic vpc parameters

### DIFF
--- a/install/rbac/peer-pod.yaml
+++ b/install/rbac/peer-pod.yaml
@@ -49,3 +49,25 @@ roleRef:
   kind: ClusterRole
   name: peerpod-editor
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-viewer
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-viewer
+subjects:
+- kind: ServiceAccount
+  name: cloud-api-adaptor
+  namespace: confidential-containers-system
+roleRef:
+  kind: ClusterRole
+  name: node-viewer
+  apiGroup: rbac.authorization.k8s.io

--- a/install/yamls/caa-pod.yaml
+++ b/install/yamls/caa-pod.yaml
@@ -18,6 +18,11 @@ spec:
       containers:
       - command:
         - /usr/local/bin/entrypoint.sh
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         envFrom:
         - secretRef:
             name: peer-pods-secret

--- a/pkg/adaptor/cloud/ibmcloud/provider.go
+++ b/pkg/adaptor/cloud/ibmcloud/provider.go
@@ -85,16 +85,18 @@ func (p *ibmcloudVPCProvider) getInstancePrototype(instanceName, userData string
 		UserData: &userData,
 		Profile:  &vpcv1.InstanceProfileIdentity{Name: &p.serviceConfig.ProfileName},
 		Zone:     &vpcv1.ZoneIdentity{Name: &p.serviceConfig.ZoneName},
-		Keys: []vpcv1.KeyIdentityIntf{
-			&vpcv1.KeyIdentity{ID: &p.serviceConfig.KeyID},
-		},
-		VPC: &vpcv1.VPCIdentity{ID: &p.serviceConfig.VpcID},
+		Keys:     []vpcv1.KeyIdentityIntf{},
+		VPC:      &vpcv1.VPCIdentity{ID: &p.serviceConfig.VpcID},
 		PrimaryNetworkInterface: &vpcv1.NetworkInterfacePrototype{
 			Subnet: &vpcv1.SubnetIdentity{ID: &p.serviceConfig.PrimarySubnetID},
 			SecurityGroups: []vpcv1.SecurityGroupIdentityIntf{
 				&vpcv1.SecurityGroupIdentityByID{ID: &p.serviceConfig.PrimarySecurityGroupID},
 			},
 		},
+	}
+
+	if p.serviceConfig.KeyID != "" {
+		prototype.Keys = append(prototype.Keys, &vpcv1.KeyIdentity{ID: &p.serviceConfig.KeyID})
 	}
 
 	if p.serviceConfig.ResourceGroupID != "" {

--- a/pkg/adaptor/k8sops/node.go
+++ b/pkg/adaptor/k8sops/node.go
@@ -1,0 +1,29 @@
+package k8sops
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+func NodeLabels(ctx context.Context, name string) (map[string]string, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get k8s rest config: %w", err)
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create k8s clientset: %w", err)
+	}
+
+	node, err := clientset.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return node.Labels, nil
+
+}


### PR DESCRIPTION
By only setting the following values I could deploy a peer pod on an ibmcloud managed cluster (IKS).

```yaml
configMapGenerator:
- name: peer-pods-cm
  namespace: confidential-containers-system
  literals:
  - CLOUD_PROVIDER="ibmcloud"
  - IBMCLOUD_PODVM_IMAGE_ID="r018-943c68bb-0741-485c-8256-78299593b9eb" #set
  - IBMCLOUD_PODVM_INSTANCE_PROFILE_NAME="bz2-2x8" #set
```
&
```yaml
secretGenerator:
- name: peer-pods-secret
  namespace: confidential-containers-system
  literals:
  - IBMCLOUD_IAM_PROFILE_ID="<profile_id>" # set
```