### PR TITLE
Webhook: Update curl image to point at 8.1.1

### DIFF
--- a/webhook/hack/extended-resources/ext-res-ds.yaml
+++ b/webhook/hack/extended-resources/ext-res-ds.yaml
@@ -18,7 +18,7 @@ spec:
         node-role.kubernetes.io/worker: ""
       serviceAccountName: ext-res-updater
       containers:
-      - image: curlimages/curl
+      - image: curlimages/curl:8.1.1
         command: ["sh"]
         args: ["/ext-res-updater.sh"]
         name: updater


### PR DESCRIPTION
Content of commit
Add workaround to fix bug with the webhook extended resources

Fixes: #1070