### PR TITLE
e2e-test: use a new way to get caa commit_it in ibmcloud e2e-test pipeline

### DIFF
--- a/.github/workflows/daily-e2e-tests-ibmcloud.yaml
+++ b/.github/workflows/daily-e2e-tests-ibmcloud.yaml
@@ -64,7 +64,8 @@ jobs:
             echo "ibmcloud e2e test (${{matrix.type}}) is failed."
             exit 2
           fi
-          caa_commitid=$(grep "CAA commit_id:" $log_name | cut -d " " -f 4)
+          caa_commitid=$(cat $log_name | grep -oP 'CAA commit_id: \K\S+')
+          echo "The CAA commit_id: ${caa_commitid}"
           echo ${caa_commitid} > caa_commitid
         env:
           bucket_name : "daily-e2e-test-bucket"


### PR DESCRIPTION
- fix daily podvm image failed to push issue

fixes: #1079