### PR TITLE
ibmcloud: self-managed cluster qol updates

### DIFF
--- a/ibmcloud/README.md
+++ b/ibmcloud/README.md
@@ -79,13 +79,6 @@ If you don't have a Kubernetes cluster for testing, you can follow the open-sour
 [instructions](./cluster)
  to set up a basic cluster where the Kubernetes nodes run on IBM Cloud provided infrastructure.
 
-After creating the cluster and setting up `kubeconfig` as described, ensure that the node has the worker label set. To do
-this you can run:
-```
-node=$(kubectl get nodes -o json | jq -r '.items[-1].metadata.name')
-kubectl label node $node node-role.kubernetes.io/worker=
-```
-
 ## Deploy PeerPod Webhook
 
 #### Deploy cert-manager
@@ -130,25 +123,17 @@ This will create `caa-provisioner-cli` in the `test/tools` directory. To use the
 ```bash
 export IBMCLOUD_API_KEY= # your ibmcloud apikey
 export PODVM_IMAGE_ID= # the image id of the peerpod vm uploaded in the previous step
-export PODVM_IMAGE_ARCH= # the architecture of the peerpod image (amd64/s390x)
 export PODVM_INSTANCE_PROFILE= # instance profile name that runs the peerpod (bx2-2x8 or bz2-2x8 for example)
-
+export CAA_IMAGE_TAG= # cloud-api-adaptor image tag that supports this arch, see quay.io/confidential-containers/cloud-api-adaptor
 pushd ibmcloud/cluster
 
 cat <<EOF > ../../selfmanaged_cluster.properties
 IBMCLOUD_PROVIDER="ibmcloud"
 APIKEY="$IBMCLOUD_API_KEY"
 PODVM_IMAGE_ID="$PODVM_IMAGE_ID"
-PODVM_IMAGE_ARCH="$PODVM_IMAGE_ARCH"
 INSTANCE_PROFILE_NAME="$PODVM_INSTANCE_PROFILE"
-WORKER_FLAVOR="$PODVM_INSTANCE_PROFILE"
-REGION="$(terraform output --raw region)"
-ZONE="$(terraform output --raw zone)"
-RESOURCE_GROUP_ID="$(terraform output --raw resource_group_id)"
+CAA_IMAGE_TAG="$CAA_IMAGE_TAG"
 SSH_KEY_ID="$(terraform output --raw ssh_key_id)"
-VPC_SUBNET_ID="$(terraform output --raw subnet_id)"
-VPC_SECURITY_GROUP_ID="$(terraform output --raw security_group_id)"
-VPC_ID="$(terraform output --raw vpc_id)"
 EOF
 
 popd

--- a/ibmcloud/cluster/ansible/tasks/bootstrap.yaml
+++ b/ibmcloud/cluster/ansible/tasks/bootstrap.yaml
@@ -4,15 +4,19 @@
 #
 
 ---
+
+- name: Stop service unattended-upgrades if running
+  ansible.builtin.systemd:
+    name: unattended-upgrades
+    state: stopped
+
+- name: Remove unattended-upgrades
+  apt:
+    name: unattended-upgrades
+    state: absent
+
 - name: "Install required packages on Ubuntu"
   apt:
     update_cache: true
-    name: "{{ item }}"
+    name: ['unzip', 'tar', 'apt-transport-https', 'libbtrfs-dev', 'libseccomp2', 'util-linux']
     state: latest
-  with_items:
-      - unzip
-      - tar
-      - apt-transport-https
-      - libbtrfs-dev
-      - libseccomp2
-      - util-linux

--- a/ibmcloud/cluster/ansible/tasks/k8s.yaml
+++ b/ibmcloud/cluster/ansible/tasks/k8s.yaml
@@ -15,15 +15,8 @@
     state: present
     filename: "kubernetes"
 
-- name: "Update the repository cache "
-  apt:
-    update_cache: yes
-
 - name: "Install kubelet, kubeadm, kubectl "
-  apt: name={{item}} state=present
-  with_items:
-    - kubelet
-    - kubeadm
-    - kubectl
-    - kubernetes-cni
-    - cri-tools
+  apt:
+    update_cache: true
+    name: ['kubelet', 'kubeadm', 'kubectl', 'kubernetes-cni', 'cri-tools']
+    state: present

--- a/ibmcloud/cluster/label-nodes.sh
+++ b/ibmcloud/cluster/label-nodes.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# (C) Copyright Confidential Containers Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+region="$1"
+zone="$2"
+subnet_id="$3"
+
+nodes=$(kubectl --kubeconfig config get nodes -o name)
+
+worker=
+for node in $nodes; do
+    if [ -n "$worker" ]; then
+        kubectl --kubeconfig config label "$node" node-role.kubernetes.io/worker=
+    fi
+    worker=true
+    kubectl --kubeconfig config label "$node" "topology.kubernetes.io/region=$region"
+    kubectl --kubeconfig config label "$node" "topology.kubernetes.io/zone=$zone"
+    kubectl --kubeconfig config label "$node" "ibm-cloud.kubernetes.io/subnet-id=$subnet_id"
+done

--- a/ibmcloud/cluster/main.tf
+++ b/ibmcloud/cluster/main.tf
@@ -80,3 +80,12 @@ resource "null_resource" "kubeadm" {
     command = "./kube-init.sh ${module.nodes[0].private_ip}"
   }
 }
+
+resource "null_resource" "label_nodes" {
+  depends_on = [
+    null_resource.kubeadm
+  ]
+  provisioner "local-exec" {
+    command = "./label-nodes.sh ${var.region} ${var.zone} ${module.vpc.subnet_id}"
+  }
+}

--- a/ibmcloud/cluster/vpc/main.tf
+++ b/ibmcloud/cluster/vpc/main.tf
@@ -5,6 +5,7 @@
 
 resource "ibm_is_vpc" "vpc" {
   name = "${var.cluster_name}-vpc"
+  default_security_group_name = "${var.cluster_name}-security-group"
 }
 
 resource "ibm_is_floating_ip" "gateway" {
@@ -29,25 +30,20 @@ resource "ibm_is_subnet" "primary" {
   public_gateway           = ibm_is_public_gateway.gateway.id
 }
 
-resource "ibm_is_security_group" "primary" {
-  name = "${var.cluster_name}-security-group"
-  vpc  = ibm_is_vpc.vpc.id
-}
-
 resource "ibm_is_security_group_rule" "primary_outbound" {
-  group      = ibm_is_security_group.primary.id
+  group      = ibm_is_vpc.vpc.default_security_group
   direction  = "outbound"
   remote     = "0.0.0.0/0"
 }
 
 resource "ibm_is_security_group_rule" "primary_inbound" {
-  group      = ibm_is_security_group.primary.id
+  group      = ibm_is_vpc.vpc.default_security_group
   direction  = "inbound"
-  remote     = ibm_is_security_group.primary.id
+  remote     = ibm_is_vpc.vpc.default_security_group
 }
 
 resource "ibm_is_security_group_rule" "primary_ssh" {
-  group      = ibm_is_security_group.primary.id
+  group      = ibm_is_vpc.vpc.default_security_group
   direction  = "inbound"
   remote     = "0.0.0.0/0"
 
@@ -58,7 +54,7 @@ resource "ibm_is_security_group_rule" "primary_ssh" {
 }
 
 resource "ibm_is_security_group_rule" "primary_ping" {
-  group      = ibm_is_security_group.primary.id
+  group      = ibm_is_vpc.vpc.default_security_group
   direction  = "inbound"
   remote     = "0.0.0.0/0"
 
@@ -69,7 +65,7 @@ resource "ibm_is_security_group_rule" "primary_ping" {
 }
 
 resource "ibm_is_security_group_rule" "primary_api_server" {
-  group      = ibm_is_security_group.primary.id
+  group      = ibm_is_vpc.vpc.default_security_group
   direction  = "inbound"
   remote     = "0.0.0.0/0"
 

--- a/ibmcloud/cluster/vpc/outputs.tf
+++ b/ibmcloud/cluster/vpc/outputs.tf
@@ -12,5 +12,5 @@ output "subnet_id" {
 }
 
 output "security_group_id" {
-  value = ibm_is_security_group.primary.id
+  value = ibm_is_vpc.vpc.default_security_group
 }

--- a/test/provisioner/provision_ibmcloud_initializer.go
+++ b/test/provisioner/provision_ibmcloud_initializer.go
@@ -135,10 +135,10 @@ func initProperties(properties map[string]string) error {
 		return errors.New("APIKEY was not set.")
 	}
 	if len(IBMCloudProps.ResourceGroupID) <= 0 {
-		return errors.New("RESOURCE_GROUP_ID was not set.")
+		log.Info("[warning] RESOURCE_GROUP_ID was not set.")
 	}
 	if len(IBMCloudProps.Zone) <= 0 {
-		return errors.New("ZONE was not set.")
+		log.Info("[warning] ZONE was not set.")
 	}
 
 	// IAM_SERVICE_URL can overwrite default IamServiceURL, for example: IAM_SERVICE_URL="https://iam.test.cloud.ibm.com/identity/token"
@@ -149,7 +149,11 @@ func initProperties(properties map[string]string) error {
 
 	// VPC_SERVICE_URL can overwrite default VpcServiceURL https://{REGION}.iaas.cloud.ibm.com/v1, for example: VPC_SERVICE_URL="https://jp-tok.iaas.test.cloud.ibm.com/v1"
 	if len(IBMCloudProps.VpcServiceURL) <= 0 {
-		IBMCloudProps.VpcServiceURL = "https://" + IBMCloudProps.Region + ".iaas.cloud.ibm.com/v1"
+		if len(IBMCloudProps.Region) > 0 {
+			IBMCloudProps.VpcServiceURL = "https://" + IBMCloudProps.Region + ".iaas.cloud.ibm.com/v1"
+		} else {
+			log.Info("[warning] REGION was not set.")
+		}
 	}
 	log.Infof("VpcServiceURL is: %s.", IBMCloudProps.VpcServiceURL)
 
@@ -173,16 +177,16 @@ func initProperties(properties map[string]string) error {
 			return errors.New("PODVM_IMAGE_ID was not set, set it with existing custom image id in VPC")
 		}
 		if len(IBMCloudProps.SshKeyID) <= 0 {
-			return errors.New("SSH_KEY_ID was not set, set it with existing SSH key id in VPC")
+			log.Info("[warning] SSH_KEY_ID was not set.")
 		}
 		if len(IBMCloudProps.SubnetID) <= 0 {
-			return errors.New("VPC_SUBNET_ID was not set, set it with existing subnet id in VPC")
+			log.Info("[warning] VPC_SUBNET_ID was not set.")
 		}
 		if len(IBMCloudProps.SecurityGroupID) <= 0 {
-			return errors.New("VPC_SECURITY_GROUP_ID was not set, set it with existing security group id in VPC")
+			log.Info("[warning] VPC_SECURITY_GROUP_ID was not set.")
 		}
 		if len(IBMCloudProps.VpcID) <= 0 {
-			return errors.New("VPC_ID was not set, set it with existing VPC id")
+			log.Info("[warning] VPC_ID was not set.")
 		}
 	}
 


### PR DESCRIPTION
Since #1074 has been merged we can achieve the same outcome with the selfmanaged cluster by adding our own labels.

At the same time I have done some quality of life updates to the cluster and README.md to reduce the about of variables that need to be specifed. This also includes no longer erroring if these variables are not set in the provisioner-cli.

