### PR TITLE
dependabot: Skip Fixes Check if user is dependabot

### DIFF
--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -15,10 +15,11 @@ env:
 jobs:
   commit-message-check:
     runs-on: ubuntu-latest
+    env:
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
     name: Commit Message Check
     steps:
       - name: Get PR Commits
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         id: "get-pr-commits"
         uses: tim-actions/get-pr-commits@v1.2.0
         with:
@@ -31,13 +32,13 @@ jobs:
           filter_out_pattern: '^Revert "'
 
       - name: Commit Body Missing Check
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && ( success() || failure() ) }}
+        if: ${{ ( success() || failure() ) }}
         uses: tim-actions/commit-body-check@v1.0.2
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}
 
       - name: Check Subject Line Length
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && ( success() || failure() ) }}
+        if: ${{ ( success() || failure() ) }}
         uses: tim-actions/commit-message-checker-with-regex@v0.3.1
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}
@@ -46,7 +47,7 @@ jobs:
           post_error: ${{ env.error_msg }}
 
       - name: Check Body Line Length
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && ( success() || failure() ) }}
+        if: ${{ ( success() || failure() ) }}
         uses: tim-actions/commit-message-checker-with-regex@v0.3.1
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}
@@ -73,7 +74,7 @@ jobs:
           post_error: ${{ env.error_msg }}
 
       - name: Check Fixes
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && ( success() || failure() ) }}
+        if: ${{ (env.PR_AUTHOR != 'dependabot[bot]') && ( success() || failure() ) }}
         uses: tim-actions/commit-message-checker-with-regex@v0.3.1
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}
@@ -84,7 +85,7 @@ jobs:
           one_pass_all_pass: "true"
 
       - name: Check Subsystem
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && ( success() || failure() ) }}
+        if: ${{ ( success() || failure() ) }}
         uses: tim-actions/commit-message-checker-with-regex@v0.3.1
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}


### PR DESCRIPTION
When the commit message check runs skip if the author of the PR is dependabot

Fixes: #1096