### PR TITLE
ibmcloud: Added test cases to check peer pod logs environment variables

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -23,6 +23,12 @@ func withCommand(command []string) podOption {
 	}
 }
 
+func withEnvironmentalVariables(envVar []corev1.EnvVar) podOption {
+	return func(p *corev1.Pod) {
+		p.Spec.Containers[0].Env = envVar
+	}
+}
+
 func withConfigMapBinding(mountPath string, configMapName string) podOption {
 	return func(p *corev1.Pod) {
 		p.Spec.Containers[0].VolumeMounts = append(p.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{Name: "config-volume", MountPath: mountPath})

--- a/test/e2e/fixtures/Dockerfile.testenv
+++ b/test/e2e/fixtures/Dockerfile.testenv
@@ -1,0 +1,3 @@
+FROM --platform="${TARGETPLATFORM}" alpine:latest
+ENV ISPRODUCTION=false
+ENTRYPOINT [ "/bin/sh", "-c", "env" ]

--- a/test/e2e/ibmcloud_test.go
+++ b/test/e2e/ibmcloud_test.go
@@ -106,6 +106,27 @@ func TestCreatePeerPodAndCheckWorkDirLogs(t *testing.T) {
 	doTestCreatePeerPodAndCheckWorkDirLogs(t, assert)
 }
 
+func TestCreatePeerPodAndCheckEnvVariableLogsWithImageOnly(t *testing.T) {
+	assert := IBMCloudAssert{
+		vpc: pv.IBMCloudProps.VPC,
+	}
+	doTestCreatePeerPodAndCheckEnvVariableLogsWithImageOnly(t, assert)
+}
+
+func TestCreatePeerPodAndCheckEnvVariableLogsWithDeploymentOnly(t *testing.T) {
+	assert := IBMCloudAssert{
+		vpc: pv.IBMCloudProps.VPC,
+	}
+	doTestCreatePeerPodAndCheckEnvVariableLogsWithDeploymentOnly(t, assert)
+}
+
+func TestCreatePeerPodAndCheckEnvVariableLogsWithImageAndDeployment(t *testing.T) {
+	assert := IBMCloudAssert{
+		vpc: pv.IBMCloudProps.VPC,
+	}
+	doTestCreatePeerPodAndCheckEnvVariableLogsWithImageAndDeployment(t, assert)
+}
+
 // IBMCloudAssert implements the CloudAssert interface for ibmcloud.
 type IBMCloudAssert struct {
 	vpc *vpcv1.VpcV1


### PR DESCRIPTION
Added test cases to check peer pod logs environment variables in ibmcloud cloud-provider

Fixes: #1044, https://github.com/kata-containers/kata-containers/issues/5730