### PR TITLE
image: use golang-fedora as builder

### DIFF
--- a/.github/workflows/build-golang-fedora.yaml
+++ b/.github/workflows/build-golang-fedora.yaml
@@ -1,0 +1,117 @@
+# (C) Copyright Confidential Containers Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+name: "build golang-fedora container image"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "hack/Dockerfile.golang"
+      - "hack/update-go-container.sh"
+  workflow_dispatch:
+    inputs:
+      registry:
+        description: "The container registry to push the image to. Must be either 'ghcr.io' or 'quay.io'"
+        default: "quay.io"
+      image_repository:
+        description: "The name of the container image repository to push the image to."
+        default: "confidential-containers"
+      image_name:
+        description: "The name the container image should be tagged with"
+        default: "golang-fedora"
+      image_tag:
+        description: "The tag part of the container image name"
+        default: ""
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout cloud-api-adaptor repository
+        uses: actions/checkout@v3
+
+      - name: Container tags from input and repository state
+        id: tags
+        run: |
+          if [[ -n "${{ inputs.registry }}" ]]; then
+            if [[ "${{ inputs.registry }}" != "ghcr.io" && "${{ inputs.registry }}" != "quay.io" ]]; then
+              echo "Invalid registry '${{ inputs.registry }}'. Must be either 'ghcr.io' or 'quay.io'"
+              exit 1
+            fi
+            registry="${{ inputs.registry }}"
+          else
+            registry="quay.io"
+          fi
+          echo "registry=${registry}" | tee "$GITHUB_OUTPUT"
+
+          if [[ -n "${{ inputs.image_repository }}" ]]; then
+            repository="${{ inputs.image_repository }}"
+          else
+            repository="confidential-containers"
+          fi
+          echo "repository=${repository}" | tee -a "$GITHUB_OUTPUT"
+
+          if [[ -n "${{ inputs.image_name }}" ]]; then
+            name="${{ inputs.image_name }}"
+          else
+            name="golang-fedora"
+          fi
+          echo "name=${name}" | tee -a "$GITHUB_OUTPUT"
+
+          if [[ -n "${{ inputs.image_tag }}" ]]; then
+            tag="${{ inputs.image_tag }}"
+          else
+            goVersion=$(grep GO_VERSION= hack/Dockerfile.golang | cut -d= -f2)
+            if [[ -z "${goVersion}" ]]; then
+              echo "Failed to determine GO_VERSION from hack/Dockerfile.golang"
+              exit 1
+            fi
+            fedoraVersion=$(grep BASE_IMAGE= hack/Dockerfile.golang | cut -d: -f2)
+            if [[ -z "${fedoraVersion}" ]]; then
+              echo "Failed to determine Fedora version from BASE_IMAGE variable in hack/Dockerfile.golang"
+              exit 1
+            fi
+            tag="${goVersion}-${fedoraVersion}"
+          fi
+          echo "tag=${tag}" | tee -a "$GITHUB_OUTPUT"
+
+          echo "fullImageName=${registry}/${repository}/${name}:${tag}" | tee -a "$GITHUB_OUTPUT"
+          echo "fullImageNameGitSha=${registry}/${repository}/${name}:${tag}-${{ github.sha }}" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to the ghcr Container registry
+        if: steps.tags.outputs.registry == 'ghcr.io'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to quay Container Registry
+        if: steps.tags.outputs.registry == 'quay.io'
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build the container image
+        uses: docker/build-push-action@v4
+        with:
+          context: ./hack
+          file: ./hack/Dockerfile.golang
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+          tags: |
+            ${{ steps.tags.outputs.fullImageName }}
+            ${{ steps.tags.outputs.fullImageNameGitSha }}
+          push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
 ARG BUILD_TYPE=dev
-ARG GOLANG=golang:1.19
-ARG BASE=fedora:36 
+ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.20.5-36
+ARG BASE=fedora:36
 
-FROM --platform=$BUILDPLATFORM $GOLANG AS builder
+
+FROM --platform=$TARGETPLATFORM $BUILDER_BASE as builder-release
+
+FROM builder-release as builder-dev
+RUN dnf install -y libvirt-devel && dnf clean all
+
+FROM builder-${BUILD_TYPE} AS builder
 ARG RELEASE_BUILD
 ARG COMMIT
 ARG VERSION
 ARG TARGETARCH
-# Install additional packages required to build libvirt provider
-# Need to use the [] syntax as default shell is /bin/sh
-RUN if [ "$RELEASE_BUILD" != true ]; then apt-get update -y && apt-get install -y libvirt-dev; fi
 WORKDIR /work
 COPY go.mod go.sum ./
 RUN go mod download

--- a/hack/Dockerfile.golang
+++ b/hack/Dockerfile.golang
@@ -1,0 +1,50 @@
+# syntax=docker/dockerfile:1.5-labs
+
+ARG BASE_IMAGE=fedora:36
+FROM --platform=$TARGETPLATFORM ${BASE_IMAGE} as base
+
+ARG GO_VERSION=1.20.5
+ARG GO_LINUX_ARM64_SHA256=aa2fab0a7da20213ff975fa7876a66d47b48351558d98851b87d1cfef4360d09
+ARG GO_LINUX_AMD64_SHA256=d7ec48cde0d3d2be2c69203bc3e0a44de8660b9c09a6e85c4732a3f7dc442612
+ARG GO_LINUX_PPC64LE_SHA256=049b8ab07d34077b90c0642138e10207f6db14bdd1743ea994a21e228f8ca53d
+ARG GO_LINUX_S390X_SHA256=bac14667f1217ccce1d2ef4e204687fe6191e6dc19a8870cfb81a41f78b04e48
+
+FROM base AS base-amd64
+ADD --checksum=sha256:${GO_LINUX_AMD64_SHA256} https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz .
+
+FROM base AS base-arm64
+ADD --checksum=sha256:${GO_LINUX_ARM64_SHA256} https://go.dev/dl/go${GO_VERSION}.linux-arm64.tar.gz .
+
+FROM base AS base-ppc64le
+ADD --checksum=sha256:${GO_LINUX_PPC64LE_SHA256} https://go.dev/dl/go${GO_VERSION}.linux-ppc64le.tar.gz .
+
+FROM base AS base-s390x
+ADD --checksum=sha256:${GO_LINUX_S390X_SHA256} https://go.dev/dl/go${GO_VERSION}.linux-s390x.tar.gz .
+
+ARG TARGETARCH
+FROM base-${TARGETARCH}
+
+ARG TARGETARCH
+ARG GO_VERSION
+RUN tar -C /usr/local -xzf go${GO_VERSION}.linux-${TARGETARCH}.tar.gz && \
+    rm go${GO_VERSION}.linux-${TARGETARCH}.tar.gz
+
+# install cgo-related dependencies
+RUN set -eux; \
+	dnf install -y \
+		g++ \
+		gcc \
+		glibc-devel \
+		make \
+		pkg-config \
+	; \
+	dnf clean all
+
+ENV PATH /usr/local/go/bin:$PATH
+
+RUN set -eux; go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
+WORKDIR $GOPATH

--- a/hack/update-go-container.sh
+++ b/hack/update-go-container.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# (C) Copyright Confidential Containers Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Update the golang-fedora Containerfile with the latest Go version.
+
+set -eou pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <version>"
+    exit 1
+fi
+
+version=$1
+
+archs=(amd64 arm64 ppc64le s390x)
+
+sed -i 's/^ARG GO_VERSION=.*/ARG GO_VERSION='"${version}"'/' Dockerfile.golang
+
+for arch in "${archs[@]}"; do
+    wget "https://go.dev/dl/go${version}.linux-${arch}.tar.gz"
+    shasum=$(sha256sum "go${version}.linux-${arch}.tar.gz" | cut -d' ' -f1)
+    archUpper=$(echo "${arch}" | tr '[:lower:]' '[:upper:]')
+    sed -i 's/^ARG GO_LINUX_'"${archUpper}"'_SHA256=.*/ARG GO_LINUX_'"${archUpper}"'_SHA256='"${shasum}"'/' Dockerfile.golang
+    rm "go${version}.linux-${arch}.tar.gz"
+done


### PR DESCRIPTION
Previously, the docker build used the golang image, which is based
on debian, and copied the dynamically linked binary into a fedora
layer. This change switches the build to use a custom golang-fedora
image as builder.

Fixes #1093
Fixes #1113

Please check if this works for other platforms than amd64.