### PR TITLE
ci: fix broken link to community repo

### DIFF
--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -10,7 +10,7 @@ env:
   error_msg: |+
     See the document below for help on formatting commits for the project.
 
-    https://github.com/confidential-containers/community/blob/main/CONTRIBUTING.md#patch-format
+    https://github.com/confidential-containers/confidential-containers/blob/main/CONTRIBUTING.md#patch-format
 
 jobs:
   commit-message-check:


### PR DESCRIPTION
community was renamed to confidential-containers, so fixing the broken link.

Fixes: #1120