### PR TITLE
e2e: csi-wrapper test case base on ibm-vpc-block-csi-driver:master

### DIFF
--- a/test/e2e/ibmcloud_test.go
+++ b/test/e2e/ibmcloud_test.go
@@ -7,11 +7,16 @@ package e2e
 
 import (
 	"bytes"
+	"os"
+	"strings"
+	"testing"
+
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	pv "github.com/confidential-containers/cloud-api-adaptor/test/provisioner"
 	log "github.com/sirupsen/logrus"
-	"strings"
-	"testing"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 )
 
 func TestCreateSimplePod(t *testing.T) {
@@ -131,6 +136,248 @@ func TestCreatePeerPodWithLargeImage(t *testing.T) {
 		vpc: pv.IBMCloudProps.VPC,
 	}
 	doTestCreatePeerPodWithLargeImage(t, assert)
+}
+
+func TestCreatePeerPodWithPVC(t *testing.T) {
+	if os.Getenv("TEST_CSI_WRAPPER") == "yes" {
+		assert := IBMCloudAssert{
+			vpc: pv.IBMCloudProps.VPC,
+		}
+		nameSpace := "kube-system"
+		pvcName := "my-pvc"
+		mountPath := "/mount-path"
+		storageClassName := "ibmc-vpc-block-5iops-tier"
+		storageSize := "10Gi"
+		podName := "nginx-pvc-pod"
+		imageName := "nginx"
+		csiContainerName := "ibm-vpc-block-podvm-node-driver"
+		csiImageName := "gcr.io/k8s-staging-cloud-provider-ibm/ibm-vpc-block-csi-driver:v5.2.0"
+
+		myPVC := newPVC(nameSpace, pvcName, storageClassName, storageSize, corev1.ReadWriteOnce)
+		myPodwithPVC := newPodWithPVCFromIBMVPCBlockDriver(nameSpace, podName, imageName, imageName, csiContainerName, csiImageName, withRestartPolicy(corev1.RestartPolicyNever), withPVCBinding(mountPath, pvcName))
+		doTestCreatePeerPodWithPVCAndCSIWrapper(t, assert, myPVC, myPodwithPVC, mountPath)
+	} else {
+		log.Infof("Ignore PeerPod with PVC (CSI wrapper) test")
+	}
+}
+
+func newPodWithPVCFromIBMVPCBlockDriver(namespace, podName, containerName, imageName, csiContainerName, csiImageName string, options ...podOption) *corev1.Pod {
+	runtimeClassName := "kata-remote"
+	propagationBidirectional := corev1.MountPropagationBidirectional
+	propagationHostPathDirectory := corev1.HostPathDirectory
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: namespace},
+		Spec: corev1.PodSpec{
+			RuntimeClassName: &runtimeClassName,
+			Containers: []corev1.Container{
+				{
+					Name: csiContainerName,
+					Env: []corev1.EnvVar{
+						{
+							Name: "KUBE_NODE_NAME",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "spec.nodeName",
+								},
+							},
+						},
+					},
+					EnvFrom: []corev1.EnvFromSource{
+						{
+							ConfigMapRef: &corev1.ConfigMapEnvSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "ibm-vpc-block-csi-configmap",
+								},
+							},
+						},
+					},
+					Image:           csiImageName,
+					ImagePullPolicy: corev1.PullAlways,
+					SecurityContext: &corev1.SecurityContext{
+						Privileged:   pointer.Bool(true),
+						RunAsNonRoot: pointer.Bool(false),
+						RunAsUser:    pointer.Int64(0),
+					},
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "healthz",
+							ContainerPort: 9808,
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:             "kubelet-data-dir",
+							MountPath:        "/var/lib/kubelet",
+							MountPropagation: &propagationBidirectional,
+						},
+						{
+							Name:      "plugin-dir",
+							MountPath: "/tmp",
+						},
+						{
+							Name:      "device-dir",
+							MountPath: "/dev",
+						},
+						{
+							Name:      "etcudevpath",
+							MountPath: "/etc/udev",
+						},
+						{
+							Name:      "runudevpath",
+							MountPath: "/run/udev",
+						},
+						{
+							Name:      "libudevpath",
+							MountPath: "/lib/udev",
+						},
+						{
+							Name:      "syspath",
+							MountPath: "/sys",
+						},
+						{
+							Name:      "customer-auth",
+							MountPath: "/etc/storage_ibmc",
+							ReadOnly:  true,
+						},
+					},
+				},
+				{
+					Name: "csi-podvm-wrapper",
+					Env: []corev1.EnvVar{
+						{
+							Name: "POD_NAME",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.name",
+								},
+							},
+						},
+						{
+							Name: "POD_NAME_SPACE",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.namespace",
+								},
+							},
+						},
+						{
+							Name: "POD_UID",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.uid",
+								},
+							},
+						},
+						{
+							Name: "POD_NODE_NAME",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "spec.nodeName",
+								},
+							},
+						},
+					},
+					Args: []string{
+						"--v=5",
+						"--endpoint=/tmp/csi-podvm-wrapper.sock",
+						"--target-endpoint=/tmp/csi.sock",
+						"--namespace=kube-system",
+					},
+					Image:           "quay.io/confidential-containers/csi-podvm-wrapper:latest",
+					ImagePullPolicy: corev1.PullAlways,
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "plugin-dir",
+							MountPath: "/tmp",
+						},
+					},
+				},
+				{
+					Name:            containerName,
+					Image:           imageName,
+					ImagePullPolicy: corev1.PullAlways,
+				},
+			},
+			ServiceAccountName: "ibm-vpc-block-node-sa",
+			Volumes: []corev1.Volume{
+				{
+					Name: "kubelet-data-dir",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/var/lib/kubelet",
+							Type: &propagationHostPathDirectory,
+						},
+					},
+				},
+				{
+					Name: "plugin-dir",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+				{
+					Name: "device-dir",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/dev",
+							Type: &propagationHostPathDirectory,
+						},
+					},
+				},
+				{
+					Name: "etcudevpath",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/etc/udev",
+							Type: &propagationHostPathDirectory,
+						},
+					},
+				},
+				{
+					Name: "runudevpath",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/run/udev",
+							Type: &propagationHostPathDirectory,
+						},
+					},
+				},
+				{
+					Name: "libudevpath",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/lib/udev",
+							Type: &propagationHostPathDirectory,
+						},
+					},
+				},
+				{
+					Name: "syspath",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/sys",
+							Type: &propagationHostPathDirectory,
+						},
+					},
+				},
+				{
+					Name: "customer-auth",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "storage-secret-store",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, option := range options {
+		option(pod)
+	}
+
+	return pod
 }
 
 // IBMCloudAssert implements the CloudAssert interface for ibmcloud.

--- a/volumes/csi-wrapper/README.md
+++ b/volumes/csi-wrapper/README.md
@@ -83,7 +83,7 @@ node/liudali-csi-amd64-node-1 labeled
 node/liudali-csi-amd64-node-1 labeled
 ```
 
-5. Create the [slclient_Gen2.toml](https://github.com/kubernetes-sigs/ibm-vpc-block-csi-driver/blob/master/deploy/kubernetes/driver/kubernetes/slclient_Gen2.toml) for the cluster:
+5. Create the [slclient_Gen2.toml](https://github.com/kubernetes-sigs/ibm-vpc-block-csi-driver/blob/v5.2.0/deploy/kubernetes/driver/kubernetes/slclient_Gen2.toml) for the cluster:
 ```bash
 export IBMCLOUD_VPC_REGION=<the_region_name>
 export IBMCLOUD_RESOURCE_GROUP_ID=<check via `ibmcloud resource groups`>
@@ -105,8 +105,8 @@ cat slclient_Gen2.toml
 6. Deploy original `ibm-vpc-block-csi-driver`:
 ```bash
 encodeVal=$(base64 -w 0 slclient_Gen2.toml)
-sed -i "s/REPLACE_ME/$encodeVal/g" ./hack/ibm/ibm-vpc-block-csi-driver-master.yaml
-kubectl create -f ./hack/ibm/ibm-vpc-block-csi-driver-master.yaml
+sed -i "s/REPLACE_ME/$encodeVal/g" ./hack/ibm/ibm-vpc-block-csi-driver-v5.2.0.yaml
+kubectl create -f ./hack/ibm/ibm-vpc-block-csi-driver-v5.2.0.yaml
 ```
 Check `ibm-vpc-block-csi-driver related` pod status
 ```bash

--- a/volumes/csi-wrapper/hack/ibm/cleanandreinstall.sh
+++ b/volumes/csi-wrapper/hack/ibm/cleanandreinstall.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# this script is for develop test only, user must prepared env via wrap-ibm-vpc-block-csi-driver.md
+# this script is for develop test only, user must prepare value of slclient.toml via README.md
+# make the `REPLACE_ME` is replaced in ibm-vpc-block-csi-driver-master.yaml
 kubectl delete po nginx
 kubectl delete pvc my-pvc
 kubectl -n kube-system delete po nginx
@@ -7,23 +8,12 @@ kubectl -n kube-system delete pvc my-pvc
 pv_name=$(kubectl get pv |grep ibmc-vpc-block-5iops-tier|awk '{print $1}')
 kubectl delete pv $pv_name
 
-if cd ~/ibm-vpc-block-csi-driver; then
-    kustomize build deploy/kubernetes/driver/kubernetes/overlays/stage | kubectl delete -f -
-    kustomize build deploy/kubernetes/driver/kubernetes/overlays/stage | kubectl apply -f -
-else
-    echo "Warning: path '~/ibm-vpc-block-csi-driver' not found"
-fi
+kubectl delete -f ./ibm-vpc-block-csi-driver-v5.2.0.yaml
+kubectl delete -f ../../crd/peerpodvolume.yaml
+kubectl delete -f ./vpc-block-csi-wrapper-runner.yaml
+kubectl create -f ./ibm-vpc-block-csi-driver-v5.2.0.yaml
+kubectl create -f ../../crd/peerpodvolume.yaml
+kubectl create -f ./vpc-block-csi-wrapper-runner.yaml
 
-if cd ~/csi-wrapper; then
-    kubectl delete -f crd/peerpodvolume.yaml
-    kubectl delete -f hack/ibm/vpc-block-csi-wrapper-runner.yaml
-    kubectl create -f crd/peerpodvolume.yaml
-    kubectl create -f hack/ibm/vpc-block-csi-wrapper-runner.yaml
-    make import-csi-controller-wrapper-docker
-    make import-csi-node-wrapper-docker
-    make import-csi-podvm-wrapper-docker
-    kubectl patch statefulset ibm-vpc-block-csi-controller -n kube-system --patch-file hack/ibm/patch-controller.yaml
-    kubectl patch ds ibm-vpc-block-csi-node -n kube-system --patch-file hack/ibm/patch-node.yaml
-else
-    echo "Warning: path '~/csi-wrapper' not found"
-fi
+kubectl patch Deployment ibm-vpc-block-csi-controller -n kube-system --patch-file ./patch-controller.yaml
+kubectl patch ds ibm-vpc-block-csi-node -n kube-system --patch-file ./patch-node.yaml

--- a/volumes/csi-wrapper/hack/ibm/ibm-vpc-block-csi-driver-v5.2.0.yaml
+++ b/volumes/csi-wrapper/hack/ibm/ibm-vpc-block-csi-driver-v5.2.0.yaml
@@ -547,7 +547,7 @@ spec:
         envFrom:
         - configMapRef:
             name: ibm-vpc-block-csi-configmap
-        image: gcr.io/k8s-staging-cloud-provider-ibm/ibm-vpc-block-csi-driver:master
+        image: gcr.io/k8s-staging-cloud-provider-ibm/ibm-vpc-block-csi-driver:v5.2.0
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5
@@ -799,7 +799,7 @@ spec:
         envFrom:
         - configMapRef:
             name: ibm-vpc-block-csi-configmap
-        image: gcr.io/k8s-staging-cloud-provider-ibm/ibm-vpc-block-csi-driver:master
+        image: gcr.io/k8s-staging-cloud-provider-ibm/ibm-vpc-block-csi-driver:v5.2.0
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5

--- a/volumes/csi-wrapper/hack/ibm/nginx-kata-with-my-pvc-and-csi-wrapper.yaml
+++ b/volumes/csi-wrapper/hack/ibm/nginx-kata-with-my-pvc-and-csi-wrapper.yaml
@@ -17,7 +17,7 @@ spec:
       envFrom:
         - configMapRef:
             name: ibm-vpc-block-csi-configmap
-      image: gcr.io/k8s-staging-cloud-provider-ibm/ibm-vpc-block-csi-driver:v4.3.1
+      image: gcr.io/k8s-staging-cloud-provider-ibm/ibm-vpc-block-csi-driver:v5.2.0
       imagePullPolicy: Always
       securityContext:
         privileged: true


### PR DESCRIPTION
- csi-wrapper must is ready to use
- only run the test case when env TEST_CSI_WRAPPER=yes
- create pvc and pod with csi-wrapper containers
- clean created pvc after the test case

fixes: #1124

Signed-off-by: Da Li Liu <liudali@cn.ibm.com>