### PR TITLE
Azure: Use env file for secrets in kustomization

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -409,10 +409,8 @@ configMapGenerator:
 secretGenerator:
 - name: peer-pods-secret
   namespace: confidential-containers-system
-  literals:
-  - AZURE_CLIENT_ID="${AZURE_CLIENT_ID}"
-  - AZURE_CLIENT_SECRET="${AZURE_CAA_CLIENT_SECRET}"
-  - AZURE_TENANT_ID="${AZURE_TENANT_ID}"
+  envs:
+  - service-principal.env
 - name: ssh-key-secret
   namespace: confidential-containers-system
   files:
@@ -425,6 +423,17 @@ The ssh public key should be accessible to the kustomization file:
 ```bash
 cp $SSH_KEY install/overlays/azure/id_rsa.pub
 ```
+
+Populate an env file w/ the service principal:
+
+```bash
+cat <<EOF > install/overlays/azure/service-principal.env
+AZURE_CLIENT_ID=${AZURE_CLIENT_ID}
+AZURE_CLIENT_SECRET=${AZURE_CAA_CLIENT_SECRET}
+AZURE_TENANT_ID=${AZURE_TENANT_ID}
+EOF
+```
+
 
 ### Deploy CAA on the Kubernetes cluster
 

--- a/install/overlays/azure/.gitignore
+++ b/install/overlays/azure/.gitignore
@@ -1,0 +1,2 @@
+service-principal.env
+id_rsa.pub

--- a/install/overlays/azure/kustomization.yaml
+++ b/install/overlays/azure/kustomization.yaml
@@ -48,10 +48,12 @@ secretGenerator:
   #- auth.json # set - path to auth.json pull credentials file
 - name: peer-pods-secret
   namespace: confidential-containers-system
-  literals:
-  - AZURE_CLIENT_ID="" # set
-  - AZURE_CLIENT_SECRET="" # set
-  - AZURE_TENANT_ID="" #set
+  # This file should look like this (w/o quotes!):
+  # AZURE_CLIENT_ID=...
+  # AZURE_CLIENT_SECRET=...
+  # AZURE_TENANT_ID=...
+  envs:
+  - service-principal.env
 - name: ssh-key-secret
   namespace: confidential-containers-system
   files: # key generation example: ssh-keygen -f ./id_rsa -N ""


### PR DESCRIPTION
This PR uses the kustomization facility to reference an env file for a key/value map. We can then put the env file into gitignore.

fixes #1131