### PR TITLE
ci: add workflow to detect broken links 

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,28 @@
+name: check links
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  checklinks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Restore lychee cache
+        uses: actions/cache@v3
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: "--cache --max-cache-age 1d ."
+          fail: true

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,1 @@
+https://github.com/\$USER/cloud-api-adaptor/tree/my-changes-in-a-branch

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -73,9 +73,9 @@ for the *libvirt* provider.
 
 Create a new Go file (.go) named `provision_<CLOUD_PROVIDER>`.go (e.g., `provision_libvirt.go`)
 that should be tagged with `//go:build <CLOUD_PROVIDER>`. That file should have the implementation
-of the `CloudProvisioner` interface (see its definition in [provision.go](./provisioner/provision.go)).
+of the `CloudProvisioner` interface (see its definition in [provision.go](../provisioner/provision.go)).
 
-Apart from that, it should be added an entry to the `GetCloudProvisioner()` factory function in [provision.go](./provisioner/provision.go).
+Apart from that, it should be added an entry to the `GetCloudProvisioner()` factory function in [provision.go](../provisioner/provision.go).
 
 ## Create the test suite
 


### PR DESCRIPTION
This new workflow will detect broken links.

Fixes: https://github.com/confidential-containers/cloud-api-adaptor/issues/1134