### PR TITLE
test/e2e: increase timeout to wait cc-operator-daemon-install

### DIFF
--- a/test/provisioner/provision.go
+++ b/test/provisioner/provision.go
@@ -231,7 +231,7 @@ func (p *CloudAPIAdaptor) Deploy(ctx context.Context, cfg *envconf.Config, props
 			ds = object.(*appsv1.DaemonSet)
 
 			return ds.Status.CurrentNumberScheduled > 0
-		}), wait.WithTimeout(time.Second*60)); err != nil {
+		}), wait.WithTimeout(time.Minute*5)); err != nil {
 			return err
 		}
 		pods, err := GetDaemonSetOwnedPods(ctx, cfg, ds)


### PR DESCRIPTION
Apparently 60 seconds is not enough to wait for the cc-operator-daemon-install DaemonSet to be scheduled, as the libvirt e2e has failed on waiting. So increased the timeout to 5 minutes.