### PR TITLE
azure: Fix IP address parsing error

### DIFF
--- a/pkg/adaptor/cloud/azure/provider.go
+++ b/pkg/adaptor/cloud/azure/provider.go
@@ -68,7 +68,7 @@ func getIPs(nic *armnetwork.Interface) ([]netip.Addr, error) {
 		}
 
 		ip, err := netip.ParseAddr(*addr)
-		if err == nil {
+		if err != nil {
 			return nil, fmt.Errorf("parsing pod node IP %q: %w", *addr, err)
 		}
 


### PR DESCRIPTION
https://github.com/confidential-containers/cloud-api-adaptor/pull/954 introduces a bug in Azure provider.

Fixes #1150
