### PR TITLE
tests: add worker label through go

### DIFF
--- a/test/provisioner/common.go
+++ b/test/provisioner/common.go
@@ -1,0 +1,54 @@
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package provisioner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+)
+
+type patchLabel struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value string `json:"value"`
+}
+
+// Adds the worker label to all workers nodes in a given cluster
+func AddNodeRoleWorkerLabel(ctx context.Context, clusterName string, cfg *envconf.Config) error {
+	fmt.Printf("Adding worker label to nodes belonging to: %s\n", clusterName)
+	client, err := cfg.NewClient()
+	if err != nil {
+		return err
+	}
+
+	nodelist := &corev1.NodeList{}
+	if err := client.Resources().List(ctx, nodelist); err != nil {
+		return err
+	}
+	// Use full path to avoid overwriting other labels (see RFC 6902)
+	payload := []patchLabel{{
+		Op: "add",
+		// "/" must be written as ~1 (see RFC 6901)
+		Path:  "/metadata/labels/node.kubernetes.io~1worker",
+		Value: "",
+	}}
+	payloadBytes, _ := json.Marshal(payload)
+	workerStr := clusterName + "-worker"
+	for _, node := range nodelist.Items {
+		if strings.Contains(node.Name, workerStr) {
+			if err := client.Resources().Patch(ctx, &node, k8s.Patch{PatchType: types.JSONPatchType, Data: payloadBytes}); err != nil {
+				return err
+			}
+		}
+
+	}
+	return nil
+}

--- a/test/provisioner/provision_libvirt.go
+++ b/test/provisioner/provision_libvirt.go
@@ -89,6 +89,7 @@ func NewLibvirtProvisioner(properties map[string]string) (CloudProvisioner, erro
 }
 
 func (l *LibvirtProvisioner) CreateCluster(ctx context.Context, cfg *envconf.Config) error {
+
 	cmd := exec.Command("/bin/bash", "-c", "./kcli_cluster.sh create")
 	cmd.Dir = l.wd
 	cmd.Stdout = os.Stdout
@@ -104,6 +105,11 @@ func (l *LibvirtProvisioner) CreateCluster(ctx context.Context, cfg *envconf.Con
 	home, _ := os.UserHomeDir()
 	kubeconfig := path.Join(home, ".kcli/clusters", clusterName, "auth/kubeconfig")
 	cfg.WithKubeconfigFile(kubeconfig)
+
+	if err := AddNodeRoleWorkerLabel(ctx, clusterName, cfg); err != nil {
+
+		return fmt.Errorf("labeling nodes: %w", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
libvirt e2e tests did not properly label worker nodes with the worker label.

This creates a function in test/provisioner/common.go that adds the worker label to the libvirt e2e createCluster.

Fixes: #1107