### PR TITLE
tls-certs: tow tiny changes for tls-proxy-forwarder document

### DIFF
--- a/docs/tls-proxy-forwarder.md
+++ b/docs/tls-proxy-forwarder.md
@@ -77,7 +77,7 @@ Ensure SAN contains `podvm-server`.
 ```
 openssl genrsa -out tls.key 2048
 
-openssl req -new -key tls.key -days 30 -out tls.csr \
+openssl req -new -key tls.key -out tls.csr \
   -subj "/C=IN/ST=KA/L=BLR/O=Self/OU=Self/CN=podvm-server"
 
 openssl x509  -req -in tls.csr \
@@ -91,7 +91,7 @@ openssl x509  -req -in tls.csr \
 ```
   openssl genrsa -out client.key 2048
 
-  openssl req -new -key client.key -days 30 -out client.csr \
+  openssl req -new -key client.key -out client.csr \
     -subj "/C=IN/ST=KA/L=BLR/O=Self/OU=Self/CN=podvm_client"
 
   openssl x509  -req -in client.csr \

--- a/install/overlays/aws/kustomization.yaml
+++ b/install/overlays/aws/kustomization.yaml
@@ -49,9 +49,9 @@ secretGenerator:
 #- name: certs-for-tls
 #  namespace: confidential-containers-system
 #  files:
-#  - <path_to_ca.crt> # set - path to ca.crt
-#  - <path_to_client.crt> # set - path to client.crt
-#  - <path_to_client.key> # set - path to client.key
+#  - <path_to_ca.crt> # set - relative path to ca.crt, located either in the same folder as the kustomization.yaml file or within a subfolder
+#  - <path_to_client.crt> # set - relative path to client.crt, located either in the same folder as the kustomization.yaml file or within a subfolder
+#  - <path_to_client.key> # set - relative path to client.key, located either in the same folder as the kustomization.yaml file or within a subfolder
 ##TLS_SETTINGS
 
 patchesStrategicMerge:

--- a/install/overlays/azure/kustomization.yaml
+++ b/install/overlays/azure/kustomization.yaml
@@ -63,9 +63,9 @@ secretGenerator:
 #- name: certs-for-tls
 #  namespace: confidential-containers-system
 #  files:
-#  - <path_to_ca.crt> # set - path to ca.crt
-#  - <path_to_client.crt> # set - path to client.crt
-#  - <path_to_client.key> # set - path to client.key
+#  - <path_to_ca.crt> # set - relative path to ca.crt, located either in the same folder as the kustomization.yaml file or within a subfolder
+#  - <path_to_client.crt> # set - relative path to client.crt, located either in the same folder as the kustomization.yaml file or within a subfolder
+#  - <path_to_client.key> # set - relative path to client.key, located either in the same folder as the kustomization.yaml file or within a subfolder
 ##TLS_SETTINGS
 
 patchesStrategicMerge:

--- a/install/overlays/ibmcloud-powervs/kustomization.yaml
+++ b/install/overlays/ibmcloud-powervs/kustomization.yaml
@@ -51,9 +51,9 @@ secretGenerator:
 #- name: certs-for-tls
 #  namespace: confidential-containers-system
 #  files:
-#  - <path_to_ca.crt> # set - path to ca.crt
-#  - <path_to_client.crt> # set - path to client.crt
-#  - <path_to_client.key> # set - path to client.key
+#  - <path_to_ca.crt> # set - relative path to ca.crt, located either in the same folder as the kustomization.yaml file or within a subfolder
+#  - <path_to_client.crt> # set - relative path to client.crt, located either in the same folder as the kustomization.yaml file or within a subfolder
+#  - <path_to_client.key> # set - relative path to client.key, located either in the same folder as the kustomization.yaml file or within a subfolder
 ##TLS_SETTINGS
 
 patchesStrategicMerge:

--- a/install/overlays/ibmcloud/kustomization.yaml
+++ b/install/overlays/ibmcloud/kustomization.yaml
@@ -54,9 +54,9 @@ secretGenerator:
 #- name: certs-for-tls
 #  namespace: confidential-containers-system
 #  files:
-#  - <path_to_ca.crt> # set - path to ca.crt
-#  - <path_to_client.crt> # set - path to client.crt
-#  - <path_to_client.key> # set - path to client.key
+#  - <path_to_ca.crt> # set - relative path to ca.crt, located either in the same folder as the kustomization.yaml file or within a subfolder
+#  - <path_to_client.crt> # set - relative path to client.crt, located either in the same folder as the kustomization.yaml file or within a subfolder
+#  - <path_to_client.key> # set - relative path to client.key, located either in the same folder as the kustomization.yaml file or within a subfolder
 ##TLS_SETTINGS
 
 patchesStrategicMerge:

--- a/install/overlays/libvirt/kustomization.yaml
+++ b/install/overlays/libvirt/kustomization.yaml
@@ -45,9 +45,9 @@ secretGenerator:
 #- name: certs-for-tls
 #  namespace: confidential-containers-system
 #  files:
-#  - <path_to_ca.crt> # set - path to ca.crt
-#  - <path_to_client.crt> # set - path to client.crt
-#  - <path_to_client.key> # set - path to client.key
+#  - <path_to_ca.crt> # set - relative path to ca.crt, located either in the same folder as the kustomization.yaml file or within a subfolder
+#  - <path_to_client.crt> # set - relative path to client.crt, located either in the same folder as the kustomization.yaml file or within a subfolder
+#  - <path_to_client.key> # set - relative path to client.key, located either in the same folder as the kustomization.yaml file or within a subfolder
 ##TLS_SETTINGS
 
 patchesStrategicMerge:

--- a/install/overlays/vsphere/kustomization.yaml
+++ b/install/overlays/vsphere/kustomization.yaml
@@ -69,9 +69,9 @@ secretGenerator:
 #- name: certs-for-tls
 #  namespace: confidential-containers-system
 #  files:
-#  - <path_to_ca.crt> # set - path to ca.crt
-#  - <path_to_client.crt> # set - path to client.crt
-#  - <path_to_client.key> # set - path to client.key
+#  - <path_to_ca.crt> # set - relative path to ca.crt, located either in the same folder as the kustomization.yaml file or within a subfolder
+#  - <path_to_client.crt> # set - relative path to client.crt, located either in the same folder as the kustomization.yaml file or within a subfolder
+#  - <path_to_client.key> # set - relative path to client.key, located either in the same folder as the kustomization.yaml file or within a subfolder
 ##TLS_SETTINGS
 
 patchesStrategicMerge:


### PR DESCRIPTION
- update related strings to make it more clearly where the created cert files will be put
- remove bad arg '-days' when create *.crs file to avoid `Ignoring -days; not generating a certificate` message

fixes: #1154

Signed-off-by: Da Li Liu <liudali@cn.ibm.com>