### PR TITLE
ci: minor refactoring of workflow triggers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,11 @@
 # Build binary and run unit tests
 ---
 name: build
-on: [pull_request]
+
+on:
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   build_job:
     name: build

--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -1,10 +1,7 @@
 name: Commit Message Check
+
 on:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
 
 env:
   error_msg: |+

--- a/.github/workflows/controller.yaml
+++ b/.github/workflows/controller.yaml
@@ -4,7 +4,11 @@
 # Run tests for peer-pod controller.
 ---
 name: controller
-on: [pull_request]
+
+on:
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   controller_job:
     name: peerpodconfig-ctrl

--- a/.github/workflows/csi_wrapper_images.yaml
+++ b/.github/workflows/csi_wrapper_images.yaml
@@ -4,13 +4,17 @@
 # Build and push csi wrapper images for each arch.
 ---
 name: csi wrapper images
+
 on:
   push:
     branches:
       - 'main'
-      - 'csi-wrapper-images'
+    paths:
+      - 'volumes/csi-wrapper/**'
+  pull_request:
     paths:
     - 'volumes/csi-wrapper/**'
+  workflow_dispatch:
 
 env:
   go_version: "1.20.6"
@@ -22,8 +26,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        binary: [csi-controller-wrapper, csi-node-wrapper, csi-podvm-wrapper]
-
+        binary:
+          - csi-controller-wrapper
+          - csi-node-wrapper
+          - csi-podvm-wrapper
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
@@ -50,8 +56,7 @@ jobs:
           push: true
           context: volumes/csi-wrapper
           platforms: linux/amd64, linux/s390x, linux/ppc64le
-          file: |
-            volumes/csi-wrapper/Dockerfile.csi_wrappers
+          file: volumes/csi-wrapper/Dockerfile.csi_wrappers
           build-args: |
             "BINARY=${{matrix.binary}}"
             "SOURCE_FROM=remote"

--- a/.github/workflows/daily-e2e-tests-ibmcloud.yaml
+++ b/.github/workflows/daily-e2e-tests-ibmcloud.yaml
@@ -4,15 +4,13 @@
 # Build and push container images for each cloud provider.
 ---
 name: daily e2e tests for ibmcloud
+
 on:
   schedule:
     # Runs "at 05:00(UTC time) every day" (see https://crontab.guru)
     # will base on default branch `main`
     - cron: '0 5 * * *'
-  push:
-    branches:    
-      - daily-e2e-ibmcloud
-      - develop
+  workflow_dispatch:
 
 jobs:
   daily-e2e-tests:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -4,10 +4,13 @@
 # Build and push container images for each cloud provider.
 ---
 name: image
+
 on:
   push:
     branches:
       - 'main'
+  workflow_dispatch:
+
 env:
   go_version: "1.20.6"
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,9 +4,17 @@
 # Run linting tools on the sources of the project.
 ---
 name: lint
-on: [workflow_dispatch, pull_request]
+
+on:
+  push:
+    branches:
+        - 'main'
+  pull_request:
+  workflow_dispatch:
+
 env:
   GO_VERSION: "1.20.6"
+
 jobs:
   vet-and-fmt:
     name: vet and fmt

--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -1,9 +1,10 @@
 name: Create Test Images
+
 on:
   workflow_dispatch:
   push:
     branches:
-      - "main"
+      - 'main'
     paths:
       - 'test/e2e/fixtures/Dockerfile.*'
       - '.github/workflows/test-images.yaml'

--- a/.github/workflows/webhook-build.yaml
+++ b/.github/workflows/webhook-build.yaml
@@ -10,6 +10,7 @@ on:
       - main
     paths:
       - 'webhook/**'
+
 env:
   go_version: "1.20.6"
 
@@ -18,7 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash
         working-directory: webhook
     steps:
       - name: Checkout the code

--- a/.github/workflows/webhook-test.yaml
+++ b/.github/workflows/webhook-test.yaml
@@ -4,16 +4,22 @@
 # Run end-to-end tests if any webhook source files changed.
 ---
 name: webhook-test
+
 on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'webhook/**'
   pull_request:
     paths:
       - 'webhook/**'
+
 jobs:
   test-e2e:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash
         working-directory: webhook
     steps:
       - name: Checkout the pull request code


### PR DESCRIPTION
Adding workflow_dispatch as trigger where it makes sense, so workflows can be triggered manually when needed, e.g., on forks. Removing values that are already present as default.

Fixes: https://github.com/confidential-containers/cloud-api-adaptor/issues/1170