### PR TITLE
test/e2e/livirt: allow prop file overwrite cluster name

### DIFF
--- a/libvirt/kcli_cluster.sh
+++ b/libvirt/kcli_cluster.sh
@@ -52,7 +52,7 @@ create () {
 		-P disk_size="$CLUSTER_DISK_SIZE" \
 		"$CLUSTER_NAME"
 
-	export KUBECONFIG=$HOME/.kcli/clusters/peer-pods/auth/kubeconfig
+	export KUBECONFIG=$HOME/.kcli/clusters/$CLUSTER_NAME/auth/kubeconfig
 
 	local cmd="kubectl get nodes | grep '\<Ready\>.*worker'"
 	echo "Wait at least one worker be Ready"

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -63,6 +63,7 @@ Use the properties on the table below for Libvirt:
 |libvirt_ssh_key_file|Path to SSH private key||
 |pause_image|k8s pause image||
 |vxlan_port| VXLAN port number||
+|cluster_name|Cluster Name| "peer-pods"|
 
 # Adding support for a new cloud provider
 


### PR DESCRIPTION
Creates a cluster_name property that can be added to the libvirt properties file and corresponding LibvirtProvisioner struct.

Before createCluster executes kcli_cluster.sh, it adds the cluster name, network, and storage pool to the environment.

Fixes: #1163