### PR TITLE
azure-packer: Provide consistent path of toupload dir

### DIFF
--- a/azure/image/centos/azure-centos.pkr.hcl
+++ b/azure/image/centos/azure-centos.pkr.hcl
@@ -33,7 +33,7 @@ build {
   }
 
   provisioner "file" {
-    source      = "./toupload"
+    source      = "toupload"
     destination = "/tmp/"
   }
 

--- a/azure/image/rhel/azure-rhel.pkr.hcl
+++ b/azure/image/rhel/azure-rhel.pkr.hcl
@@ -33,7 +33,7 @@ build {
   }
 
   provisioner "file" {
-    source      = "./toupload"
+    source      = "toupload"
     destination = "/tmp/"
   }
 

--- a/azure/image/ubuntu/azure-ubuntu.pkr.hcl
+++ b/azure/image/ubuntu/azure-ubuntu.pkr.hcl
@@ -35,7 +35,7 @@ build {
   }
 
   provisioner "file" {
-    source      = "./toupload"
+    source      = "toupload"
     destination = "/tmp/"
   }
 


### PR DESCRIPTION
Right now the `toupload` directory is referenced with ./ in some places
and in some places without it. This causes the packer to be not able to
find the directory and hence the build fails.

Fixes #1179