### PR TITLE
e2e: add workflow for csi wrapper e2e test

### DIFF
--- a/.github/workflows/daily-e2e-tests-ibmcloud.yaml
+++ b/.github/workflows/daily-e2e-tests-ibmcloud.yaml
@@ -23,6 +23,7 @@ jobs:
           - type: amd64
           - type: s390x-non-secure-execution
           - type: s390x-secure-execution
+          - type: csi_wrapper_x86_64
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
@@ -79,22 +80,24 @@ jobs:
           echo "The built podvm image is based on CAA commit_id: ${caa_commit_id}"
           arch_string=""
           podvm_docker_name=""
-          case "${{matrix.type}}" in
-            amd64)
-              arch_string="amd64"
-              ;;
-            s390x-non-secure-execution)
-              arch_string="s390x"
-              ;;
-            s390x-secure-execution)
-              arch_string="s390x-se"
-              ;;
-          esac
-          podvm_image_tar_name="podvm-generic-ubuntu-${arch_string}-${caa_commit_id}.tar"
-          podvm_docker_name="quay.io/confidential-containers/podvm-generic-ubuntu-${arch_string}:${caa_commit_id}"
-          ibmcloud cos object-get --bucket daily-e2e-test-bucket --key=$podvm_image_tar_name $podvm_image_tar_name
-          docker load -i $podvm_image_tar_name
-          docker push ${podvm_docker_name}
-          echo "${podvm_docker_name} is pushed"
+          if [[ "${{matrix.type}}" != "csi_wrapper_x86_64" ]]; then
+            case "${{matrix.type}}" in
+              amd64)
+                arch_string="amd64"
+                ;;
+              s390x-non-secure-execution)
+                arch_string="s390x"
+                ;;
+              s390x-secure-execution)
+                arch_string="s390x-se"
+                ;;
+            esac
+            podvm_image_tar_name="podvm-generic-ubuntu-${arch_string}-${caa_commit_id}.tar"
+            podvm_docker_name="quay.io/confidential-containers/podvm-generic-ubuntu-${arch_string}:${caa_commit_id}"
+            ibmcloud cos object-get --bucket daily-e2e-test-bucket --key=$podvm_image_tar_name $podvm_image_tar_name
+            docker load -i $podvm_image_tar_name
+            docker push ${podvm_docker_name}
+            echo "${podvm_docker_name} is pushed"
+          fi
         env:
           bucket_name : "daily-e2e-test-bucket"


### PR DESCRIPTION
fix: https://github.com/confidential-containers/cloud-api-adaptor/issues/1188

This enable workflow to display e2e test result of csi wrapper. The e2e test of csi wrapper includes creating self managed kubeadm cluster in IBMCloud, then installing cloud api adapater and csi wrapper to the cluster, at last testing csi wrapper.

Signed-off-by: yuanyuanwang wyuany@cn.ibm.com