### PR TITLE
ibmcloud: Bug fix to resolve unstable testuser image

### DIFF
--- a/test/e2e/fixtures/Dockerfile.testuser
+++ b/test/e2e/fixtures/Dockerfile.testuser
@@ -1,4 +1,4 @@
 FROM --platform="${TARGETPLATFORM}" alpine:latest
-RUN addgroup -S othergroup && adduser -S otheruser -G othergroup
+RUN addgroup -S othergroup && adduser -S otheruser -G othergroup --uid 1000
 USER otheruser
 ENTRYPOINT [ "/bin/sh", "-c", "whoami" ]


### PR DESCRIPTION
Modified Dockerfile to resolve unstable test results of TestCreatePeerPodAndCheckUserLogs

Fixes: #1127