### PR TITLE
Automatically fetch config map values

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,11 +60,13 @@ aws() {
 }
 
 azure() {
-    test_vars AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID AZURE_RESOURCE_GROUP AZURE_SUBNET_ID AZURE_IMAGE_ID
+    test_vars AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID AZURE_RESOURCE_GROUP AZURE_IMAGE_ID
 
     [[ "${SSH_USERNAME}" ]] && optionals+="-ssh-username ${SSH_USERNAME} "
     [[ "${DISABLECVM}" == "true" ]] && optionals+="-disable-cvm "
     [[ "${AZURE_INSTANCE_SIZES}" ]] && optionals+="-instance-sizes ${AZURE_INSTANCE_SIZES} "
+    [[ "${AZURE_SUBNET_ID}" ]] && optionals+="-subnetid ${AZURE_SUBNET_ID} "
+    [[ "${AZURE_NSG_ID}" ]] && optionals+="-securitygroupid ${AZURE_NSG_ID} "
     [[ "${TAGS}" ]] && optionals+="-tags ${TAGS} " # Custom tags applied to pod vm
     [[ "${DISABLE_CLOUD_CONFIG}" == "true" ]] && optionals+="-disable-cloud-config "
 
@@ -75,8 +77,6 @@ azure() {
         -instance-size "${AZURE_INSTANCE_SIZE}" \
         -resourcegroup "${AZURE_RESOURCE_GROUP}" \
         -vxlan-port 8472 \
-        -subnetid "${AZURE_SUBNET_ID}" \
-        -securitygroupid "${AZURE_NSG_ID}" \
         -imageid "${AZURE_IMAGE_ID}" \
         ${optionals}
 }

--- a/pkg/adaptor/cloud/azure/types.go
+++ b/pkg/adaptor/cloud/azure/types.go
@@ -34,7 +34,6 @@ type Config struct {
 	Zone                 string
 	Region               string
 	SubnetId             string
-	SecurityGroupName    string
 	SecurityGroupId      string
 	Size                 string
 	ImageId              string


### PR DESCRIPTION
This PR gets rid of some ConfigMap parameters that must be provided to CAA in order to make it run on Azure/AWS.

More specifically:
- In Azure, ConfigMap was
```
    cat <<EOF | oc apply -f -
apiVersion: v1
kind: ConfigMap
metadata:
  name: ${CM}
  namespace: ${OP_NAME}
data:
  CLOUD_PROVIDER: "azure"
  VXLAN_PORT: "9000"
  AZURE_INSTANCE_SIZE: "Standard_D8as_v5" #set
  PROXY_TIMEOUT: "15m"
  AZURE_IMAGE_ID: ${AZURE_IMAGE_ID}
  AZURE_SUBNET_ID: ${AZURE_SUBNET_ID}
  AZURE_NSG_ID: ${AZURE_NSG_ID}
  DISABLECVM: "true"
EOF
```
and becomes now
```
    cat <<EOF | oc apply -f -
apiVersion: v1
kind: ConfigMap
metadata:
  name: ${CM}
  namespace: ${OP_NAME}
data:
  CLOUD_PROVIDER: "azure"
  VXLAN_PORT: "9000"
  AZURE_INSTANCE_SIZE: "Standard_D8as_v5" #set
  PROXY_TIMEOUT: "15m"
  AZURE_IMAGE_ID: ${AZURE_IMAGE_ID}
  DISABLECVM: "true"
EOF
```

### Current limitations of this patch

azure:
- tested on Azure

Fixes: #1200