### PR TITLE
podvm changes: add tdx deps to Azure image and gRPC build of AA

### DIFF
--- a/azure/image/Makefile
+++ b/azure/image/Makefile
@@ -4,6 +4,8 @@
 
 include ../../podvm/Makefile.inc
 
+BINARIES += $(ATTESTATION_AGENT_GRPC)
+
 .PHONY: image clean
 
 image: $(IMAGE_FILE)

--- a/azure/image/misc-settings.sh
+++ b/azure/image/misc-settings.sh
@@ -40,8 +40,11 @@ fi
 
 if [[ "$CLOUD_PROVIDER" == "azure" && "$PODVM_DISTRO" == "ubuntu" ]]; then
     export DEBIAN_FRONTEND=noninteractive
+    curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
+    echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+
     sudo apt-get update
-    sudo apt-get install -y libtss2-tctildr0
+    sudo apt-get install -y --no-install-recommends libtss2-tctildr0 libtdx-attest
 fi
 
 # Setup oneshot systemd service for AWS and Azure to enable NAT rules

--- a/podvm/Makefile.inc
+++ b/podvm/Makefile.inc
@@ -54,6 +54,7 @@ AGENT_PROTOCOL_FORWARDER = $(FILES_DIR)/usr/local/bin/agent-protocol-forwarder
 KATA_AGENT    = $(FILES_DIR)/usr/local/bin/kata-agent
 PAUSE         = $(FILES_DIR)/$(PAUSE_BUNDLE)/rootfs/pause
 ATTESTATION_AGENT = $(FILES_DIR)/usr/local/bin/attestation-agent
+ATTESTATION_AGENT_GRPC = $(FILES_DIR)/usr/local/bin/attestation-agent.grpc
 
 # Allow BINARIES to be overriden externally
 BINARIES ?= $(AGENT_PROTOCOL_FORWARDER) $(KATA_AGENT) $(PAUSE)
@@ -140,13 +141,22 @@ $(PAUSE): | $(PAUSE_SRC) $(UMOCI_SRC)/umoci
 $(GUEST_COMPONENTS_SRC):
 	$(call git_clone_repo_ref,$(GUEST_COMPONENTS_REPO),$(GUEST_COMPONENTS_SRC),$(GUEST_COMPONENTS_VERSION))
 
+$(GUEST_COMPONENTS_SRC).grpc: $(GUEST_COMPONENTS_SRC)
+	git clone --depth=1 $< $@
+
 $(ATTESTATION_AGENT): $(GUEST_COMPONENTS_SRC)
-	cd "$(GUEST_COMPONENTS_SRC)/attestation-agent" && CC= ARCH=$(ARCH) $(MAKE) KBC="$(AA_KBC)" ttrpc=true LIBC="$(LIBC)"
+	cd "$(<)/attestation-agent" && CC= ARCH=$(ARCH) $(MAKE) KBC="$(AA_KBC)" ttrpc=true LIBC="$(LIBC)"
 	mkdir -p "$(@D)"
-	install --compare "$(GUEST_COMPONENTS_SRC)/target/$(RUST_TARGET)/release/attestation-agent" "$@"
+	install --compare "$(<)/target/$(RUST_TARGET)/release/attestation-agent" "$@"
+
+$(ATTESTATION_AGENT_GRPC): $(GUEST_COMPONENTS_SRC).grpc
+	cd "$(<)/attestation-agent" && CC= ARCH=$(ARCH) $(MAKE) KBC="$(AA_KBC)" grpc=true LIBC="$(LIBC)"
+	mkdir -p "$(@D)"
+	install --compare "$(<)/target/$(RUST_TARGET)/release/attestation-agent" "$@"
 
 clean_sources:
 	[ -d "$(GUEST_COMPONENTS_SRC)" ] && cd "$(GUEST_COMPONENTS_SRC)" && git clean -xfd
+	[ -d "$(GUEST_COMPONENTS_SRC).grpc" ] && cd "$(GUEST_COMPONENTS_SRC).grpc" && git clean -xfd
 	[ -d "$(KATA_AGENT_SRC)" ] && cd "$(KATA_AGENT_SRC)" && git clean -xfd
 	[ -d "$(AGENT_PROTOCOL_FORWARDER_SRC)" ] && cd "$(AGENT_PROTOCOL_FORWARDER_SRC)" && git clean -xfd -e podvm
 	[ -d "$(PAUSE_SRC)" ] && cd "$(PAUSE_SRC)" && rm -rf *

--- a/podvm/files/etc/systemd/system/attestation-agent.service
+++ b/podvm/files/etc/systemd/system/attestation-agent.service
@@ -1,12 +1,13 @@
 [Unit]
 Description=Attestation Agent Service
+ConditionFileIsExecutable=/usr/local/bin/attestation-agent.grpc
 BindsTo=netns@podns.service
 After=network.target kata-agent.service netns@podns.service
 
 [Service]
 Type=simple
 NetworkNamespacePath=/run/netns/podns
-ExecStart=/usr/local/bin/attestation-agent --getresource_sock 127.0.0.1:50001
+ExecStart=/usr/local/bin/attestation-agent.grpc --getresource_sock 127.0.0.1:50001
 Restart=always
 
 [Install]


### PR DESCRIPTION
Add the option of including a gRPC attestation-agent in podvm image, and launch it using systemd. Use that in the Azure image.
Also install TDX deps to Azure image, so that AA can be built with all attesters.