### PR TITLE
podnetwork: Fix workerNodeTunneler.Setup() panic

### DIFF
--- a/pkg/podnetwork/tunneler/vxlan/workernode.go
+++ b/pkg/podnetwork/tunneler/vxlan/workernode.go
@@ -34,7 +34,15 @@ func (t *workerNodeTunneler) Setup(nsPath string, podNodeIPs []netip.Addr, confi
 
 	var dstAddr netip.Addr
 
+	numIPs := len(podNodeIPs)
+	if numIPs == 0 {
+		return fmt.Errorf("pod node has no IPs")
+	}
+
 	if config.Dedicated {
+		if numIPs < 2 {
+			return fmt.Errorf("dedicated tunnel missing destination address")
+		}
 		dstAddr = podNodeIPs[1]
 	} else {
 		dstAddr = podNodeIPs[0]


### PR DESCRIPTION
The workerNodeTunneler.Setup() can get an empty list of pod node IPs and it will panic due to `index out of range` access. Added handlers for the following situations:

* podNodeIPs is zero then return error
* podNodeIPs is less than 2 IPs on a dedicated tunnel config then return error

Fixes #1207
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>