### PR TITLE
csi-wrapper: fix README

### DIFF
--- a/volumes/csi-wrapper/examples/azure/README.md
+++ b/volumes/csi-wrapper/examples/azure/README.md
@@ -77,7 +77,7 @@ docker push ${REGISTRY}/csi-podvm-wrapper:latest
 
 5. Change image in CSI wrapper k8s resources
 ```bash
-sed -i "s#quay.io/confidential-containers#${REGISTRY}#g" volumes/csi-wrapper/hack/azure/*.yaml
+sed -i "s#quay.io/confidential-containers#${REGISTRY}#g" volumes/csi-wrapper/examples/azure/*.yaml
 ```
 
 ### Deploy csi-wrapper to patch azurefiles-csi-driver
@@ -99,27 +99,27 @@ customresourcedefinition.apiextensions.k8s.io/peerpodvolumes.confidentialcontain
 
 3. Configure RBAC so that the wrapper has access to the required operations
 ```bash
-kubectl apply -f volumes/csi-wrapper/hack/azure/azure-files-csi-wrapper-runner.yaml
-kubectl apply -f volumes/csi-wrapper/hack/azure/azure-files-csi-wrapper-podvm.yaml
+kubectl apply -f volumes/csi-wrapper/examples/azure/azure-files-csi-wrapper-runner.yaml
+kubectl apply -f volumes/csi-wrapper/examples/azure/azure-files-csi-wrapper-podvm.yaml
 ```
 
 4. patch csi-azurefile-driver:
 ```bash
-kubectl patch deploy csi-azurefile-controller -n kube-system --patch-file volumes/csi-wrapper/hack/azure/patch-controller.yaml
+kubectl patch deploy csi-azurefile-controller -n kube-system --patch-file volumes/csi-wrapper/examples/azure/patch-controller.yaml
 kubectl -n kube-system delete replicaset -l app=csi-azurefile-controller
-kubectl patch ds csi-azurefile-node -n kube-system --patch-file volumes/csi-wrapper/hack/azure/patch-node.yaml
+kubectl patch ds csi-azurefile-node -n kube-system --patch-file volumes/csi-wrapper/examples/azure/patch-node.yaml
 ```
 
 5. Create **storage class**:
 ```bash
-kubectl apply -f volumes/csi-wrapper/hack/azure/azure-file-StorageClass-for-peerpod.yaml
+kubectl apply -f volumes/csi-wrapper/examples/azure/azure-file-StorageClass-for-peerpod.yaml
 ```
 
 ### Run the `csi-wrapper for peerpod storage` demo
 
 1. Create one pvc that use `azurefiles-csi-driver`
 ```bash
-kubectl apply -f volumes/csi-wrapper/hack/azure/my-pvc.yaml
+kubectl apply -f volumes/csi-wrapper/examples/azure/my-pvc.yaml
 ```
 
 2. Wait for the pvc status to become `bound`
@@ -131,7 +131,7 @@ pvc-azurefile   Bound    pvc-3edc7a93-4531-4034-8818-1b1608907494   1Gi        R
 
 3. Create the nginx peer-pod demo with with `podvm-wrapper` and `azurefile-csi-driver` containers
 ```bash
-kubectl apply -f volumes/csi-wrapper/hack/azure/nginx-kata-with-my-pvc-and-csi-wrapper.yaml
+kubectl apply -f volumes/csi-wrapper/examples/azure/nginx-kata-with-my-pvc-and-csi-wrapper.yaml
 ```
 
 4. Exec into the container and check the mount


### PR DESCRIPTION
It mentions the `hack/` directory but it's now `examples/`

Fixes #1209