### PR TITLE
Release 0.7.0 tagging go modules

### DIFF
--- a/peerpod-ctrl/go.mod
+++ b/peerpod-ctrl/go.mod
@@ -3,7 +3,7 @@ module github.com/confidential-containers/cloud-api-adaptor/peerpod-ctrl
 go 1.19
 
 require (
-	github.com/confidential-containers/cloud-api-adaptor v0.7.0-alpha.1
+	github.com/confidential-containers/cloud-api-adaptor v0.7.0
 	github.com/onsi/ginkgo/v2 v2.8.1
 	github.com/onsi/gomega v1.27.1
 	k8s.io/api v0.26.0

--- a/peerpod-ctrl/go.sum
+++ b/peerpod-ctrl/go.sum
@@ -325,8 +325,8 @@ github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/confidential-containers/cloud-api-adaptor v0.7.0-alpha.1 h1:31xAxEvFLj3ZIfdecXyrFgG8K0YiII4UKVaAm4wapfY=
-github.com/confidential-containers/cloud-api-adaptor v0.7.0-alpha.1/go.mod h1:9sa2AlO2/vaeaVGgmfWwCaLA7ah6nk8gFJJQXQYQKxA=
+github.com/confidential-containers/cloud-api-adaptor v0.7.0 h1:b25nekl7ZRO+61ZEL2YQMtZnLIBIxNzpsqHsg1FULEY=
+github.com/confidential-containers/cloud-api-adaptor v0.7.0/go.mod h1:huzOXeTtonxU9LJlT7266sTVsi9n3m4va3MHG8X9jKI=
 github.com/container-orchestrated-devices/container-device-interface v0.4.0/go.mod h1:E1zcucIkq9P3eyNmY+68dBQsTcsXJh9cgRo2IVNScKQ=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
 github.com/containerd/aufs v0.0.0-20201003224125-76a6863f2989/go.mod h1:AkGGQs9NM2vtYHaUen+NljV0/baGCAPELGm2q9ZXpWU=

--- a/volumes/csi-wrapper/go.mod
+++ b/volumes/csi-wrapper/go.mod
@@ -3,7 +3,7 @@ module github.com/confidential-containers/cloud-api-adaptor/volumes/csi-wrapper
 go 1.19
 
 require (
-	github.com/confidential-containers/cloud-api-adaptor v0.7.0-alpha.1
+	github.com/confidential-containers/cloud-api-adaptor v0.7.0
 	github.com/container-storage-interface/spec v1.8.0
 	github.com/containerd/ttrpc v1.1.0
 	github.com/gofrs/uuid v4.4.0+incompatible

--- a/volumes/csi-wrapper/go.sum
+++ b/volumes/csi-wrapper/go.sum
@@ -46,8 +46,8 @@ github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XP
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/confidential-containers/cloud-api-adaptor v0.7.0-alpha.1 h1:31xAxEvFLj3ZIfdecXyrFgG8K0YiII4UKVaAm4wapfY=
-github.com/confidential-containers/cloud-api-adaptor v0.7.0-alpha.1/go.mod h1:9sa2AlO2/vaeaVGgmfWwCaLA7ah6nk8gFJJQXQYQKxA=
+github.com/confidential-containers/cloud-api-adaptor v0.7.0 h1:b25nekl7ZRO+61ZEL2YQMtZnLIBIxNzpsqHsg1FULEY=
+github.com/confidential-containers/cloud-api-adaptor v0.7.0/go.mod h1:huzOXeTtonxU9LJlT7266sTVsi9n3m4va3MHG8X9jKI=
 github.com/container-storage-interface/spec v1.8.0 h1:D0vhF3PLIZwlwZEf2eNbpujGCNwspwTYf2idJRJx4xI=
 github.com/container-storage-interface/spec v1.8.0/go.mod h1:ROLik+GhPslwwWRNFF1KasPzroNARibH2rfz1rkg4H0=
 github.com/containerd/ttrpc v1.1.0 h1:GbtyLRxb0gOLR0TYQWt3O6B0NvT8tMdorEHqIQo/lWI=


### PR DESCRIPTION
I've already tagged `main` with `v0.7.0`. It is time to update the peerpod-ctrl and csi-wrapper modules to use the tagged cloud-api-adaptor go module. 