### PR TITLE
feat: add s390x support to libvirt provider

### DIFF
--- a/pkg/adaptor/cloud/libvirt/libvirt.go
+++ b/pkg/adaptor/cloud/libvirt/libvirt.go
@@ -20,6 +20,9 @@ import (
 	libvirtxml "libvirt.org/go/libvirtxml"
 )
 
+// architecture value for the s390x architecture
+const archS390x = "s390x"
+
 type domainConfig struct {
 	name        string
 	cpu         uint
@@ -191,12 +194,12 @@ func createDomainXMLs390x(client *libvirtClient, cfg *domainConfig) (*libvirtxml
 		return nil, err
 	}
 
-	guest, err := getGuestForArchType(caps, "s390x", "hvm")
+	guest, err := getGuestForArchType(caps, archS390x, "hvm")
 	if err != nil {
 		return nil, err
 	}
 
-	canonicalmachine, err := getCanonicalMachineName(caps, "s390x", "hvm", "s390-ccw-virtio")
+	canonicalmachine, err := getCanonicalMachineName(caps, archS390x, "hvm", "s390-ccw-virtio")
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +250,7 @@ func createDomainXMLs390x(client *libvirtClient, cfg *domainConfig) (*libvirtxml
 		OS: &libvirtxml.DomainOS{
 			Type: &libvirtxml.DomainOSType{
 				Type:    "hvm",
-				Arch:    "s390x",
+				Arch:    archS390x,
 				Machine: canonicalmachine,
 			},
 		},
@@ -384,7 +387,7 @@ func createDomainXML(client *libvirtClient, cfg *domainConfig) (*libvirtxml.Doma
 		return nil, fmt.Errorf("error retrieving node info: %w", err)
 	}
 	switch node.Model {
-	case "s390x":
+	case archS390x:
 		return createDomainXMLs390x(client, cfg)
 	default:
 		return createDomainXMLx86_64(client, cfg)

--- a/pkg/adaptor/cloud/libvirt/libvirt.go
+++ b/pkg/adaptor/cloud/libvirt/libvirt.go
@@ -20,6 +20,15 @@ import (
 	libvirtxml "libvirt.org/go/libvirtxml"
 )
 
+type domainConfig struct {
+	name        string
+	cpu         uint
+	mem         uint
+	networkName string
+	bootDisk    string
+	cidataDisk  string
+}
+
 func createCloudInitISO(v *vmConfig, libvirtClient *libvirtClient) string {
 	logger.Printf("Create cloudInit iso\n")
 	cloudInitIso := libvirtClient.dataDir + "/" + v.name + "-cloudinit.iso"
@@ -49,7 +58,7 @@ func createCloudInitISO(v *vmConfig, libvirtClient *libvirtClient) string {
 	}
 	udf.Close()
 
-	fmt.Printf("Executing genisoimage\n")
+	logger.Println("Executing genisoimage")
 	// genisoimage -output cloudInitIso.iso -volid cidata -joliet -rock user-data meta-data
 	cmd := exec.Command("genisoimage", "-output", cloudInitIso, "-volid", "cidata", "-joliet", "-rock", userDataFile, v.metaData)
 	cmd.Stdout = os.Stdout
@@ -95,7 +104,7 @@ func checkDomainExistsById(id uint32, libvirtClient *libvirtClient) (exist bool,
 
 func uploadIso(isoFile string, isoVolName string, libvirtClient *libvirtClient) (string, error) {
 
-	fmt.Printf("Uploading iso file: %s\n", isoFile)
+	logger.Printf("Uploading iso file: %s\n", isoFile)
 	volumeDef := newDefVolume(isoVolName)
 
 	img, err := newImage(isoFile)
@@ -114,6 +123,272 @@ func uploadIso(isoFile string, isoVolName string, libvirtClient *libvirtClient) 
 
 	return uploadVolume(libvirtClient, volumeDef, img)
 
+}
+
+func getGuestForArchType(caps *libvirtxml.Caps, arch string, virttype string) (*libvirtxml.CapsGuest, error) {
+	for _, guest := range caps.Guests {
+		if guest.Arch.Name == arch && guest.OSType == virttype {
+			return &guest, nil
+		}
+	}
+	return nil, fmt.Errorf("could not find any guests for architecture type %s/%s", virttype, arch)
+}
+
+func getHostCapabilities(client *libvirtClient) (*libvirtxml.Caps, error) {
+	// We should perhaps think of storing this on the connect object
+	// on first call to avoid the back and forth
+	capsXML, err := client.connection.GetCapabilities()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get capabilities, cause: %w", err)
+	}
+
+	caps := &libvirtxml.Caps{}
+	err = xml.Unmarshal([]byte(capsXML), caps)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal capabilities, cause: %w", err)
+	}
+
+	return caps, nil
+}
+
+func lookupMachine(machines []libvirtxml.CapsGuestMachine, targetmachine string) string {
+	for _, machine := range machines {
+		if machine.Name == targetmachine {
+			if machine.Canonical != "" {
+				return machine.Canonical
+			}
+			return machine.Name
+		}
+	}
+	return ""
+}
+
+func getCanonicalMachineName(caps *libvirtxml.Caps, arch string, virttype string, targetmachine string) (string, error) {
+	guest, err := getGuestForArchType(caps, arch, virttype)
+	if err != nil {
+		return "", err
+	}
+
+	name := lookupMachine(guest.Arch.Machines, targetmachine)
+	if name != "" {
+		return name, nil
+	}
+
+	for _, domain := range guest.Arch.Domains {
+		name := lookupMachine(domain.Machines, targetmachine)
+		if name != "" {
+			return name, nil
+		}
+	}
+
+	return "", fmt.Errorf("cannot find machine type %s for %s/%s in %v", targetmachine, virttype, arch, caps)
+}
+
+func createDomainXMLs390x(client *libvirtClient, cfg *domainConfig) (*libvirtxml.Domain, error) {
+
+	caps, err := getHostCapabilities(client)
+	if err != nil {
+		return nil, err
+	}
+
+	guest, err := getGuestForArchType(caps, "s390x", "hvm")
+	if err != nil {
+		return nil, err
+	}
+
+	canonicalmachine, err := getCanonicalMachineName(caps, "s390x", "hvm", "s390-ccw-virtio")
+	if err != nil {
+		return nil, err
+	}
+
+	bootDisk := libvirtxml.DomainDisk{
+		Device: "disk",
+		Target: &libvirtxml.DomainDiskTarget{
+			Dev: "vda",
+			Bus: "virtio",
+		},
+		Driver: &libvirtxml.DomainDiskDriver{
+			Name:  "qemu",
+			Type:  "qcow2",
+			IOMMU: "on",
+		},
+		Source: &libvirtxml.DomainDiskSource{
+			File: &libvirtxml.DomainDiskSourceFile{
+				File: cfg.bootDisk,
+			},
+		},
+		Boot: &libvirtxml.DomainDeviceBoot{
+			Order: 1,
+		},
+	}
+
+	cloudInitDisk := libvirtxml.DomainDisk{
+		Device: "disk",
+		Target: &libvirtxml.DomainDiskTarget{
+			Dev: "vdb",
+			Bus: "virtio",
+		},
+		Driver: &libvirtxml.DomainDiskDriver{
+			Name:  "qemu",
+			Type:  "raw",
+			IOMMU: "on",
+		},
+		Source: &libvirtxml.DomainDiskSource{
+			File: &libvirtxml.DomainDiskSourceFile{
+				File: cfg.cidataDisk,
+			},
+		},
+	}
+
+	return &libvirtxml.Domain{
+		Type:        "kvm",
+		Name:        cfg.name,
+		Description: "This Virtual Machine is the peer-pod VM",
+		OS: &libvirtxml.DomainOS{
+			Type: &libvirtxml.DomainOSType{
+				Type:    "hvm",
+				Arch:    "s390x",
+				Machine: canonicalmachine,
+			},
+		},
+		Metadata: &libvirtxml.DomainMetadata{},
+		Memory: &libvirtxml.DomainMemory{
+			Value: cfg.mem, Unit: "GiB",
+		},
+		CurrentMemory: &libvirtxml.DomainCurrentMemory{
+			Value: cfg.mem, Unit: "GiB",
+		},
+		VCPU: &libvirtxml.DomainVCPU{
+			Value: cfg.cpu,
+		},
+		Clock: &libvirtxml.DomainClock{
+			Offset: "utc",
+		},
+		Devices: &libvirtxml.DomainDeviceList{
+			Disks: []libvirtxml.DomainDisk{
+				bootDisk,
+				cloudInitDisk,
+			},
+			Emulator: guest.Arch.Emulator,
+			MemBalloon: &libvirtxml.DomainMemBalloon{
+				Model: "none",
+			},
+			RNGs: []libvirtxml.DomainRNG{
+				{
+					Model: "virtio",
+					Backend: &libvirtxml.DomainRNGBackend{
+						Random: &libvirtxml.DomainRNGBackendRandom{Device: "/dev/urandom"},
+					},
+				},
+			},
+			Consoles: []libvirtxml.DomainConsole{
+				{
+					Source: &libvirtxml.DomainChardevSource{
+						Pty: &libvirtxml.DomainChardevSourcePty{},
+					},
+					Target: &libvirtxml.DomainConsoleTarget{
+						Type: "sclp",
+					},
+				},
+			},
+			Interfaces: []libvirtxml.DomainInterface{
+				{
+					Model: &libvirtxml.DomainInterfaceModel{
+						Type: "virtio",
+					},
+					Source: &libvirtxml.DomainInterfaceSource{
+						Network: &libvirtxml.DomainInterfaceSourceNetwork{
+							Network: cfg.networkName,
+						},
+					},
+					Driver: &libvirtxml.DomainInterfaceDriver{
+						IOMMU: "on",
+					},
+				},
+			},
+		},
+	}, nil
+
+}
+
+func createDomainXMLx86_64(client *libvirtClient, cfg *domainConfig) (*libvirtxml.Domain, error) {
+
+	var diskControllerAddr uint = 0
+	return &libvirtxml.Domain{
+		Type:        "kvm",
+		Name:        cfg.name,
+		Description: "This Virtual Machine is the peer-pod VM",
+		Memory:      &libvirtxml.DomainMemory{Value: uint(cfg.mem), Unit: "GiB", DumpCore: "on"},
+		VCPU:        &libvirtxml.DomainVCPU{Value: uint(cfg.cpu)},
+		OS: &libvirtxml.DomainOS{
+			Type: &libvirtxml.DomainOSType{Arch: "x86_64", Type: "hvm"},
+		},
+		// For Hot-Plug Feature.
+		Features: &libvirtxml.DomainFeatureList{
+			ACPI:   &libvirtxml.DomainFeature{},
+			APIC:   &libvirtxml.DomainFeatureAPIC{},
+			VMPort: &libvirtxml.DomainFeatureState{State: "off"},
+		},
+		CPU:      &libvirtxml.DomainCPU{Mode: "host-model"},
+		OnReboot: "restart",
+		Devices: &libvirtxml.DomainDeviceList{
+			// Disks.
+			Disks: []libvirtxml.DomainDisk{
+				{
+					Device: "disk",
+					Driver: &libvirtxml.DomainDiskDriver{Type: "qcow2"},
+					Source: &libvirtxml.DomainDiskSource{
+						File: &libvirtxml.DomainDiskSourceFile{
+							File: cfg.bootDisk}},
+					Target: &libvirtxml.DomainDiskTarget{
+						Dev: "sda", Bus: "sata"},
+					Boot: &libvirtxml.DomainDeviceBoot{Order: 1},
+					Address: &libvirtxml.DomainAddress{
+						Drive: &libvirtxml.DomainAddressDrive{
+							Controller: &diskControllerAddr, Bus: &diskControllerAddr, Target: &diskControllerAddr, Unit: &diskControllerAddr}},
+				},
+				{
+					Device: "cdrom",
+					Driver: &libvirtxml.DomainDiskDriver{Name: "qemu", Type: "raw"},
+					Source: &libvirtxml.DomainDiskSource{
+						File: &libvirtxml.DomainDiskSourceFile{File: cfg.cidataDisk},
+					},
+					Target:   &libvirtxml.DomainDiskTarget{Dev: "hda", Bus: "ide"},
+					ReadOnly: &libvirtxml.DomainDiskReadOnly{},
+					Address: &libvirtxml.DomainAddress{
+						Drive: &libvirtxml.DomainAddressDrive{
+							Controller: &diskControllerAddr, Bus: &diskControllerAddr, Target: &diskControllerAddr, Unit: &diskControllerAddr}},
+				},
+			},
+			// Network Interfaces.
+			Interfaces: []libvirtxml.DomainInterface{
+				{
+					Source: &libvirtxml.DomainInterfaceSource{Network: &libvirtxml.DomainInterfaceSourceNetwork{Network: cfg.networkName}},
+					Model:  &libvirtxml.DomainInterfaceModel{Type: "virtio"},
+				},
+			},
+			// Serial Console Devices.
+			Consoles: []libvirtxml.DomainConsole{
+				{
+					Target: &libvirtxml.DomainConsoleTarget{Type: "serial"},
+				},
+			},
+		},
+	}, nil
+}
+
+// createDomainXML detects the machine type of the libvirt host and will return a libvirt XML for that machine type
+func createDomainXML(client *libvirtClient, cfg *domainConfig) (*libvirtxml.Domain, error) {
+	node, err := client.connection.GetNodeInfo()
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving node info: %w", err)
+	}
+	switch node.Model {
+	case "s390x":
+		return createDomainXMLs390x(client, cfg)
+	default:
+		return createDomainXMLx86_64(client, cfg)
+	}
 }
 
 func CreateDomain(ctx context.Context, libvirtClient *libvirtClient, v *vmConfig) (result *createDomainOutput, err error) {
@@ -157,68 +432,18 @@ func CreateDomain(ctx context.Context, libvirtClient *libvirtClient, v *vmConfig
 		return nil, fmt.Errorf("Error retrieving volume path: %s", err)
 	}
 
-	// Gen Domain XML.
-	var diskControllerAddr uint = 0
-	domCfg := &libvirtxml.Domain{
-		Type:        "kvm",
-		Name:        v.name,
-		Description: "This Virtual Machine is the peer-pod VM",
-		Memory:      &libvirtxml.DomainMemory{Value: uint(v.mem), Unit: "GiB", DumpCore: "on"},
-		VCPU:        &libvirtxml.DomainVCPU{Value: uint(v.cpu)},
-		OS: &libvirtxml.DomainOS{
-			Type: &libvirtxml.DomainOSType{Arch: "x86_64", Type: "hvm"},
-		},
-		// For Hot-Plug Feature.
-		Features: &libvirtxml.DomainFeatureList{
-			ACPI:   &libvirtxml.DomainFeature{},
-			APIC:   &libvirtxml.DomainFeatureAPIC{},
-			VMPort: &libvirtxml.DomainFeatureState{State: "off"},
-		},
-		CPU:      &libvirtxml.DomainCPU{Mode: "host-model"},
-		OnReboot: "restart",
-		Devices: &libvirtxml.DomainDeviceList{
-			// Disks.
-			Disks: []libvirtxml.DomainDisk{
-				{
-					Device: "disk",
-					Driver: &libvirtxml.DomainDiskDriver{Type: "qcow2"},
-					Source: &libvirtxml.DomainDiskSource{
-						File: &libvirtxml.DomainDiskSourceFile{
-							File: rootVolFile}},
-					Target: &libvirtxml.DomainDiskTarget{
-						Dev: "sda", Bus: "sata"},
-					Boot: &libvirtxml.DomainDeviceBoot{Order: 1},
-					Address: &libvirtxml.DomainAddress{
-						Drive: &libvirtxml.DomainAddressDrive{
-							Controller: &diskControllerAddr, Bus: &diskControllerAddr, Target: &diskControllerAddr, Unit: &diskControllerAddr}},
-				},
-				{
-					Device: "cdrom",
-					Driver: &libvirtxml.DomainDiskDriver{Name: "qemu", Type: "raw"},
-					Source: &libvirtxml.DomainDiskSource{
-						File: &libvirtxml.DomainDiskSourceFile{File: isoVolFile},
-					},
-					Target:   &libvirtxml.DomainDiskTarget{Dev: "hda", Bus: "ide"},
-					ReadOnly: &libvirtxml.DomainDiskReadOnly{},
-					Address: &libvirtxml.DomainAddress{
-						Drive: &libvirtxml.DomainAddressDrive{
-							Controller: &diskControllerAddr, Bus: &diskControllerAddr, Target: &diskControllerAddr, Unit: &diskControllerAddr}},
-				},
-			},
-			// Network Interfaces.
-			Interfaces: []libvirtxml.DomainInterface{
-				{
-					Source: &libvirtxml.DomainInterfaceSource{Network: &libvirtxml.DomainInterfaceSourceNetwork{Network: libvirtClient.networkName}},
-					Model:  &libvirtxml.DomainInterfaceModel{Type: "virtio"},
-				},
-			},
-			// Serial Console Devices.
-			Consoles: []libvirtxml.DomainConsole{
-				{
-					Target: &libvirtxml.DomainConsoleTarget{Type: "serial"},
-				},
-			},
-		},
+	domainCfg := domainConfig{
+		name:        v.name,
+		cpu:         v.cpu,
+		mem:         v.mem,
+		networkName: libvirtClient.networkName,
+		bootDisk:    rootVolFile,
+		cidataDisk:  isoVolFile,
+	}
+
+	domCfg, err := createDomainXML(libvirtClient, &domainCfg)
+	if err != nil {
+		return nil, fmt.Errorf("error building the libvirt XML, cause: %w", err)
 	}
 
 	logger.Printf("Create XML for '%s'", v.name)
@@ -370,7 +595,7 @@ func NewLibvirtClient(libvirtCfg Config) (*libvirtClient, error) {
 		return nil, fmt.Errorf("can't find storage pool %q: %v", libvirtCfg.PoolName, err)
 	}
 
-	fmt.Printf("Created libvirt connection")
+	logger.Println("Created libvirt connection")
 
 	return &libvirtClient{
 		connection:  conn,

--- a/pkg/adaptor/cloud/libvirt/libvirt_test.go
+++ b/pkg/adaptor/cloud/libvirt/libvirt_test.go
@@ -1,0 +1,108 @@
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package libvirt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/cloud"
+	libvirtxml "libvirt.org/go/libvirtxml"
+)
+
+var testCfg Config
+
+func init() {
+	cloud.DefaultToEnv(&testCfg.URI, "LIBVIRT_URI", "") // explicitly no fallback here
+	cloud.DefaultToEnv(&testCfg.PoolName, "LIBVIRT_POOL", defaultPoolName)
+	cloud.DefaultToEnv(&testCfg.NetworkName, "LIBVIRT_NET", defaultNetworkName)
+	cloud.DefaultToEnv(&testCfg.VolName, "LIBVIRT_VOL_NAME", defaultVolName)
+}
+
+func checkConfig(t *testing.T) {
+	if testCfg.URI == "" {
+		t.Skipf("Skipping because LIBVIRT_URI is not configured")
+	}
+}
+
+func TestLibvirtConnection(t *testing.T) {
+	checkConfig(t)
+
+	client, err := NewLibvirtClient(testCfg)
+	if err != nil {
+		t.Error(err)
+	}
+	defer client.connection.Close()
+
+}
+
+func TestGetArchitecture(t *testing.T) {
+	checkConfig(t)
+
+	client, err := NewLibvirtClient(testCfg)
+	if err != nil {
+		t.Error(err)
+	}
+	defer client.connection.Close()
+
+	node, err := client.connection.GetNodeInfo()
+	if err != nil {
+		t.Error(err)
+	}
+
+	arch := node.Model
+	if arch == "" {
+		t.FailNow()
+	}
+}
+
+func verifyDomainXML(domXML *libvirtxml.Domain) error {
+	arch := domXML.OS.Type.Arch
+	if arch != "s390x" {
+		return nil
+	}
+	// verify we have iommu on the disks
+	for i, disk := range domXML.Devices.Disks {
+		if disk.Driver.IOMMU != "on" {
+			return fmt.Errorf("disk [%d] does not have IOMMU assigned", i)
+		}
+	}
+	// verify we have iommu on the networks
+	for i, iface := range domXML.Devices.Interfaces {
+		if iface.Driver.IOMMU != "on" {
+			return fmt.Errorf("interface [%d] does not have IOMMU assigned", i)
+		}
+	}
+	return nil
+}
+
+func TestCreateDomainXMLs390x(t *testing.T) {
+	checkConfig(t)
+
+	client, err := NewLibvirtClient(testCfg)
+	if err != nil {
+		t.Error(err)
+	}
+	defer client.connection.Close()
+
+	domainCfg := domainConfig{
+		name:        "TestCreateDomainS390x",
+		cpu:         2,
+		mem:         2,
+		networkName: client.networkName,
+		bootDisk:    "/var/lib/libvirt/images/root.qcow2",
+		cidataDisk:  "/var/lib/libvirt/images/cidata.iso",
+	}
+
+	domCfg, err := createDomainXML(client, &domainCfg)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// verify the config
+	err = verifyDomainXML(domCfg)
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
https://github.com/confidential-containers/cloud-api-adaptor/issues/1248

This PR creates a domainXML based on the architecture of the target host. First it finds the architecture via the `GetNodeInfo` method. Then if the architecture (aka `Model`) is `s390x` we'd create the domain XML with the s390x specifics, else it returns the `x86_64` version as before. 