### PR TITLE
Release process document improvements

### DIFF
--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -111,8 +111,16 @@ sed -i 's#\(github.com/confidential-containers/operator/config/default\)#\1?ref=
 sed -i 's#\(github.com/confidential-containers/operator/config/samples/ccruntime/peer-pods\)#\1?ref=v0.7.0#' Makefile
 ```
 
-Once this has been completed and merged in we run the latest release of the cloud-api-adaptor including the auto
-generated release notes.
+Once this has been completed and merged in we should pin the cloud-api-adaptor image used on the deployment files. You should use the commit SHA-1 of the last built `quay.io/confidentil-containers/cloud-api-image` image to update the overlays kustomization files. For example, suppose the release image is `quay.io/confidential-containers/cloud-api-adaptor:6d7d2a3fe8243809b3c3a710792c8498292e2fc3`:
+```
+cd install/overlays/
+for p in aws azure ibmcloud ibmcloud-powervs vsphere; do cd aws; kustomize edit set image cloud-api-adaptor=quay.io/confidential-containers/cloud-api-adaptor:6d7d2a3fe8243809b3c3a710792c8498292e2fc3; cd -; done
+
+# Note that the libvirt use the tag with prefix 'dev-'
+cd libvirt; kustomize edit set image cloud-api-adaptor=quay.io/confidential-containers/cloud-api-adaptor:dev-6d7d2a3fe8243809b3c3a710792c8498292e2fc3; cd -
+```
+
+After these version updates have been merged via new PR, we can run the latest release of the cloud-api-adaptor including the auto generated release notes.
 
 This will trigger the podvm builds to happen again and we should re-test the release code before updating the
 confidential-containers release team to let them know it has completed successfully
@@ -128,6 +136,12 @@ any local replace references, and be updated to use the release version of the `
 from in the `peerpod-ctrl` and `volumes/csi-wrapper` directories.
 
 The CoCo operator URLs on the [Makefile](../Makefile) should be reverted to use the latest version.
+
+The changes on the overlay kustomization files should be reverted to start using the latest cloud-api-adaptor images again:
+```
+cd install/overlays/
+for p in aws azure ibmcloud ibmcloud-powervs libvirt vsphere; do cd aws; kustomize edit set image cloud-api-adaptor=quay.io/confidential-containers/cloud-api-adaptor:latest; cd -; done
+```
 
 ## Improvements
 

--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -41,9 +41,11 @@ avoid compilation errors. This can be done by running:
 > from in the `peerpod-ctrl` and `volumes/csi-wrapper` directories.
 - The attestation-agent that is built into the peer pod vm image, by updating the `GUEST_COMPONENTS_VERSION` in the [`Makefile.inc`](../podvm/Makefile.inc)
 
+Currently there isn't automation to build the podvm images at this phase. They should be built manually to ensure they don't break.
+
 These updates should be done in a PR that is merged triggering the cloud-api-adaptor
 [image build workflow](../.github/workflows/image.yaml) to create a new container image in 
-[`quay.io](https://quay.io/repository/confidential-containers/cloud-api-adaptor?tab=tags) to use in testing.
+[`quay.io/confidential-containers/cloud-api-adaptor`](https://quay.io/repository/confidential-containers/cloud-api-adaptor?tab=tags) to use in testing.
 
 #### Tags and update go submodules
 
@@ -124,4 +126,5 @@ from in the `peerpod-ctrl` and `volumes/csi-wrapper` directories.
 Issues that we have to improve the release process that will impact this doc:
 
 - Create tags for the cloud-api-adaptor and webhook images on release and update the overlays to point to these
-versions in the tag [Issue #1109](https://github.com/confidential-containers/cloud-api-adaptor/issues/1109)
+versions in the tag ([Issue #1109](https://github.com/confidential-containers/cloud-api-adaptor/issues/1109))
+- Build the podvm images on the [release candidate testing](#release-candidate-testing) phase ([Issue #1253](https://github.com/confidential-containers/cloud-api-adaptor/issues/1253))

--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -39,8 +39,7 @@ avoid compilation errors. This can be done by running:
 > go mod tidy
 > ```
 > from in the `peerpod-ctrl` and `volumes/csi-wrapper` directories.
-- The attestation-agent that is built into the peer pod vm image, by updating the `AA_VERSION` in the 
-[`Makefile.inc`](../podvm/Makefile.inc)
+- The attestation-agent that is built into the peer pod vm image, by updating the `GUEST_COMPONENTS_VERSION` in the [`Makefile.inc`](../podvm/Makefile.inc)
 
 These updates should be done in a PR that is merged triggering the cloud-api-adaptor
 [image build workflow](../.github/workflows/image.yaml) to create a new container image in 

--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -143,6 +143,12 @@ cd install/overlays/
 for p in aws azure ibmcloud ibmcloud-powervs libvirt vsphere; do cd aws; kustomize edit set image cloud-api-adaptor=quay.io/confidential-containers/cloud-api-adaptor:latest; cd -; done
 ```
 
+References to Kata Containers should be reverted to the CCv0 branch in:
+
+* [podvm_builder.yaml workflow](../.github/workflows/podvm_builder.yaml)
+* [podvm_builder `Dockerfiles`](../podvm/)
+* go modules (`cloud-api-adaptor` [`go.mod`](../go.mod), the `peerpod-ctl` [`go.mod`](../peerpod-ctrl/go.mod) and the `csi-wrapper` [`go.mod`](../volumes/csi-wrapper/go.mod))
+
 ## Improvements
 
 Issues that we have to improve the release process that will impact this doc:

--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -105,6 +105,12 @@ For the cloud-api-adaptor we need to wait until the Kata Containers release tag 
 to have been built. We then can repeat the steps done during the release candidate phase, but this time use the
 release tags of the project dependencies e.g. `v0.6.0` and creating the tags without the `-alpha.x` suffix.
 
+Also we need to wait until the [CoCo operator](https://github.com/confidential-containers/operator/) release tag has been create to pin the URLs used by the make `deploy` target to install the operator. So edit the [Makefile](../Makefile) to replace the *github.com/confidential-containers/operator/config/default* and *github.com/confidential-containers/operator/config/samples/ccruntime/peer-pods* URLs, e.g.:
+```
+sed -i 's#\(github.com/confidential-containers/operator/config/default\)#\1?ref=v0.7.0#' Makefile
+sed -i 's#\(github.com/confidential-containers/operator/config/samples/ccruntime/peer-pods\)#\1?ref=v0.7.0#' Makefile
+```
+
 Once this has been completed and merged in we run the latest release of the cloud-api-adaptor including the auto
 generated release notes.
 
@@ -120,6 +126,8 @@ any local replace references, and be updated to use the release version of the `
   go mod tidy
   ```
 from in the `peerpod-ctrl` and `volumes/csi-wrapper` directories.
+
+The CoCo operator URLs on the [Makefile](../Makefile) should be reverted to use the latest version.
 
 ## Improvements
 


### PR DESCRIPTION
While doing the 0.7.0 I did some steps that weren't on the release process so I am updating the document to reflect that. I don't know if we will stick with steps like pinning the cloud-api-adaptor, but at least it is documented for the current release and we can always change the process later.