### PR TITLE
image: revert to use amd64 as build platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,12 @@ ARG BUILD_TYPE=dev
 ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.20.6-36
 ARG BASE=fedora:36
 
-
-FROM --platform=$TARGETPLATFORM $BUILDER_BASE as builder-release
+# This dockerfile uses Go cross-compilation to build the binary,
+# we build on the host platform ($BUILDPLATFORM) and then copy the
+# binary into the container image of the target platform ($TARGETPLATFORM)
+# that was specified with --platform. For more details see:
+# https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
+FROM --platform=$BUILDPLATFORM $BUILDER_BASE as builder-release
 
 FROM builder-release as builder-dev
 RUN dnf install -y libvirt-devel && dnf clean all


### PR DESCRIPTION
The use of `--platform=$TARGETPLATFORM` was introduced by mistake in #1116, and caused long build times, as it emulates the target platform instead of using Go cross-compilation.

Fixes: #1234

Run finished in 19 min: https://github.com/katexochen/cloud-api-adaptor/actions/runs/5678850841