### PR TITLE
pkg/adaptor/libvirt: adds support for s390x based libvirt hosts

### DIFF
--- a/pkg/adaptor/cloud/libvirt/libvirt_test.go
+++ b/pkg/adaptor/cloud/libvirt/libvirt_test.go
@@ -1,0 +1,116 @@
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package libvirt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/cloud"
+	"github.com/stretchr/testify/assert"
+	libvirtxml "libvirt.org/go/libvirtxml"
+)
+
+var testCfg Config
+
+func init() {
+	cloud.DefaultToEnv(&testCfg.URI, "LIBVIRT_URI", "") // explicitly no fallback here
+	cloud.DefaultToEnv(&testCfg.PoolName, "LIBVIRT_POOL", defaultPoolName)
+	cloud.DefaultToEnv(&testCfg.NetworkName, "LIBVIRT_NET", defaultNetworkName)
+	cloud.DefaultToEnv(&testCfg.VolName, "LIBVIRT_VOL_NAME", defaultVolName)
+}
+
+func checkConfig(t *testing.T) {
+	if testCfg.URI == "" {
+		t.Skipf("Skipping because LIBVIRT_URI is not configured")
+	}
+}
+
+func TestLibvirtConnection(t *testing.T) {
+	checkConfig(t)
+
+	client, err := NewLibvirtClient(testCfg)
+	if err != nil {
+		t.Error(err)
+	}
+	defer client.connection.Close()
+
+	assert.NotNil(t, client.nodeInfo)
+	assert.NotNil(t, client.caps)
+}
+
+func TestGetArchitecture(t *testing.T) {
+	checkConfig(t)
+
+	client, err := NewLibvirtClient(testCfg)
+	if err != nil {
+		t.Error(err)
+	}
+	defer client.connection.Close()
+
+	node, err := client.connection.GetNodeInfo()
+	if err != nil {
+		t.Error(err)
+	}
+
+	arch := node.Model
+	if arch == "" {
+		t.FailNow()
+	}
+}
+
+func verifyDomainXML(domXML *libvirtxml.Domain) error {
+	arch := domXML.OS.Type.Arch
+	if arch != archS390x {
+		return nil
+	}
+	// verify we have iommu on the disks
+	for i, disk := range domXML.Devices.Disks {
+		if disk.Driver.IOMMU != "on" {
+			return fmt.Errorf("disk [%d] does not have IOMMU assigned", i)
+		}
+	}
+	// verify we have iommu on the networks
+	for i, iface := range domXML.Devices.Interfaces {
+		if iface.Driver.IOMMU != "on" {
+			return fmt.Errorf("interface [%d] does not have IOMMU assigned", i)
+		}
+	}
+	return nil
+}
+
+func TestCreateDomainXMLs390x(t *testing.T) {
+	checkConfig(t)
+
+	client, err := NewLibvirtClient(testCfg)
+	if err != nil {
+		t.Error(err)
+	}
+	defer client.connection.Close()
+
+	domainCfg := domainConfig{
+		name:        "TestCreateDomainS390x",
+		cpu:         2,
+		mem:         2,
+		networkName: client.networkName,
+		bootDisk:    "/var/lib/libvirt/images/root.qcow2",
+		cidataDisk:  "/var/lib/libvirt/images/cidata.iso",
+	}
+
+	domCfg, err := createDomainXML(client, &domainCfg)
+	if err != nil {
+		t.Error(err)
+	}
+
+	arch := domCfg.OS.Type.Arch
+	if domCfg.OS.Type.Arch != archS390x {
+		t.Skipf("Skipping because architecture is [%s] and not [%s].", arch, archS390x)
+	}
+
+	// verify the config
+	err = verifyDomainXML(domCfg)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/pkg/adaptor/cloud/libvirt/types.go
+++ b/pkg/adaptor/cloud/libvirt/types.go
@@ -9,6 +9,7 @@ import (
 	"net/netip"
 
 	libvirt "libvirt.org/go/libvirt"
+	libvirtxml "libvirt.org/go/libvirtxml"
 )
 
 type Config struct {
@@ -48,4 +49,10 @@ type libvirtClient struct {
 	dataDir string
 
 	volName string
+
+	// information about the target node
+	nodeInfo *libvirt.NodeInfo
+
+	// host capabilities
+	caps *libvirtxml.Caps
 }


### PR DESCRIPTION
Fixes #1248

This PR creates a domainXML based on the architecture of the target host.
First it finds the architecture via the GetNodeInfo method. Then if the architecture (aka Model) is s390x we'd create the domain XML with the s390x specifics, else it returns the x86_64 version as before.