### PR TITLE
Post v0.7.0 release updates

### DIFF
--- a/.github/workflows/podvm_builder.yaml
+++ b/.github/workflows/podvm_builder.yaml
@@ -63,4 +63,4 @@ jobs:
           "CAA_SRC=https://github.com/confidential-containers/cloud-api-adaptor"
           "CAA_SRC_REF=main"
           "KATA_SRC=https://github.com/kata-containers/kata-containers"
-          "KATA_SRC_BRANCH=CC-0.7.0"
+          "KATA_SRC_BRANCH=CCv0"

--- a/Makefile
+++ b/Makefile
@@ -140,8 +140,8 @@ image: .git-commit ## Build and push docker image to $registry
 .PHONY: deploy
 deploy: ## Deploy cloud-api-adaptor using the operator, according to install/overlays/$(CLOUD_PROVIDER)/kustomization.yaml file.
 ifneq ($(CLOUD_PROVIDER),)
-	kubectl apply -k "github.com/confidential-containers/operator/config/default?ref=v0.7.0"
-	kubectl apply -k "github.com/confidential-containers/operator/config/samples/ccruntime/peer-pods?ref=v0.7.0"
+	kubectl apply -k "github.com/confidential-containers/operator/config/default"
+	kubectl apply -k "github.com/confidential-containers/operator/config/samples/ccruntime/peer-pods"
 	kubectl apply -k install/overlays/$(CLOUD_PROVIDER)
 else
 	$(error CLOUD_PROVIDER is not set)

--- a/install/overlays/aws/kustomization.yaml
+++ b/install/overlays/aws/kustomization.yaml
@@ -7,7 +7,7 @@ bases:
 images:
 - name: cloud-api-adaptor
   newName: quay.io/confidential-containers/cloud-api-adaptor # change image if needed
-  newTag: 6d7d2a3fe8243809b3c3a710792c8498292e2fc3
+  newTag: latest
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/install/overlays/azure/kustomization.yaml
+++ b/install/overlays/azure/kustomization.yaml
@@ -7,7 +7,7 @@ bases:
 images:
 - name: cloud-api-adaptor
   newName: quay.io/confidential-containers/cloud-api-adaptor # change image if needed
-  newTag: 6d7d2a3fe8243809b3c3a710792c8498292e2fc3
+  newTag: latest
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/install/overlays/ibmcloud-powervs/kustomization.yaml
+++ b/install/overlays/ibmcloud-powervs/kustomization.yaml
@@ -7,7 +7,7 @@ bases:
 images:
 - name: cloud-api-adaptor
   newName: quay.io/confidential-containers/cloud-api-adaptor # change image if needed
-  newTag: 6d7d2a3fe8243809b3c3a710792c8498292e2fc3
+  newTag: latest
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/install/overlays/libvirt/kustomization.yaml
+++ b/install/overlays/libvirt/kustomization.yaml
@@ -7,7 +7,7 @@ bases:
 images:
 - name: cloud-api-adaptor
   newName: quay.io/confidential-containers/cloud-api-adaptor # change image if needed
-  newTag: dev-6d7d2a3fe8243809b3c3a710792c8498292e2fc3
+  newTag: latest
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/install/overlays/vsphere/kustomization.yaml
+++ b/install/overlays/vsphere/kustomization.yaml
@@ -7,7 +7,7 @@ bases:
 images:
 - name: cloud-api-adaptor
   newName: quay.io/confidential-containers/cloud-api-adaptor # change image if needed
-  newTag: 6d7d2a3fe8243809b3c3a710792c8498292e2fc3
+  newTag: latest
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/podvm/Dockerfile.podvm_builder
+++ b/podvm/Dockerfile.podvm_builder
@@ -49,7 +49,7 @@ ARG CAA_SRC="https://github.com/confidential-containers/cloud-api-adaptor"
 ARG CAA_SRC_REF="main"
 
 ARG KATA_SRC="https://github.com/kata-containers/kata-containers"
-ARG KATA_SRC_BRANCH="CC-0.7.0"
+ARG KATA_SRC_BRANCH="CCv0"
 
 RUN echo $CAA_SRC
 

--- a/podvm/Dockerfile.podvm_builder.centos
+++ b/podvm/Dockerfile.podvm_builder.centos
@@ -52,7 +52,7 @@ ARG CAA_SRC="https://github.com/confidential-containers/cloud-api-adaptor"
 ARG CAA_SRC_REF="main"
 
 ARG KATA_SRC="https://github.com/kata-containers/kata-containers"
-ARG KATA_SRC_BRANCH="CC-0.7.0"
+ARG KATA_SRC_BRANCH="CCv0"
 
 RUN echo $CAA_SRC
 

--- a/podvm/Dockerfile.podvm_builder.rhel
+++ b/podvm/Dockerfile.podvm_builder.rhel
@@ -48,7 +48,7 @@ ARG CAA_SRC="https://github.com/confidential-containers/cloud-api-adaptor"
 ARG CAA_SRC_REF="main"
 
 ARG KATA_SRC="https://github.com/kata-containers/kata-containers"
-ARG KATA_SRC_BRANCH="CC-0.7.0"
+ARG KATA_SRC_BRANCH="CCv0"
 
 RUN echo $CAA_SRC
 


### PR DESCRIPTION
As delineated in our [release process post-release phase](https://github.com/confidential-containers/cloud-api-adaptor/blob/main/docs/Release-Process.md#post-release) we should revert some changes after the release to get latest updates of components. Actually this PR contain two reverts that aren't described on current release document, but are on the new version on PR #1254 (Release process document improvements).

Ran the libvirt e2e tests successfully: 

```
Wait for the cc-operator-daemon-install DaemonSet be available
Wait for the pod cc-operator-daemon-install-xr8kf be ready
Wait for the cloud-api-adaptor-daemonset DaemonSet be available
Wait for the pod cloud-api-adaptor-daemonset-f9bwl be ready
Wait for the kata-remote runtimeclass be created
=== RUN   TestLibvirtCreateSimplePod
=== RUN   TestLibvirtCreateSimplePod/SimplePeerPod_test
=== RUN   TestLibvirtCreateSimplePod/SimplePeerPod_test/PodVM_is_created
time="2023-07-27T15:58:23-03:00" level=info msg="Deleting pod... nginx"
--- PASS: TestLibvirtCreateSimplePod (85.07s)
    --- PASS: TestLibvirtCreateSimplePod/SimplePeerPod_test (85.07s)
        --- PASS: TestLibvirtCreateSimplePod/SimplePeerPod_test/PodVM_is_created (0.04s)
=== RUN   TestLibvirtCreatePodWithConfigMap
=== RUN   TestLibvirtCreatePodWithConfigMap/ConfigMapPeerPod_test
=== RUN   TestLibvirtCreatePodWithConfigMap/ConfigMapPeerPod_test/Configmap_is_created_and_contains_data
time="2023-07-27T15:59:33-03:00" level=info msg="Data Inside Configmap: Hello, world"
time="2023-07-27T15:59:33-03:00" level=info msg="Deleting Configmap... nginx-config"
time="2023-07-27T15:59:33-03:00" level=info msg="Deleting pod... nginx-configmap-pod"
--- PASS: TestLibvirtCreatePodWithConfigMap (70.11s)
    --- PASS: TestLibvirtCreatePodWithConfigMap/ConfigMapPeerPod_test (70.11s)
        --- PASS: TestLibvirtCreatePodWithConfigMap/ConfigMapPeerPod_test/Configmap_is_created_and_contains_data (5.07s)
=== RUN   TestLibvirtCreatePodWithSecret
=== RUN   TestLibvirtCreatePodWithSecret/SecretPeerPod_test
=== RUN   TestLibvirtCreatePodWithSecret/SecretPeerPod_test/Secret_has_been_created_and_contains_data
time="2023-07-27T16:00:58-03:00" level=info msg="Username from secret inside pod: admin"
time="2023-07-27T16:01:03-03:00" level=info msg="Password from secret inside pod: password"
time="2023-07-27T16:01:03-03:00" level=info msg="Deleting Secret... nginx-secret"
time="2023-07-27T16:01:03-03:00" level=info msg="Deleting pod... nginx-secret-pod"
--- PASS: TestLibvirtCreatePodWithSecret (90.14s)
    --- PASS: TestLibvirtCreatePodWithSecret/SecretPeerPod_test (90.14s)
        --- PASS: TestLibvirtCreatePodWithSecret/SecretPeerPod_test/Secret_has_been_created_and_contains_data (10.10s)
PASS
ok      github.com/confidential-containers/cloud-api-adaptor/test/e2e   1554.011s
```