### PR TITLE
ibmcloud: allow list of image-ids

### DIFF
--- a/pkg/adaptor/cloud/ibmcloud/manager.go
+++ b/pkg/adaptor/cloud/ibmcloud/manager.go
@@ -24,7 +24,7 @@ func (*Manager) ParseCmd(flags *flag.FlagSet) {
 	flags.StringVar(&ibmcloudVPCConfig.ProfileName, "profile-name", "", "Default instance profile name to be used for the Pod VMs")
 	flags.Var(&ibmcloudVPCConfig.InstanceProfiles, "profile-list", "List of instance profile names to be used for the Pod VMs, comma separated")
 	flags.StringVar(&ibmcloudVPCConfig.ZoneName, "zone-name", "", "Zone name")
-	flags.StringVar(&ibmcloudVPCConfig.ImageID, "image-id", "", "Image ID")
+	flags.Var(&ibmcloudVPCConfig.Images, "image-id", "List of Image IDs, comma separated")
 	flags.StringVar(&ibmcloudVPCConfig.PrimarySubnetID, "primary-subnet-id", "", "Primary subnet ID")
 	flags.StringVar(&ibmcloudVPCConfig.PrimarySecurityGroupID, "primary-security-group-id", "", "Primary security group ID")
 	flags.StringVar(&ibmcloudVPCConfig.SecondarySubnetID, "secondary-subnet-id", "", "Secondary subnet ID")

--- a/pkg/adaptor/cloud/ibmcloud/provider_test.go
+++ b/pkg/adaptor/cloud/ibmcloud/provider_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/IBM/go-sdk-core/v5/core"
@@ -95,6 +96,24 @@ func (v *mockVPC) GetInstanceProfileWithContext(context context.Context, options
 	return &vpcv1.InstanceProfile{VcpuCount: &vpcv1.InstanceProfileVcpu{Value: &vcpu}, Memory: &vpcv1.InstanceProfileMemory{Value: &mem}}, nil, nil
 }
 
+func (v *mockVPC) GetImageWithContext(context context.Context, options *vpcv1.GetImageOptions) (*vpcv1.Image, *core.DetailedResponse, error) {
+
+	imageID := options.ID
+	if strings.HasPrefix(*imageID, "notfound") {
+		return nil, nil, fmt.Errorf("image not found")
+	}
+
+	arch := "s390x"
+	os := "ubuntu"
+
+	return &vpcv1.Image{
+		OperatingSystem: &vpcv1.OperatingSystem{
+			Architecture: &arch,
+			Name:         &os,
+		},
+	}, nil, nil
+}
+
 type mockCloudConfig struct{}
 
 func (c *mockCloudConfig) Generate() (string, error) {
@@ -114,10 +133,16 @@ func TestCreateInstance(t *testing.T) {
 
 	vpc := &mockVPC{}
 
+	images := make(Images, 0)
+	err := images.Set("valid-image-id")
+	if err != nil {
+		t.Errorf("Images.Set() error %v", err)
+	}
 	provider := &ibmcloudVPCProvider{
 		vpc: vpc,
 		serviceConfig: &Config{
 			ProfileName: "bx2-2x8",
+			Images:      images,
 		},
 	}
 
@@ -203,6 +228,116 @@ func TestGetInstanceTypeInformation(t *testing.T) {
 			}
 			if gotMemory != tt.wantMemory {
 				t.Errorf("ibmcloudProvider.getProfileNameInformation() gotMemory = %v, want %v", gotMemory, tt.wantMemory)
+			}
+		})
+	}
+}
+
+func TestGetImageDetails(t *testing.T) {
+
+	validImageList := make(Images, 0)
+	err := validImageList.Set("valid-id-1,valid-id-2,valid-id-3")
+	if err != nil {
+		t.Errorf("Images.Set() error %v", err)
+	}
+	emptyImageList := make(Images, 0)
+	invalidImageList := make(Images, 0)
+	err = invalidImageList.Set("notfound-id-1")
+	if err != nil {
+		t.Errorf("Images.Set() error %v", err)
+	}
+
+	tests := []struct {
+		name            string
+		provider        *ibmcloudVPCProvider
+		instanceSpec    cloud.InstanceTypeSpec
+		expectListErr   bool
+		expectSelectErr bool
+		wantID          string
+	}{
+		// Test selecting an image from a valid image list
+		{
+			name: "selectImageForValidIDs",
+			provider: &ibmcloudVPCProvider{
+				vpc: &mockVPC{},
+				serviceConfig: &Config{
+					Images: validImageList,
+				},
+			},
+			instanceSpec: cloud.InstanceTypeSpec{
+				Arch: "s390x",
+			},
+			expectListErr:   false,
+			expectSelectErr: false,
+			wantID:          "valid-id-1",
+		},
+		// Test selecting an image from an empty image list
+		{
+			name: "selectImageForEmptyList",
+			provider: &ibmcloudVPCProvider{
+				vpc: &mockVPC{},
+				serviceConfig: &Config{
+					Images: emptyImageList,
+				},
+			},
+			instanceSpec: cloud.InstanceTypeSpec{
+				Arch: "s390x",
+			},
+			expectListErr:   true,
+			expectSelectErr: false,
+			wantID:          "",
+		},
+		// Test selecting an image from an image list with no valid ids
+		{
+			name: "selectImageForInvalidList",
+			provider: &ibmcloudVPCProvider{
+				vpc: &mockVPC{},
+				serviceConfig: &Config{
+					Images: invalidImageList,
+				},
+			},
+			instanceSpec: cloud.InstanceTypeSpec{
+				Arch: "s390x",
+			},
+			expectListErr:   true,
+			expectSelectErr: false,
+			wantID:          "",
+		},
+		// Test selecting an image from an image list with no valid archs
+		{
+			name: "selectImageForInvalidArch",
+			provider: &ibmcloudVPCProvider{
+				vpc: &mockVPC{},
+				serviceConfig: &Config{
+					Images: validImageList,
+				},
+			},
+			instanceSpec: cloud.InstanceTypeSpec{
+				Arch: "amd64",
+			},
+			expectListErr:   false,
+			expectSelectErr: true,
+			wantID:          "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.provider.updateImageList(context.Background())
+			if tt.expectListErr {
+				if err == nil {
+					t.Errorf("ibmcloudProvider.updateImageList() error = %v, expectListErr %v", err, tt.expectListErr)
+				}
+				return
+			}
+			id, err := tt.provider.selectImage(context.Background(), tt.instanceSpec)
+			if tt.expectSelectErr {
+				if err == nil {
+					t.Errorf("ibmcloudProvider.selectImage() error = %v, expectSelectErr %v", err, tt.expectSelectErr)
+				}
+				return
+			}
+			if id != tt.wantID {
+				t.Errorf("ibmcloudProvider.selectImage() gotID = %v, want %v", id, tt.wantID)
 			}
 		})
 	}

--- a/pkg/adaptor/cloud/ibmcloud/types.go
+++ b/pkg/adaptor/cloud/ibmcloud/types.go
@@ -17,12 +17,46 @@ func (i *instanceProfiles) String() string {
 }
 
 func (i *instanceProfiles) Set(value string) error {
-	if len(value) == 0 {
-		*i = make(instanceProfiles, 0)
-	} else {
-		*i = append(*i, strings.Split(value, ",")...)
+	*i = append(*i, toList(value, ",")...)
+	return nil
+}
+
+type Images []Image
+type Image struct {
+	ID   string
+	Arch string
+	OS   string
+}
+
+func (i *Images) String() string {
+	switch len(*i) {
+	case 0:
+		return ""
+	case 1:
+		return (*i)[0].ID
+	}
+	var b strings.Builder
+	b.WriteString((*i)[0].ID)
+	for _, image := range (*i)[1:] {
+		b.WriteString(",")
+		b.WriteString(image.ID)
+	}
+	return b.String()
+}
+
+func (i *Images) Set(value string) error {
+	IDs := toList(value, ",")
+	for _, id := range IDs {
+		*i = append(*i, Image{ID: id})
 	}
 	return nil
+}
+
+func toList(value, sep string) []string {
+	if len(value) == 0 {
+		return make([]string, 0)
+	}
+	return strings.Split(value, sep)
 }
 
 type Config struct {
@@ -34,7 +68,7 @@ type Config struct {
 	ResourceGroupID          string
 	ProfileName              string
 	ZoneName                 string
-	ImageID                  string
+	Images                   Images
 	PrimarySubnetID          string
 	PrimarySecurityGroupID   string
 	SecondarySubnetID        string

--- a/pkg/adaptor/cloud/ibmcloud/types_test.go
+++ b/pkg/adaptor/cloud/ibmcloud/types_test.go
@@ -45,3 +45,26 @@ func TestEmptyList(t *testing.T) {
 		t.Errorf("Expect 0 length, got %d", len(list))
 	}
 }
+
+func TestImageIDs(t *testing.T) {
+	var images Images
+	err := images.Set("abc,xyz")
+	if err != nil {
+		t.Errorf("Image Set failed, %v", err)
+	}
+	if len(images) != 2 {
+		t.Errorf("Expect 2 length, got %d", len(images))
+	}
+}
+
+func TestImagesToString(t *testing.T) {
+	var images Images
+	ids := "123-1231-123,adasd-ada-adad,asd-123-asd"
+	err := images.Set(ids)
+	if err != nil {
+		t.Errorf("Image Set failed, %v", err)
+	}
+	if ids != images.String() {
+		t.Errorf("Expect %v, got %v", ids, images.String())
+	}
+}


### PR DESCRIPTION
Add the ability to specify a list of allowed image-ids Trim the list to remove image-ids not found in the same region as the node

Adds check that the ARCH matches the spec request, but that currently doesn't work as the instance spec ARCH value doesn't currently get populated.

Fixes: #1266