### PR TITLE
deps: upgrade rust to 1.69.0

### DIFF
--- a/.github/workflows/podvm_builder.yaml
+++ b/.github/workflows/podvm_builder.yaml
@@ -59,7 +59,7 @@ jobs:
         build-args: |
           "GO_VERSION=1.20.6"
           "PROTOC_VERSION=3.11.4"
-          "RUST_VERSION=1.66.0"
+          "RUST_VERSION=1.69.0"
           "CAA_SRC=https://github.com/confidential-containers/cloud-api-adaptor"
           "CAA_SRC_REF=main"
           "KATA_SRC=https://github.com/kata-containers/kata-containers"

--- a/ibmcloud-powervs/image/prereq.sh
+++ b/ibmcloud-powervs/image/prereq.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 GO_VERSION="1.20.6"
-RUST_VERSION="1.66.0"
+RUST_VERSION="1.69.0"
 SKOPEO_VERSION="1.5.0"
 
 # Install dependencies

--- a/podvm/Dockerfile.podvm_builder
+++ b/podvm/Dockerfile.podvm_builder
@@ -9,7 +9,7 @@ FROM ubuntu:20.04
 
 ARG GO_VERSION="1.20.6"
 ARG PROTOC_VERSION="3.11.4"
-ARG RUST_VERSION="1.66.0"
+ARG RUST_VERSION="1.69.0"
 
 # Without setting ENV gh-action is failing to use the correct values
 ENV GO_VERSION ${GO_VERSION}

--- a/podvm/Dockerfile.podvm_builder.centos
+++ b/podvm/Dockerfile.podvm_builder.centos
@@ -9,7 +9,7 @@ FROM quay.io/centos/centos:stream8
 
 ARG GO_VERSION="1.20.6"
 ARG PROTOC_VERSION="3.11.4"
-ARG RUST_VERSION="1.66.0"
+ARG RUST_VERSION="1.69.0"
 
 # Without setting ENV gh-action is failing to use the correct values
 ENV GO_VERSION ${GO_VERSION}

--- a/podvm/Dockerfile.podvm_builder.rhel
+++ b/podvm/Dockerfile.podvm_builder.rhel
@@ -9,7 +9,7 @@ FROM registry.access.redhat.com/ubi9/ubi:9.1
 
 ARG GO_VERSION="1.20.6"
 ARG PROTOC_VERSION="3.11.4"
-ARG RUST_VERSION="1.66.0"
+ARG RUST_VERSION="1.69.0"
 
 # This must be running on subscribed RHEL host !!!
 # If you are running a UBI container on a registered and subscribed RHEL host, the main RHEL Server repository is enabled inside the standard UBI container

--- a/podvm/README.md
+++ b/podvm/README.md
@@ -54,15 +54,15 @@ $ docker build -t podvm_builder \
 Use `--build-arg` to pass build arguments to docker to overwrite default values if needed. Following are the arguments
 currently accepted:
 
-|Argument|Default value|Description|
-|--------|-------------|-----------|
-|CAA\_SRC |https://github.com/confidential-containers/cloud-api-adaptor | The cloud-api-adaptor source repository |
-|CAA\_SRC\_REF|main| cloud-api-adaptor repository branch or commit |
-|KATA\_SRC | https://github.com/kata-containers/kata-containers | The Kata Containers source repository |
-|KATA\_SRC\_BRANCH | CCv0 | The Kata Containers repository branch |
-|GO\_VERSION | 1.18.7 | Go version |
-|PROTOC\_VERSION | 3.11.4 | [Protobuf](https://github.com/protocolbuffers/protobuf) version |
-|RUST\_VERSION | 1.66.0 | Rust version |
+| Argument          | Default value                                                | Description                                                     |
+| ----------------- | ------------------------------------------------------------ | --------------------------------------------------------------- |
+| CAA\_SRC          | https://github.com/confidential-containers/cloud-api-adaptor | The cloud-api-adaptor source repository                         |
+| CAA\_SRC\_REF     | main                                                         | cloud-api-adaptor repository branch or commit                   |
+| KATA\_SRC         | https://github.com/kata-containers/kata-containers           | The Kata Containers source repository                           |
+| KATA\_SRC\_BRANCH | CCv0                                                         | The Kata Containers repository branch                           |
+| GO\_VERSION       | 1.18.7                                                       | Go version                                                      |
+| PROTOC\_VERSION   | 3.11.4                                                       | [Protobuf](https://github.com/protocolbuffers/protobuf) version |
+| RUST\_VERSION     | 1.69.0                                                       | Rust version                                                    |
 
 As it can be noted in the table above the cloud-api-adaptor repository is cloned within the builder image, so rather than
 copying the local source tree, it will be using the upstream source. But if you want to test local changes then you should:

--- a/versions.yaml
+++ b/versions.yaml
@@ -16,7 +16,7 @@ cloudimg:
         checksum: "sha256:b80ca9ccad8715aa1aeee582906096d3190b91cebe05fcb3ac7cb197fd68a7fe"
 tools:
   golang: 1.20.6
-  rust: 1.66.0
+  rust: 1.69.0
   protoc: 3.11.4
 # Referenced Git repositories
 git:


### PR DESCRIPTION
Upgrading to the version currently used by kata. A dependency of attestation-agent required a upgrade to at least 1.67.

Fixes: #1277