### PR TITLE
provisioner-cli: Update provisioner files to include profile id support

### DIFF
--- a/install/overlays/ibmcloud/kustomization.yaml
+++ b/install/overlays/ibmcloud/kustomization.yaml
@@ -46,7 +46,7 @@ secretGenerator:
   namespace: confidential-containers-system
   literals:
 ##IAM PROFILE SETTINGS
-# - IBMCLOUD_IAM_PROFILE_ID="" # set
+  - IBMCLOUD_IAM_PROFILE_ID="" # set
 ##/IAM PROFILE SETTINGS
   - IBMCLOUD_API_KEY="" # set if not using IAM profile ID
   - IBMCLOUD_IAM_ENDPOINT="" #set
@@ -64,7 +64,7 @@ patchesStrategicMerge:
   - cri_runtime_endpoint.yaml # set (modify host's runtime cri socket path in the file, default is /run/containerd/containerd.sock)
   - kata_direct_volumes_mount.yaml # set (for volumes/csi-wrapper)
 ##IAM PROFILE SETTINGS
-# - cr_token_projection.yaml
+  - cr_token_projection.yaml
 ##/IAM PROFILE SETTINGS
 ##TLS_SETTINGS
 # - tls_certs_volume_mount.yaml # set (for tls)

--- a/test/provisioner/provision_ibmcloud.go
+++ b/test/provisioner/provision_ibmcloud.go
@@ -803,6 +803,10 @@ func getSha256sum(imagePath string) (string, error) {
 func (p *IBMCloudProvisioner) UploadPodvm(imagePath string, ctx context.Context, cfg *envconf.Config) error {
 	log.Trace("UploadPodvm()")
 
+	if len(IBMCloudProps.ApiKey) <= 0 {
+		return errors.New("APIKEY must be set to upload podvm image")
+	}
+
 	filePath, err := filepath.Abs(imagePath)
 	if err != nil {
 		return err
@@ -941,6 +945,7 @@ func (p *IBMCloudProvisioner) GetProperties(ctx context.Context, cfg *envconf.Co
 		"IBMCLOUD_VPC_ID":                      IBMCloudProps.VpcID,
 		"CRI_RUNTIME_ENDPOINT":                 "/run/cri-runtime/containerd.sock",
 		"IBMCLOUD_API_KEY":                     IBMCloudProps.ApiKey,
+		"IBMCLOUD_IAM_PROFILE_ID":              IBMCloudProps.IamProfileID,
 		"IBMCLOUD_IAM_ENDPOINT":                IBMCloudProps.IamServiceURL,
 	}
 }

--- a/test/provisioner/provision_ibmcloud.properties
+++ b/test/provisioner/provision_ibmcloud.properties
@@ -1,6 +1,7 @@
 IBMCLOUD_PROVIDER="ibmcloud"
 # Manage -> Access -> API Keys -> My IBM Cloud API Keys
 APIKEY="${MY_VPC_APIKEY}"
+IAM_PROFILE_ID="${MY_IAM_PROFILE_ID}"
 CLUSTER_NAME="e2e-test1"
 # Resource list -> storage -> a cos service ->
 COS_BUCKET="peerpod-cos-bucket"

--- a/test/provisioner/provision_ibmcloud_kustomize.go
+++ b/test/provisioner/provision_ibmcloud_kustomize.go
@@ -72,6 +72,8 @@ func isKustomizeSecretKey(key string) bool {
 	switch key {
 	case "IBMCLOUD_API_KEY":
 		return true
+	case "IBMCLOUD_IAM_PROFILE_ID":
+		return true
 	case "IBMCLOUD_IAM_ENDPOINT":
 		return true
 	case "IBMCLOUD_ZONE":


### PR DESCRIPTION
Uncomment profile id steps in kustomize.yaml
Add extra validation for steps which require API key to be set

Fixes: #1243