### PR TITLE
azure-provisioner: Get RG when using CI managed RG

### DIFF
--- a/test/provisioner/provision_azure.go
+++ b/test/provisioner/provision_azure.go
@@ -34,6 +34,16 @@ func init() {
 func createResourceGroup() error {
 	if AzureProps.IsCIManaged {
 		log.Infof("Resource group %q is CI managed. No need to create new one manually.", AzureProps.ResourceGroupName)
+
+		resp, err := AzureProps.ResourceGroupClient.Get(context.Background(), AzureProps.ResourceGroupName, nil)
+		if err != nil {
+			err = fmt.Errorf("getting resource group %s: %w", AzureProps.ResourceGroupName, err)
+			log.Errorf("%v", err)
+			return err
+		}
+
+		AzureProps.ResourceGroup = &resp.ResourceGroup
+
 		return nil
 	}
 


### PR DESCRIPTION
When we create the "Resource Group" from the test provisioner code we get the RG object and we use it as is when running the code. But when the RG is managed by CI we don't get the RG object and we need to get it from the Azure API. This commit adds the code to get the RG object when the RG is managed by CI.

Currently the test panics because there is no RG object.

Fixes #1290