### PR TITLE
azure-provisioner: Default to CVM instead of VM

### DIFF
--- a/test/provisioner/provision_azure_initializer.go
+++ b/test/provisioner/provision_azure_initializer.go
@@ -82,7 +82,7 @@ func initAzureProperties(properties map[string]string) error {
 
 	AzureProps.VnetName = AzureProps.ClusterName + "_vnet"
 	AzureProps.SubnetName = AzureProps.ClusterName + "_subnet"
-	AzureProps.InstanceSize = "Standard_D2as_v5"
+	AzureProps.InstanceSize = "Standard_DC2as_v5"
 	AzureProps.NodeName = "caaaks"
 	AzureProps.OsType = "Ubuntu"
 


### PR DESCRIPTION
Right now the default instance type for podvm is a regular VM instead of a CVM. This commit switches the default to CVM.

Fixes: #1295