### PR TITLE
test/libvirt: allow libvirt conn URI to be specified

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -58,8 +58,9 @@ Use the properties on the table below for Libvirt:
 |---|---|---|
 |libvirt_network|Libvirt Network|"default"|
 |libvirt_storage|Libvirt storage pool|"default"|
-|libvirt_url|Libvirt connection URI|"qemu+ssh://root@192.168.122.1/system?no_verify=1"|
 |libvirt_vol_name|Volume name|"podvm-base.qcow2"|
+|libvirt_uri|Libvirt pod URI|"qemu+ssh://root@192.168.122.1/system?no_verify=1"|
+|libvirt_conn_uri|Libvirt host URI|"qemu:///system"|
 |libvirt_ssh_key_file|Path to SSH private key||
 |pause_image|k8s pause image||
 |vxlan_port| VXLAN port number||

--- a/test/provisioner/provision_libvirt.go
+++ b/test/provisioner/provision_libvirt.go
@@ -73,8 +73,11 @@ func NewLibvirtProvisioner(properties map[string]string) (CloudProvisioner, erro
 		vol_name = properties["libvirt_vol_name"]
 	}
 
-	// TODO: accept a different URI.
-	conn, err := libvirt.NewConnect("qemu:///system")
+	conn_uri := "qemu:///system"
+	if properties["libvirt_conn_uri"] != "" {
+		conn_uri = properties["libvirt_conn_uri"]
+	}
+	conn, err := libvirt.NewConnect(conn_uri)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The libvirt tests currently assumes that it is always running on a local instance and hard codes "qemu:///system" as the URI to create the Connection object with.

This allows us to specify libvirt_conn_uri in the libvirt properties file to change it to a different instance.

Also updates test/provisioner/e2e/README.md to add this option to the documentation and clarify the difference with libvirt_uri.

Fixes: #1164