### PR TITLE
ibmcloud: allow kubernetes service endpoint to be overridden

### DIFF
--- a/test/provisioner/provision_ibmcloud.properties
+++ b/test/provisioner/provision_ibmcloud.properties
@@ -48,3 +48,9 @@ VPC_SECURITY_GROUP_ID=""
 VPC_NAME=""
 # optional, existing VPC id if using existing VPC and cluster for testing
 VPC_ID=""
+# optional, URL for the IAM token server endpoint. Defaults to the IAM token server endpoint for the public IBM Cloud if not provided
+IAM_SERVICE_URL=""
+# optional, URL for the VPC Infrastrcuture service endpoint. Defaults to the VPC Infrastructure endpoint for the provided IBM Cloud region if not provided
+VPC_SERVICE_URL=""
+# optional, URL for the Kubernetes service endpoint. Defaults to the global Kubernetes service endpoint for the public IBM Cloud if not provided
+IKS_SERVICE_URL=""


### PR DESCRIPTION
Fixes: #1328

Allow the default IBM Cloud Kubernetes Service endpoint to be overriddden by a custom private or Staging Kubernetes service endpoint.