### PR TITLE
workflow: retry caa image build

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -49,9 +49,16 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
       - name: Build and push image
-        run: |
-          if [ ${{ matrix.type }} == "release" ]; then
-            ARCHES=${{matrix.arches}} RELEASE_BUILD=true make image
-          else
-            ARCHES=${{matrix.arches}} RELEASE_BUILD=false make image
-          fi
+        uses: nick-fields/retry@v2
+        with:
+          # We are not interested in timeout but this field is required
+          # so setting to 4x the time it usually take to complete.
+          timeout_minutes: 60
+          retry_wait_seconds: 120
+          max_attempts: 3
+          command: |
+            if [ ${{ matrix.type }} == "release" ]; then
+              ARCHES=${{matrix.arches}} RELEASE_BUILD=true make image
+            else
+              ARCHES=${{matrix.arches}} RELEASE_BUILD=false make image
+            fi


### PR DESCRIPTION
The CAA image build on push is very important to not fail otherwise features and fixes don't properly get into devel/release cycle. But we recently have noticed errors like:

ERROR: failed to solve: DeadlineExceeded: failed to push quay.io/confidential-containers/cloud-api-adaptor:b277c1ae739ae318926ef4f39c88fac16050d13a: no active session for pj7teq3k1b3tqjew1y3tf5mgp: context deadline exceeded

Error that goes away when the workflow is manually re-trigger after a few minutes. So this added a retry mechanism that will try again the build command after 2 minutes and for the maximum of 3 tentatives.