### PR TITLE
webhook: add verify targets

### DIFF
--- a/.github/workflows/webhook-test.yaml
+++ b/.github/workflows/webhook-test.yaml
@@ -38,6 +38,8 @@ jobs:
           git clone https://github.com/bats-core/bats-core.git
           cd bats-core
           ./install.sh ~/.local
+      - name: Verify go modules and manifests
+        run: make verify
       - name: Run end-to-end tests
         run: |
           make test-e2e

--- a/webhook/Makefile
+++ b/webhook/Makefile
@@ -153,3 +153,32 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+##@ Verify
+
+ALL_VERIFY_CHECKS = modules gen manifests
+
+.PHONY: verify
+verify: $(addprefix verify-,$(ALL_VERIFY_CHECKS)) ## Run all verify-* targets
+
+.PHONY: verify-modules
+verify-modules: ## Verify go modules are up to date
+	go mod tidy
+	@if !(git diff --quiet HEAD -- go.sum go.mod); then \
+		git diff; \
+		echo "go module files are out of date"; exit 1; \
+	fi
+
+.PHONY: verify-gen
+verify-gen: generate ## Verfiy go generated files are up to date
+	@if !(git diff --quiet HEAD); then \
+		git diff; \
+		echo "generated files are out of date, run make generate"; exit 1; \
+	fi
+
+.PHONY: verify-manifests
+verify-manifests: manifests ## Verfiy manifests are up to date
+	@if !(git diff --quiet HEAD); then \
+		git diff; \
+		echo "generated files are out of date, run make manifests"; exit 1; \
+	fi

--- a/webhook/config/webhook/kustomization.yaml
+++ b/webhook/config/webhook/kustomization.yaml
@@ -4,3 +4,12 @@ resources:
 
 configurations:
 - kustomizeconfig.yaml
+
+patches:
+- path: namespace_selector_patch.yaml
+- patch: |-
+    - op: add
+      path: /webhooks/0/rules/0/scope
+      value: Namespaced
+  target:
+    kind: MutatingWebhookConfiguration

--- a/webhook/config/webhook/manifests.yaml
+++ b/webhook/config/webhook/manifests.yaml
@@ -24,12 +24,4 @@ webhooks:
     - UPDATE
     resources:
     - pods
-    scope: Namespaced
   sideEffects: None
-  namespaceSelector:
-    matchExpressions:
-      - key: kubernetes.io/metadata.name
-        operator: NotIn
-        values:
-        - peer-pods-webhook-system
-        - kube-system

--- a/webhook/config/webhook/namespace_selector_patch.yaml
+++ b/webhook/config/webhook/namespace_selector_patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- name: mwebhook.peerpods.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - peer-pods-webhook-system
+      - kube-system


### PR DESCRIPTION
This PR adds verify targets to check if go modules and manifests are up to date. It also adds the check in webhook test workflow.

Fixes: #1347