### PR TITLE
WIP: Libvirt SEV-SNP support

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -117,6 +117,7 @@ ibmcloud_powervs() {
 libvirt() {
     test_vars LIBVIRT_URI
 
+    [[ "${DISABLECVM}" ]] && optionals+="-disable-cvm "
     set -x
     exec cloud-api-adaptor libvirt \
         -uri "${LIBVIRT_URI}" \

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/cri-api v0.23.1
 	libvirt.org/go/libvirt v1.8002.0
-	libvirt.org/go/libvirtxml v1.8002.0
+	libvirt.org/go/libvirtxml v1.9004.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2669,8 +2669,8 @@ k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 h1:KTgPnR10d5zhztWptI952TNtt/4u5
 k8s.io/utils v0.0.0-20221128185143-99ec85e7a448/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 libvirt.org/go/libvirt v1.8002.0 h1:X8gz2Sa1ek4S5FznpDpeRz6JpNb7NdkfzTii5GMIwDY=
 libvirt.org/go/libvirt v1.8002.0/go.mod h1:1WiFE8EjZfq+FCVog+rvr1yatKbKZ9FaFMZgEqxEJqQ=
-libvirt.org/go/libvirtxml v1.8002.0 h1:ES5bU3/G/dykJ4WIO5NJ3cTvvr5xSCaqwjYeRxkTX40=
-libvirt.org/go/libvirtxml v1.8002.0/go.mod h1:7Oq2BLDstLr/XtoQD8Fr3mfDNrzlI3utYKySXF2xkng=
+libvirt.org/go/libvirtxml v1.9004.0 h1:h+nhEZCABCnK4go0GLRN2WZhIhRrLAqsz84t553oiM4=
+libvirt.org/go/libvirtxml v1.9004.0/go.mod h1:7Oq2BLDstLr/XtoQD8Fr3mfDNrzlI3utYKySXF2xkng=
 mvdan.cc/gofumpt v0.1.1/go.mod h1:yXG1r1WqZVKWbVRtBWKWX9+CxGYfA51nSomhM0woR48=
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=

--- a/install/overlays/libvirt/kustomization.yaml
+++ b/install/overlays/libvirt/kustomization.yaml
@@ -20,6 +20,8 @@ configMapGenerator:
   - LIBVIRT_URI="qemu+ssh://root@192.168.122.1/system?no_verify=1" #set
   - LIBVIRT_NET="default" # set
   - LIBVIRT_POOL="default" # set
+  #- LIBVIRT_LAUNCH_SECURITY="sev"
+  #- LIBVIRT_FIRMWARE=""
   #- LIBVIRT_VOL_NAME="" # Uncomment and set if you want to use a specific volume name. Defaults to podvm-base.qcow2
   #- PAUSE_IMAGE="" # Uncomment and set if you want to use a specific pause image
   #- VXLAN_PORT="" # Uncomment and set if you want to use a specific vxlan port. Defaults to 4789

--- a/pkg/adaptor/cloud/libvirt/libvirt.go
+++ b/pkg/adaptor/cloud/libvirt/libvirt.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// architecture value for the s390x architecture
-	archS390x = "s390x"
+	ArchS390x = "s390x"
 	// hvm indicates that the OS is one designed to run on bare metal, so requires full virtualization.
 	typeHardwareVirtualMachine = "hvm"
 	// The amount of retries to get the domain IP addresses
@@ -186,7 +186,7 @@ func getHostCapabilities(conn *libvirt.Connect) (*libvirtxml.Caps, error) {
 	return caps, nil
 }
 
-func getDomainCapabilities(conn *libvirt.Connect, emulatorbin string, arch string, machine string, virttype string, flags uint32) (*libvirtxml.DomainCaps, error) {
+func GetDomainCapabilities(conn *libvirt.Connect, emulatorbin string, arch string, machine string, virttype string, flags uint32) (*libvirtxml.DomainCaps, error) {
 	capsXML, err := conn.GetDomainCapabilities(emulatorbin, arch, machine, virttype, flags)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get domain capabilities, cause: %w", err)
@@ -238,12 +238,12 @@ func getCanonicalMachineName(caps *libvirtxml.Caps, arch string, virttype string
 
 func createDomainXMLs390x(client *libvirtClient, cfg *domainConfig, vm *vmConfig) (*libvirtxml.Domain, error) {
 
-	guest, err := getGuestForArchType(client.caps, archS390x, typeHardwareVirtualMachine)
+	guest, err := getGuestForArchType(client.caps, ArchS390x, typeHardwareVirtualMachine)
 	if err != nil {
 		return nil, err
 	}
 
-	canonicalmachine, err := getCanonicalMachineName(client.caps, archS390x, typeHardwareVirtualMachine, "s390-ccw-virtio")
+	canonicalmachine, err := getCanonicalMachineName(client.caps, ArchS390x, typeHardwareVirtualMachine, "s390-ccw-virtio")
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +294,7 @@ func createDomainXMLs390x(client *libvirtClient, cfg *domainConfig, vm *vmConfig
 		OS: &libvirtxml.DomainOS{
 			Type: &libvirtxml.DomainOSType{
 				Type:    typeHardwareVirtualMachine,
-				Arch:    archS390x,
+				Arch:    ArchS390x,
 				Machine: canonicalmachine,
 			},
 		},
@@ -456,7 +456,7 @@ func enableSEV(client *libvirtClient, cfg *domainConfig, vm *vmConfig, domain *l
 	if err != nil {
 		return nil, fmt.Errorf("unable to find guest machine to determine SEV capabilities")
 	}
-	domCaps, err := getDomainCapabilities(client.connection, guest.Arch.Emulator, arch, sevMachine, virttype, domCapflags)
+	domCaps, err := GetDomainCapabilities(client.connection, guest.Arch.Emulator, arch, sevMachine, virttype, domCapflags)
 	if err != nil {
 		return nil, fmt.Errorf("unable to determine guest domain capabilities: %+v", err)
 	}
@@ -535,7 +535,7 @@ func enableSEV(client *libvirtClient, cfg *domainConfig, vm *vmConfig, domain *l
 // createDomainXML detects the machine type of the libvirt host and will return a libvirt XML for that machine type
 func createDomainXML(client *libvirtClient, cfg *domainConfig, vm *vmConfig) (*libvirtxml.Domain, error) {
 	switch client.nodeInfo.Model {
-	case archS390x:
+	case ArchS390x:
 		return createDomainXMLs390x(client, cfg, vm)
 	default:
 		return createDomainXMLx86_64(client, cfg, vm)

--- a/pkg/adaptor/cloud/libvirt/libvirt_test.go
+++ b/pkg/adaptor/cloud/libvirt/libvirt_test.go
@@ -98,7 +98,9 @@ func TestCreateDomainXMLs390x(t *testing.T) {
 		cidataDisk:  "/var/lib/libvirt/images/cidata.iso",
 	}
 
-	domCfg, err := createDomainXML(client, &domainCfg)
+	vm := vmConfig{}
+
+	domCfg, err := createDomainXML(client, &domainCfg, &vm)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/adaptor/cloud/libvirt/libvirt_test.go
+++ b/pkg/adaptor/cloud/libvirt/libvirt_test.go
@@ -64,6 +64,14 @@ func TestGetArchitecture(t *testing.T) {
 	}
 }
 
+func TestGetLaunchSecurity(t *testing.T) {
+	launchSecurity, err := GetLaunchSecurityType("qemu:///system")
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("%s", launchSecurity.String())
+}
+
 func verifyVirtioIOMMU(domXML *libvirtxml.Domain) error {
 	// verify we have iommu on the disks
 	for i, disk := range domXML.Devices.Disks {

--- a/pkg/adaptor/cloud/libvirt/manager.go
+++ b/pkg/adaptor/cloud/libvirt/manager.go
@@ -16,29 +16,36 @@ var libvirtcfg Config
 type Manager struct{}
 
 const (
-	defaultURI         = "qemu:///system"
-	defaultPoolName    = "default"
-	defaultNetworkName = "default"
-	defaultDataDir     = "/var/lib/libvirt/images"
-	defaultVolName     = "podvm-base.qcow2"
+	defaultURI            = "qemu:///system"
+	defaultPoolName       = "default"
+	defaultNetworkName    = "default"
+	defaultDataDir        = "/var/lib/libvirt/images"
+	defaultVolName        = "podvm-base.qcow2"
+	defaultLaunchSecurity = ""
+	defaultFirmware       = "/usr/share/edk2/ovmf/OVMF_CODE.fd"
 )
 
-func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
+func (*Manager) ParseCmd(flags *flag.FlagSet) {
 
 	flags.StringVar(&libvirtcfg.URI, "uri", defaultURI, "libvirt URI")
 	flags.StringVar(&libvirtcfg.PoolName, "pool-name", defaultPoolName, "libvirt storage pool")
 	flags.StringVar(&libvirtcfg.NetworkName, "network-name", defaultNetworkName, "libvirt network pool")
 	flags.StringVar(&libvirtcfg.DataDir, "data-dir", defaultDataDir, "libvirt storage dir")
+	flags.BoolVar(&libvirtcfg.DisableCVM, "disable-cvm", false, "Use non-CVMs for peer pods")
+	flags.StringVar(&libvirtcfg.LaunchSecurity, "launch-security", defaultLaunchSecurity, "Libvirt's LaunchSecurity element for Confidential VMs. SEV or s390-pv. If omitted, will automatically determine.")
+	flags.StringVar(&libvirtcfg.Firmware, "firmware", defaultFirmware, "Path to OVMF")
 
 }
 
-func (_ *Manager) LoadEnv() {
+func (*Manager) LoadEnv() {
 	cloud.DefaultToEnv(&libvirtcfg.URI, "LIBVIRT_URI", defaultURI)
 	cloud.DefaultToEnv(&libvirtcfg.PoolName, "LIBVIRT_POOL", defaultPoolName)
 	cloud.DefaultToEnv(&libvirtcfg.NetworkName, "LIBVIRT_NET", defaultNetworkName)
 	cloud.DefaultToEnv(&libvirtcfg.VolName, "LIBVIRT_VOL_NAME", defaultVolName)
+	cloud.DefaultToEnv(&libvirtcfg.LaunchSecurity, "LIBVIRT_LAUNCH_SECURITY", defaultLaunchSecurity)
+	cloud.DefaultToEnv(&libvirtcfg.Firmware, "LIBVIRT_FIRMWARE", defaultFirmware)
 }
 
-func (_ *Manager) NewProvider() (cloud.Provider, error) {
+func (*Manager) NewProvider() (cloud.Provider, error) {
 	return NewProvider(&libvirtcfg)
 }

--- a/pkg/adaptor/cloud/libvirt/provider.go
+++ b/pkg/adaptor/cloud/libvirt/provider.go
@@ -7,6 +7,7 @@ package libvirt
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/netip"
 
@@ -58,6 +59,7 @@ func (p *libvirtProvider) CreateInstance(ctx context.Context, podName, sandboxID
 	// TODO: Specify the maximum instance name length in Libvirt
 	vm := &vmConfig{name: instanceName, userData: userData, firmware: p.serviceConfig.Firmware}
 
+	logger.Printf("DisableCVM: %t", p.serviceConfig.DisableCVM)
 	if p.serviceConfig.DisableCVM {
 		vm.launchSecurityType = NoLaunchSecurity
 	} else if p.serviceConfig.LaunchSecurity != "" {
@@ -66,14 +68,17 @@ func (p *libvirtProvider) CreateInstance(ctx context.Context, podName, sandboxID
 			vm.launchSecurityType = SEV
 		case "s390-pv":
 			vm.launchSecurityType = S390PV
+		default:
+			return nil, fmt.Errorf("[%s] is not a known launch security setting", p.serviceConfig.LaunchSecurity)
 		}
 	} else {
-		vm.launchSecurityType, err = GetLaunchSecurityType()
+		vm.launchSecurityType, err = GetLaunchSecurityType(p.serviceConfig.URI)
 		if err != nil {
 			logger.Printf("unable to determine launch security type [%v]", err)
 			return nil, err
 		}
 	}
+	logger.Printf("LaunchSecurityType: %s", vm.launchSecurityType.String())
 
 	result, err := CreateDomain(ctx, p.libvirtClient, vm)
 	if err != nil {

--- a/pkg/adaptor/cloud/libvirt/types.go
+++ b/pkg/adaptor/cloud/libvirt/types.go
@@ -13,22 +13,27 @@ import (
 )
 
 type Config struct {
-	URI         string
-	PoolName    string
-	NetworkName string
-	DataDir     string
-	VolName     string
+	URI            string
+	PoolName       string
+	NetworkName    string
+	DataDir        string
+	DisableCVM     bool
+	VolName        string
+	LaunchSecurity string
+	Firmware       string
 }
 
 type vmConfig struct {
-	name         string
-	cpu          uint
-	mem          uint
-	rootDiskSize uint64
-	userData     string
-	metaData     string
-	ips          []netip.Addr
-	instanceId   string //keeping it consistent with sandbox.vsi
+	name               string
+	cpu                uint
+	mem                uint
+	rootDiskSize       uint64
+	userData           string
+	metaData           string
+	ips                []netip.Addr
+	instanceId         string //keeping it consistent with sandbox.vsi
+	launchSecurityType LaunchSecurityType
+	firmware           string
 }
 
 type createDomainOutput struct {
@@ -55,4 +60,25 @@ type libvirtClient struct {
 
 	// host capabilities
 	caps *libvirtxml.Caps
+}
+
+type LaunchSecurityType int
+
+const (
+	NoLaunchSecurity LaunchSecurityType = iota
+	SEV
+	S390PV
+)
+
+func (l LaunchSecurityType) String() string {
+	switch l {
+	case NoLaunchSecurity:
+		return ""
+	case SEV:
+		return "SEV"
+	case S390PV:
+		return "S390PV"
+	default:
+		return "unknown"
+	}
 }

--- a/pkg/adaptor/cloud/libvirt/types.go
+++ b/pkg/adaptor/cloud/libvirt/types.go
@@ -73,7 +73,7 @@ const (
 func (l LaunchSecurityType) String() string {
 	switch l {
 	case NoLaunchSecurity:
-		return ""
+		return "None"
 	case SEV:
 		return "SEV"
 	case S390PV:

--- a/pkg/adaptor/proxy/proxy.go
+++ b/pkg/adaptor/proxy/proxy.go
@@ -122,6 +122,7 @@ func (p *agentProxy) dial(ctx context.Context, address string) (net.Conn, error)
 		func() error {
 			var err error
 			conn, err = dialer.DialContext(ctx, "tcp", address)
+			logger.Printf("%+v", err)
 			return err
 		},
 		retry.Attempts(0),

--- a/test/e2e/libvirt_test.go
+++ b/test/e2e/libvirt_test.go
@@ -18,7 +18,7 @@ func TestLibvirtCreateSimplePod(t *testing.T) {
 func TestLibvirtCreateConfidentialPod(t *testing.T) {
 	assert := LibvirtAssert{}
 
-	launchSecurity, err := libvirtAdaptor.GetLaunchSecurityType()
+	launchSecurity, err := libvirtAdaptor.GetLaunchSecurityType("qemu:///system")
 	if err != nil {
 		t.Errorf("Unable to determine machine confidentiality capabilities: [%v]", err)
 	}

--- a/test/e2e/libvirt_test.go
+++ b/test/e2e/libvirt_test.go
@@ -3,6 +3,8 @@
 package e2e
 
 import (
+	libvirtAdaptor "github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/cloud/libvirt"
+
 	"libvirt.org/go/libvirt"
 	"strings"
 	"testing"
@@ -13,6 +15,24 @@ func TestLibvirtCreateSimplePod(t *testing.T) {
 	doTestCreateSimplePod(t, assert)
 }
 
+func TestLibvirtCreateConfidentialPod(t *testing.T) {
+	assert := LibvirtAssert{}
+
+	launchSecurity, err := libvirtAdaptor.GetLaunchSecurityType()
+	if err != nil {
+		t.Errorf("Unable to determine machine confidentiality capabilities: [%v]", err)
+	}
+	switch launchSecurity {
+	case libvirtAdaptor.SEV:
+		testCommands := []testCommand{}
+		doTestCreateConfidentialPod(t, assert, testCommands)
+	case libvirtAdaptor.S390PV:
+		t.Skip("Unimplemented")
+	default:
+		t.Skip("No confidential hardware detected on the machine")
+	}
+
+}
 func TestLibvirtCreatePodWithConfigMap(t *testing.T) {
 	assert := LibvirtAssert{}
 	doTestCreatePodWithConfigMap(t, assert)


### PR DESCRIPTION
WIP Adds support for SEV-SNP.

For reference: https://libvirt.org/kbase/launch_security_sev.html

I currently also have a commit for remote libvirt connection cherry-picked on for testing purposes (using a remote machine with sev support, but running the cluster on my machine at the moment)

If LAUNCH_SECURITY is specified as "sev" and the machine suppports sev, it adds the necessary changes.

Some questions I have on the implementation:

- I have the sev changes be modifications of the x86_64 domainxml creation. I was debating whether it would be better to just create a whole separate domainxml creation function to isolate it more. I especially don't feel very comfortable with how I overwrote one of the disks and think that it might be better to make everything explicit. Thoughts? 
- The reason the disk had to be overwritten was because q35 machines do not support IDE connections. I tried connecting a disk with SATA, but it threw an error (bug?), so I switched to SCSI. Let me know if there are better ways to do this.
- In terms of guest policy (https://libvirt.org/formatdomain.html#launch-security), I left everything as disabled because I assumed this was currently mostly being used for testing and being permissive would be fine. Should this be set to anything specific or be specifiable?
- I assumed that secure boot should be on for the DomainLoader. Also, set it as stateless for boot attestation.
-  In https://libvirt.org/kbase/launch_security_sev.html#memory, it mentions two ways of addressing the extra memory needed. We chose to add 512 MiB on top of the 8 GiB and it seems boot successfully.


I need help determining what exactly I should be testing.

in terms of manual testing, I have been building an image and uploading it to a separate quay repository. I was having trouble setting up a cluster on a remote machine, so I am setting up a cluster locally and having the peer-pod vm be created on the remote machine. However, I have also been having trouble in containerCreating when creating a remote instance. Also, if you try this route, note that install_operator.sh assumes that you are not using a remote_uri and will overwrite libvirt_uri in the kustomization file with the local ip and user, so that will need to be manually changed back.