### PR TITLE
1092: Skip checking properties unnecessary for image upload are set if the provisioner only does the upload image action

### DIFF
--- a/test/provisioner/common.go
+++ b/test/provisioner/common.go
@@ -21,6 +21,8 @@ type patchLabel struct {
 	Value string `json:"value"`
 }
 
+var Action string
+
 // Adds the worker label to all workers nodes in a given cluster
 func AddNodeRoleWorkerLabel(ctx context.Context, clusterName string, cfg *envconf.Config) error {
 	fmt.Printf("Adding worker label to nodes belonging to: %s\n", clusterName)

--- a/test/provisioner/provision_ibmcloud_initializer.go
+++ b/test/provisioner/provision_ibmcloud_initializer.go
@@ -135,10 +135,6 @@ func initProperties(properties map[string]string) error {
 
 	log.Debugf("%+v", IBMCloudProps)
 
-	if len(IBMCloudProps.ApiKey) <= 0 && len(IBMCloudProps.IamProfileID) <= 0 {
-		return errors.New("APIKEY or IAM_PROFILE_ID must be set")
-	}
-
 	if len(IBMCloudProps.ResourceGroupID) <= 0 {
 		log.Info("[warning] RESOURCE_GROUP_ID was not set.")
 	}
@@ -169,13 +165,16 @@ func initProperties(properties map[string]string) error {
 	log.Infof("IksServiceURL is: %s.", IBMCloudProps.IksServiceURL)
 
 	needProvisionStr := os.Getenv("TEST_PROVISION")
-	if strings.EqualFold(needProvisionStr, "yes") || strings.EqualFold(needProvisionStr, "true") {
+	if strings.EqualFold(needProvisionStr, "yes") || strings.EqualFold(needProvisionStr, "true") || Action == "uploadimage" {
 		if len(IBMCloudProps.ApiKey) <= 0 {
 			return errors.New("APIKEY is required for provisioning")
 		}
 		if len(IBMCloudProps.Region) <= 0 {
 			return errors.New("REGION was not set.")
 		}
+	}
+
+	if strings.EqualFold(needProvisionStr, "yes") || strings.EqualFold(needProvisionStr, "true") {
 		if len(IBMCloudProps.KubeVersion) <= 0 {
 			return errors.New("KUBE_VERSION was not set, get it via command: ibmcloud cs versions")
 		}
@@ -213,6 +212,10 @@ func initProperties(properties map[string]string) error {
 		}
 	} else if len(IBMCloudProps.PodvmImageID) <= 0 {
 		return errors.New("PODVM_IMAGE_ID was not set, set it with existing custom image id in VPC")
+	}
+
+	if len(IBMCloudProps.ApiKey) <= 0 && len(IBMCloudProps.IamProfileID) <= 0 {
+		return errors.New("APIKEY or IAM_PROFILE_ID must be set")
 	}
 
 	if len(IBMCloudProps.ApiKey) > 0 {

--- a/test/tools/provisioner-cli/main.go
+++ b/test/tools/provisioner-cli/main.go
@@ -43,15 +43,17 @@ func main() {
 		installDirectory = "../../install"
 	}
 
+	action := flag.String("action", "provision", "string")
+	flag.Parse()
+
+	pv.Action = *action
+
 	cfg := envconf.New()
 
 	provisioner, err := pv.GetCloudProvisioner(cloudProvider, provisionPropsFile)
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	action := flag.String("action", "provision", "string")
-	flag.Parse()
 
 	if *action == "provision" {
 		log.Info("Creating VPC...")
@@ -97,6 +99,9 @@ func main() {
 
 	if *action == "uploadimage" {
 		log.Info("Uploading PodVM Image...")
+		if len(podvmImage) <= 0 {
+			log.Fatal("Environment variable TEST_PODVM_IMAGE must be set")
+		}
 		if _, err := os.Stat(podvmImage); os.IsNotExist(err) {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
Skip checking properties unnecessary for image upload are set if the provisioner only does the upload image action

Use the Action variable as a way to check if uploadimage is being performed 
Skip checks for unneeded variables if this is the action set
Set TEST_PROVISION to yes if the action is only uploadimage

Fixes #1092 

Signed-off-by: Tia Shah <tia.shah@ibm.com>