### PR TITLE
1091: Make the provisioner CLI Makefile choose the GOOS automatically

### DIFF
--- a/test/tools/Makefile
+++ b/test/tools/Makefile
@@ -6,7 +6,13 @@
 ARCH                    ?= $(subst x86_64,amd64,$(shell uname -m))
 BUILTIN_CLOUD_PROVIDERS ?= aws azure ibmcloud vsphere libvirt
 GOFLAGS                 ?=
-GOOPTIONS               ?= GOOS=linux GOARCH=$(ARCH) CGO_ENABLED=0
+GOOS 					?= $(shell uname)
+ifeq ($(GOOS), Linux)
+	GOOS := linux 
+else ifeq ($(GOOS), Darwin)
+	GOOS := darwin 
+endif
+GOOPTIONS               ?= GOOS=$(GOOS) GOARCH=$(ARCH) CGO_ENABLED=0
 BINARIES                := caa-provisioner-cli
 
 space := $() $()

--- a/test/tools/Makefile
+++ b/test/tools/Makefile
@@ -6,12 +6,7 @@
 ARCH                    ?= $(subst x86_64,amd64,$(shell uname -m))
 BUILTIN_CLOUD_PROVIDERS ?= aws azure ibmcloud vsphere libvirt
 GOFLAGS                 ?=
-GOOS                    ?= $(shell uname)
-ifeq ($(GOOS), Linux)
-	GOOS := linux 
-else ifeq ($(GOOS), Darwin)
-	GOOS := darwin 
-endif
+GOOS                    ?= $(shell uname | tr A-Z a-z)
 GOOPTIONS               ?= GOOS=$(GOOS) GOARCH=$(ARCH) CGO_ENABLED=0
 BINARIES                := caa-provisioner-cli
 

--- a/test/tools/Makefile
+++ b/test/tools/Makefile
@@ -6,7 +6,7 @@
 ARCH                    ?= $(subst x86_64,amd64,$(shell uname -m))
 BUILTIN_CLOUD_PROVIDERS ?= aws azure ibmcloud vsphere libvirt
 GOFLAGS                 ?=
-GOOS 					?= $(shell uname)
+GOOS                    ?= $(shell uname)
 ifeq ($(GOOS), Linux)
 	GOOS := linux 
 else ifeq ($(GOOS), Darwin)


### PR DESCRIPTION
Make the provisioner CLI Makefile choose the GOOS automatically

Choose the default GOOS based on the machine type the provisioner CLI is being built on 
Set the value to either linux or darwin

Fixes #1091

Signed-off-by: Tia Shah <tia.shah@ibm.com>