### PR TITLE
aws: Enable publicIP usage for pod VM

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,7 @@ one_of() {
 aws() {
     test_vars AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
 
+
     [[ "${PODVM_LAUNCHTEMPLATE_NAME}" ]] && optionals+="-use-lt -aws-lt-name ${PODVM_LAUNCHTEMPLATE_NAME} " # has precedence if set
     [[ "${AWS_SG_IDS}" ]] && optionals+="-securitygroupids ${AWS_SG_IDS} "                                  # MUST if template is not used
     [[ "${PODVM_AMI_ID}" ]] && optionals+="-imageid ${PODVM_AMI_ID} "                                       # MUST if template is not used
@@ -43,6 +44,7 @@ aws() {
     [[ "${AWS_SUBNET_ID}" ]] && optionals+="-subnetid ${AWS_SUBNET_ID} " # if not set retrieved from IMDS
     [[ "${AWS_REGION}" ]] && optionals+="-aws-region ${AWS_REGION} "     # if not set retrieved from IMDS
     [[ "${TAGS}" ]] && optionals+="-tags ${TAGS} " # Custom tags applied to pod vm
+    [[ "${USE_PUBLIC_IP}" == "true" ]] && optionals+="-use-public-ip " # Use public IP for pod vm
 
     set -x
     exec cloud-api-adaptor aws \

--- a/install/overlays/aws/kustomization.yaml
+++ b/install/overlays/aws/kustomization.yaml
@@ -29,6 +29,7 @@ configMapGenerator:
   #- SSH_KP_NAME="" # if not set retrieved from IMDS
   #- AWS_SUBNET_ID="" # if not set retrieved from IMDS
   #- TAGS="" # Uncomment and add key1=value1,key2=value2 etc if you want to use specific tags for podvm
+  #- USE_PUBLIC_IP="true" # Uncomment if you want to use public ip for podvm
 ##TLS_SETTINGS
   #- CACERT_FILE="/etc/certificates/ca.crt" # for TLS
   #- CERT_FILE="/etc/certificates/client.crt" # for TLS

--- a/pkg/adaptor/cloud/aws/manager.go
+++ b/pkg/adaptor/cloud/aws/manager.go
@@ -18,7 +18,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	flags.StringVar(&awscfg.AccessKeyId, "aws-access-key-id", "", "Access Key ID, defaults to `AWS_ACCESS_KEY_ID`")
 	flags.StringVar(&awscfg.SecretKey, "aws-secret-key", "", "Secret Key, defaults to `AWS_SECRET_ACCESS_KEY`")
 	flags.StringVar(&awscfg.Region, "aws-region", "", "Region")
-	flags.StringVar(&awscfg.LoginProfile, "aws-profile", "test", "AWS Login Profile")
+	flags.StringVar(&awscfg.LoginProfile, "aws-profile", "", "AWS Login Profile")
 	flags.StringVar(&awscfg.LaunchTemplateName, "aws-lt-name", "kata", "AWS Launch Template Name")
 	flags.BoolVar(&awscfg.UseLaunchTemplate, "use-lt", false, "Use EC2 Launch Template for the Pod VMs")
 	flags.StringVar(&awscfg.ImageId, "imageid", "", "Pod VM ami id")
@@ -30,6 +30,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	flags.Var(&awscfg.InstanceTypes, "instance-types", "Instance types to be used for the Pod VMs, comma separated")
 	// Add a key value list parameter to indicate custom tags to be used for the Pod VMs
 	flags.Var(&awscfg.Tags, "tags", "Custom tags (key=value pairs) to be used for the Pod VMs, comma separated")
+	flags.BoolVar(&awscfg.UsePublicIP, "use-public-ip", false, "Use Public IP for connecting to the kata-agent inside the Pod VM")
 
 }
 

--- a/pkg/adaptor/cloud/aws/types.go
+++ b/pkg/adaptor/cloud/aws/types.go
@@ -51,6 +51,7 @@ type Config struct {
 	InstanceTypes        instanceTypes
 	InstanceTypeSpecList []cloud.InstanceTypeSpec
 	Tags                 cloud.KeyValueFlag
+	UsePublicIP          bool
 }
 
 func (c Config) Redact() Config {


### PR DESCRIPTION
This change allows CAA to use the public IP of the pod VM to make a connection to the kata-agent.
The communication between CAA and podVM uses TLS.

Fixes: #1379