### PR TITLE
podvm: Add clang libraries from llvm

### DIFF
--- a/podvm/Dockerfile.podvm_builder
+++ b/podvm/Dockerfile.podvm_builder
@@ -22,6 +22,9 @@ RUN apt-get update -y && \
     apt-get install --no-install-recommends -y build-essential cloud-image-utils curl git gnupg \
         libdevmapper-dev libgpgme-dev lsb-release pkg-config qemu-kvm \
         musl-tools unzip wget git && \
+    wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
+    echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-17 main" | tee -a /etc/apt/sources.list && \
+    apt-get update && apt-get install -y clang-17 && \
     curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
     echo "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee -a /etc/apt/sources.list && \
     apt-get update && apt-get install --no-install-recommends -y packer && \

--- a/podvm/Dockerfile.podvm_builder.centos
+++ b/podvm/Dockerfile.podvm_builder.centos
@@ -21,7 +21,7 @@ RUN dnf install -y 'dnf-command(config-manager)' && dnf config-manager --set-ena
     dnf groupinstall -y 'Development Tools' && \
     dnf install -y yum-utils gnupg git curl pkg-config libseccomp-devel gpgme-devel \
         device-mapper-devel qemu-kvm unzip wget libassuan-devel golang-github-cpuguy83-md2man \
-	genisoimage cloud-utils-growpart cloud-init && \
+	genisoimage cloud-utils-growpart cloud-init clang && \
     yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo && \
     dnf install -y packer && \
     dnf clean all && \

--- a/podvm/Dockerfile.podvm_builder.rhel
+++ b/podvm/Dockerfile.podvm_builder.rhel
@@ -17,7 +17,7 @@ ARG RUST_VERSION="1.69.0"
 RUN dnf groupinstall -y 'Development Tools' && \
     dnf install -y yum-utils gnupg git perl-core pkg-config libseccomp-devel gpgme-devel \
         device-mapper-devel qemu-kvm unzip wget libassuan-devel \
-	genisoimage cloud-utils-growpart cloud-init && \
+	genisoimage cloud-utils-growpart cloud-init clang && \
     yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo && \
     dnf install -y packer && \
     dnf clean all && \


### PR DESCRIPTION
Fixes: #1357

Tested creating a podvm qcow2 image in docker. After uploading it to ibmcloud.

```
$ ibmcloud is instances
Listing instances in all resource groups and region eu-gb under account James Tumber's Account as user james.tumber@ibm.com...
ID                                          Name                   Status    Reserved IP    Floating IP      Profile   Image                                VPC               Zone      Resource group   
07a7_6ba80928-d0ce-4505-85fc-f7851d1073e5   caa-cluster-node-0     running   10.242.128.4   158.176.188.76   bx2-2x8   ibm-ubuntu-20-04-3-minimal-amd64-1   caa-cluster-vpc   eu-gb-3   Default   
07a7_ca0fa384-83c5-49bc-b843-5ccd4af06741   caa-cluster-node-1     running   10.242.128.5   158.176.175.94   bx2-2x8   ibm-ubuntu-20-04-3-minimal-amd64-1   caa-cluster-vpc   eu-gb-3   Default   
07a7_e8f9a71f-2b7c-4803-aa4d-3def6f8a0c92   podvm-nginx-5c801609   running   10.242.128.6   -                bz2-2x8   podvm-739dcab-dirty-s390x            caa-cluster-vpc   eu-gb-3   Default   
$ kubectl get pods --watch
NAME    READY   STATUS              RESTARTS   AGE
nginx   0/1     ContainerCreating   0          21s
nginx   1/1     Running             0          26s
```