### PR TITLE
podvm builder: need libclang binaries on ubuntu

### DIFF
--- a/podvm/Dockerfile.podvm_builder
+++ b/podvm/Dockerfile.podvm_builder
@@ -20,7 +20,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y build-essential cloud-image-utils curl git gnupg \
-        libdevmapper-dev libgpgme-dev lsb-release pkg-config qemu-kvm \
+        libdevmapper-dev libgpgme-dev libclang-dev lsb-release pkg-config qemu-kvm \
         musl-tools unzip wget git && \
     curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
     echo "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee -a /etc/apt/sources.list && \


### PR DESCRIPTION
Failed to build Pod VM binaries on Ubuntu with following errors:
```
[2023-09-01T00:15:56.738Z]   thread 'main' panicked at 'Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"', /root/.cargo/registry/src/github.com-1ecc6299db9ec823/bindgen-0.63.0/./lib.rs:2338:31
```

To fix it, install `libclang-dev` in podvm_builder image.