### PR TITLE
test: misc enhancements to the azure e2e test code

### DIFF
--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -104,7 +104,6 @@ jobs:
           SSH_KEY_ID="id_rsa.pub"
           AZURE_IMAGE_ID="$AZURE_IMAGE_ID"
           IS_CI_MANAGED_CLUSTER="true"
-          AZURE_CLI_AUTH="true"
           MANAGED_IDENTITY_NAME="${{ secrets.AZURE_MANAGED_IDENTITY_NAME}}"
           CAA_IMAGE="${{ secrets.ACR_URL }}/cloud-api-adaptor:dev-${GITHUB_SHA}"
         EOF

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -10,42 +10,33 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	pv "github.com/confidential-containers/cloud-api-adaptor/test/provisioner"
 	log "github.com/sirupsen/logrus"
 )
 
+// AzureCloudAssert implements the CloudAssert interface for azure.
+type AzureCloudAssert struct{}
+
+var assert = &AzureCloudAssert{}
+
 func TestDeletePodAzure(t *testing.T) {
-	assert := AzureCloudAssert{
-		group: pv.AzureProps.ResourceGroup,
-	}
+	t.Parallel()
 	doTestDeleteSimplePod(t, assert)
 }
 
 func TestCreateSimplePodAzure(t *testing.T) {
-	assert := AzureCloudAssert{
-		group: pv.AzureProps.ResourceGroup,
-	}
+	t.Parallel()
 	doTestCreateSimplePod(t, assert)
 }
 
 func TestCreatePodWithConfigMapAzure(t *testing.T) {
-	assert := AzureCloudAssert{
-		group: pv.AzureProps.ResourceGroup,
-	}
+	t.Parallel()
 	doTestCreatePodWithConfigMap(t, assert)
 }
 
 func TestCreatePodWithSecretAzure(t *testing.T) {
-	assert := AzureCloudAssert{
-		group: pv.AzureProps.ResourceGroup,
-	}
+	t.Parallel()
 	doTestCreatePodWithSecret(t, assert)
-}
-
-// AzureCloudAssert implements the CloudAssert interface for azure.
-type AzureCloudAssert struct {
-	group *armresources.ResourceGroup
 }
 
 func checkVMExistence(resourceGroupName, prefixName string) bool {
@@ -72,10 +63,11 @@ func checkVMExistence(resourceGroupName, prefixName string) bool {
 
 func (c AzureCloudAssert) HasPodVM(t *testing.T, id string) {
 	pod_vm_prefix := "podvm-" + id
-	if checkVMExistence(*c.group.Name, pod_vm_prefix) {
+	rg := pv.AzureProps.ResourceGroupName
+	if checkVMExistence(rg, pod_vm_prefix) {
 		log.Infof("VM found in resource group")
 	} else {
-		log.Infof("Virtual machine %s not found in resource group ", id)
+		log.Infof("Virtual machine %s not found in resource group %s", id, rg)
 		t.Error("PodVM was not created")
 	}
 }

--- a/test/provisioner/provision_azure_cli_auth.properties
+++ b/test/provisioner/provision_azure_cli_auth.properties
@@ -1,7 +1,6 @@
 AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID}"
-# use az ad sp create-for-rbac   --role Contributor   --scopes "/subscriptions/$SUBSCRIPTION_ID" --query "{ client_id: appId, client_secret: password, tenant_id: tenant }"
-AZURE_TENANT_ID="${AZURE_TENANT_ID}"
-
+# retrieve client_id from federated credential
+AZURE_CLIENT_ID=""
 RESOURCE_GROUP_NAME="e2e-test-rg"
 CLUSTER_NAME="e2e-test-cluster"
 LOCATION="eastus"

--- a/test/provisioner/provision_azure_initializer.go
+++ b/test/provisioner/provision_azure_initializer.go
@@ -18,22 +18,18 @@ import (
 )
 
 type AzureProperties struct {
-	ResourceGroup       *armresources.ResourceGroup
 	SubscriptionID      string
 	ClientID            string
-	ClientSecret        string
-	TenantID            string
 	ResourceGroupName   string
 	ClusterName         string
 	Location            string
-	SshPrivateKey       string
+	SSHKeyID            string
 	SubnetName          string
 	VnetName            string
 	SubnetID            string
 	ImageID             string
 	SshUserName         string
 	ManagedIdentityName string
-	IsAzCliAuth         bool
 	IsCIManaged         bool
 	CaaImage            string
 
@@ -53,16 +49,15 @@ type AzureProperties struct {
 var AzureProps = &AzureProperties{}
 
 func initAzureProperties(properties map[string]string) error {
-	log.Trace("initazureProperties()")
+	log.Trace("initAzureProperties()")
+
 	AzureProps = &AzureProperties{
 		SubscriptionID:      properties["AZURE_SUBSCRIPTION_ID"],
 		ClientID:            properties["AZURE_CLIENT_ID"],
-		ClientSecret:        properties["AZURE_CLIENT_SECRET"],
-		TenantID:            properties["AZURE_TENANT_ID"],
 		ResourceGroupName:   properties["RESOURCE_GROUP_NAME"],
 		ClusterName:         properties["CLUSTER_NAME"],
 		Location:            properties["LOCATION"],
-		SshPrivateKey:       properties["SSH_KEY_ID"],
+		SSHKeyID:            properties["SSH_KEY_ID"],
 		ImageID:             properties["AZURE_IMAGE_ID"],
 		SubnetID:            properties["AZURE_SUBNET_ID"],
 		SshUserName:         properties["SSH_USERNAME"],
@@ -76,18 +71,6 @@ func initAzureProperties(properties map[string]string) error {
 		AzureProps.IsCIManaged = true
 	}
 
-	CliAuthStr := properties["AZURE_CLI_AUTH"]
-	AzureProps.IsAzCliAuth = false
-	if strings.EqualFold(CliAuthStr, "yes") || strings.EqualFold(CliAuthStr, "true") {
-		AzureProps.IsAzCliAuth = true
-	}
-
-	AzureProps.VnetName = AzureProps.ClusterName + "_vnet"
-	AzureProps.SubnetName = AzureProps.ClusterName + "_subnet"
-	AzureProps.InstanceSize = "Standard_DC2as_v5"
-	AzureProps.NodeName = "caaaks"
-	AzureProps.OsType = "Ubuntu"
-
 	if AzureProps.SubscriptionID == "" {
 		return errors.New("AZURE_SUBSCRIPTION_ID was not set.")
 	}
@@ -98,14 +81,8 @@ func initAzureProperties(properties map[string]string) error {
 	if AzureProps.ClientID == "" {
 		return errors.New("AZURE_CLIENT_ID was not set.")
 	}
-	if AzureProps.ClientSecret == "" && !AzureProps.IsAzCliAuth {
-		return errors.New("AZURE_CLIENT_SECRET was not set")
-	}
 	if AzureProps.Location == "" {
 		return errors.New("LOCATION was not set.")
-	}
-	if AzureProps.SshPrivateKey == "" {
-		return errors.New("SSH_KEY_ID was not set.")
 	}
 	if AzureProps.ImageID == "" {
 		return errors.New("AZURE_IMAGE_ID was not set.")
@@ -113,6 +90,13 @@ func initAzureProperties(properties map[string]string) error {
 	if AzureProps.ClusterName == "" {
 		AzureProps.ClusterName = "e2e_test_cluster"
 	}
+
+	AzureProps.VnetName = AzureProps.ClusterName + "_vnet"
+	AzureProps.SubnetName = AzureProps.ClusterName + "_subnet"
+	AzureProps.InstanceSize = "Standard_DC2as_v5"
+	AzureProps.NodeName = "caaaks"
+	AzureProps.OsType = "Ubuntu"
+
 	if AzureProps.ResourceGroupName == "" {
 		AzureProps.ResourceGroupName = AzureProps.ClusterName + "_rg"
 	}


### PR DESCRIPTION
I've thrown those in a single PR, mostly because it's friday. We can untangle, if desired, ofc.

- Remove option to pass secrets to test run

  since leakage of secrets in the CI is a risk and federated credentials work well on github actions we remove the option to pass a CLIENT_SECRET to a test run. Local runs can keep using cli auth.

- Parallize the tests

  it will speed up a test run and is a valid test path. there are no dependencies between the test cases, so flakes due to this would imply a bug we want to be aware of.
  
  Later, when we add more tests, we probably want to increase the parallelism when invoking go test, since it'll use nproc by default but the tests are not cpu-bound.
 
- There is a misnomer in the ssh key parameter.

- There is no need to query the API for the rg name in the cloud asserter, since we have the name in all cases.

Successful test run [here](https://github.com/mkulke/cloud-api-adaptor/actions/runs/6049213330)