### PR TITLE
podvm: force Make to use shell with redirect

### DIFF
--- a/Makefile.defaults
+++ b/Makefile.defaults
@@ -1,4 +1,4 @@
-ifeq (, $(shell command -v yq))
+ifeq (, $(shell command -v yq 2> /dev/null))
 $(error "No yq on PATH, consider doing snap install yq")
 endif
 


### PR DESCRIPTION
On some systems Make would not find the `command` command. As Make tries to avoid launching a new shell for a simple command. The issue is then that `command` is a built-in and does not have an associated executable.

By adding the redirect we force Make to launch the new shell.