### PR TITLE
Libvirt e2e_on_pull workflow fixes

### DIFF
--- a/.github/workflows/caa_build_and_push.yaml
+++ b/.github/workflows/caa_build_and_push.yaml
@@ -28,6 +28,11 @@ on:
         description: 'Likewise but for the release built image'
         required: false
         type: string
+      git_ref:
+        default: 'main'
+        description: Git ref to checkout the cloud-api-adaptor repository. Defaults to main.
+        required: false
+        type: string
 
 env:
   GO_VERSION: "1.20.6"
@@ -49,6 +54,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: "${{ inputs.git_ref }}"
+
       - name: Setup Golang version ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -15,6 +15,11 @@ on:
         default: ''
         required: false
         type: string
+      git_ref:
+        default: 'main'
+        description: Git ref to checkout the cloud-api-adaptor repository. Defaults to main.
+        required: false
+        type: string
 
 env:
   CLOUD_PROVIDER: libvirt
@@ -27,6 +32,9 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
 
       - name: Setup Golang version ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4

--- a/.github/workflows/e2e_on_pull.yaml
+++ b/.github/workflows/e2e_on_pull.yaml
@@ -6,6 +6,14 @@
 name: e2e tests
 
 on:
+  # Note on repository checkout: pull_request_target sets `GITHUB_SHA` to the
+  # "last commit on the PR base branch", meaning that by default `actions/checkout`
+  # is going to checkout the repository main branch. In order to pick up the pull
+  # request code, this workflow uses the `github.event.pull_request.head.sha`
+  # property to get the last commit on the HEAD branch. One limitation of this approach
+  # is that, unlike the `pull_request` event, the checked pull request isn't necessarily
+  # rebased to main (so it is up to users ensure the pull request is rebased **before*
+  # triggering this workflow).
   pull_request_target:
     types:
       # This workflow will be run if the pull request is labeled test_e2e_libvirt, so
@@ -59,6 +67,9 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Extract the podvm qcow2
         run: ./hack/download-image.sh ${{ env.registry }}/${{ env.podvm_image }} . -o ${{ env.qcow2 }}
@@ -90,6 +101,7 @@ jobs:
       registry: ghcr.io/${{ github.repository_owner }}
       dev_tags: ci-pr${{ github.event.number  }}-dev
       release_tags: ci-pr${{ github.event.number  }}
+      git_ref: ${{ github.event.pull_request.head.sha }}
     secrets: inherit
 
   # Edit the kustomize files under the install directory to reference the
@@ -108,6 +120,9 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install kustomize
         run: |
@@ -162,3 +177,4 @@ jobs:
     with:
       qcow2_artifact: podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ matrix.arch }}.qcow2
       install_directory_artifact: install_directory
+      git_ref: ${{ github.event.pull_request.head.sha }}

--- a/test/e2e/common_suite_test.go
+++ b/test/e2e/common_suite_test.go
@@ -597,6 +597,15 @@ func getAuthenticatedImageStatus(ctx context.Context, client klient.Client, expe
 	return errors.New("PodVM Start Error")
 }
 
+// skipTestOnCI skips the test if running on CI
+func skipTestOnCI(t *testing.T) {
+	ci := os.Getenv("CI")
+
+	if ci == "true" {
+		t.Skip("Failing on CI")
+	}
+}
+
 // doTestCreateSimplePod tests a simple peer-pod can be created.
 func doTestCreateSimplePod(t *testing.T, assert CloudAssert) {
 	namespace := envconf.RandomName("default", 7)

--- a/test/e2e/libvirt_test.go
+++ b/test/e2e/libvirt_test.go
@@ -15,7 +15,7 @@ func TestLibvirtCreateSimplePod(t *testing.T) {
 }
 
 func TestLibvirtCreatePodWithConfigMap(t *testing.T) {
-	t.Skip("Failing on CI")
+	skipTestOnCI(t)
 	assert := LibvirtAssert{}
 	doTestCreatePodWithConfigMap(t, assert)
 }
@@ -26,7 +26,7 @@ func TestLibvirtCreatePodWithSecret(t *testing.T) {
 }
 
 func TestLibvirtCreatePeerPodContainerWithExternalIPAccess(t *testing.T) {
-	t.Skip("Failing on CI")
+	skipTestOnCI(t)
 	assert := LibvirtAssert{}
 	doTestCreatePeerPodContainerWithExternalIPAccess(t, assert)
 


### PR DESCRIPTION
Two fixes, being the first really important:

* fix checkout on libvirt workflow
* skip libvirt tests only on CI

Cc @ldoktor the last being your suggestion :)