### PR TITLE
workflows: read properties from versions.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,16 +21,18 @@ jobs:
           - release
         runner:
           - ubuntu-latest
-        go_version:
-          - "1.20.8"
-
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@v3
-      - name: Setup Golang version ${{ matrix.go_version }}
+      - name: Read properties from versions.yaml
+        run: |
+          go_version="$(yq '.tools.golang' versions.yaml)"
+          [ -n "$go_version" ]
+          echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"
+      - name: Setup Golang version ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go_version }}
+          go-version: ${{ env.GO_VERSION }}
       - name: Install build dependencies
         if: matrix.type == 'dev'
         run: |
@@ -57,6 +59,6 @@ jobs:
         uses: actions/upload-artifact@v3
         if: matrix.type == 'dev'
         with:
-          name: tests_report_junit-${{ matrix.runner }}_${{ matrix.go_version }}
+          name: tests_report_junit-${{ matrix.runner }}_${{ env.GO_VERSION }}
           path: ${{ github.workspace }}/tests_report_junit.xml
           retention-days: 1

--- a/.github/workflows/caa_build_and_push.yaml
+++ b/.github/workflows/caa_build_and_push.yaml
@@ -34,9 +34,6 @@ on:
         required: false
         type: string
 
-env:
-  GO_VERSION: "1.20.6"
-
 jobs:
   build_push_job:
     name: build and push
@@ -55,6 +52,12 @@ jobs:
         with:
           fetch-depth: 0
           ref: "${{ inputs.git_ref }}"
+
+      - name: Read properties from versions.yaml
+        run: |
+          go_version="$(yq '.tools.golang' versions.yaml)"
+          [ -n "$go_version" ]
+          echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"
 
       - name: Setup Golang version ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4

--- a/.github/workflows/controllers.yaml
+++ b/.github/workflows/controllers.yaml
@@ -16,17 +16,18 @@ jobs:
     defaults:
       run:
         working-directory: peerpodconfig-ctrl
-    strategy:
-      matrix:
-        go_version:
-          - "1.20.8"
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@v3
-      - name: Setup Golang version ${{ matrix.go_version }}
+      - name: Read properties from versions.yaml
+        run: |
+          go_version="$(yq '.tools.golang' ../versions.yaml)"
+          [ -n "$go_version" ]
+          echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"
+      - name: Setup Golang version ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go_version }}
+          go-version: ${{ env.GO_VERSION }}
       - name: Verify go modules and manifests
         run: make verify
       - name: Build the controller manager
@@ -41,21 +42,22 @@ jobs:
     defaults:
       run:
         working-directory: peerpod-ctrl
-    strategy:
-      matrix:
-        go_version:
-          - "1.20.8"
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@v3
+      - name: Read properties from versions.yaml
+        run: |
+          go_version="$(yq '.tools.golang' ../versions.yaml)"
+          [ -n "$go_version" ]
+          echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"
       - name: Install build dependencies
         run: |
          sudo apt-get update -y
          sudo apt-get install -y libvirt-dev
-      - name: Setup Golang version ${{ matrix.go_version }}
+      - name: Setup Golang version ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go_version }}
+          go-version: ${{ env.GO_VERSION }}
       - name: Verify go modules and manifests
         run: make verify
       - name: Build the controller manager

--- a/.github/workflows/csi_wrapper_images.yaml
+++ b/.github/workflows/csi_wrapper_images.yaml
@@ -13,9 +13,6 @@ on:
       - 'volumes/csi-wrapper/**'
   workflow_dispatch:
 
-env:
-  go_version: "1.20.8"
-
 jobs:
   build_push_job:
     name: build and push
@@ -32,10 +29,15 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup Golang version ${{ env.go_version }}
+      - name: Read properties from versions.yaml
+        run: |
+          go_version="$(yq '.tools.golang' versions.yaml)"
+          [ -n "$go_version" ]
+          echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"
+      - name: Setup Golang version ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.go_version }}
+          go-version: ${{ env.GO_VERSION }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to quay Container Registry

--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -23,7 +23,6 @@ on:
 
 env:
   CLOUD_PROVIDER: libvirt
-  GO_VERSION: "1.20.8"
   DEBIAN_FRONTEND: noninteractive
 
 jobs:
@@ -35,6 +34,12 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
+
+      - name: Read properties from versions.yaml
+        run: |
+          go_version="$(yq '.tools.golang' versions.yaml)"
+          [ -n "$go_version" ]
+          echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"
 
       - name: Setup Golang version ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -11,9 +11,6 @@ on:
       - 'main'
   workflow_dispatch:
 
-env:
-  go_version: "1.20.8"
-
 jobs:
   build_push_job:
     name: build and push

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,9 +12,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  GO_VERSION: "1.20.8"
-
 jobs:
   vet-and-fmt:
     name: vet and fmt
@@ -24,6 +21,11 @@ jobs:
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@v3
+      - name: Read properties from versions.yaml
+        run: |
+          go_version="$(yq '.tools.golang' versions.yaml)"
+          [ -n "$go_version" ]
+          echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"
       - name: Setup Golang version ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4
         with:
@@ -45,6 +47,11 @@ jobs:
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@v3
+      - name: Read properties from versions.yaml
+        run: |
+          go_version="$(yq '.tools.golang' versions.yaml)"
+          [ -n "$go_version" ]
+          echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"
       - name: Setup Golang version ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4
         with:
@@ -81,6 +88,11 @@ jobs:
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@v3
+      - name: Read properties from versions.yaml
+        run: |
+          go_version="$(yq '.tools.golang' versions.yaml)"
+          [ -n "$go_version" ]
+          echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"
       - name: Setup Golang version ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4
         with:
@@ -94,6 +106,11 @@ jobs:
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@v3
+      - name: Read properties from versions.yaml
+        run: |
+          go_version="$(yq '.tools.golang' versions.yaml)"
+          [ -n "$go_version" ]
+          echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"
       - name: Setup Golang version ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/podvm_builder.yaml
+++ b/.github/workflows/podvm_builder.yaml
@@ -25,6 +25,36 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@v3
 
+    - name: Read properties from versions.yaml
+      run: |
+        go_version="$(yq '.tools.golang' versions.yaml)"
+        [ -n "$go_version" ]
+        echo "GO_VERSION=${go_version}" >> $GITHUB_ENV
+
+        protoc_version="$(yq '.tools.protoc' versions.yaml)"
+        [ -n "$protoc_version" ]
+        echo "PROTOC_VERSION=${protoc_version}" >> $GITHUB_ENV
+
+        rust_version="$(yq '.tools.rust' versions.yaml)"
+        [ -n "$rust_version" ]
+        echo "RUST_VERSION=${rust_version}" >> $GITHUB_ENV
+
+        caa_src="$(yq '.git.cloud-api-adaptor.url' versions.yaml)"
+        [ -n "$caa_src" ]
+        echo "CAA_SRC=${caa_src}" >> $GITHUB_ENV
+
+        caa_src_ref="$(yq '.git.cloud-api-adaptor.reference' versions.yaml)"
+        [ -n "$caa_src_ref" ]
+        echo "CAA_SRC_REF=${caa_src_ref}" >> $GITHUB_ENV
+
+        kata_src="$(yq '.git.kata-containers.url' versions.yaml)"
+        [ -n "$kata_src" ]
+        echo "KATA_SRC=${kata_src}" >> $GITHUB_ENV
+
+        kata_src_branch="$(yq '.git.kata-containers.reference' versions.yaml)"
+        [ "$kata_src_branch" ]
+        echo "KATA_SRC_BRANCH=${kata_src_branch}" >> $GITHUB_ENV
+
     #- name: Set up QEMU
     #  uses: docker/setup-qemu-action@v2
 
@@ -57,10 +87,10 @@ jobs:
         file: |
           podvm/${{ matrix.dockerfile }}
         build-args: |
-          "GO_VERSION=1.20.8"
-          "PROTOC_VERSION=3.11.4"
-          "RUST_VERSION=1.69.0"
-          "CAA_SRC=https://github.com/confidential-containers/cloud-api-adaptor"
-          "CAA_SRC_REF=main"
-          "KATA_SRC=https://github.com/kata-containers/kata-containers"
-          "KATA_SRC_BRANCH=CCv0"
+          "GO_VERSION=${{ env.GO_VERSION }}"
+          "PROTOC_VERSION=${{ env.PROTOC_VERSION }}"
+          "RUST_VERSION=${{ env.RUST_VERSION }}"
+          "CAA_SRC=${{ env.CAA_SRC }}"
+          "CAA_SRC_REF=${{ env.CAA_SRC_REF }}"
+          "KATA_SRC=${{ env.KATA_SRC }}"
+          "KATA_SRC_BRANCH=${{ env.KATA_SRC_BRANCH }}"

--- a/.github/workflows/webhook-build.yaml
+++ b/.github/workflows/webhook-build.yaml
@@ -11,9 +11,6 @@ on:
     paths:
       - 'webhook/**'
 
-env:
-  go_version: "1.20.8"
-
 jobs:
   build_push_webhook:
     runs-on: ubuntu-latest
@@ -25,10 +22,15 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup Golang version ${{ env.go_version }}
+      - name: Read properties from versions.yaml
+        run: |
+          go_version="$(yq '.tools.golang' versions.yaml)"
+          [ -n "$go_version" ]
+          echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"
+      - name: Setup Golang version ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.go_version }}
+          go-version: ${{ env.GO_VERSION }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to quay Container Registry

--- a/.github/workflows/webhook-test.yaml
+++ b/.github/workflows/webhook-test.yaml
@@ -24,10 +24,15 @@ jobs:
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@v3
-      - name: Setup Golang version 1.20
+      - name: Read properties from versions.yaml
+        run: |
+          go_version="$(yq '.tools.golang' versions.yaml)"
+          [ -n "$go_version" ]
+          echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"
+      - name: Setup Golang version ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20.8"
+          go-version: ${{ env.GO_VERSION }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Install kind


### PR DESCRIPTION
A bunch of our workflows have hard-coded go version and bumping the value requires "search & replace" of many files. This is error prone. On the other hand, we got the `versions.yaml` that ideally should be the source of truth of external dependencies. Thus, in this PR I changed most workflows that had go version declared on them to read the value from `versions.yaml`

Related to https://github.com/confidential-containers/cloud-api-adaptor/pull/1422#discussion_r1319834023

Note:
 * Split in several commits to ease review. As the changes are repetitive I will squash them all before the merge
 * I didn't change Azure workflows as I don't know if they should be following `versions.yaml` (FYI @sudharshanibm3)
 * Looked at `ibmcloud-powervs/image/prereq.sh` but decided to not touch it because I don't know how it is used. Apparently it could be just installing `yq` to read `versions.yaml` (as long as that file is present on the machine, otherwise should be downloaded...)