### PR TITLE
Refactor podvm workflows and enable on libvirt e2e

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -7,7 +7,7 @@ name: (Callable) libvirt e2e tests
 on:
   workflow_call:
     inputs:
-      qcow2_artifact:
+      podvm_image:
         required: true
         type: string
       install_directory_artifact:
@@ -47,10 +47,12 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - uses: actions/download-artifact@v3
-        with:
-          name: ${{ inputs.qcow2_artifact }}
-          path: podvm
+      - name: Extract qcow2 from ${{ inputs.podvm_image }}
+        run: |
+           qcow2=$(echo ${{ inputs.podvm_image }} | sed -e "s#.*/\(.*\):.*#\1.qcow2#")
+           ./hack/download-image.sh ${{ inputs.podvm_image }} . -o ${qcow2}
+           echo "PODVM_QCOW2=$(pwd)/${qcow2}" >> "$GITHUB_ENV"
+        working-directory: podvm
 
       - name: Get the install directory
         if: ${{ inputs.install_directory_artifact != '' }}
@@ -155,7 +157,7 @@ jobs:
           export TEST_PROVISION="yes"
           export TEST_TEARDOWN="no"
           export TEST_PROVISION_FILE="$PWD/libvirt.properties"
-          export TEST_PODVM_IMAGE="${PWD}/podvm/${{ inputs.qcow2_artifact }}"
+          export TEST_PODVM_IMAGE="${{ env.PODVM_QCOW2 }}"
           export TEST_E2E_TIMEOUT="50m"
 
           make test-e2e

--- a/.github/workflows/e2e_on_pull.yaml
+++ b/.github/workflows/e2e_on_pull.yaml
@@ -43,43 +43,29 @@ jobs:
 
   # Build the podvm images.
   #
-  # Currently it will not build the podvm, instead it downloads the qcow2 file
-  # from the built image. The file will be archived so that downstream jobs can
-  # just download the file on their runners.
-  podvm:
-    name: podvm
+  podvm_builder:
     needs: [authorize]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        os:
-          - centos
-          - ubuntu
-        provider:
-          - generic
-        arch:
-          - amd64
-    env:
-      registry: quay.io/confidential-containers
-      podvm_image: podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ matrix.arch }}
-      qcow2: podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ matrix.arch }}.qcow2
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+    uses: ./.github/workflows/podvm_builder.yaml
+    with:
+      registry: ghcr.io/${{ github.repository_owner }}
+      image_tag: ci-pr${{ github.event.number }}
+    secrets: inherit
 
-      - name: Extract the podvm qcow2
-        run: ./hack/download-image.sh ${{ env.registry }}/${{ env.podvm_image }} . -o ${{ env.qcow2 }}
-        working-directory: podvm
+  podvm_binaries:
+    needs: [podvm_builder]
+    uses: ./.github/workflows/podvm_binaries.yaml
+    with:
+      registry: ghcr.io/${{ github.repository_owner }}
+      image_tag: ci-pr${{ github.event.number }}
+    secrets: inherit
 
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.qcow2 }}
-          path: podvm/${{ env.qcow2 }}
-          retention-days: 1
+  podvm:
+    needs: [podvm_binaries]
+    uses: ./.github/workflows/podvm.yaml
+    with:
+      registry: ghcr.io/${{ github.repository_owner }}
+      image_tag: ci-pr${{ github.event.number }}
+    secrets: inherit
 
   # Build and push the cloud-api-adaptor image
   #
@@ -175,6 +161,6 @@ jobs:
           - amd64
     uses: ./.github/workflows/e2e_libvirt.yaml
     with:
-      qcow2_artifact: podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ matrix.arch }}.qcow2
+      podvm_image: ghcr.io/${{ github.repository_owner }}/podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ matrix.arch }}:ci-pr${{ github.event.number  }}
       install_directory_artifact: install_directory
       git_ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/podvm.yaml
+++ b/.github/workflows/podvm.yaml
@@ -1,14 +1,10 @@
 name: Create Pod VM Image
 on:
-  workflow_run:
-    workflows: ["Create Pod VM Binaries Image"]
-    types:
-      - completed
+  workflow_call:
 
 jobs:
   build:
     name: Create pod vm image
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/podvm.yaml
+++ b/.github/workflows/podvm.yaml
@@ -1,6 +1,11 @@
 name: Create Pod VM Image
 on:
   workflow_call:
+    inputs:
+      registry:
+        default: 'quay.io/confidential-containers'
+        required: false
+        type: string
 
 jobs:
   build:
@@ -31,15 +36,25 @@ jobs:
 
     - name: Login to Quay container Registry
       uses: docker/login-action@v2
+      if: ${{ startsWith(inputs.registry, 'quay.io') }}
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
 
+    - name: Login to Github Container Registry
+      if: ${{ startsWith(inputs.registry, 'ghcr.io') }}
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Build and push
       run: make podvm-image
       env:
         PUSH: true
+        REGISTRY: ${{ inputs.registry }}
         ARCH: ${{ matrix.arch }}
         PODVM_DISTRO: ${{ matrix.os }}
         CLOUD_PROVIDER: ${{ matrix.provider }}

--- a/.github/workflows/podvm.yaml
+++ b/.github/workflows/podvm.yaml
@@ -6,6 +6,10 @@ on:
         default: 'quay.io/confidential-containers'
         required: false
         type: string
+      image_tag:
+        default: ''
+        required: false
+        type: string
 
 jobs:
   build:
@@ -56,5 +60,6 @@ jobs:
         PUSH: true
         REGISTRY: ${{ inputs.registry }}
         ARCH: ${{ matrix.arch }}
+        PODVM_TAG: ${{ inputs.image_tag }}
         PODVM_DISTRO: ${{ matrix.os }}
         CLOUD_PROVIDER: ${{ matrix.provider }}

--- a/.github/workflows/podvm_binaries.yaml
+++ b/.github/workflows/podvm_binaries.yaml
@@ -1,14 +1,10 @@
 name: Create Pod VM Binaries Image
 on:
-  workflow_run:
-    workflows: ["Create Pod VM Builder Image"]
-    types:
-      - completed
+  workflow_call:
 
 jobs:
   build:
     name: Create pod vm binaries image
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/podvm_binaries.yaml
+++ b/.github/workflows/podvm_binaries.yaml
@@ -1,6 +1,11 @@
 name: Create Pod VM Binaries Image
 on:
   workflow_call:
+    inputs:
+      registry:
+        default: 'quay.io/confidential-containers'
+        required: false
+        type: string
 
 jobs:
   build:
@@ -32,15 +37,25 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Login to Quay container Registry
+      if: ${{ startsWith(inputs.registry, 'quay.io') }}
       uses: docker/login-action@v2
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
 
+    - name: Login to Github Container Registry
+      if: ${{ startsWith(inputs.registry, 'ghcr.io') }}
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Build and push
       run: make podvm-binaries
       env:
           PUSH: true
+          REGISTRY: ${{ inputs.registry }}
           ARCH: ${{ matrix.arch }}
           PODVM_DISTRO: ${{ matrix.os }}

--- a/.github/workflows/podvm_binaries.yaml
+++ b/.github/workflows/podvm_binaries.yaml
@@ -6,6 +6,10 @@ on:
         default: 'quay.io/confidential-containers'
         required: false
         type: string
+      image_tag:
+        default: ''
+        required: false
+        type: string
 
 jobs:
   build:
@@ -58,4 +62,5 @@ jobs:
           PUSH: true
           REGISTRY: ${{ inputs.registry }}
           ARCH: ${{ matrix.arch }}
+          PODVM_TAG: ${{ inputs.image_tag }}
           PODVM_DISTRO: ${{ matrix.os }}

--- a/.github/workflows/podvm_builder.yaml
+++ b/.github/workflows/podvm_builder.yaml
@@ -1,7 +1,6 @@
 name: Create Pod VM Builder Image
 on:
-  release:
-    types: [created]
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/podvm_builder.yaml
+++ b/.github/workflows/podvm_builder.yaml
@@ -6,6 +6,10 @@ on:
         default: 'quay.io/confidential-containers'
         required: false
         type: string
+      image_tag:
+        default: ''
+        required: false
+        type: string
 
 jobs:
   build:
@@ -55,4 +59,5 @@ jobs:
       env:
           PUSH: true
           REGISTRY: ${{ inputs.registry }}
+          PODVM_TAG: ${{ inputs.image_tag }}
           PODVM_DISTRO: ${{ matrix.os }}

--- a/.github/workflows/podvm_builder.yaml
+++ b/.github/workflows/podvm_builder.yaml
@@ -1,6 +1,11 @@
 name: Create Pod VM Builder Image
 on:
   workflow_call:
+    inputs:
+      registry:
+        default: 'quay.io/confidential-containers'
+        required: false
+        type: string
 
 jobs:
   build:
@@ -30,14 +35,24 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Login to Quay container Registry
+      if: ${{ startsWith(inputs.registry, 'quay.io') }}
       uses: docker/login-action@v2
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
 
+    - name: Login to Github Container Registry
+      if: ${{ startsWith(inputs.registry, 'ghcr.io') }}
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Build and push
       run: make podvm-builder
       env:
           PUSH: true
+          REGISTRY: ${{ inputs.registry }}
           PODVM_DISTRO: ${{ matrix.os }}

--- a/.github/workflows/podvm_publish.yaml
+++ b/.github/workflows/podvm_publish.yaml
@@ -1,0 +1,27 @@
+# Copyright Confidential Containers Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build and push the pod VM images.
+---
+name: Publish pod VM Images
+on:
+  # Create release Pod VM Images
+  release:
+    types: [created]
+
+  workflow_dispatch:
+
+jobs:
+  podvm_builder:
+    uses: ./.github/workflows/podvm_builder.yaml
+    secrets: inherit
+
+  podvm_binaries:
+    needs: [podvm_builder]
+    uses: ./.github/workflows/podvm_binaries.yaml
+    secrets: inherit
+
+  podvm:
+    needs: [podvm_binaries]
+    uses: ./.github/workflows/podvm.yaml
+    secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -191,10 +191,11 @@ endif
 REGISTRY ?= quay.io/confidential-containers
 
 PODVM_DISTRO ?= ubuntu
+PODVM_TAG ?= $(VERSIONS_HASH)
 
-PODVM_BUILDER_IMAGE ?= $(REGISTRY)/podvm-builder-$(PODVM_DISTRO):$(VERSIONS_HASH)
-PODVM_BINARIES_IMAGE ?= $(REGISTRY)/podvm-binaries-$(PODVM_DISTRO)-$(ARCH):$(VERSIONS_HASH)
-PODVM_IMAGE ?= $(REGISTRY)/podvm-$(or $(CLOUD_PROVIDER),generic)-$(PODVM_DISTRO)-$(ARCH):$(VERSIONS_HASH)
+PODVM_BUILDER_IMAGE ?= $(REGISTRY)/podvm-builder-$(PODVM_DISTRO):$(PODVM_TAG)
+PODVM_BINARIES_IMAGE ?= $(REGISTRY)/podvm-binaries-$(PODVM_DISTRO)-$(ARCH):$(PODVM_TAG)
+PODVM_IMAGE ?= $(REGISTRY)/podvm-$(or $(CLOUD_PROVIDER),generic)-$(PODVM_DISTRO)-$(ARCH):$(PODVM_TAG)
 
 PUSH ?= false
 # If not pushing `--load` into the local docker cache


### PR DESCRIPTION
The [libvirt e2e workflow on pull request](https://github.com/confidential-containers/cloud-api-adaptor/actions/workflows/e2e_on_pull.yaml) currently does not create a podvm, instead it uses the pre-built images. We have two problems here: 1) podvm built images are usually old and outdated; 2) not building on pull request means changes on podvm aren't tested on CI.

By the time I introduced the libvirt e2e workflow in PR #1318, @stevenhorsman mentioned on Slack that it would be better to build the podvm too. I agreed, and despite its build takes a lot of time to complete, then I am sending these changes to exactly enable podvm build alongside the libvirt e2e workflow.

Currently the [podvm_builder](https://github.com/confidential-containers/cloud-api-adaptor/tree/main/.github/workflows/podvm_builder.yaml), [podvm_binaries](https://github.com/confidential-containers/cloud-api-adaptor/tree/main/.github/workflows/podvm_binaries.yaml) and [podvm](https://github.com/confidential-containers/cloud-api-adaptor/tree/main/.github/workflows/podvm_builder.yaml) workflows are triggered and gated on release time to publish images on quay.io. I wanted to reuse those workflows on libvirt e2e, so the first commits are meant to prepare the workflows for reuse.

The podvm images created on the libvirt e2e workflow will be published on ghcr.io with the `ci-prN` (where `N` is the PR number) tag, so not mixing up with the official images on quay.io. BTW, the caa images for that workflow are already published this way. I've a script to clean up the ghcr.io from images for PRs closed, I should contribute it soon...

OK, I tested those changes on my cloud-api-adaptor fork, on https://github.com/wainersm/cc-cloud-api-adaptor/actions/runs/6173089285 . Unfortunately as libvirt e2e runs on `pull_request_target` we will only be able to fully test it after merging. The podvm release workflow couldn't be tested, unfortunately, and I'm okay if we find prudent to not merge this changes before the 0.8.0 release.

Caching... it has been discussed at least in https://github.com/confidential-containers/cloud-api-adaptor/issues/1410 on how to use cache to speed up the binaries build by leverage caching or another similar mechanism. At begin I thought in implement something on that direction but then I realized it would be too much changes (well, I don't have a solid proposal too) so I preferred to stick with the silly approach took here: it will simple build the builder, binaries and finally podvms all the time. And this whole process can take ~1h.... that to say it is in my radar how to improve that situation on follow up changes.



 