### PR TITLE
install: enhance start probe checker conditions

### DIFF
--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -7,11 +7,13 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 )
 
 var logger = log.New(log.Writer(), "[probe/probe] ", log.LstdFlags|log.Lmsgprefix)
 var podsReadizProbesDone bool
 var checker Checker
+var startTime time.Time
 
 const DEFAULT_CC_RUNTIMECLASS_NAME string = "kata-remote"
 
@@ -29,7 +31,7 @@ func StartupHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !podsReadizProbesDone {
-		ret, err := checker.GetAllPeerPods()
+		ret, err := checker.GetAllPeerPods(startTime)
 		podsReadizProbesDone = ret
 		if err != nil || !podsReadizProbesDone {
 			logger.Printf("Not all PeerPods ready, because %s", err)
@@ -42,6 +44,8 @@ func StartupHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func Start(socketPath string) {
+	startTime = time.Now()
+
 	port := os.Getenv("PROBE_PORT")
 	if port == "" {
 		port = "8000"


### PR DESCRIPTION
When creating e2e test case for CAA DeamonSet rolling update, I found the test sometimes fails. For a peerpod deployment with 2 replicas, the **AvailableReplicas** may change to zero when CAA DeamonSet rolling update. That means the service based on the deployment will be unavailable when rolling update. It's not as expected.

After investigation, it looks like it's not a good idea to check `pod.Status.Phase` is "Running" to determine if the PeerPod is available or not:
https://github.com/confidential-containers/cloud-api-adaptor/blob/c30eaac2f971229c9059f4a7a935294c8d9f8524/pkg/probe/checker.go#L50C4-L50C4

According to go docs, pod phase **Running** means:
https://pkg.go.dev/k8s.io/api/core/v1#PodPhase
```
// PodRunning means the pod has been bound to a node and all of the containers have been started.
// At least one container is still running or is in the process of being restarted.
PodRunning PodPhase = "Running"
```

In following CAA logs, we can see the PodPhase is "Running", however, the Ready Condition is "False":
*v1.PodCondition{Type:"Ready", Status:"False", LastProbeTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), LastTransitionTime:time.Date(2023, time.September, 14, 6, 21, 58, 0, time.Local), Reason:"ContainersNotReady", Message:"containers with unready status: [nginx]"}*
```
2023/09/14 06:22:19 [probe/probe] Dealing with PeerPod: nginx-deployment-6c59c6f6d-jwzv6, in phase: Running
2023/09/14 06:22:19 [probe/probe] Last time the Pod ready: 2023-09-14 06:21:58 +0000 UTC
2023/09/14 06:22:19 [probe/probe] pod has not restarted: v1.PodStatus{Phase:"Running", Conditions:[]v1.PodCondition{v1.PodCondition{Type:"Initialized", Status:"True", LastProbeTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), LastTransitionTime:time.Date(2023, time.September, 14, 6, 18, 7, 0, time.Local), Reason:"", Message:""}, v1.PodCondition{Type:"Ready", Status:"False", LastProbeTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), LastTransitionTime:time.Date(2023, time.September, 14, 6, 21, 58, 0, time.Local), Reason:"ContainersNotReady", Message:"containers with unready status: [nginx]"}, v1.PodCondition{Type:"ContainersReady", Status:"False", LastProbeTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), LastTransitionTime:time.Date(2023, time.September, 14, 6, 21, 58, 0, time.Local), Reason:"ContainersNotReady", Message:"containers with unready status: [nginx]"}, v1.PodCondition{Type:"PodScheduled", Status:"True", LastProbeTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), LastTransitionTime:time.Date(2023, time.September, 14, 6, 18, 7, 0, time.Local), Reason:"", Message:""}}, Message:"", Reason:"", NominatedNodeName:"", HostIP:"10.241.0.5", PodIP:"172.17.17.236", PodIPs:[]v1.PodIP{v1.PodIP{IP:"172.17.17.236"}}, StartTime:time.Date(2023, time.September, 14, 6, 18, 7, 0, time.Local), InitContainerStatuses:[]v1.ContainerStatus(nil), ContainerStatuses:[]v1.ContainerStatus{v1.ContainerStatus{Name:"nginx", State:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(nil), Terminated:(*v1.ContainerStateTerminated)(0xc0003f8380)}, LastTerminationState:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(nil), Terminated:(*v1.ContainerStateTerminated)(nil)}, Ready:false, RestartCount:0, Image:"[Encrypted]", ImageID:"[Encrypted]", ContainerID:"containerd://28dcc4efe3b5c0dda7c7a399fa4fcbb1111def15c6be832f72e15137f8736778", Started:(*bool)(0xc0009ebd28)}}, QOSClass:"BestEffort", EphemeralContainerStatuses:[]v1.ContainerStatus(nil)}
```

So it's better to check `pod.Status.Conditions` with type "Ready", if the Status is "True":
https://pkg.go.dev/k8s.io/api/core/v1#PodConditionType
```
// PodReady means the pod is able to service requests and should be added to the
// load balancing pools of all matching services.
PodReady PodConditionType = "Ready"
```

Moreover, we can compare the Probe start time and the Ready condition LastTransitionTime, make sure the Peer Pod is ready after CAA pod restarted.
