### PR TITLE
Handle container registry authentication via userdata

### DIFF
--- a/cmd/process-user-data/provision.go
+++ b/cmd/process-user-data/provision.go
@@ -148,5 +148,23 @@ func provisionFiles(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Copy the authJson to the authJsonFilePath
+	config := getConfigFromUserData(cfg.userData)
+	if config.AuthJson != "" {
+		// Create the file
+		file, err := os.Create(defaultAuthJsonFilePath)
+		if err != nil {
+			return fmt.Errorf("failed to create file: %s", err)
+		}
+		defer file.Close()
+
+		// Write the authJson to the file
+		_, err = file.WriteString(config.AuthJson)
+		if err != nil {
+			return fmt.Errorf("failed to write authJson to file: %s", err)
+		}
+
+	}
+
 	return nil
 }

--- a/cmd/process-user-data/test-data/sample-agent-config.toml
+++ b/cmd/process-user-data/test-data/sample-agent-config.toml
@@ -1,0 +1,51 @@
+# This disables signature verification which now defaults to true.
+# We should consider a better solution. See #331 for more info
+enable_signature_verification=false
+
+# When using the agent-config.toml the KATA_AGENT_SERVER_ADDR env var seems to be ignored, so set it here
+server_addr="unix:///run/kata-containers/agent.sock"
+
+# This field sets up the KBC that attestation agent uses
+# This is replaced in the makefile steps so do not set it manually
+aa_kbc_params = ""
+
+# This field sets up the container registry auth 
+image_registry_auth_file="file:///etc/attestation-agent/auth.json"
+
+# temp workaround for kata-containers/kata-containers#5590
+[endpoints]
+allowed = [
+"AddARPNeighborsRequest",
+"AddSwapRequest",
+"CloseStdinRequest",
+"CopyFileRequest",
+"CreateContainerRequest",
+"CreateSandboxRequest",
+"DestroySandboxRequest",
+"ExecProcessRequest",
+"GetMetricsRequest",
+"GetOOMEventRequest",
+"GuestDetailsRequest",
+"ListInterfacesRequest",
+"ListRoutesRequest",
+"MemHotplugByProbeRequest",
+"OnlineCPUMemRequest",
+"PauseContainerRequest",
+"PullImageRequest",
+"ReadStreamRequest",
+"RemoveContainerRequest",
+"ReseedRandomDevRequest",
+"ResumeContainerRequest",
+"SetGuestDateTimeRequest",
+"SignalProcessRequest",
+"StartContainerRequest",
+"StartTracingRequest",
+"StatsContainerRequest",
+"StopTracingRequest",
+"TtyWinResizeRequest",
+"UpdateContainerRequest",
+"UpdateInterfaceRequest",
+"UpdateRoutesRequest",
+"WaitProcessRequest",
+"WriteStreamRequest"
+]

--- a/cmd/process-user-data/types.go
+++ b/cmd/process-user-data/types.go
@@ -5,7 +5,9 @@ const (
 	providerAzure = "azure"
 	providerAws   = "aws"
 
-	defaultAgentConfigPath = "/etc/agent-config.toml"
+	defaultAgentConfigPath  = "/etc/agent-config.toml"
+	defaultAuthJsonFilePath = "/etc/auth.json"
+	offlineKbcAuthFile      = "/etc/aa-offline_fs_kbc-resources.json"
 )
 
 type Config struct {

--- a/cmd/process-user-data/types.go
+++ b/cmd/process-user-data/types.go
@@ -1,9 +1,10 @@
 package main
 
 const (
-	programName            = "process-user-data"
-	AzureImdsUrl           = "http://169.254.169.254/metadata/instance/compute?api-version=2021-01-01"
-	AzureUserDataImdsUrl   = "http://169.254.169.254/metadata/instance/compute/userData?api-version=2021-01-01&format=text"
+	programName   = "process-user-data"
+	providerAzure = "azure"
+	providerAws   = "aws"
+
 	defaultAgentConfigPath = "/etc/agent-config.toml"
 )
 
@@ -12,4 +13,16 @@ type Config struct {
 	agentConfigPath      string
 	userData             string
 	userDataFetchTimeout int
+}
+
+type Endpoints struct {
+	Allowed []string `toml:"allowed"`
+}
+
+type AgentConfig struct {
+	EnableSignatureVerification bool      `toml:"enable_signature_verification"`
+	ServerAddr                  string    `toml:"server_addr"`
+	AaKbcParams                 string    `toml:"aa_kbc_params"`
+	ImageRegistryAuthFile       string    `toml:"image_registry_auth_file"`
+	Endpoints                   Endpoints `toml:"endpoints"`
 }

--- a/cmd/process-user-data/update.go
+++ b/cmd/process-user-data/update.go
@@ -106,6 +106,25 @@ func updateAgentConfig(cmd *cobra.Command, args []string) error {
 		agentConfig.AaKbcParams = config.AAKBCParams
 	}
 
+	if config.AuthJson != "" {
+
+		fmt.Printf("Updating image_registry_auth_file in agent config file with value\n")
+
+		// Check if authJsonFilePath exists. If it doesn't exists create the file
+
+		if _, err := os.Stat(defaultAuthJsonFilePath); err != nil && os.IsNotExist(err) {
+			// Write the authJson to the defaultAuthJsonFilePath
+			err = os.WriteFile(defaultAuthJsonFilePath, []byte(config.AuthJson), 0644)
+			if err != nil {
+				return fmt.Errorf("failed to write auth.json file: %s", err)
+			}
+		}
+
+		// Update the file path in the agent config
+		agentConfig.ImageRegistryAuthFile = "file://" + defaultAuthJsonFilePath
+
+	}
+
 	// Write the updated agent config file
 	err = writeAgentConfig(*agentConfig, cfg.agentConfigPath)
 	if err != nil {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,6 +48,7 @@ aws() {
     [[ "${TAGS}" ]] && optionals+="-tags ${TAGS} " # Custom tags applied to pod vm
     [[ "${USE_PUBLIC_IP}" == "true" ]] && optionals+="-use-public-ip " # Use public IP for pod vm
     [[ "${ROOT_VOLUME_SIZE}" ]] && optionals+="-root-volume-size ${ROOT_VOLUME_SIZE} " # Specify root volume size for pod vm
+    [[ "${DISABLECVM}" == "true" ]] && optionals+="-disable-cvm "
     [[ "${DISABLE_CLOUD_CONFIG}" == "true" ]] && optionals+="-disable-cloud-config "
 
     set -x
@@ -62,7 +63,7 @@ azure() {
     test_vars AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID AZURE_RESOURCE_GROUP AZURE_SUBNET_ID AZURE_IMAGE_ID
 
     [[ "${SSH_USERNAME}" ]] && optionals+="-ssh-username ${SSH_USERNAME} "
-    [[ "${DISABLECVM}" ]] && optionals+="-disable-cvm "
+    [[ "${DISABLECVM}" == "true" ]] && optionals+="-disable-cvm "
     [[ "${AZURE_INSTANCE_SIZES}" ]] && optionals+="-instance-sizes ${AZURE_INSTANCE_SIZES} "
     [[ "${TAGS}" ]] && optionals+="-tags ${TAGS} " # Custom tags applied to pod vm
     [[ "${DISABLE_CLOUD_CONFIG}" == "true" ]] && optionals+="-disable-cloud-config "

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,6 +48,7 @@ aws() {
     [[ "${TAGS}" ]] && optionals+="-tags ${TAGS} " # Custom tags applied to pod vm
     [[ "${USE_PUBLIC_IP}" == "true" ]] && optionals+="-use-public-ip " # Use public IP for pod vm
     [[ "${ROOT_VOLUME_SIZE}" ]] && optionals+="-root-volume-size ${ROOT_VOLUME_SIZE} " # Specify root volume size for pod vm
+    [[ "${DISABLE_CLOUD_CONFIG}" == "true" ]] && optionals+="-disable-cloud-config "
 
     set -x
     exec cloud-api-adaptor aws \

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/uuid v1.3.0
 	github.com/opencontainers/runtime-spec v1.1.0-rc.1
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.8.4
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f
 	github.com/vmware/govmomi v0.29.0
@@ -53,6 +53,7 @@ require (
 	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20230721195217-16d6e37196cb
 	github.com/kdomanski/iso9660 v0.3.5
 	github.com/moby/sys/mountinfo v0.6.2
+	github.com/pelletier/go-toml/v2 v2.1.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.7.0
 	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.21.0
 	github.com/aws/aws-sdk-go-v2/config v1.15.11
 	github.com/aws/aws-sdk-go-v2/credentials v1.12.6
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.114.0
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.117.0
 	github.com/containerd/containerd v1.6.8
 	github.com/containerd/ttrpc v1.1.0
 	github.com/containernetworking/plugins v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1543,6 +1543,8 @@ github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAv
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
+github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d/go.mod h1:3OzsM7FXDQlpCiw2j81fOmAwQLnZnLGXVKUzeKQXIAw=
 github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
@@ -1726,8 +1728,9 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/sylabs/sif/v2 v2.7.1/go.mod h1:bBse2nEFd3yHkmq6KmAOFEWQg5LdFYiQUdVcgamxlc8=
 github.com/sylvia7788/contextcheck v1.0.4/go.mod h1:vuPKJMQ7MQ91ZTqfdyreNKwZjyUg6KO+IebVyQDedZQ=

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.3.13 h1:L/l0WbIpIadRO7i44jZh1/XeXpN
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.13/go.mod h1:hiM/y1XPp3DoEPhoVEYc/CZcS58dP6RKJRDFp99wdX0=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.1.4 h1:6lJvvkQ9HmbHZ4h/IEwclwv2mrTW8Uq1SOB/kXy0mfw=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.1.4/go.mod h1:1PrKYwxTM+zjpw9Y41KFtoJCQrJ34Z47Y4VgVbfndjo=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.114.0 h1:DL2wK3AoLAIRygGA5/v1abCfJBISn8OlcDsbjV4nKy8=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.114.0/go.mod h1:0FhI2Rzcv5BNM3dNnbcCx2qa2naFZoAidJi11cQgzL0=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.117.0 h1:Yq39vbwQX+Xw+Ubcsg/ElwO+TWAxAIAdrREtpjGnCHw=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.117.0/go.mod h1:0FhI2Rzcv5BNM3dNnbcCx2qa2naFZoAidJi11cQgzL0=
 github.com/aws/aws-sdk-go-v2/service/eks v1.29.5 h1:6eSpTHOsDixcFIvPdiAAVdyCru3k2jIVRPdIQfGzfc8=
 github.com/aws/aws-sdk-go-v2/service/eks v1.29.5/go.mod h1:TwqefcyPlF31NTF+fH34tJ2VwMMR6c74IbiiUgA6kVY=
 github.com/aws/aws-sdk-go-v2/service/iam v1.22.5 h1:qGv+oW4uV1T3kbE9uSYEfdZbo38OqxgRxxfStfDr4BU=

--- a/pkg/adaptor/cloud/aws/manager.go
+++ b/pkg/adaptor/cloud/aws/manager.go
@@ -37,6 +37,8 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	// Setting disable-cvm to true as there are still some rough edges with CVMs.
 	// Once the issues are fixed, we can set it to false by default
 	flags.BoolVar(&awscfg.DisableCVM, "disable-cvm", true, "Use non-CVMs for peer pods")
+	// Add a flag to disable cloud config and use userdata via metadata service
+	flags.BoolVar(&awscfg.DisableCloudConfig, "disable-cloud-config", false, "Disable cloud config and use userdata via metadata service")
 
 }
 

--- a/pkg/adaptor/cloud/aws/manager.go
+++ b/pkg/adaptor/cloud/aws/manager.go
@@ -34,6 +34,9 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	// Add a parameter to indicate the root volume size for the Pod VMs
 	// Default is 30GiBs for free tier. Hence use it as default
 	flags.IntVar(&awscfg.RootVolumeSize, "root-volume-size", 30, "Root volume size (in GiB) for the Pod VMs")
+	// Setting disable-cvm to true as there are still some rough edges with CVMs.
+	// Once the issues are fixed, we can set it to false by default
+	flags.BoolVar(&awscfg.DisableCVM, "disable-cvm", true, "Use non-CVMs for peer pods")
 
 }
 

--- a/pkg/adaptor/cloud/aws/manager_test.go
+++ b/pkg/adaptor/cloud/aws/manager_test.go
@@ -1,0 +1,238 @@
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+)
+
+func TestManager_ParseCmd(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected Config
+	}{
+		{
+			name: "AllFlagsSet",
+			args: []string{
+				"-aws-access-key-id=test-access-key",
+				"-aws-secret-key=test-secret-key",
+				"-aws-region=test-region",
+				"-aws-profile=test-profile",
+				"-aws-lt-name=test-lt-name",
+				"-use-lt=true",
+				"-imageid=test-image-id",
+				"-instance-type=test-instance-type",
+				"-securitygroupids=sg-1,sg-2",
+				"-keyname=test-key-name",
+				"-subnetid=test-subnet-id",
+				"-use-public-ip=true",
+				"-instance-types=t2.micro,t3.small",
+				"-tags=key1=value1,key2=value2",
+				"-root-volume-size=60",
+				"-disable-cvm=true",
+			},
+			expected: Config{
+				AccessKeyId:        "test-access-key",
+				SecretKey:          "test-secret-key",
+				Region:             "test-region",
+				LoginProfile:       "test-profile",
+				LaunchTemplateName: "test-lt-name",
+				UseLaunchTemplate:  true,
+				ImageId:            "test-image-id",
+				InstanceType:       "test-instance-type",
+				SecurityGroupIds:   []string{"sg-1", "sg-2"},
+				KeyName:            "test-key-name",
+				SubnetId:           "test-subnet-id",
+				InstanceTypes:      []string{"t2.micro", "t3.small"},
+				Tags:               map[string]string{"key1": "value1", "key2": "value2"},
+				UsePublicIP:        true,
+				RootVolumeSize:     60,
+				DisableCVM:         true,
+			},
+		},
+		{
+			name: "DefaultValues",
+			args: []string{},
+			expected: Config{
+				AccessKeyId:        "",
+				SecretKey:          "",
+				Region:             "",
+				LoginProfile:       "",
+				LaunchTemplateName: "kata",
+				UseLaunchTemplate:  false,
+				ImageId:            "",
+				InstanceType:       "t3.small",
+				SecurityGroupIds:   securityGroupIds{},
+				KeyName:            "",
+				SubnetId:           "",
+				InstanceTypes:      instanceTypes{},
+				Tags:               nil,
+				UsePublicIP:        false,
+				RootVolumeSize:     30,
+				DisableCVM:         true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create a new flag set
+			flags := flag.NewFlagSet("test", flag.ContinueOnError)
+
+			// Create a new Manager instance
+			manager := &Manager{}
+
+			// Parse the command-line flags
+			manager.ParseCmd(flags)
+
+			// Set the command-line arguments
+			err := flags.Parse(test.args)
+			if err != nil {
+				t.Errorf("Failed to parse flags: %v", err)
+			}
+
+			// Compare the expected and actual values using comparestructs
+			if !comparestructs(test.expected, awscfg) {
+				t.Errorf("Expected config: %+v, but got: %+v", test.expected, awscfg)
+			}
+
+			// Delete the flag set
+			flags = nil
+
+			// Reset the awscfg
+			awscfg = Config{}
+		})
+	}
+}
+
+// Add a comparestructs function to compare the expected and actual values of the Config struct
+// This is needed because the reflect.DeepEqual() function does not work with maps
+// Print the expected and actual values to the console if they do not match
+func comparestructs(expected, actual Config) bool {
+	if expected.AccessKeyId != actual.AccessKeyId {
+		// Print the expected and actual values to the console if they do not match
+		fmt.Printf("Expected AccessKeyId: %s, but got: %s\n", expected.AccessKeyId, actual.AccessKeyId)
+		return false
+	}
+	if expected.SecretKey != actual.SecretKey {
+		// Print the expected and actual values to the console if they do not match
+		fmt.Printf("Expected SecretKey: %s, but got: %s\n", expected.SecretKey, actual.SecretKey)
+		return false
+	}
+	if expected.Region != actual.Region {
+		// Print the expected and actual values to the console if they do not match
+		fmt.Printf("Expected Region: %s, but got: %s\n", expected.Region, actual.Region)
+		return false
+	}
+	if expected.LoginProfile != actual.LoginProfile {
+		// Print the expected and actual values to the console if they do not match
+		fmt.Printf("Expected LoginProfile: %s, but got: %s\n", expected.LoginProfile, actual.LoginProfile)
+		return false
+	}
+	if expected.LaunchTemplateName != actual.LaunchTemplateName {
+		// Print the expected and actual values to the console if they do not match
+		fmt.Printf("Expected LaunchTemplateName: %s, but got: %s\n", expected.LaunchTemplateName, actual.LaunchTemplateName)
+		return false
+	}
+	if expected.UseLaunchTemplate != actual.UseLaunchTemplate {
+		// Print the expected and actual values to the console if they do not match
+		fmt.Printf("Expected UseLaunchTemplate: %t, but got: %t\n", expected.UseLaunchTemplate, actual.UseLaunchTemplate)
+		return false
+
+	}
+	if expected.ImageId != actual.ImageId {
+		// Print the expected and actual values to the console if they do not match
+		fmt.Printf("Expected ImageId: %s, but got: %s\n", expected.ImageId, actual.ImageId)
+		return false
+	}
+	if expected.InstanceType != actual.InstanceType {
+		// Print the expected and actual values to the console if they do not match
+		fmt.Printf("Expected InstanceType: %s, but got: %s\n", expected.InstanceType, actual.InstanceType)
+		return false
+	}
+
+	// DeepEqual() does not work with slices
+	fmt.Printf("sg %v\n", actual.SecurityGroupIds)
+
+	// Compare the length of the expected and actual values of the SecurityGroupIds slice.
+	if len(expected.SecurityGroupIds) != len(actual.SecurityGroupIds) {
+		// Print the expected and actual values to the console if they do not match
+		fmt.Printf("Expected length of SecurityGroupIds: %s, but got: %s\n", expected.SecurityGroupIds, actual.SecurityGroupIds)
+		return false
+	}
+
+	// Compare the expected and actual values of the SecurityGroupIds slice.
+	for i := range expected.SecurityGroupIds {
+		if expected.SecurityGroupIds[i] != actual.SecurityGroupIds[i] {
+			// Print the expected and actual values to the console if they do not match
+			fmt.Printf("Expected SecurityGroupIds: %s, but got: %s\n", expected.SecurityGroupIds, actual.SecurityGroupIds)
+			return false
+		}
+	}
+
+	if expected.KeyName != actual.KeyName {
+		// Print the expected and actual values to the console if they do not match
+		fmt.Printf("Expected KeyName: %s, but got: %s\n", expected.KeyName, actual.KeyName)
+		return false
+	}
+	if expected.SubnetId != actual.SubnetId {
+		// Print the expected and actual values to the console if they do not match
+		fmt.Printf("Expected SubnetId: %s, but got: %s\n", expected.SubnetId, actual.SubnetId)
+		return false
+	}
+	if expected.UsePublicIP != actual.UsePublicIP {
+		// Print the expected and actual values to the console if they do not match
+		fmt.Printf("Expected UsePublicIP: %t, but got: %t\n", expected.UsePublicIP, actual.UsePublicIP)
+		return false
+	}
+
+	// DeepEqual() does not work with slices
+	// Compare the length of the expected and actual values of the InstanceTypes slice.
+	if len(expected.InstanceTypes) != len(actual.InstanceTypes) {
+		// Print the expected and actual values to the console if they do not match
+		fmt.Printf("Expected length of InstanceTypes: %s, but got: %s\n", expected.InstanceTypes, actual.InstanceTypes)
+		return false
+	}
+
+	// Compare the expected and actual values of the InstanceTypes slice.
+	for i := range expected.InstanceTypes {
+		if expected.InstanceTypes[i] != actual.InstanceTypes[i] {
+			// Print the expected and actual values to the console if they do not match
+			fmt.Printf("Expected InstanceTypes: %s, but got: %s\n", expected.InstanceTypes, actual.InstanceTypes)
+			return false
+		}
+	}
+
+	// DeepEqual() does not work with maps
+	// Compare the length of the expected and actual values of the Tags map.
+	if len(expected.Tags) != len(actual.Tags) {
+		// Print the expected and actual values to the console if they do not match
+		fmt.Printf("Expected length of Tags: %s, but got: %s\n", expected.Tags, actual.Tags)
+		return false
+	}
+	for key, value := range expected.Tags {
+		if actualValue, ok := actual.Tags[key]; !ok || actualValue != value {
+			// Print the expected and actual values to the console if they do not match
+			fmt.Printf("Expected Tags: %s, but got: %s\n", expected.Tags, actual.Tags)
+			return false
+		}
+	}
+
+	if expected.RootVolumeSize != actual.RootVolumeSize {
+		// Print the expected and actual values to the console if they do not match
+		fmt.Printf("Expected RootVolumeSize: %d, but got: %d\n", expected.RootVolumeSize, actual.RootVolumeSize)
+		return false
+	}
+
+	if expected.DisableCVM != actual.DisableCVM {
+		// Print the expected and actual values to the console if they do not match
+		fmt.Printf("Expected DisableCVM: %t, but got: %t\n", expected.DisableCVM, actual.DisableCVM)
+		return false
+	}
+
+	return true
+}

--- a/pkg/adaptor/cloud/aws/misc.go
+++ b/pkg/adaptor/cloud/aws/misc.go
@@ -1,0 +1,86 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const (
+	// Ref: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html
+	AWSImdsUrl         = "http://169.254.169.254/latest/dynamic/instance-identity/document"
+	AWSUserDataImdsUrl = "http://169.254.169.254/latest/user-data"
+)
+
+// Method to check if the VM is running on AWS
+// by checking if the AWS IMDS endpoint is reachable
+// If the VM is running on AWS, return true
+func IsAWS(ctx context.Context) bool {
+
+	// Create a new HTTP client
+	client := &http.Client{}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, AWSImdsUrl, nil)
+	if err != nil {
+		fmt.Printf("failed to create request: %s\n", err)
+		return false
+	}
+
+	// Send the request and retrieve the response
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Printf("failed to send request: %s\n", err)
+		return false
+	}
+	defer resp.Body.Close()
+
+	// Check if the response was successful
+	return resp.StatusCode == http.StatusOK
+}
+
+// Method to retrieve userData from the instance metadata service
+// and return it as a string
+func GetUserData(ctx context.Context, url string) (string, error) {
+
+	// If url is empty then return empty string
+	if url == "" {
+		return "", fmt.Errorf("url is empty")
+	}
+
+	// Create a new HTTP client
+	client := &http.Client{}
+
+	// Create a new request to retrieve the VM's userData
+	// Example request for AWS.
+	// curl http://169.254.169.254/latest/user-data
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %s", err)
+
+	}
+
+	// Send the request and retrieve the response
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %s", err)
+
+	}
+	defer resp.Body.Close()
+
+	// Check if the response was successful
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to retrieve userData: %s", resp.Status)
+
+	}
+
+	// Read the response body and return it as a string
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %s", err)
+
+	}
+
+	return string(body), nil
+}

--- a/pkg/adaptor/cloud/aws/types.go
+++ b/pkg/adaptor/cloud/aws/types.go
@@ -54,6 +54,7 @@ type Config struct {
 	UsePublicIP          bool
 	RootVolumeSize       int
 	RootDeviceName       string
+	DisableCVM           bool
 }
 
 func (c Config) Redact() Config {

--- a/pkg/adaptor/cloud/aws/types.go
+++ b/pkg/adaptor/cloud/aws/types.go
@@ -55,6 +55,7 @@ type Config struct {
 	RootVolumeSize       int
 	RootDeviceName       string
 	DisableCVM           bool
+	DisableCloudConfig   bool
 }
 
 func (c Config) Redact() Config {

--- a/pkg/adaptor/cloud/aws/types_test.go
+++ b/pkg/adaptor/cloud/aws/types_test.go
@@ -33,7 +33,23 @@ func TestAWSMasking(t *testing.T) {
 	}
 }
 
-func TestEmptyList(t *testing.T) {
+// Test instanceTypes
+func TestInstanceTypes(t *testing.T) {
+	var list instanceTypes
+	err := list.Set("t2.micro,t2.small")
+	if err != nil {
+		t.Errorf("List Set failed, %v", err)
+	}
+	if len(list) != 2 {
+		t.Errorf("Expect 2 length, got %d", len(list))
+	}
+	if list.String() != "t2.micro, t2.small" {
+		t.Errorf("Expect 't2.micro, t2.small', got %s", list.String())
+	}
+}
+
+// Test empty instanceTypes
+func TestEmptyInstanceTypes(t *testing.T) {
 	var list instanceTypes
 	err := list.Set("")
 	if err != nil {
@@ -41,5 +57,36 @@ func TestEmptyList(t *testing.T) {
 	}
 	if len(list) != 0 {
 		t.Errorf("Expect 0 length, got %d", len(list))
+	}
+	if list.String() != "" {
+		t.Errorf("Expect '', got %s", list.String())
+	}
+}
+
+// Test securityGroupIds
+func TestSecurityGroupIds(t *testing.T) {
+	var list securityGroupIds
+	err := list.Set("sg-1234,sg-5678")
+	if err != nil {
+		t.Errorf("List Set failed, %v", err)
+	}
+	if len(list) != 2 {
+		t.Errorf("Expect 2 length, got %d", len(list))
+	}
+	if list.String() != "sg-1234, sg-5678" {
+		t.Errorf("Expect 'sg-1234, sg-5678', got %s", list.String())
+	}
+}
+
+// Test empty securityGroupIds
+func TestEmptySecurityGroupIds(t *testing.T) {
+	var list securityGroupIds
+	err := list.Set("")
+	if err != nil {
+		t.Errorf("List Set failed, %v", err)
+	}
+
+	if list.String() != "" {
+		t.Errorf("Expect '', got %s", list.String())
 	}
 }

--- a/pkg/adaptor/cloud/azure/misc.go
+++ b/pkg/adaptor/cloud/azure/misc.go
@@ -1,0 +1,132 @@
+package azure
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const (
+	AzureImdsUrl         = "http://169.254.169.254/metadata/instance/compute?api-version=2021-01-01"
+	AzureUserDataImdsUrl = "http://169.254.169.254/metadata/instance/compute/userData?api-version=2021-01-01&format=text"
+)
+
+// Method to check if the VM is running on Azure
+// by checking if the Azure IMDS endpoint is reachable
+// Set Metadata:true header to confirm that the VM is running on Azure
+// If the VM is running on Azure, return true
+func IsAzure(ctx context.Context) bool {
+
+	// Create a new HTTP client
+	client := &http.Client{}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, AzureImdsUrl, nil)
+	if err != nil {
+		fmt.Printf("failed to create request: %s\n", err)
+		return false
+	}
+	// Add the required headers to the request
+	req.Header.Add("Metadata", "true")
+
+	// Send the request and retrieve the response
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Printf("failed to send request: %s\n", err)
+		return false
+	}
+	defer resp.Body.Close()
+
+	// Check if the response was successful
+	return resp.StatusCode == http.StatusOK
+}
+
+// Method to retrieve userData from the instance metadata service
+// and return it as a string
+func GetUserData(ctx context.Context, url string) (string, error) {
+
+	// If url is empty then return empty string
+	if url == "" {
+		return "", fmt.Errorf("url is empty")
+	}
+
+	// Create a new HTTP client
+	client := &http.Client{}
+
+	// Create a new request to retrieve the VM's userData
+	// Example request for Azure.
+	// curl -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance/compute/userData?api-version=2021-01-01&format=text" | base64 --decode
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %s", err)
+
+	}
+	// Add the required headers to the request
+	req.Header.Add("Metadata", "true")
+
+	// Send the request and retrieve the response
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %s", err)
+
+	}
+	defer resp.Body.Close()
+
+	// Check if the response was successful
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to retrieve userData: %s", resp.Status)
+
+	}
+
+	// Read the response body and return it as a string
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %s", err)
+
+	}
+
+	// Sample data
+	/*
+			{
+		    "pod-network": {
+		        "podip": "10.244.0.19/24",
+		        "pod-hw-addr": "0e:8f:62:f3:81:ad",
+		        "interface": "eth0",
+		        "worker-node-ip": "10.224.0.4/16",
+		        "tunnel-type": "vxlan",
+		        "routes": [
+		            {
+		                "Dst": "",
+		                "GW": "10.244.0.1",
+		                "Dev": "eth0"
+		            }
+		        ],
+		        "mtu": 1500,
+		        "index": 1,
+		        "vxlan-port": 8472,
+		        "vxlan-id": 555001,
+		        "dedicated": false
+		    },
+		    "pod-namespace": "default",
+		    "pod-name": "nginx-866fdb5bfb-b98nw",
+		    "tls-server-key": "-----BEGIN PRIVATE KEY-----\n....\n-----END PRIVATE KEY-----\n",
+		    "tls-server-cert": "-----BEGIN CERTIFICATE-----\n....\n-----END CERTIFICATE-----\n",
+		    "tls-client-ca": "-----BEGIN CERTIFICATE-----\n....\n-----END CERTIFICATE-----\n",
+		    "aa-kbc-params": "cc_kbc::http://192.168.100.2:8080"
+		    "auth-json": "..."
+
+		}
+	*/
+
+	// The response is base64 encoded
+
+	// Decode the base64 response
+	decoded, err := base64.StdEncoding.DecodeString(string(body))
+	if err != nil {
+		return "", fmt.Errorf("failed to decode b64 encoded userData: %s", err)
+	}
+
+	return string(decoded), nil
+}

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -44,6 +44,8 @@ type Config struct {
 	TLSClientCA   string `json:"tls-client-ca,omitempty"`
 
 	AAKBCParams string `json:"aa-kbc-params,omitempty"`
+
+	AuthJson string `json:"auth-json,omitempty"`
 }
 
 type Daemon interface {

--- a/pkg/util/cloudinit/cloudconfig.go
+++ b/pkg/util/cloudinit/cloudconfig.go
@@ -13,9 +13,9 @@ import (
 
 const (
 	DefaultAuthfileSrcPath = "/root/containers/auth.json"
-	// image-rs fixed dst path for support at the agent, we convert it explictly to the resources file format
-	// e.g. https://github.com/confidential-containers/guest-components/blob/main/attestation-agent/kbc/src/offline_fs_kbc/aa-offline_fs_kbc-resources.json
-	DefaultAuthfileDstPath = "/etc/aa-offline_fs_kbc-resources.json"
+
+	// Location of the container registry auth json file
+	DefaultAuthfileDstPath = "/etc/attestation-agent/auth.json"
 	DefaultAuthfileLimit   = 12288 // TODO: use a whole userdata limit mechanism instead of limiting authfile
 	DefaultAAKBCParamsPath = "/etc/attestation-agent/kbc-params.json"
 )


### PR DESCRIPTION
This patch series includes the following:
1. Adds support for providing the registry authentication file via userdata. 
2. Removes usage of multiple files via cloud-config. All required values are part of daemon Config which is then processed by process-user-data command inside podvm
3. Adds support for fetching of userdata from metadata service in AWS.
4. Adds some misc improvements and tests to the AWS code