### PR TITLE
volumes: fix the error to create nginx pod for ibm

### DIFF
--- a/volumes/csi-wrapper/examples/ibm/nginx-kata-with-my-pvc-and-csi-wrapper.yaml
+++ b/volumes/csi-wrapper/examples/ibm/nginx-kata-with-my-pvc-and-csi-wrapper.yaml
@@ -64,6 +64,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+      command: ["csi-podvm-wrapper"]
       args:
         - --v=5
         - --endpoint=/tmp/csi-podvm-wrapper.sock


### PR DESCRIPTION
Specify Command in yaml

Not sure why the entrypoint in image is not be used. Maybe we need dig into kata agent code for image later.