### PR TITLE
azure: fix cwd for versions.yaml parsing

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -49,6 +49,7 @@ jobs:
         ref: "${{ inputs.git-ref || 'main' }}"
 
     - name: Read properties from versions.yaml
+      working-directory: cloud-api-adaptor
       run: |
         go_version="$(yq '.tools.golang' versions.yaml)"
         [ -n "$go_version" ]


### PR DESCRIPTION
The versions parsing is happening in the wrong working directory, [breaking the builds](https://github.com/confidential-containers/cloud-api-adaptor/actions/workflows/azure-e2e-test.yml).