### PR TITLE
powervs: use public IP to connect to the peer pod vm

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -109,6 +109,7 @@ ibmcloud_powervs() {
     [[ "${POWERVS_PROCESSORS}" ]] && optionals+="-cpu ${POWERVS_PROCESSORS} "
     [[ "${POWERVS_PROCESSOR_TYPE}" ]] && optionals+="-proc-type ${POWERVS_PROCESSOR_TYPE} "
     [[ "${POWERVS_SYSTEM_TYPE}" ]] && optionals+="-sys-type ${POWERVS_SYSTEM_TYPE} "
+    [[ "${USE_PUBLIC_IP}" == "true" ]] && optionals+="-use-public-ip " # Use public IP for pod vm
 
     set -x
     exec cloud-api-adaptor ibmcloud-powervs \

--- a/install/overlays/ibmcloud-powervs/kustomization.yaml
+++ b/install/overlays/ibmcloud-powervs/kustomization.yaml
@@ -31,6 +31,7 @@ configMapGenerator:
   #- PAUSE_IMAGE="" # Uncomment and set if you want to use a specific pause image
   #- VXLAN_PORT="" # Uncomment and set if you want to use a specific vxlan port. Defaults to 4789
   #- PROXY_TIMEOUT="" # Uncomment and set if you want to pass a specific timeout. Defaults to 5m
+  #- USE_PUBLIC_IP="true" # Uncomment if you want to use public ip for podvm
 ##TLS_SETTINGS
   #- CACERT_FILE="/etc/certificates/ca.crt" # for TLS
   #- CERT_FILE="/etc/certificates/client.crt" # for TLS

--- a/pkg/adaptor/cloud/ibmcloud-powervs/manager.go
+++ b/pkg/adaptor/cloud/ibmcloud-powervs/manager.go
@@ -25,6 +25,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	flags.Float64Var(&ibmcloudPowerVSConfig.Processors, "cpu", 0.5, "Number of processors allocated")
 	flags.StringVar(&ibmcloudPowerVSConfig.ProcessorType, "proc-type", "shared", "Name of the processor type")
 	flags.StringVar(&ibmcloudPowerVSConfig.SystemType, "sys-type", "s922", "Name of the system type")
+	flags.BoolVar(&ibmcloudPowerVSConfig.UsePublicIP, "use-public-ip", false, "Use Public IP for connecting to the agent-protocol-forwarder inside the Pod VM")
 
 }
 

--- a/pkg/adaptor/cloud/ibmcloud-powervs/provider.go
+++ b/pkg/adaptor/cloud/ibmcloud-powervs/provider.go
@@ -159,7 +159,12 @@ func (p *ibmcloudPowerVSProvider) getVMIPs(ctx context.Context, instance *models
 
 	for i, network := range ins.Networks {
 		if ins.Networks[i].Type == "fixed" {
-			ip, err := netip.ParseAddr(network.IPAddress)
+			ip_address := network.IPAddress
+			if p.serviceConfig.UsePublicIP {
+				ip_address = network.ExternalIP
+			}
+
+			ip, err := netip.ParseAddr(ip_address)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse pod node IP %q: %w", network.IPAddress, err)
 			}

--- a/pkg/adaptor/cloud/ibmcloud-powervs/types.go
+++ b/pkg/adaptor/cloud/ibmcloud-powervs/types.go
@@ -16,6 +16,7 @@ type Config struct {
 	Processors        float64
 	ProcessorType     string
 	SystemType        string
+	UsePublicIP       bool
 }
 
 func (c Config) Redact() Config {


### PR DESCRIPTION
Adds support to use public IP to connect to the agent-protocol-forwarder running in the peer pod VM.

Fixes: #1461