### PR TITLE
build: make yq version.yml processing more robust

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -103,7 +103,9 @@ jobs:
       env:
         GOPATH: /home/runner/go
       if: steps.kata-agent-cache.outputs.cache-hit != 'true'
-      run: make "$(realpath -m ../../podvm/files/usr/local/bin/kata-agent)"
+      run: |
+        make "$(realpath -m ../../podvm/files/usr/local/bin/kata-agent)"
+        rm -f "${GOPATH}/bin/yq"
 
     - name: Set up pause cache
       id: pause-cache

--- a/Makefile.defaults
+++ b/Makefile.defaults
@@ -1,9 +1,15 @@
-ifeq (, $(shell command -v yq 2> /dev/null))
-$(error "No yq on PATH, consider doing snap install yq")
+YQ_COMMAND ?= yq
+VERSIONS_SRC := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))/versions.yaml
+
+ifeq (, $(shell command -v $(YQ_COMMAND) 2> /dev/null))
+$(error "$(YQ_COMMAND) not found, consider doing snap install yq")
 endif
 
-YQ_COMMAND     := yq
-VERSIONS_SRC := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))/versions.yaml
+YQ_MAJOR_VERSION := $(shell $(YQ_COMMAND) --version | sed -nE 's/.* v?([0-9]+).*/\1/p')
+
+ifneq (4, $(YQ_MAJOR_VERSION))
+$(error "yq major version should be 4, is: $(YQ_MAJOR_VERSION)")
+endif
 
 define query
 $(or $(shell $(YQ_COMMAND) '.$(1) | select(. != null)' $(VERSIONS_SRC)), \


### PR DESCRIPTION
fixes #1446 

A kata build process will install yq v3 to `/usr/local/bin`, taking preference over the system-provided yq v4, which we need. The workaround is not particularly pretty, but it's a stopgap to make nighly builds work, until we make the switch to mkosi-based builds. 

- Add a yq version assertion to the Makefiles (a kata build will install v3, but our yq queries require v4)
- Make the yq command overridable
- In the azure podvm build remove the yq v3 installed by kata-agent

```bash
$ yq_v3 --version | sed -nE 's/.* v?([0-9]+).*/\1/p'
3
$ yq --version | sed -nE 's/.* v?([0-9]+).*/\1/p'
4
```