### PR TITLE
podvm: fix attestation-agent build on ppc64le

### DIFF
--- a/ibmcloud-powervs/image/prereq.sh
+++ b/ibmcloud-powervs/image/prereq.sh
@@ -5,7 +5,7 @@ RUST_VERSION="1.72.0"
 SKOPEO_VERSION="1.5.0"
 
 # Install dependencies
-yum install -y curl protobuf-compiler libseccomp-devel openssl openssl-devel skopeo-${SKOPEO_VERSION}
+yum install -y curl protobuf-compiler libseccomp-devel openssl openssl-devel perl skopeo-${SKOPEO_VERSION}
 
 # Install Golang
 curl https://dl.google.com/go/go${GO_VERSION}.linux-ppc64le.tar.gz -o go${GO_VERSION}.linux-ppc64le.tar.gz && \


### PR DESCRIPTION
Fix the attestation-agent build by installing perl packages as one of the dependencies.

Fixes: #1468