### PR TITLE
azure: build podvm with cc_kbc by default

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -32,10 +32,11 @@ env:
   PODVM_IMAGE_NAME: "peerpod-image-${{ github.run_id }}-${{ github.run_attempt }}"
   SSH_USERNAME: "peerpod"
   VM_SIZE: "Standard_D2as_v5"
+  AA_KBC: "cc_kbc_az_snp_vtpm"
 
 jobs:
   build-podvm-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: cloud-api-adaptor/azure/image
@@ -78,7 +79,17 @@ jobs:
         cache-dependency-path: cloud-api-adaptor/go.sum
 
     - name: Install build dependencies
-      run: sudo apt-get install -y musl-tools libdevmapper-dev libgpgme-dev
+      run: |
+        sudo curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
+        sudo echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+        sudo apt-get update
+        sudo apt-get install -y \
+          libdevmapper-dev \
+          libgpgme-dev \
+          libtdx-attest-dev \
+          musl-tools \
+          libssl-dev \
+          libtss2-dev
 
     - name: Build CAA binaries
       env:
@@ -133,11 +144,11 @@ jobs:
       uses: actions/cache@v3
       with:
         path: cloud-api-adaptor/podvm/files/usr/local/bin/attestation-agent
-        key: aa-${{ env.GUEST_COMPONENTS_REF }}
+        key: aa-${{ env.AA_KBC }}_${{ env.GUEST_COMPONENTS_REF }}_rust${{ env.RUST_VERSION }}
 
     - name: Build attestation-agent
       if: steps.aa-cache.outputs.cache-hit != 'true'
-      run: make "$(realpath -m ../../podvm/files/usr/local/bin/attestation-agent)"
+      run: make "$(realpath -m ../../podvm/files/usr/local/bin/attestation-agent)" LIBC=gnu
 
     - uses: azure/login@v1
       name: 'Az CLI login'
@@ -160,6 +171,7 @@ jobs:
         PKR_VAR_az_gallery_image_name: ${{ env.AZURE_PODVM_IMAGE_DEF_NAME }}
         PKR_VAR_az_gallery_image_version: ${{ env.AZURE_PODVM_IMAGE_VERSION }}
         PKR_VAR_use_azure_cli_auth: "true"
+        CLOUD_PROVIDER: "azure"
         PODVM_DISTRO: "ubuntu"
       run: |
         make image BINARIES=


### PR DESCRIPTION
We probably want to have `cc_kbc` (being able to talk to kbs) in the nightly images instead of `offlinefs_kbc`, which is the default. it's not trivial to have a build that supports that feature, so it would be good to have it baked into the image