### PR TITLE
podvm: fix CDH's api-server-rest startup

### DIFF
--- a/podvm/files/etc/systemd/system/api-server-rest.service
+++ b/podvm/files/etc/systemd/system/api-server-rest.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=CDH API Server Rest Service
 BindsTo=netns@podns.service
-After=network.target confidential-data-hub.service netns@podns.service
+After=network.target confidential-data-hub.service attestation-agent.service netns@podns.service
 
 [Service]
 Type=simple
 NetworkNamespacePath=/run/netns/podns
 ExecStart=/usr/local/bin/api-server-rest --features all 
-
+RestartSec=0.5
 Restart=always
 
 [Install]

--- a/podvm/files/etc/systemd/system/confidential-data-hub.service
+++ b/podvm/files/etc/systemd/system/confidential-data-hub.service
@@ -6,8 +6,8 @@ After=network.target attestation-agent.service netns@podns.service
 [Service]
 Type=simple
 NetworkNamespacePath=/run/netns/podns
-ExecStart=/usr/local/bin/confidential-data-hub
-
+ExecStartPre=rm -f /run/confidential-containers/cdh.sock
+ExecStart=/usr/local/bin/confidential-data-hub -s unix:///run/confidential-containers/cdh.sock
 Restart=always
 
 [Install]


### PR DESCRIPTION
There is a race condition in the current code flow that is starting the CDH binaries. The `api-server-rest` unit will fail after 5 unsuccessful restart attempts ultimately. This is because it's relying on a unix sockets provided by `attestation-agent` and `confidential-data-hub`:

The sockets aren't created socket immediately, but the units are already active. `api-server-rest`, being a small app, fails to detect the necessary socket and restarts 5 times in quick succession. (the same applies to `confidential-data-hub` (dependent on the aa socket), but it, being a larger app and having only 1 socket doesn't fail as quickly, so it'll only have 2 restarts, before it's able to use the AA the socket.

The easiest fix is to add a delay between the restarts to `api-server-rest`, after 2 restarts should come up. A more elegant fix would be to have systemd manage the socket files, but that would require code changes on CDH code.

We also make sure that the CDH socket is removed prior to startup, so the unit is restart-able (it's not at the moment, if the socket file exists)