### PR TITLE
e2e-tests: Add a default deletion time for all tests

### DIFF
--- a/test/e2e/common_suite_test.go
+++ b/test/e2e/common_suite_test.go
@@ -345,15 +345,20 @@ func (tc *testCase) run() {
 				}
 				log.Infof("Deleting pod %s...", tc.pod.Name)
 
-				if tc.deletionWithin != nil {
-					if err = wait.For(conditions.New(
-						client.Resources()).ResourceDeleted(tc.pod),
-						wait.WithInterval(5*time.Second),
-						wait.WithTimeout(*tc.deletionWithin)); err != nil {
-						t.Fatal(err)
-					}
-					log.Infof("Pod %s has been successfully deleted within %.0fs", tc.pod.Name, tc.deletionWithin.Seconds())
+				// Add a default deleteWithin time.
+				if tc.deletionWithin == nil {
+					deleteWithin := time.Second * 300
+					tc.deletionWithin = &deleteWithin
 				}
+
+				if err = wait.For(conditions.New(
+					client.Resources()).ResourceDeleted(tc.pod),
+					wait.WithInterval(5*time.Second),
+					wait.WithTimeout(*tc.deletionWithin)); err != nil {
+					t.Fatal(err)
+				}
+
+				log.Infof("Pod %s has been successfully deleted", tc.pod.Name)
 			}
 
 			if tc.pvc != nil {


### PR DESCRIPTION
This ensures that all the pods are deleted before we move on to clean up CAA and other resources.

Fixes: #1480