### PR TITLE
podvm: bump guest-components version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -22,7 +22,7 @@ tools:
 git:
   guest-components:
     url: https://github.com/confidential-containers/guest-components
-    reference: f4f89dab52652c31ebda65aae797462d3697d8c2
+    reference: ebceb0c52ddd9fbd4cc3ac10133bec2ab7ea5795
   kata-containers:
     url: https://github.com/kata-containers/kata-containers
     reference: CCv0


### PR DESCRIPTION
Since confidential-containers/guest-components/pull/371 has been merged, we need to update guest components in the podvm. Otherwise remote attestation via cc_kbc will not work for peer pods.