### PR TITLE
azure-build-pod-vm-image: Default to SNP vTPM KBC

### DIFF
--- a/azure/build-image.md
+++ b/azure/build-image.md
@@ -86,6 +86,8 @@ export PKR_VAR_az_gallery_image_name="${GALLERY_IMAGE_DEF_NAME}"
 export PKR_VAR_az_gallery_image_version="0.0.1"
 export PKR_VAR_offer=0001-com-ubuntu-confidential-vm-jammy
 export PKR_VAR_sku=22_04-lts-cvm
+
+export AA_KBC="cc_kbc_az_snp_vtpm"
 export CLOUD_PROVIDER=azure
 PODVM_DISTRO=ubuntu make image
 ```


### PR DESCRIPTION
Right now we don't specify any KBC for the Azure's PodVM. So defaulting to the Azure SNP vTPM KBC will allow users to utilize the attestation features provided on the Azure CVM.