### PR TITLE
e2e/test: enhance TestCaaDaemonsetRollingUpdate

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -162,3 +162,9 @@ func newPVC(namespace, name, storageClassName, diskSize string, accessModel core
 type CloudAssert interface {
 	HasPodVM(t *testing.T, id string) // Assert there is a PodVM with `id`.
 }
+
+// RollingUpdateAssert defines assertions for rolling update test
+type RollingUpdateAssert interface {
+	CachePodVmIDs(t *testing.T, deploymentName string) // Cache Pod VM IDs before rolling update
+	VerifyOldVmDeleted(t *testing.T)                   // Verify old Pod VMs have been deleted
+}


### PR DESCRIPTION
We have test case `TestCaaDaemonsetRollingUpdate` to test CAA DS rolling update feature. We need enhance this test to also verify if **peerpod-ctrl** can work as expected to delete old Pod VMs caused by rolling update after peer pod deleted.

Just for ibmcloud provider so far
