### PR TITLE
Azure: Use versions.yaml to read go version in e2e test

### DIFF
--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -52,10 +52,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Extract go version number
+      run: echo "GO_VERSION=$(yq -e '.tools.golang' versions.yaml)" >> "$GITHUB_ENV"
+
     - name: Set up Go environment
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: ${{ env.GO_VERSION }}
         cache-dependency-path: go.sum
 
     - uses: azure/login@v1
@@ -97,10 +100,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Extract go version number
+      run: echo "GO_VERSION=$(yq -e '.tools.golang' versions.yaml)" >> "$GITHUB_ENV"
+
     - name: Set up Go environment
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Create provisioner file
       env:
@@ -160,10 +166,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Extract go version number
+      run: echo "GO_VERSION=$(yq -e '.tools.golang' versions.yaml)" >> "$GITHUB_ENV"
+
     - name: Set up Go environment
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Restore the configuration created before
       uses: actions/download-artifact@v3
@@ -199,10 +208,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Extract go version number
+      run: echo "GO_VERSION=$(yq -e '.tools.golang' versions.yaml)" >> "$GITHUB_ENV"
+
     - name: Set up Go environment
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Restore the configuration created before
       uses: actions/download-artifact@v3


### PR DESCRIPTION
Use versions.yaml to read go version in e2e test

Fixes: #1496