### PR TITLE
WIP: copy-files: coco-default.rego as default policy

### DIFF
--- a/aws/image/copy-files.sh
+++ b/aws/image/copy-files.sh
@@ -26,3 +26,9 @@ sudo mkdir -p /usr/local/bin
 sudo cp -a /tmp/files/usr/* /usr/
 
 sudo cp -a /tmp/files/pause_bundle /
+
+# Use the policy file providing the same agent enpoint restrictions as agent-config.toml
+default_policy="/etc/kata-opa/default-policy.rego"
+if [ -f "${default_policy}" ]; then
+	ln -sf "coco-default.rego" "${default_policy}"
+fi

--- a/azure/image/copy-files.sh
+++ b/azure/image/copy-files.sh
@@ -26,3 +26,9 @@ sudo mkdir -p /usr/local/bin
 sudo cp -a /tmp/files/usr/* /usr/
 
 sudo cp -a /tmp/files/pause_bundle /
+
+# Use the policy file providing the same agent enpoint restrictions as agent-config.toml
+default_policy="/etc/kata-opa/default-policy.rego"
+if [ -f "${default_policy}" ]; then
+	ln -sf "coco-default.rego" "${default_policy}"
+fi

--- a/ibmcloud-powervs/image/copy-files.sh
+++ b/ibmcloud-powervs/image/copy-files.sh
@@ -24,3 +24,9 @@ if [ -e ${PODVM_DIR}/files/auth.json ]; then
        sudo mkdir -p /root/.config/containers/
        sudo cp -a ${PODVM_DIR}/files/auth.json /root/.config/containers/auth.json
 fi
+
+# Use the policy file providing the same agent enpoint restrictions as agent-config.toml
+default_policy="/etc/kata-opa/default-policy.rego"
+if [ -f "${default_policy}" ]; then
+	ln -sf "coco-default.rego" "${default_policy}"
+fi

--- a/podvm/qcow2/copy-files.sh
+++ b/podvm/qcow2/copy-files.sh
@@ -26,3 +26,9 @@ sudo mkdir -p /usr/local/bin
 sudo cp -a /tmp/files/usr/* /usr/
 
 sudo cp -a /tmp/files/pause_bundle /
+
+# Use the policy file providing the same agent enpoint restrictions as agent-config.toml
+default_policy="/etc/kata-opa/default-policy.rego"
+if [ -f "${default_policy}" ]; then
+	ln -sf "coco-default.rego" "${default_policy}"
+fi


### PR DESCRIPTION
The Kata Containers default agent policy allows access to all the agent endpoints - including SetPolicy and ExecProcess. Therefore, change the default policy to coco-default.rego, that denies access to the same endpoints that agent-config.toml denies - in preparation for the future removal of the endpoint restriction support from agent-config.toml.