### PR TITLE
Misc controller fixes

### DIFF
--- a/.github/workflows/peerpodconfig-ctrl_image.yaml
+++ b/.github/workflows/peerpodconfig-ctrl_image.yaml
@@ -1,0 +1,49 @@
+# Copyright Confidential Containers Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Push peerpodconfig-ctrl image
+---
+name: peerpodconfig-ctrl image push
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'peerpodconfig-ctrl/**'
+
+jobs:
+  peerpod_push:
+    name: Push peerpodconfig-ctrl image
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: peerpodconfig-ctrl
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Quay container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Validate build args contains the essentials
+        run: |
+           make list-build-args | grep -e 'CGO_ENABLED=[0|1]' && \
+           make list-build-args | grep 'GOFLAGS=' | grep -E '\-tags=[a-z,]*'
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          tags: |
+            quay.io/confidential-containers/peerpodconfig-ctrl:latest
+            quay.io/confidential-containers/peerpodconfig-ctrl:${{ github.sha }}
+          push: true
+          context: peerpodconfig-ctrl
+          platforms: linux/amd64, linux/s390x, linux/ppc64le
+          build-args: |
+            GOFLAGS=-tags=aws,azure,ibmcloud,vsphere,libvirt
+

--- a/.github/workflows/webhook-build.yaml
+++ b/.github/workflows/webhook-build.yaml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - name: Read properties from versions.yaml
         run: |
-          go_version="$(yq '.tools.golang' versions.yaml)"
+          go_version="$(yq '.tools.golang' ../versions.yaml)"
           [ -n "$go_version" ]
           echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"
       - name: Setup Golang version ${{ env.GO_VERSION }}

--- a/.github/workflows/webhook-test.yaml
+++ b/.github/workflows/webhook-test.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Read properties from versions.yaml
         run: |
-          go_version="$(yq '.tools.golang' versions.yaml)"
+          go_version="$(yq '.tools.golang' ../versions.yaml)"
           [ -n "$go_version" ]
           echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"
       - name: Setup Golang version ${{ env.GO_VERSION }}

--- a/peerpodconfig-ctrl/Makefile
+++ b/peerpodconfig-ctrl/Makefile
@@ -47,7 +47,7 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 endif
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= quay.io/confidential-containers/peerpodconfig-ctrl:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
 

--- a/peerpodconfig-ctrl/config/manager/kustomization.yaml
+++ b/peerpodconfig-ctrl/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/confidential-containers/peerpodconfig-ctrl
-  newTag: 0.2.0
+  newTag: latest

--- a/peerpodconfig-ctrl/config/rbac/role.yaml
+++ b/peerpodconfig-ctrl/config/rbac/role.yaml
@@ -56,6 +56,26 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resourceNames:
+  - peerpodconfig-ctrl-caa-daemon
+  resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets/finalizers
+  verbs:
+  - update
+- apiGroups:
   - confidentialcontainers.org
   resources:
   - peerpodconfigs

--- a/webhook/Makefile
+++ b/webhook/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= quay.io/confidential-containers/peer-pods-webhook:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.2
 

--- a/webhook/config/manager/kustomization.yaml
+++ b/webhook/config/manager/kustomization.yaml
@@ -13,3 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/confidential-containers/peer-pods-webhook
+  newTag: latest


### PR DESCRIPTION
This series includes misc fixes for webhook and peerpodconfig-ctrl
1. Updates the Makefile and kustomization.yaml to use the default images. This makes it easy to deploy these controllers via simple `make -C <dir> <target>` invocation
2. Create a gh-action job to build and push peerpodconfig-ctrl image to quay.io
3. Adds missing daemonset related rbac rules for peerpodconfig-ctrl
4. Fix the webhook gh-action jobs to point to the correct location for versions.yaml