### PR TITLE
Release process document improvements

### DIFF
--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -46,9 +46,11 @@ avoid compilation errors. This can be done by running:
   - [Dockerfile.podvm_binaries.rhel](../podvm/Dockerfile.podvm_binaries.rhel)
   - [versions.yaml](../versions.yaml)
 
+Currently there isn't automation to build the podvm images at this phase. They should be built manually to ensure they don't break.
+
 These updates should be done in a PR that is merged triggering the cloud-api-adaptor
 [image build workflow](../.github/workflows/image.yaml) to create a new container image in
-[`quay.io](https://quay.io/repository/confidential-containers/cloud-api-adaptor?tab=tags) to use in testing.
+[`quay.io/confidential-containers/cloud-api-adaptor`](https://quay.io/repository/confidential-containers/cloud-api-adaptor?tab=tags) to use in testing.
 
 #### Tags and update go submodules
 
@@ -131,4 +133,5 @@ The `CITATION.cff` needs to be updated with the dates from the release.
 Issues that we have to improve the release process that will impact this doc:
 
 - Create tags for the cloud-api-adaptor and webhook images on release and update the overlays to point to these
-versions in the tag [Issue #1109](https://github.com/confidential-containers/cloud-api-adaptor/issues/1109)
+versions in the tag ([Issue #1109](https://github.com/confidential-containers/cloud-api-adaptor/issues/1109))
+- Build the podvm images on the [release candidate testing](#release-candidate-testing) phase ([Issue #1253](https://github.com/confidential-containers/cloud-api-adaptor/issues/1253))

--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -17,7 +17,7 @@ lists the tasks involved in doing a release and these largely break down to thre
 In the release candidate selection and testing phase, we ensure that the dependencies we have within the
 confidential-containers projects are updated and that Kata Containers is updated to use these new versions, the
 [Kata Containers Runtime Payload CI](https://github.com/kata-containers/kata-containers/actions/workflows/cc-payload-after-push.yaml)
-image is updated, the operator is updated and the tests pass with all of these. 
+image is updated, the operator is updated and the tests pass with all of these.
 
 At this point, we should update the cloud-api-adaptor versions to use these release candidate versions of:
 - The kata-containers source branch that we use in the [podvm_builder `Dockerfiles`](../podvm/) and the
@@ -33,13 +33,13 @@ This can be done by running
 in the top-level repo directory, and the `peerpod-ctl` and `volumes/csi-wrapper` directories.
 > **Note:** If there are API changes in the kata-runtime go modules and we need to cloud-api-adaptor to implement,
 then it may be necessary to temporarily get the peerpod-ctrl and csi-wrapper to self-reference the parent folder to
-avoid compilation errors. This can be done by running: 
+avoid compilation errors. This can be done by running:
 > ```
 > go mod edit -replace github.com/confidential-containers/cloud-api-adaptor=../
 > go mod tidy
 > ```
 > from in the `peerpod-ctrl` and `volumes/csi-wrapper` directories.
-- The attestation-agent that is built into the peer pod vm image, by updating the `GUEST_COMPONENTS_VERSION` in 
+- The attestation-agent that is built into the peer pod vm image, by updating the `GUEST_COMPONENTS_VERSION` in
   - [`Makefile.inc`](../podvm/Makefile.inc)
   - [Dockerfile.podvm_binaries](../podvm/Dockerfile.podvm_binaries)
   - [Dockerfile.podvm_binaries.centos](../podvm/Dockerfile.podvm_binaries.centos)
@@ -47,7 +47,7 @@ avoid compilation errors. This can be done by running:
   - [versions.yaml](../versions.yaml)
 
 These updates should be done in a PR that is merged triggering the cloud-api-adaptor
-[image build workflow](../.github/workflows/image.yaml) to create a new container image in 
+[image build workflow](../.github/workflows/image.yaml) to create a new container image in
 [`quay.io](https://quay.io/repository/confidential-containers/cloud-api-adaptor?tab=tags) to use in testing.
 
 #### Tags and update go submodules

--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -148,6 +148,12 @@ cd install/overlays/
 for p in aws azure ibmcloud ibmcloud-powervs libvirt vsphere; do cd aws; kustomize edit set image cloud-api-adaptor=quay.io/confidential-containers/cloud-api-adaptor:latest; cd -; done
 ```
 
+References to Kata Containers should be reverted to the CCv0 branch in:
+
+* [podvm_builder.yaml workflow](../.github/workflows/podvm_builder.yaml)
+* [podvm_builder `Dockerfiles`](../podvm/)
+* go modules (`cloud-api-adaptor` [`go.mod`](../go.mod), the `peerpod-ctl` [`go.mod`](../peerpod-ctrl/go.mod) and the `csi-wrapper` [`go.mod`](../volumes/csi-wrapper/go.mod))
+
 The `CITATION.cff` needs to be updated with the dates from the release.
 
 ## Improvements

--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -56,7 +56,14 @@ These updates should be done in a PR that is merged triggering the cloud-api-ada
 
 As mentioned above we have some go submodules with dependencies in the cloud-api-adaptor repo, so in order to allow
 people to use `go get` on these submodules, we need to ensure we create tags for each of the go modules we have in
-the correct order. The process should go something like:
+the correct order.
+
+> [!IMPORTANT]\
+> After a tag has been set, it cannot be moved!
+> The Go module proxy caches the hash of the first tag and will refuse any update.
+> If you mess up, you need to restart the tagging with the next patch version.
+
+The process should go something like:
 - Create a tag for the main [go module](../go.mod) pointing to the latest commit (including the version updates just
 merged) with the name `v<version>-alpha.1` (e.g. `v0.7.0-alpha.1` for the confidential containers `0.7.0` release release candidate). This can be done by running:
     ```

--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -116,8 +116,16 @@ sed -i 's#\(github.com/confidential-containers/operator/config/default\)#\1?ref=
 sed -i 's#\(github.com/confidential-containers/operator/config/samples/ccruntime/peer-pods\)#\1?ref=v0.7.0#' Makefile
 ```
 
-Once this has been completed and merged in we run the latest release of the cloud-api-adaptor including the auto
-generated release notes.
+Once this has been completed and merged in we should pin the cloud-api-adaptor image used on the deployment files. You should use the commit SHA-1 of the last built `quay.io/confidentil-containers/cloud-api-image` image to update the overlays kustomization files. For example, suppose the release image is `quay.io/confidential-containers/cloud-api-adaptor:6d7d2a3fe8243809b3c3a710792c8498292e2fc3`:
+```
+cd install/overlays/
+for p in aws azure ibmcloud ibmcloud-powervs vsphere; do cd aws; kustomize edit set image cloud-api-adaptor=quay.io/confidential-containers/cloud-api-adaptor:6d7d2a3fe8243809b3c3a710792c8498292e2fc3; cd -; done
+
+# Note that the libvirt use the tag with prefix 'dev-'
+cd libvirt; kustomize edit set image cloud-api-adaptor=quay.io/confidential-containers/cloud-api-adaptor:dev-6d7d2a3fe8243809b3c3a710792c8498292e2fc3; cd -
+```
+
+After these version updates have been merged via new PR, we can run the latest release of the cloud-api-adaptor including the auto generated release notes.
 
 This will trigger the podvm builds to happen again and we should re-test the release code before updating the
 confidential-containers release team to let them know it has completed successfully
@@ -133,6 +141,12 @@ any local replace references, and be updated to use the release version of the `
 from in the `peerpod-ctrl` and `volumes/csi-wrapper` directories.
 
 The CoCo operator URLs on the [Makefile](../Makefile) should be reverted to use the latest version.
+
+The changes on the overlay kustomization files should be reverted to start using the latest cloud-api-adaptor images again:
+```
+cd install/overlays/
+for p in aws azure ibmcloud ibmcloud-powervs libvirt vsphere; do cd aws; kustomize edit set image cloud-api-adaptor=quay.io/confidential-containers/cloud-api-adaptor:latest; cd -; done
+```
 
 The `CITATION.cff` needs to be updated with the dates from the release.
 

--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -110,6 +110,12 @@ For the cloud-api-adaptor we need to wait until the Kata Containers release tag 
 to have been built. We then can repeat the steps done during the release candidate phase, but this time use the
 release tags of the project dependencies e.g. `v0.6.0` and creating the tags without the `-alpha.x` suffix.
 
+Also we need to wait until the [CoCo operator](https://github.com/confidential-containers/operator/) release tag has been create to pin the URLs used by the make `deploy` target to install the operator. So edit the [Makefile](../Makefile) to replace the *github.com/confidential-containers/operator/config/default* and *github.com/confidential-containers/operator/config/samples/ccruntime/peer-pods* URLs, e.g.:
+```
+sed -i 's#\(github.com/confidential-containers/operator/config/default\)#\1?ref=v0.7.0#' Makefile
+sed -i 's#\(github.com/confidential-containers/operator/config/samples/ccruntime/peer-pods\)#\1?ref=v0.7.0#' Makefile
+```
+
 Once this has been completed and merged in we run the latest release of the cloud-api-adaptor including the auto
 generated release notes.
 
@@ -125,6 +131,8 @@ any local replace references, and be updated to use the release version of the `
   go mod tidy
   ```
 from in the `peerpod-ctrl` and `volumes/csi-wrapper` directories.
+
+The CoCo operator URLs on the [Makefile](../Makefile) should be reverted to use the latest version.
 
 The `CITATION.cff` needs to be updated with the dates from the release.
 


### PR DESCRIPTION
Closes #1254

I've rebased Wainer's PR, resolved the conflicts and added the only outstanding change I requested in https://github.com/confidential-containers/cloud-api-adaptor/pull/1254#issuecomment-1659840822, so we can get this merged before the next release.

