### PR TITLE
podvm-mkosi: remove cloud-init

### DIFF
--- a/podvm-mkosi/README.md
+++ b/podvm-mkosi/README.md
@@ -65,5 +65,6 @@ Packages=
 The following limitations apply to these images. Notice that the limitations are intentional to
 reduce complexity of configuration and CI and shall not be seen as open to-dos.
 
-- `DISABLE_CLOUD_CONFIG=false` is implied. The mkosi images are currently using
-    cloud init/cloud config, and there is no possibility to disable it.
+- `DISABLE_CLOUD_CONFIG=true` is implied. The mkosi images are using
+    our own mechanism to fetch metadata from the IMDS API. Cloud init is not supported.
+    Ensure that `DISABLE_CLOUD_CONFIG=true` in your `install/overlay/${CSP}/kustomization.yaml`.

--- a/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-debug.conf
+++ b/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-debug.conf
@@ -15,3 +15,6 @@ Packages=
     strace
     openssh-server
     file
+    iputils
+    curl
+    wget

--- a/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora.conf
+++ b/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora.conf
@@ -22,4 +22,4 @@ Packages=
     tpm2-tools
     iproute
     iptables
-    cloud-init
+    afterburn

--- a/podvm-mkosi/mkosi.skeleton/etc/systemd/system/process-user-data.service.d/10-override.conf
+++ b/podvm-mkosi/mkosi.skeleton/etc/systemd/system/process-user-data.service.d/10-override.conf
@@ -1,8 +1,0 @@
-# DISABLE_CLOUD_CONFIG=false is required.
-# Add cloud-init.target as a dependency for process-user-data.service so that
-# required files via cloud-config are available before kata-agent starts
-[Unit]
-After=cloud-config.service
-
-[Service]
-ExecStartPre=

--- a/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system-preset/20-coco-sys.preset
+++ b/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system-preset/20-coco-sys.preset
@@ -1,10 +1,7 @@
 enable systemd-networkd.service
 enable systemd-resolved.service
 enable dbus.service
-enable cloud-init.service
-enable cloud-final.service
-enable cloud-init-hotplugd.service
-enable cloud-init-local.service
+enable afterburn-checkin.service
 
 # For debug images.
 # This units are not part of the production image.

--- a/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system/afterburn-checkin.service.d/10-override.conf
+++ b/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system/afterburn-checkin.service.d/10-override.conf
@@ -1,0 +1,8 @@
+# As our image is generic, we don't set the cloud provider on the kernel command line.
+# Instead, we always run the unit, even if it is only needed on Azure right now.
+[Unit]
+ConditionKernelCommandLine=
+
+[Service]
+ExecStart=
+ExecStart=-/usr/bin/afterburn --provider=azure --check-in


### PR DESCRIPTION
This is based on #1524, which should be reviewed and merged first.

Fixes #1467 (for x86, we should check with the IBM folks if they want to remove cloud init for s390x as well)

This requires `DISABLE_CLOUD_CONFIG=true` in your `install/overlay/${CSP}/kustomization.yaml`