### PR TITLE
e2e/test: improve TestCaaDaemonsetRollingUpdate

### DIFF
--- a/test/e2e/ibmcloud_test.go
+++ b/test/e2e/ibmcloud_test.go
@@ -547,12 +547,17 @@ func (c *IBMRollingUpdateAssert) VerifyOldVmDeleted(t *testing.T) {
 		options := &vpcv1.GetInstanceOptions{
 			ID: &id,
 		}
-		_, _, err := c.vpc.GetInstance(options)
+		in, _, err := c.vpc.GetInstance(options)
 
 		if err != nil {
 			log.Printf("Instance %s has been deleted: %v", id, err)
 		} else {
-			t.Fatalf("Instance %s still exists", id)
+			if *in.Status == "deleting" {
+				log.Printf("Instance %s is being deleting", id)
+			} else {
+				log.Printf("Instance %s current status: %s", id, *in.Status)
+				t.Fatalf("Instance %s still exists", id)
+			}
 		}
 	}
 }


### PR DESCRIPTION
* replace nginx image with python image, because it's not stable to create a peerpod with nginx image (#1450)
* wait for CAA DaemonSet updated before assess
* refine "VerifyOldVmDeleted", if old instance exists, check if status is "deleting"