### PR TITLE
e2e/test: Use multi-arch images in quay for update test

### DIFF
--- a/test/e2e/rolling_update_test.go
+++ b/test/e2e/rolling_update_test.go
@@ -43,7 +43,7 @@ func doTestCaaDaemonsetRollingUpdate(t *testing.T, assert RollingUpdateAssert) {
 	}
 	verifyPodName := "verify-pod"
 	verifyContainerName := "verify-container"
-	verifyImageName := "radial/busyboxplus:curl"
+	verifyImageName := "quay.io/curl/curl:latest"
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Use "quay.io/curl/curl:latest" that supports multi-arch images: https://quay.io/repository/curl/curl?tab=tags