### PR TITLE
Misc CVM fixes for AWS

### DIFF
--- a/aws/raw-to-ami.sh
+++ b/aws/raw-to-ami.sh
@@ -158,11 +158,11 @@ register_image() {
     "Description": "Peer-pod image",
     "RootDeviceName": "/dev/xvda",
     "VirtualizationType": "hvm",
-    "EnaSupport": true
+    "EnaSupport": true,
+    "BootMode": "uefi"
 }
 EOF
-
-	AMI_ID=$(aws ec2 register-image --name ${AMI_NAME} --cli-input-json="file://${AMI_REGISTER_JSON_FILE}" --output json --region ${REGION} | jq -r '.ImageId')
+	AMI_ID=$(aws ec2 register-image --name ${AMI_NAME} --cli-input-json="file://${AMI_REGISTER_JSON_FILE}" --tpm-support v2.0 --output json --region ${REGION} | jq -r '.ImageId')
 	echo "AMI name: ${AMI_NAME}"
 	echo "AMI ID: ${AMI_ID}"
 }

--- a/pkg/adaptor/cloud/aws/manager.go
+++ b/pkg/adaptor/cloud/aws/manager.go
@@ -34,9 +34,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	// Add a parameter to indicate the root volume size for the Pod VMs
 	// Default is 30GiBs for free tier. Hence use it as default
 	flags.IntVar(&awscfg.RootVolumeSize, "root-volume-size", 30, "Root volume size (in GiB) for the Pod VMs")
-	// Setting disable-cvm to true as there are still some rough edges with CVMs.
-	// Once the issues are fixed, we can set it to false by default
-	flags.BoolVar(&awscfg.DisableCVM, "disable-cvm", true, "Use non-CVMs for peer pods")
+	flags.BoolVar(&awscfg.DisableCVM, "disable-cvm", false, "Use non-CVMs for peer pods")
 	// Add a flag to disable cloud config and use userdata via metadata service
 	flags.BoolVar(&awscfg.DisableCloudConfig, "disable-cloud-config", false, "Disable cloud config and use userdata via metadata service")
 

--- a/pkg/adaptor/cloud/aws/manager_test.go
+++ b/pkg/adaptor/cloud/aws/manager_test.go
@@ -33,7 +33,7 @@ func TestManager_ParseCmd(t *testing.T) {
 				"-instance-types=t2.micro,t3.small",
 				"-tags=key1=value1,key2=value2",
 				"-root-volume-size=60",
-				"-disable-cvm=true",
+				"-disable-cvm=false",
 			},
 			expected: Config{
 				AccessKeyId:        "test-access-key",
@@ -51,7 +51,7 @@ func TestManager_ParseCmd(t *testing.T) {
 				Tags:               map[string]string{"key1": "value1", "key2": "value2"},
 				UsePublicIP:        true,
 				RootVolumeSize:     60,
-				DisableCVM:         true,
+				DisableCVM:         false,
 			},
 		},
 		{
@@ -73,7 +73,7 @@ func TestManager_ParseCmd(t *testing.T) {
 				Tags:               nil,
 				UsePublicIP:        false,
 				RootVolumeSize:     30,
-				DisableCVM:         true,
+				DisableCVM:         false,
 			},
 		},
 	}


### PR DESCRIPTION
1. Add uefi support when registering AMI created from raw image. This is tested with mkosi fedora image
2. Adjust disable-cvm option to align with other providers