### PR TITLE
caa: cross-compile for release images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ ARG BUILD_TYPE=dev
 ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.20.8-36
 ARG BASE=registry.fedoraproject.org/fedora:38
 
-FROM --platform=$TARGETPLATFORM $BUILDER_BASE as builder-release
+FROM --platform=$BUILDPLATFORM $BUILDER_BASE as builder-release
+FROM --platform=$TARGETPLATFORM $BUILDER_BASE as builder-dev
 
-FROM builder-release as builder-dev
 RUN dnf install -y libvirt-devel && dnf clean all
 
 FROM builder-${BUILD_TYPE} AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,14 @@ ARG BUILD_TYPE=dev
 ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.20.8-36
 ARG BASE=registry.fedoraproject.org/fedora:38
 
+# This dockerfile uses Go cross-compilation to build the binary,
+# we build on the host platform ($BUILDPLATFORM) and then copy the
+# binary into the container image of the target platform ($TARGETPLATFORM)
+# that was specified with --platform. For more details see:
+# https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
 FROM --platform=$BUILDPLATFORM $BUILDER_BASE as builder-release
+# For `dev` builds due to CGO constraints we have to emulate the target platform
+# instead of using Go's cross-compilation
 FROM --platform=$TARGETPLATFORM $BUILDER_BASE as builder-dev
 
 RUN dnf install -y libvirt-devel && dnf clean all


### PR DESCRIPTION
Save some computation by using cross-compiliation vs. emulation when we don't need CGO.

Testing building s390x release/dev image (exact timings don't matter but shows clear improvement).

```
RELEASE_BUILD=true ARCHES="linux/s390x" make image-with-arch 
 => [builder 9/9] RUN CC=gcc make ARCH=s390x COMMIT=dcb7b651d6f7b5f348c3930dcc28dd52c248  32.7s

RELEASE_BUILD=false ARCHES="linux/s390x" make image-with-arch 
 => [builder 9/9] RUN CC=gcc make ARCH=s390x COMMIT=dcb7b651d6f7b5f348c3930dcc28dd52c24  380.4s
 ```
 
 Roughly 10x improvement for the release image vs dev image. 