### PR TITLE
Add nydus-snapshotter enablement and verification

### DIFF
--- a/test/e2e/assessment_runner_test.go
+++ b/test/e2e/assessment_runner_test.go
@@ -55,6 +55,7 @@ type testCase struct {
 	AuthImageStatus      string
 	deletionWithin       *time.Duration
 	testInstanceTypes    instanceValidatorFunctions
+	isNydusSnapshotter   bool
 }
 
 func (tc *testCase) withConfigMap(configMap *v1.ConfigMap) *testCase {
@@ -119,6 +120,11 @@ func (tc *testCase) withAuthenticatedImage() *testCase {
 
 func (tc *testCase) withAuthImageStatus(status string) *testCase {
 	tc.AuthImageStatus = status
+	return tc
+}
+
+func (tc *testCase) withNydusSnapshotter() *testCase {
+	tc.isNydusSnapshotter = true
 	return tc
 }
 
@@ -322,6 +328,16 @@ func (tc *testCase) run() {
 					}
 
 					tc.assert.HasPodVM(t, tc.pod.Name)
+				}
+
+				if tc.isNydusSnapshotter {
+					usedNydusSnapshotter, err := IsPulledWithNydusSnapshotter(ctx, t, client)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !usedNydusSnapshotter {
+						t.Fatal("Expected to pull with nydus, but that didn't happen")
+					}
 				}
 			}
 			return ctx

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -88,8 +88,11 @@ func withAnnotations(data map[string]string) podOption {
 
 func newPod(namespace string, podName string, containerName string, imageName string, options ...podOption) *corev1.Pod {
 	runtimeClassName := "kata-remote"
+	annotationData := map[string]string{
+		"io.containerd.cri.runtime-handler": runtimeClassName,
+	}
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: namespace, Annotations: annotationData},
 		Spec: corev1.PodSpec{
 			Containers:       []corev1.Container{{Name: containerName, Image: imageName, ImagePullPolicy: corev1.PullAlways}},
 			RuntimeClassName: &runtimeClassName,
@@ -135,12 +138,16 @@ func newSecret(namespace string, name string, data map[string][]byte, secretType
 // newJob returns a new job
 func newJob(namespace string, name string) *batchv1.Job {
 	runtimeClassName := "kata-remote"
+	annotationData := map[string]string{
+		"io.containerd.cri.runtime-handler": runtimeClassName,
+	}
 	BackoffLimit := int32(8)
 	TerminateGracePeriod := int64(0)
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotationData,
 		},
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{

--- a/test/e2e/common_suite_test.go
+++ b/test/e2e/common_suite_test.go
@@ -22,7 +22,7 @@ import (
 func doTestCreateSimplePod(t *testing.T, assert CloudAssert) {
 	namespace := envconf.RandomName("default", 7)
 	pod := newNginxPod(namespace)
-	newTestCase(t, "SimplePeerPod", assert, "PodVM is created").withPod(pod).run()
+	newTestCase(t, "SimplePeerPod", assert, "PodVM is created").withPod(pod).withNydusSnapshotter().run()
 }
 
 func doTestDeleteSimplePod(t *testing.T, assert CloudAssert) {


### PR DESCRIPTION
- Add io.containerd.cri.runtime-handler annotation
to pods and jobs, so that the nydus-snapshotter can be picked
up by containerd if configured
- Add a new function to check the CAA logs
for messages to indicate if nydus-snapshotter
was used to pull the image in the peer pod

Note: this only enables things for the simple pod test, we might want to roll it out to all of the tests?