### PR TITLE
tests/e2e_libvirt: install yq

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Read properties from versions.yaml
         run: |
+          sudo snap install yq
           go_version="$(yq '.tools.golang' versions.yaml)"
           [ -n "$go_version" ]
           echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"


### PR DESCRIPTION
On commit 662d96b27d02 the workflow changed to get Go from versions.yaml but yq is not installed so it fails.