### PR TITLE
Release 0.8.0-rc1 - update dependencies

### DIFF
--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -20,8 +20,8 @@ confidential-containers projects are updated and that Kata Containers is updated
 image is updated, the operator is updated and the tests pass with all of these.
 
 At this point, we should update the cloud-api-adaptor versions to use these release candidate versions of:
-- The kata-containers source branch that we use in the [podvm_builder `Dockerfiles`](../podvm/) and the
-[`podvm_builder.yaml` workflow](../.github/workflows/podvm_builder.yaml), by updating the `KATA_SRC_BRANCH` value to
+- The kata-containers source branch that we use in the [podvm `Dockerfiles`](../podvm/) and the
+[podvm workflows](../.github/workflows), by updating the `git.kata-containers.reference` value in [versions.yaml](../versions.yaml) to
 the tag of the kata-containers release candidate.
 - The `kata-containers/src/runtime` go module that we include in the main `cloud-api-adaptor` [`go.mod`](../go.mod),
 the `peerpod-ctl` [`go.mod`](../peerpod-ctrl/go.mod) and the `csi-wrapper` [`go.mod`](../volumes/csi-wrapper/go.mod).
@@ -39,12 +39,7 @@ avoid compilation errors. This can be done by running:
 > go mod tidy
 > ```
 > from in the `peerpod-ctrl` and `volumes/csi-wrapper` directories.
-- The attestation-agent that is built into the peer pod vm image, by updating the `GUEST_COMPONENTS_VERSION` in
-  - [`Makefile.inc`](../podvm/Makefile.inc)
-  - [Dockerfile.podvm_binaries](../podvm/Dockerfile.podvm_binaries)
-  - [Dockerfile.podvm_binaries.centos](../podvm/Dockerfile.podvm_binaries.centos)
-  - [Dockerfile.podvm_binaries.rhel](../podvm/Dockerfile.podvm_binaries.rhel)
-  - [versions.yaml](../versions.yaml)
+- The attestation-agent that is built into the peer pod vm image, by updating the `git.guest-components.reference` value in [versions.yaml](../versions.yaml)
 
 Currently there isn't automation to build the podvm images at this phase. They should be built manually to ensure they don't break.
 

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.38.5
 	github.com/confidential-containers/cloud-api-adaptor/peerpod-ctrl v0.0.0-20230329054732-0d6eda047e81
 	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
-	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20230721195217-16d6e37196cb
+	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20231031090015-424de1cbfa4e
 	github.com/kdomanski/iso9660 v0.3.5
 	github.com/moby/sys/mountinfo v0.6.2
 	github.com/pelletier/go-toml/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -1211,8 +1211,8 @@ github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaR
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/karrick/godirwalk v1.15.3/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20230721195217-16d6e37196cb h1:XpcSeQWRQeGqV38RvxB6ulEHpBkH9DlkCTMnA0ALm2c=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20230721195217-16d6e37196cb/go.mod h1:4i+EBdCeAg34WOxQMjiJ9e7ZtwtI7C5ZSK4tg70hoeE=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20231031090015-424de1cbfa4e h1:46qLLHhDvJ1/SMT+QCztYnHllue7Rn87SSMtnC+nS+w=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20231031090015-424de1cbfa4e/go.mod h1:4i+EBdCeAg34WOxQMjiJ9e7ZtwtI7C5ZSK4tg70hoeE=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kdomanski/iso9660 v0.3.5 h1:LO1n75zPjLeDQkz0Pyk1eZ7JGinjKjk2C174GSABVwY=
 github.com/kdomanski/iso9660 v0.3.5/go.mod h1:K+UlIGxKgtrdAWyoigPnFbeQLVs/Xudz4iztWFThBwo=

--- a/peerpod-ctrl/go.mod
+++ b/peerpod-ctrl/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20230721195217-16d6e37196cb // indirect
+	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20231031090015-424de1cbfa4e // indirect
 	github.com/kdomanski/iso9660 v0.3.5 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect

--- a/peerpod-ctrl/go.sum
+++ b/peerpod-ctrl/go.sum
@@ -1180,8 +1180,8 @@ github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaR
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/karrick/godirwalk v1.15.3/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20230721195217-16d6e37196cb h1:XpcSeQWRQeGqV38RvxB6ulEHpBkH9DlkCTMnA0ALm2c=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20230721195217-16d6e37196cb/go.mod h1:4i+EBdCeAg34WOxQMjiJ9e7ZtwtI7C5ZSK4tg70hoeE=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20231031090015-424de1cbfa4e h1:46qLLHhDvJ1/SMT+QCztYnHllue7Rn87SSMtnC+nS+w=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20231031090015-424de1cbfa4e/go.mod h1:4i+EBdCeAg34WOxQMjiJ9e7ZtwtI7C5ZSK4tg70hoeE=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kdomanski/iso9660 v0.3.5 h1:LO1n75zPjLeDQkz0Pyk1eZ7JGinjKjk2C174GSABVwY=
 github.com/kdomanski/iso9660 v0.3.5/go.mod h1:K+UlIGxKgtrdAWyoigPnFbeQLVs/Xudz4iztWFThBwo=

--- a/versions.yaml
+++ b/versions.yaml
@@ -31,7 +31,7 @@ git:
     reference: ebceb0c52ddd9fbd4cc3ac10133bec2ab7ea5795
   kata-containers:
     url: https://github.com/kata-containers/kata-containers
-    reference: CCv0
+    reference: 424de1cbfa4e1da9ecf9a56b1d1e1a11a4f339cd
   umoci:
     url: https://github.com/opencontainers/umoci
     reference: v0.4.7

--- a/versions.yaml
+++ b/versions.yaml
@@ -28,7 +28,7 @@ tools:
 git:
   guest-components:
     url: https://github.com/confidential-containers/guest-components
-    reference: ebceb0c52ddd9fbd4cc3ac10133bec2ab7ea5795
+    reference: 615a46ff16ee8670014946d14e44e85cede82f01
   kata-containers:
     url: https://github.com/kata-containers/kata-containers
     reference: 424de1cbfa4e1da9ecf9a56b1d1e1a11a4f339cd

--- a/volumes/csi-wrapper/go.mod
+++ b/volumes/csi-wrapper/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang/glog v1.1.0
 	github.com/golang/protobuf v1.5.3
-	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20230721195217-16d6e37196cb
+	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20231031090015-424de1cbfa4e
 	golang.org/x/net v0.9.0
 	google.golang.org/grpc v1.56.3
 	k8s.io/apimachinery v0.26.0

--- a/volumes/csi-wrapper/go.sum
+++ b/volumes/csi-wrapper/go.sum
@@ -65,8 +65,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20230721195217-16d6e37196cb h1:XpcSeQWRQeGqV38RvxB6ulEHpBkH9DlkCTMnA0ALm2c=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20230721195217-16d6e37196cb/go.mod h1:4i+EBdCeAg34WOxQMjiJ9e7ZtwtI7C5ZSK4tg70hoeE=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20231031090015-424de1cbfa4e h1:46qLLHhDvJ1/SMT+QCztYnHllue7Rn87SSMtnC+nS+w=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20231031090015-424de1cbfa4e/go.mod h1:4i+EBdCeAg34WOxQMjiJ9e7ZtwtI7C5ZSK4tg70hoeE=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
Beginning the [release candidate testing](https://github.com/confidential-containers/cloud-api-adaptor/blob/main/docs/Release-Process.md#release-candidate-testing) phase for the release 0.8.0.

* Updated kata-containers/runtime to commit 424de1cbfa4e1da9ecf9a56b1d1e1a11a4f339cd which is the actual payload reference on CoCo's operator.
 
* Updated guest-components to commit 615a46ff16ee8670014946d14e44e85cede82f01 (same commit pinned on kata's 424de1cbfa4e1da9ecf9a56b1d1e1a11a4f339cd)