### PR TITLE
Fix workflow podvm builds

### DIFF
--- a/.github/workflows/podvm.yaml
+++ b/.github/workflows/podvm.yaml
@@ -18,9 +18,7 @@ jobs:
         provider: [generic, vsphere]
         include:
           - os: centos
-            dockerfile: Dockerfile.podvm.centos
           - os: ubuntu
-            dockerfile: Dockerfile.podvm
         exclude:
           - os: centos
             arch: s390x
@@ -31,9 +29,6 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
-
-    #- name: Set up QEMU
-    #  uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
@@ -46,19 +41,8 @@ jobs:
         password: ${{ secrets.QUAY_PASSWORD }}
 
     - name: Build and push
-      uses: docker/build-push-action@v3
-      with:
-        tags: |
-          quay.io/confidential-containers/podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ matrix.arch }}:latest
-          quay.io/confidential-containers/podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ matrix.arch }}:${{ github.sha }}
-        push: true
-        context: podvm
-        platforms: linux/amd64
-        file: |
-          podvm/${{ matrix.dockerfile }}
-        build-args: |
-          "CLOUD_PROVIDER=${{ matrix.provider }}"
-          "ARCH=${{ matrix.arch }}"
-          "UBUNTU_IMAGE_URL="
-          "UBUNTU_IMAGE_CHECKSUM="
-          "BINARIES_IMG=quay.io/confidential-containers/podvm-binaries-${{ matrix.os }}-${{ matrix.arch }}"
+      run: make podvm-image
+      env:
+        PUSH: true
+        ARCH: ${{ matrix.arch }}
+        PODVM_DISTRO: ${{ matrix.os }}

--- a/.github/workflows/podvm.yaml
+++ b/.github/workflows/podvm.yaml
@@ -46,3 +46,4 @@ jobs:
         PUSH: true
         ARCH: ${{ matrix.arch }}
         PODVM_DISTRO: ${{ matrix.os }}
+        CLOUD_PROVIDER: ${{ matrix.provider }}

--- a/.github/workflows/podvm_binaries.yaml
+++ b/.github/workflows/podvm_binaries.yaml
@@ -17,18 +17,13 @@ jobs:
         arch: [amd64, s390x]
         include:
           - os: centos
-            dockerfile: Dockerfile.podvm_binaries.centos
           - os: ubuntu
-            dockerfile: Dockerfile.podvm_binaries
         exclude:
           - os: centos
             arch: s390x
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
-
-    #- name: Set up QEMU
-    #  uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
@@ -48,17 +43,8 @@ jobs:
         password: ${{ secrets.QUAY_PASSWORD }}
 
     - name: Build and push
-      uses: docker/build-push-action@v3
-      with:
-        tags: |
-          quay.io/confidential-containers/podvm-binaries-${{ matrix.os }}-${{ matrix.arch }}:latest
-          quay.io/confidential-containers/podvm-binaries-${{ matrix.os }}-${{ matrix.arch }}:${{ github.sha }}
-        push: true
-        context: podvm
-        platforms: linux/amd64
-        file: |
-          podvm/${{ matrix.dockerfile }}
-        build-args: |
-          "ARCH=${{ matrix.arch }}"
-          "UBUNTU_IMAGE_URL="
-          "UBUNTU_IMAGE_CHECKSUM="
+      run: make podvm-binaries
+      env:
+          PUSH: true
+          ARCH: ${{ matrix.arch }}
+          PODVM_DISTRO: ${{ matrix.os }}

--- a/.github/workflows/podvm_builder.yaml
+++ b/.github/workflows/podvm_builder.yaml
@@ -14,49 +14,11 @@ jobs:
           # Please keep this list in alphabetical order.
           - centos
           - ubuntu
-        include:
-          - os: centos
-            dockerfile: Dockerfile.podvm_builder.centos
-          - os: ubuntu
-            dockerfile: Dockerfile.podvm_builder
         runner:
           - ubuntu-latest
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
-
-    - name: Read properties from versions.yaml
-      run: |
-        go_version="$(yq '.tools.golang' versions.yaml)"
-        [ -n "$go_version" ]
-        echo "GO_VERSION=${go_version}" >> $GITHUB_ENV
-
-        protoc_version="$(yq '.tools.protoc' versions.yaml)"
-        [ -n "$protoc_version" ]
-        echo "PROTOC_VERSION=${protoc_version}" >> $GITHUB_ENV
-
-        rust_version="$(yq '.tools.rust' versions.yaml)"
-        [ -n "$rust_version" ]
-        echo "RUST_VERSION=${rust_version}" >> $GITHUB_ENV
-
-        caa_src="$(yq '.git.cloud-api-adaptor.url' versions.yaml)"
-        [ -n "$caa_src" ]
-        echo "CAA_SRC=${caa_src}" >> $GITHUB_ENV
-
-        caa_src_ref="$(yq '.git.cloud-api-adaptor.reference' versions.yaml)"
-        [ -n "$caa_src_ref" ]
-        echo "CAA_SRC_REF=${caa_src_ref}" >> $GITHUB_ENV
-
-        kata_src="$(yq '.git.kata-containers.url' versions.yaml)"
-        [ -n "$kata_src" ]
-        echo "KATA_SRC=${kata_src}" >> $GITHUB_ENV
-
-        kata_src_branch="$(yq '.git.kata-containers.reference' versions.yaml)"
-        [ "$kata_src_branch" ]
-        echo "KATA_SRC_BRANCH=${kata_src_branch}" >> $GITHUB_ENV
-
-    #- name: Set up QEMU
-    #  uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
@@ -76,21 +38,7 @@ jobs:
         password: ${{ secrets.QUAY_PASSWORD }}
 
     - name: Build and push
-      uses: docker/build-push-action@v3
-      with:
-        tags: |
-          quay.io/confidential-containers/podvm-builder-${{ matrix.os }}:latest
-          quay.io/confidential-containers/podvm-builder-${{ matrix.os }}:${{ github.sha }}
-        push: true
-        context: podvm
-        platforms: linux/amd64
-        file: |
-          podvm/${{ matrix.dockerfile }}
-        build-args: |
-          "GO_VERSION=${{ env.GO_VERSION }}"
-          "PROTOC_VERSION=${{ env.PROTOC_VERSION }}"
-          "RUST_VERSION=${{ env.RUST_VERSION }}"
-          "CAA_SRC=${{ env.CAA_SRC }}"
-          "CAA_SRC_REF=${{ env.CAA_SRC_REF }}"
-          "KATA_SRC=${{ env.KATA_SRC }}"
-          "KATA_SRC_BRANCH=${{ env.KATA_SRC_BRANCH }}"
+      run: make podvm-builder
+      env:
+          PUSH: true
+          PODVM_DISTRO: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -197,9 +197,8 @@ PODVM_BINARIES_IMAGE ?= $(REGISTRY)/podvm-binaries-$(PODVM_DISTRO)-$(ARCH):$(VER
 PODVM_IMAGE ?= $(REGISTRY)/podvm-$(PODVM_DISTRO)-$(ARCH):$(VERSIONS_HASH)
 
 PUSH ?= false
-# Always import (--load) the image into the local docker images for use in future
-# steps, otherwise it just stays in the builder cache
-DOCKER_OPTS := --load $(if $(filter $(PUSH),true),--push) $(EXTRA_DOCKER_OPTS)
+# If not pushing `--load` into the local docker cache
+DOCKER_OPTS := $(if $(filter $(PUSH),true),--push,--load) $(EXTRA_DOCKER_OPTS)
 
 DOCKERFILE_SUFFIX := $(if $(filter $(PODVM_DISTRO),ubuntu),,.$(PODVM_DISTRO))
 BUILDER_DOCKERFILE := Dockerfile.podvm_builder$(DOCKERFILE_SUFFIX)

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ PODVM_DISTRO ?= ubuntu
 
 PODVM_BUILDER_IMAGE ?= $(REGISTRY)/podvm-builder-$(PODVM_DISTRO):$(VERSIONS_HASH)
 PODVM_BINARIES_IMAGE ?= $(REGISTRY)/podvm-binaries-$(PODVM_DISTRO)-$(ARCH):$(VERSIONS_HASH)
-PODVM_IMAGE ?= $(REGISTRY)/podvm-$(PODVM_DISTRO)-$(ARCH):$(VERSIONS_HASH)
+PODVM_IMAGE ?= $(REGISTRY)/podvm-$(or $(CLOUD_PROVIDER),generic)-$(PODVM_DISTRO)-$(ARCH):$(VERSIONS_HASH)
 
 PUSH ?= false
 # If not pushing `--load` into the local docker cache
@@ -228,4 +228,5 @@ podvm-image:
 	--build-arg BINARIES_IMG=$(PODVM_BINARIES_IMAGE) \
 	--build-arg PODVM_DISTRO=$(PODVM_DISTRO) \
 	--build-arg ARCH=$(ARCH) \
+	--build-arg CLOUD_PROVIDER=$(or $(CLOUD_PROVIDER),generic) \
 	$(DOCKER_OPTS) .

--- a/podvm/Dockerfile.podvm.centos
+++ b/podvm/Dockerfile.podvm.centos
@@ -48,7 +48,7 @@ RUN tar xvf /src/cloud-api-adaptor/podvm/files/pause-bundle.tar.gz -C /src/cloud
 COPY . /src/cloud-api-adaptor
 
 RUN cd cloud-api-adaptor/podvm && \
-     make image
+    LIBC=gnu make image
 
 # The below instructions can be used if you prefer to rebuild all the binaries
 #RUN cd cloud-api-adaptor/podvm && \

--- a/podvm/Dockerfile.podvm.centos
+++ b/podvm/Dockerfile.podvm.centos
@@ -26,16 +26,6 @@ ENV PODVM_DISTRO ${PODVM_DISTRO}
 ENV ARCH ${ARCH}
 ENV UEFI ${UEFI}
 
-RUN if [ -n "${CAA_SRC}" ]; then \
-       rm -rf cloud-api-adaptor && \
-       git clone ${CAA_SRC} cloud-api-adaptor;\
-     fi && \
-     if [ -n "${CAA_SRC_REF}" ]; then \
-       cd cloud-api-adaptor && \
-       git fetch origin ${CAA_SRC_REF} && \
-       git checkout FETCH_HEAD -b ${CAA_SRC_REF} ;\
-     fi
-
 # Defaults to CentOS 8-stream x86_64 image. These variables can be overriden as needed
 ARG IMAGE_URL=
 ARG IMAGE_CHECKSUM=
@@ -48,15 +38,17 @@ ENV IMAGE_CHECKSUM ${IMAGE_CHECKSUM}
 ENV PATH="/usr/bin:${PATH}"
 
 # Copy the binaries to podvm/files folder
-COPY --from=podvm_binaries /podvm-binaries.tar.gz /src/cloud-api-adaptor/podvm/files
+COPY --from=podvm_binaries /podvm-binaries.tar.gz /src/cloud-api-adaptor/podvm/files/podvm-binaries.tar.gz
 RUN tar xvf /src/cloud-api-adaptor/podvm/files/podvm-binaries.tar.gz -C /src/cloud-api-adaptor/podvm/files
 
 # Copy the pause_bundle to podvm/files folder
-COPY --from=podvm_binaries /pause-bundle.tar.gz /src/cloud-api-adaptor/podvm/files
+COPY --from=podvm_binaries /pause-bundle.tar.gz /src/cloud-api-adaptor/podvm/files/pause-bundle.tar.gz
 RUN tar xvf /src/cloud-api-adaptor/podvm/files/pause-bundle.tar.gz -C /src/cloud-api-adaptor/podvm/files
 
+COPY . /src/cloud-api-adaptor
+
 RUN cd cloud-api-adaptor/podvm && \
-     make BINARIES=  PAUSE_BUNDLE= image
+     make image
 
 # The below instructions can be used if you prefer to rebuild all the binaries
 #RUN cd cloud-api-adaptor/podvm && \

--- a/podvm/Dockerfile.podvm.rhel
+++ b/podvm/Dockerfile.podvm.rhel
@@ -24,16 +24,6 @@ ENV PODVM_DISTRO ${PODVM_DISTRO}
 ENV ARCH ${ARCH}
 ENV UEFI ${UEFI}
 
-RUN if [ -n "${CAA_SRC}" ]; then \
-       rm -rf cloud-api-adaptor && \
-       git clone ${CAA_SRC} cloud-api-adaptor;\
-     fi && \
-     if [ -n "${CAA_SRC_REF}" ]; then \
-       cd cloud-api-adaptor && \
-       git fetch origin ${CAA_SRC_REF} && \
-       git checkout FETCH_HEAD -b ${CAA_SRC_REF} ;\
-     fi
-
 ARG IMAGE_URL="/tmp/rhel.qcow2"
 ARG IMAGE_CHECKSUM
 
@@ -45,15 +35,17 @@ ENV IMAGE_CHECKSUM ${IMAGE_CHECKSUM}
 ENV PATH="/usr/bin:${PATH}"
 
 # Copy the binaries to podvm/files folder
-COPY --from=podvm_binaries /podvm-binaries.tar.gz /src/cloud-api-adaptor/podvm/files
+COPY --from=podvm_binaries /podvm-binaries.tar.gz /src/cloud-api-adaptor/podvm/files/podvm-binaries.tar.gz
 RUN tar xvf /src/cloud-api-adaptor/podvm/files/podvm-binaries.tar.gz -C /src/cloud-api-adaptor/podvm/files
 
 # Copy the pause_bundle to podvm/files folder
-COPY --from=podvm_binaries /pause-bundle.tar.gz /src/cloud-api-adaptor/podvm/files
+COPY --from=podvm_binaries /pause-bundle.tar.gz /src/cloud-api-adaptor/podvm/files/pause-bundle.tar.gz
 RUN tar xvf /src/cloud-api-adaptor/podvm/files/pause-bundle.tar.gz -C /src/cloud-api-adaptor/podvm/files
 
+COPY . /src/cloud-api-adaptor
+
 RUN cd cloud-api-adaptor/podvm && \
-     make BINARIES= PAUSE_BUNDLE= image
+     make image
 
 # The below instructions can be used if you prefer to rebuild all the binaries
 #RUN cd cloud-api-adaptor/podvm && \

--- a/podvm/Dockerfile.podvm.rhel
+++ b/podvm/Dockerfile.podvm.rhel
@@ -45,7 +45,7 @@ RUN tar xvf /src/cloud-api-adaptor/podvm/files/pause-bundle.tar.gz -C /src/cloud
 COPY . /src/cloud-api-adaptor
 
 RUN cd cloud-api-adaptor/podvm && \
-     make image
+    LIBC=gnu make image
 
 # The below instructions can be used if you prefer to rebuild all the binaries
 #RUN cd cloud-api-adaptor/podvm && \

--- a/podvm/Makefile.inc
+++ b/podvm/Makefile.inc
@@ -156,12 +156,12 @@ $(ATTESTATION_AGENT): $(FORCE_TARGET) | $(GUEST_COMPONENTS_SRC)
 	mkdir -p "$(@D)"
 	install --compare "$(GUEST_COMPONENTS_SRC)/target/$(RUST_TARGET)/release/attestation-agent" "$@"
 
-$(CONFIDENTIAL_DATA_HUB): $(GUEST_COMPONENTS_SRC)
+$(CONFIDENTIAL_DATA_HUB): $(FORCE_TARGET) | $(GUEST_COMPONENTS_SRC)
 	cd "$(GUEST_COMPONENTS_SRC)/confidential-data-hub" && CC= ARCH=$(ARCH) $(MAKE) RESOURCE_PROVIDER="$(CDH_RESOURCE_PROVIDER)" LIBC="$(LIBC)"
 	mkdir -p "$(@D)"
 	install --compare "$(GUEST_COMPONENTS_SRC)/target/$(RUST_TARGET)/release/confidential-data-hub" "$@"
 
-$(API_SERVER_REST): $(GUEST_COMPONENTS_SRC)
+$(API_SERVER_REST): $(FORCE_TARGET) | $(GUEST_COMPONENTS_SRC)
 	cd "$(GUEST_COMPONENTS_SRC)/api-server-rest" && CC= ARCH=$(ARCH) $(MAKE) LIBC="$(LIBC)"
 	mkdir -p "$(@D)"
 	install --compare "$(GUEST_COMPONENTS_SRC)/target/$(RUST_TARGET)/release/api-server-rest" "$@"


### PR DESCRIPTION
I've run tests for creating the builders using act.

Still running through the rest but it is a slow process. 

- Using the make targets for the steps, so that is grabs the versions 
- Added back in the cloud-provider specific image builds for the vsphere build
- Minor clean up of the workflow