### PR TITLE
V0.8.0 alpha.1 caa tag updates

### DIFF
--- a/peerpod-ctrl/go.mod
+++ b/peerpod-ctrl/go.mod
@@ -3,7 +3,7 @@ module github.com/confidential-containers/cloud-api-adaptor/peerpod-ctrl
 go 1.20
 
 require (
-	github.com/confidential-containers/cloud-api-adaptor v0.7.1-0.20230928070042-349e42984339
+	github.com/confidential-containers/cloud-api-adaptor v0.8.0-alpha.1
 	github.com/onsi/ginkgo/v2 v2.8.1
 	github.com/onsi/gomega v1.27.1
 	k8s.io/api v0.26.0

--- a/peerpod-ctrl/go.sum
+++ b/peerpod-ctrl/go.sum
@@ -326,8 +326,8 @@ github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/confidential-containers/cloud-api-adaptor v0.7.1-0.20230928070042-349e42984339 h1:XSWnRpSNXju7bksvxWA2uCICKqik33onzZVTsxSxQx4=
-github.com/confidential-containers/cloud-api-adaptor v0.7.1-0.20230928070042-349e42984339/go.mod h1:QjPNV/1mJx5NfhwLQ3PTY/1rLAB34sEia+k6r14CkXw=
+github.com/confidential-containers/cloud-api-adaptor v0.8.0-alpha.1 h1:s1fDOkKSRN/sVJx/VTIhxVJCK/AFG8R95JVGV0qdsSE=
+github.com/confidential-containers/cloud-api-adaptor v0.8.0-alpha.1/go.mod h1:tpHaeetmLLDIIArMHHtBLR4C0v47bVAR5TI1n3x+QaI=
 github.com/container-orchestrated-devices/container-device-interface v0.4.0/go.mod h1:E1zcucIkq9P3eyNmY+68dBQsTcsXJh9cgRo2IVNScKQ=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
 github.com/containerd/aufs v0.0.0-20201003224125-76a6863f2989/go.mod h1:AkGGQs9NM2vtYHaUen+NljV0/baGCAPELGm2q9ZXpWU=

--- a/volumes/csi-wrapper/go.mod
+++ b/volumes/csi-wrapper/go.mod
@@ -3,7 +3,7 @@ module github.com/confidential-containers/cloud-api-adaptor/volumes/csi-wrapper
 go 1.20
 
 require (
-	github.com/confidential-containers/cloud-api-adaptor v0.7.0
+	github.com/confidential-containers/cloud-api-adaptor v0.8.0-alpha.1
 	github.com/container-storage-interface/spec v1.8.0
 	github.com/containerd/ttrpc v1.1.0
 	github.com/gofrs/uuid v4.4.0+incompatible

--- a/volumes/csi-wrapper/go.sum
+++ b/volumes/csi-wrapper/go.sum
@@ -2,8 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/confidential-containers/cloud-api-adaptor v0.7.0 h1:b25nekl7ZRO+61ZEL2YQMtZnLIBIxNzpsqHsg1FULEY=
-github.com/confidential-containers/cloud-api-adaptor v0.7.0/go.mod h1:huzOXeTtonxU9LJlT7266sTVsi9n3m4va3MHG8X9jKI=
+github.com/confidential-containers/cloud-api-adaptor v0.8.0-alpha.1 h1:s1fDOkKSRN/sVJx/VTIhxVJCK/AFG8R95JVGV0qdsSE=
+github.com/confidential-containers/cloud-api-adaptor v0.8.0-alpha.1/go.mod h1:tpHaeetmLLDIIArMHHtBLR4C0v47bVAR5TI1n3x+QaI=
 github.com/container-storage-interface/spec v1.8.0 h1:D0vhF3PLIZwlwZEf2eNbpujGCNwspwTYf2idJRJx4xI=
 github.com/container-storage-interface/spec v1.8.0/go.mod h1:ROLik+GhPslwwWRNFF1KasPzroNARibH2rfz1rkg4H0=
 github.com/containerd/ttrpc v1.1.0 h1:GbtyLRxb0gOLR0TYQWt3O6B0NvT8tMdorEHqIQo/lWI=
@@ -110,7 +110,7 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
Update csi-wrapper and peerpod-ctrl to use the v0.8.0-alpha.1 tagged go module following this section:
> Update the csi-wrapper and peerpod-ctrl go modules to use the tagged version of cloud-api-adapter, by running:
> ```
> go get github.com/confidential-containers/cloud-api-adaptor@v<version>-alpha.1
> go mod tidy
> ```
> in their directories and removing the local replace references if we needed to add them earlier.

Of the RC release doc