### PR TITLE
test: Add createcluster action to provisioner cli

### DIFF
--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -153,7 +153,7 @@ jobs:
       working-directory: test/tools
       run: |
         make caa-provisioner-cli
-        ./caa-provisioner-cli -action=provision
+        ./caa-provisioner-cli -action=createcluster
 
   run-e2e-test:
     runs-on: ubuntu-latest

--- a/test/tools/provisioner-cli/main.go
+++ b/test/tools/provisioner-cli/main.go
@@ -55,6 +55,13 @@ func main() {
 		log.Fatal(err)
 	}
 
+	if *action == "createcluster" {
+		log.Info("Creating Cluster...")
+		if err := provisioner.CreateCluster(context.TODO(), cfg); err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	if *action == "provision" {
 		log.Info("Creating VPC...")
 		if err := provisioner.CreateVPC(context.TODO(), cfg); err != nil {


### PR DESCRIPTION
The test itself will perform an installation of the operator/CAA on the cluster as a [setup step](https://github.com/confidential-containers/cloud-api-adaptor/blob/b18675f52f54ad7d8eae72ce7a6668be81329c11/test/e2e/main_test.go#L120), so installing it twice is redundant.

The installation should be idempotent, but having 2 places performing the installation is probably suboptimal and might lead to undesired effects if different provisioner config files are used. If we want to test whether a re-installation works, we should have a dedicated test for that.

I would opt for removing the CAA installation from the `provision` action, but a `createcluster` action might be a good middle ground.