### PR TITLE
tests/e2e: Handle multi-node cluster

### DIFF
--- a/test/e2e/assessment_runner_test.go
+++ b/test/e2e/assessment_runner_test.go
@@ -331,7 +331,12 @@ func (tc *testCase) run() {
 				}
 
 				if tc.isNydusSnapshotter {
-					usedNydusSnapshotter, err := IsPulledWithNydusSnapshotter(ctx, t, client)
+					nodeName, err := getNodeNameFromPod(ctx, client, *tc.pod)
+					if err != nil {
+						t.Fatal(err)
+					}
+					log.Tracef("Test pod running on node %s", nodeName)
+					usedNydusSnapshotter, err := IsPulledWithNydusSnapshotter(ctx, t, client, nodeName)
 					if err != nil {
 						t.Fatal(err)
 					}


### PR DESCRIPTION
If a cluster has multiple nodes running then it will also have multiple caa daemon sets running, so we want to check the logs for the correct one.

Get the node name for the pod we are testing and then use it as a check when we identify the CAA pod to get the logs for