### PR TITLE
Add separate nydus-snapshotter test

### DIFF
--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -76,6 +76,12 @@ func TestAwsCreateSimplePod(t *testing.T) {
 	doTestCreateSimplePod(t, assert)
 }
 
+func TestAwsCreateSimplePodWithNydusAnnotation(t *testing.T) {
+	assert := NewAWSAssert()
+
+	doTestCreateSimplePodWithNydusAnnotation(t, assert)
+}
+
 func TestAwsCreatePodWithConfigMap(t *testing.T) {
 	t.Skip("Test not passing")
 	assert := NewAWSAssert()

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -29,6 +29,11 @@ func TestCreateSimplePodAzure(t *testing.T) {
 	doTestCreateSimplePod(t, assert)
 }
 
+func TestCreateSimplePodWithNydusAnnotationAzure(t *testing.T) {
+	t.Parallel()
+	doTestCreateSimplePodWithNydusAnnotation(t, assert)
+}
+
 func TestCreatePodWithConfigMapAzure(t *testing.T) {
 	t.Parallel()
 	doTestCreatePodWithConfigMap(t, assert)

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -88,11 +88,12 @@ func withAnnotations(data map[string]string) podOption {
 
 func newPod(namespace string, podName string, containerName string, imageName string, options ...podOption) *corev1.Pod {
 	runtimeClassName := "kata-remote"
-	annotationData := map[string]string{
-		"io.containerd.cri.runtime-handler": runtimeClassName,
-	}
+	// Comment out adding runtime-handler until nydus-snapshotter is stable
+	// annotationData := map[string]string{
+	// 	"io.containerd.cri.runtime-handler": runtimeClassName,
+	// }
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: namespace, Annotations: annotationData},
+		ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: namespace /*, Annotations: annotationData*/},
 		Spec: corev1.PodSpec{
 			Containers:       []corev1.Container{{Name: containerName, Image: imageName, ImagePullPolicy: corev1.PullAlways}},
 			RuntimeClassName: &runtimeClassName,
@@ -138,16 +139,17 @@ func newSecret(namespace string, name string, data map[string][]byte, secretType
 // newJob returns a new job
 func newJob(namespace string, name string) *batchv1.Job {
 	runtimeClassName := "kata-remote"
-	annotationData := map[string]string{
-		"io.containerd.cri.runtime-handler": runtimeClassName,
-	}
+	// Comment out adding runtime-handler until nydus-snapshotter is stable
+	// annotationData := map[string]string{
+	// 	"io.containerd.cri.runtime-handler": runtimeClassName,
+	// }
 	BackoffLimit := int32(8)
 	TerminateGracePeriod := int64(0)
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Annotations: annotationData,
+			Name:      name,
+			Namespace: namespace,
+			// Annotations: annotationData,
 		},
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{

--- a/test/e2e/common_suite_test.go
+++ b/test/e2e/common_suite_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	envconf "sigs.k8s.io/e2e-framework/pkg/envconf"
 )
@@ -22,6 +23,15 @@ import (
 func doTestCreateSimplePod(t *testing.T, assert CloudAssert) {
 	namespace := envconf.RandomName("default", 7)
 	pod := newNginxPod(namespace)
+	newTestCase(t, "SimplePeerPod", assert, "PodVM is created").withPod(pod).run()
+}
+
+func doTestCreateSimplePodWithNydusAnnotation(t *testing.T, assert CloudAssert) {
+	namespace := envconf.RandomName("default", 7)
+	annotationData := map[string]string{
+		"io.containerd.cri.runtime-handler": "kata-remote",
+	}
+	pod := newPod(namespace, "nginx", "nginx", "nginx", withRestartPolicy(corev1.RestartPolicyNever), withAnnotations(annotationData))
 	newTestCase(t, "SimplePeerPod", assert, "PodVM is created").withPod(pod).withNydusSnapshotter().run()
 }
 

--- a/test/e2e/ibmcloud_test.go
+++ b/test/e2e/ibmcloud_test.go
@@ -29,6 +29,13 @@ func TestCreateSimplePod(t *testing.T) {
 	doTestCreateSimplePod(t, assert)
 }
 
+func TestCreateSimplePodWithNydusAnnotation(t *testing.T) {
+	assert := IBMCloudAssert{
+		vpc: pv.IBMCloudProps.VPC,
+	}
+	doTestCreateSimplePodWithNydusAnnotation(t, assert)
+}
+
 func TestCaaDaemonsetRollingUpdate(t *testing.T) {
 	if os.Getenv("TEST_CAA_ROLLING_UPDATE") == "yes" {
 		assert := IBMRollingUpdateAssert{

--- a/test/e2e/libvirt_test.go
+++ b/test/e2e/libvirt_test.go
@@ -14,6 +14,11 @@ func TestLibvirtCreateSimplePod(t *testing.T) {
 	doTestCreateSimplePod(t, assert)
 }
 
+func TestLibvirtCreateSimplePodWithNydusAnnotation(t *testing.T) {
+	assert := LibvirtAssert{}
+	doTestCreateSimplePodWithNydusAnnotation(t, assert)
+}
+
 func TestLibvirtCreatePodWithConfigMap(t *testing.T) {
 	skipTestOnCI(t)
 	assert := LibvirtAssert{}


### PR DESCRIPTION
 - Given that nydus-snapshotter doesn't seem stable, we want to
    add a separate test for the nydus snapshotter
    so that we can consider skipping it for cloud-providers that aren't
    working
 - Given that on AKS the runtime-handler annotation seems to cause issues
    and the nydus-snapshotter isn't stable, we don't want to add it
    to every pod.job anymore