### PR TITLE
install: pin cloud-api-adaptor image for v0.8.0

### DIFF
--- a/install/overlays/aws/kustomization.yaml
+++ b/install/overlays/aws/kustomization.yaml
@@ -7,7 +7,7 @@ bases:
 images:
 - name: cloud-api-adaptor
   newName: quay.io/confidential-containers/cloud-api-adaptor # change image if needed
-  newTag: latest
+  newTag: d4496d008b65c979a4d24767979a77ed1ba21e76
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/install/overlays/azure/kustomization.yaml
+++ b/install/overlays/azure/kustomization.yaml
@@ -7,7 +7,7 @@ bases:
 images:
 - name: cloud-api-adaptor
   newName: quay.io/confidential-containers/cloud-api-adaptor # change image if needed
-  newTag: latest
+  newTag: d4496d008b65c979a4d24767979a77ed1ba21e76
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/install/overlays/ibmcloud-powervs/kustomization.yaml
+++ b/install/overlays/ibmcloud-powervs/kustomization.yaml
@@ -7,7 +7,7 @@ bases:
 images:
 - name: cloud-api-adaptor
   newName: quay.io/confidential-containers/cloud-api-adaptor # change image if needed
-  newTag: latest
+  newTag: d4496d008b65c979a4d24767979a77ed1ba21e76
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/install/overlays/ibmcloud/kustomization.yaml
+++ b/install/overlays/ibmcloud/kustomization.yaml
@@ -7,7 +7,7 @@ bases:
 images:
 - name: cloud-api-adaptor
   newName: quay.io/confidential-containers/cloud-api-adaptor # change image if needed
-  newTag: latest
+  newTag: d4496d008b65c979a4d24767979a77ed1ba21e76
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/install/overlays/libvirt/kustomization.yaml
+++ b/install/overlays/libvirt/kustomization.yaml
@@ -7,7 +7,7 @@ bases:
 images:
 - name: cloud-api-adaptor
   newName: quay.io/confidential-containers/cloud-api-adaptor # change image if needed
-  newTag: latest
+  newTag: dev-d4496d008b65c979a4d24767979a77ed1ba21e76
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/install/overlays/vsphere/kustomization.yaml
+++ b/install/overlays/vsphere/kustomization.yaml
@@ -7,7 +7,7 @@ bases:
 images:
 - name: cloud-api-adaptor
   newName: quay.io/confidential-containers/cloud-api-adaptor # change image if needed
-  newTag: latest
+  newTag: d4496d008b65c979a4d24767979a77ed1ba21e76
 
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
Using the
 quay.io/repository/confidential-containers/cloud-api-adaptor:d4496d008b65c979a4d24767979a77ed1ba21e76
image.

Fixes #1548
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>