### PR TITLE
Nydus test fixes

### DIFF
--- a/test/e2e/assessment_helpers_test.go
+++ b/test/e2e/assessment_helpers_test.go
@@ -138,7 +138,7 @@ func IsPulledWithNydusSnapshotter(ctx context.Context, t *testing.T, client klie
 	if err != nil {
 		return false, err
 	}
-	legacyPullRegex, err := regexp.Compile(`.*"CreateContainer: calling PullImage.*before CreateContainer.*$`)
+	legacyPullRegex, err := regexp.Compile(`.*CreateContainer: calling PullImage.*before CreateContainer.*$`)
 	if err != nil {
 		return false, err
 	}
@@ -163,7 +163,7 @@ func IsPulledWithNydusSnapshotter(ctx context.Context, t *testing.T, client klie
 					return false, nil
 				}
 			}
-			return false, nil
+			return false, fmt.Errorf("Didn't find pull image for snapshotter, or directly")
 		}
 	}
 	return false, fmt.Errorf("No cloud-api-adaptor pod found in podList: %v", podlist.Items)

--- a/test/e2e/common_suite_test.go
+++ b/test/e2e/common_suite_test.go
@@ -31,7 +31,7 @@ func doTestCreateSimplePodWithNydusAnnotation(t *testing.T, assert CloudAssert) 
 	annotationData := map[string]string{
 		"io.containerd.cri.runtime-handler": "kata-remote",
 	}
-	pod := newPod(namespace, "nginx", "nginx", "nginx", withRestartPolicy(corev1.RestartPolicyNever), withAnnotations(annotationData))
+	pod := newPod(namespace, "alpine", "alpine", "alpine", withRestartPolicy(corev1.RestartPolicyNever), withAnnotations(annotationData))
 	newTestCase(t, "SimplePeerPod", assert, "PodVM is created").withPod(pod).withNydusSnapshotter().run()
 }
 


### PR DESCRIPTION
- Fix the regex matcher and improve error handling
- Switch the nydus test to use alpine over nginx to avoid hitting annotation caching issues reported in: https://github.com/kata-containers/kata-containers/issues/8337