### PR TITLE
set defaults from environment to instanceTypes

### DIFF
--- a/pkg/adaptor/cloud/aws/manager.go
+++ b/pkg/adaptor/cloud/aws/manager.go
@@ -22,7 +22,6 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	flags.StringVar(&awscfg.LaunchTemplateName, "aws-lt-name", "kata", "AWS Launch Template Name")
 	flags.BoolVar(&awscfg.UseLaunchTemplate, "use-lt", false, "Use EC2 Launch Template for the Pod VMs")
 	flags.StringVar(&awscfg.ImageId, "imageid", "", "Pod VM ami id")
-	flags.StringVar(&awscfg.InstanceType, "instance-type", "t3.small", "Pod VM instance type")
 	flags.Var(&awscfg.SecurityGroupIds, "securitygroupids", "Security Group Ids to be used for the Pod VM, comma separated")
 	flags.StringVar(&awscfg.KeyName, "keyname", "", "SSH Keypair name to be used with the Pod VM")
 	flags.StringVar(&awscfg.SubnetId, "subnetid", "", "Subnet ID to be used for the Pod VMs")
@@ -43,7 +42,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 func (_ *Manager) LoadEnv() {
 	cloud.DefaultToEnv(&awscfg.AccessKeyId, "AWS_ACCESS_KEY_ID", "")
 	cloud.DefaultToEnv(&awscfg.SecretKey, "AWS_SECRET_ACCESS_KEY", "")
-
+	cloud.DefaultToEnv(&awscfg.InstanceType, "PODVM_INSTANCE_TYPE", "t3.small")
 }
 
 func (_ *Manager) NewProvider() (cloud.Provider, error) {

--- a/pkg/adaptor/cloud/azure/manager.go
+++ b/pkg/adaptor/cloud/azure/manager.go
@@ -22,7 +22,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	flags.StringVar(&azurecfg.Region, "region", "", "Region")
 	flags.StringVar(&azurecfg.SubnetId, "subnetid", "", "Network Subnet Id")
 	flags.StringVar(&azurecfg.SecurityGroupId, "securitygroupid", "", "Security Group Id")
-	flags.StringVar(&azurecfg.Size, "instance-size", "", "Instance size")
+	flags.StringVar(&azurecfg.Size, "instance-size", "Standard_DC2as_v5", "Instance size")
 	flags.StringVar(&azurecfg.ImageId, "imageid", "", "Image Id")
 	flags.StringVar(&azurecfg.SubscriptionId, "subscriptionid", "", "Subscription ID")
 	flags.StringVar(&azurecfg.SSHKeyPath, "ssh-key-path", "$HOME/.ssh/id_rsa.pub", "Path to SSH public key")
@@ -44,6 +44,7 @@ func (_ *Manager) LoadEnv() {
 	cloud.DefaultToEnv(&azurecfg.SubscriptionId, "AZURE_SUBSCRIPTION_ID", "")
 	cloud.DefaultToEnv(&azurecfg.Region, "AZURE_REGION", "")
 	cloud.DefaultToEnv(&azurecfg.ResourceGroupName, "AZURE_RESOURCE_GROUP", "")
+	cloud.DefaultToEnv(&azurecfg.Size, "AZURE_INSTANCE_SIZE", "Standard_DC2as_v5")
 }
 
 func (_ *Manager) NewProvider() (cloud.Provider, error) {


### PR DESCRIPTION
and setting default CVM type for Azure

setting using env fixes peerpod-ctrl error:
```
The following supplied instance types do not exist: []
```