### PR TITLE
azure: aws: set defaults from environment to instanceTypes 

### DIFF
--- a/install/overlays/azure/kustomization.yaml
+++ b/install/overlays/azure/kustomization.yaml
@@ -20,7 +20,7 @@ configMapGenerator:
   - CLOUD_CONFIG_VERIFY="false" # It's better set as true to enable could config verify in production env
   - AZURE_SUBSCRIPTION_ID="" #set
   - AZURE_REGION="eastus" #set
-  - AZURE_INSTANCE_SIZE="Standard_D8as_v5" #set
+  - AZURE_INSTANCE_SIZE="Standard_DC2as_v5" #set
   - AZURE_RESOURCE_GROUP="" #set
 
   # /subscriptions/<AZURE_SUBSCRIPTION_ID>/resourceGroups/<AZURE_RESOURCE_GROUP>/providers/Microsoft.Network/virtualNetworks/<AZURE_VNET_NAME>/subnets/<AZURE_SUBNET_NAME>

--- a/pkg/adaptor/cloud/aws/manager.go
+++ b/pkg/adaptor/cloud/aws/manager.go
@@ -43,7 +43,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 func (_ *Manager) LoadEnv() {
 	cloud.DefaultToEnv(&awscfg.AccessKeyId, "AWS_ACCESS_KEY_ID", "")
 	cloud.DefaultToEnv(&awscfg.SecretKey, "AWS_SECRET_ACCESS_KEY", "")
-
+	cloud.DefaultToEnv(&awscfg.InstanceType, "PODVM_INSTANCE_TYPE", "t3.small")
 }
 
 func (_ *Manager) NewProvider() (cloud.Provider, error) {

--- a/pkg/adaptor/cloud/azure/manager.go
+++ b/pkg/adaptor/cloud/azure/manager.go
@@ -22,7 +22,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	flags.StringVar(&azurecfg.Region, "region", "", "Region")
 	flags.StringVar(&azurecfg.SubnetId, "subnetid", "", "Network Subnet Id")
 	flags.StringVar(&azurecfg.SecurityGroupId, "securitygroupid", "", "Security Group Id")
-	flags.StringVar(&azurecfg.Size, "instance-size", "", "Instance size")
+	flags.StringVar(&azurecfg.Size, "instance-size", "Standard_DC2as_v5", "Instance size")
 	flags.StringVar(&azurecfg.ImageId, "imageid", "", "Image Id")
 	flags.StringVar(&azurecfg.SubscriptionId, "subscriptionid", "", "Subscription ID")
 	flags.StringVar(&azurecfg.SSHKeyPath, "ssh-key-path", "$HOME/.ssh/id_rsa.pub", "Path to SSH public key")
@@ -44,6 +44,7 @@ func (_ *Manager) LoadEnv() {
 	cloud.DefaultToEnv(&azurecfg.SubscriptionId, "AZURE_SUBSCRIPTION_ID", "")
 	cloud.DefaultToEnv(&azurecfg.Region, "AZURE_REGION", "")
 	cloud.DefaultToEnv(&azurecfg.ResourceGroupName, "AZURE_RESOURCE_GROUP", "")
+	cloud.DefaultToEnv(&azurecfg.Size, "AZURE_INSTANCE_SIZE", "Standard_DC2as_v5")
 }
 
 func (_ *Manager) NewProvider() (cloud.Provider, error) {


### PR DESCRIPTION
and setting default CVM type for Azure

setting using env fixes peerpod-ctrl error:

`The following supplied instance types do not exist: []`