### PR TITLE
peerpod-ctrl: bump cloud-api-adaptor

### DIFF
--- a/peerpod-ctrl/go.mod
+++ b/peerpod-ctrl/go.mod
@@ -3,7 +3,7 @@ module github.com/confidential-containers/cloud-api-adaptor/peerpod-ctrl
 go 1.20
 
 require (
-	github.com/confidential-containers/cloud-api-adaptor v0.8.0
+	github.com/confidential-containers/cloud-api-adaptor v0.8.1-0.20231116150709-232acecae0ca
 	github.com/onsi/ginkgo/v2 v2.8.1
 	github.com/onsi/gomega v1.27.1
 	k8s.io/api v0.26.0

--- a/peerpod-ctrl/go.sum
+++ b/peerpod-ctrl/go.sum
@@ -326,8 +326,8 @@ github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/confidential-containers/cloud-api-adaptor v0.8.0 h1:ZZezfcfv/mqo9dVNAPJ3+6WdhDM1YC60qyAP6VEWKSc=
-github.com/confidential-containers/cloud-api-adaptor v0.8.0/go.mod h1:hlRWfbYbTJlpgsiQqlDlNRLREr6IhNbSCJ6ysF3I8v0=
+github.com/confidential-containers/cloud-api-adaptor v0.8.1-0.20231116150709-232acecae0ca h1:rZyWST0USTn7y7Wa72XSgkxnHbyDWmGtmi7Vw1w+pTI=
+github.com/confidential-containers/cloud-api-adaptor v0.8.1-0.20231116150709-232acecae0ca/go.mod h1:hlRWfbYbTJlpgsiQqlDlNRLREr6IhNbSCJ6ysF3I8v0=
 github.com/container-orchestrated-devices/container-device-interface v0.4.0/go.mod h1:E1zcucIkq9P3eyNmY+68dBQsTcsXJh9cgRo2IVNScKQ=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
 github.com/containerd/aufs v0.0.0-20201003224125-76a6863f2989/go.mod h1:AkGGQs9NM2vtYHaUen+NljV0/baGCAPELGm2q9ZXpWU=


### PR DESCRIPTION
to include latest fixes

related to: https://github.com/confidential-containers/cloud-api-adaptor/pull/1582