### PR TITLE
workflows: fix checkout of the code on podvm

### DIFF
--- a/.github/workflows/e2e_on_pull.yaml
+++ b/.github/workflows/e2e_on_pull.yaml
@@ -49,6 +49,7 @@ jobs:
     with:
       registry: ghcr.io/${{ github.repository_owner }}
       image_tag: ci-pr${{ github.event.number }}
+      git_ref: ${{ github.event.pull_request.head.sha }}
     secrets: inherit
 
   podvm_binaries:
@@ -57,6 +58,7 @@ jobs:
     with:
       registry: ghcr.io/${{ github.repository_owner }}
       image_tag: ci-pr${{ github.event.number }}
+      git_ref: ${{ github.event.pull_request.head.sha }}
     secrets: inherit
 
   podvm:
@@ -65,6 +67,7 @@ jobs:
     with:
       registry: ghcr.io/${{ github.repository_owner }}
       image_tag: ci-pr${{ github.event.number }}
+      git_ref: ${{ github.event.pull_request.head.sha }}
     secrets: inherit
 
   # Build and push the cloud-api-adaptor image

--- a/.github/workflows/podvm.yaml
+++ b/.github/workflows/podvm.yaml
@@ -10,6 +10,10 @@ on:
         default: ''
         required: false
         type: string
+      git_ref:
+        description: Git ref to checkout the cloud-api-adaptor repository.
+        required: true
+        type: string
 
 jobs:
   build:
@@ -34,6 +38,9 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        ref: "${{ inputs.git_ref }}"
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2

--- a/.github/workflows/podvm_binaries.yaml
+++ b/.github/workflows/podvm_binaries.yaml
@@ -10,6 +10,10 @@ on:
         default: ''
         required: false
         type: string
+      git_ref:
+        description: Git ref to checkout the cloud-api-adaptor repository.
+        required: true
+        type: string
 
 jobs:
   build:
@@ -29,6 +33,9 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        ref: "${{ inputs.git_ref }}"
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2

--- a/.github/workflows/podvm_builder.yaml
+++ b/.github/workflows/podvm_builder.yaml
@@ -10,6 +10,10 @@ on:
         default: ''
         required: false
         type: string
+      git_ref:
+        description: Git ref to checkout the cloud-api-adaptor repository.
+        required: true
+        type: string
 
 jobs:
   build:
@@ -27,6 +31,9 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        ref: "${{ inputs.git_ref }}"
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2

--- a/.github/workflows/podvm_publish.yaml
+++ b/.github/workflows/podvm_publish.yaml
@@ -14,14 +14,20 @@ on:
 jobs:
   podvm_builder:
     uses: ./.github/workflows/podvm_builder.yaml
+    with:
+      git_ref: ${{ github.sha }}
     secrets: inherit
 
   podvm_binaries:
     needs: [podvm_builder]
     uses: ./.github/workflows/podvm_binaries.yaml
+    with:
+      git_ref: ${{ github.sha }}
     secrets: inherit
 
   podvm:
     needs: [podvm_binaries]
     uses: ./.github/workflows/podvm.yaml
+    with:
+      git_ref: ${{ github.sha }}
     secrets: inherit


### PR DESCRIPTION
As currently implemented on builder/binaries/podvm workflows, the actions/checkout@v3 will checkout the code based on GITHUB_SHA. When used with the pull_request_target event (which is the case of the tests for libvirt on pull request), GITHUB_SHA is the SHA of the base branch but we are interested on the SHA of the head on the pull request branch (i.e. github.event.pull_request.head.sha).