### PR TITLE
terraform: add new variables for existing VPC and subnet

### DIFF
--- a/ibmcloud/cluster/README.md
+++ b/ibmcloud/cluster/README.md
@@ -86,6 +86,8 @@ Kubernetes node virtual server instances, the VPC and the subnet. If not set it 
 defaults to `jp-tok`.
 > - `zone_name` (optional) is the zone in the region Terraform will create the demo environment in. If not set it
 defaults to `jp-tok-2`.
+> - `vpc_name` (optional) is an existing VPC name. If it is not set, Terraform will create a new VPC named "${cluster_name}-vpc".
+> - `subnet_name` (optional) is an existing subnet name. If it is not set, Terraform will create a new subnet named "{cluster_name}-subnet". This must be provided if `vpc_name` has been set.
 > - `ssh_pub_key` (optional) is an variable for a SSH public key which has **not** been registered in IBM Cloud in the
 targeted region. Terraform will manage this key instead. You cannot register the same SSH public key in the same region
 twice under different SSHs key names. This key needs to be password-less and on the 'developer machine' running the terraform in order to perform the cluster set up.

--- a/ibmcloud/cluster/outputs.tf
+++ b/ibmcloud/cluster/outputs.tf
@@ -1,8 +1,8 @@
-output "vpc_id" { value = module.vpc.vpc_id }
+output "vpc_id" { value = local.vpc_id }
 output "ssh_key_id" { value = data.ibm_is_ssh_key.ssh_key.id }
-output "subnet_id" { value = module.vpc.subnet_id }
+output "subnet_id" { value = local.subnet_id }
 output "node_name" { value = "${var.cluster_name}-node-${length(module.nodes) - 1}" }
-output "security_group_id" { value = module.vpc.security_group_id }
+output "security_group_id" { value = local.security_group_id }
 output "region" { value = var.region }
 output "zone" { value = var.zone }
 output "resource_group_id" { value = data.ibm_resource_group.default_group.id }

--- a/ibmcloud/cluster/variables.tf
+++ b/ibmcloud/cluster/variables.tf
@@ -17,6 +17,18 @@ variable "ssh_pub_key" {
   default = ""
 }
 
+variable "vpc_name" {
+  type        = string
+  description = "(optional) Specify existing VPC name. If none is provided, it will create a new VPC named {cluster_name}-vpc"
+  default     = ""
+}
+
+variable "subnet_name" {
+  type        = string
+  description = "(optional) Specify existing subnet name. If none is provided, it will create a new subnet named {cluster_name}-subnet. This must be provided if vpc_name has been set"
+  default     = ""
+}
+
 # amd64: ibm-ubuntu-20-04-3-minimal-amd64-1
 # s390x: ibm-ubuntu-20-04-2-minimal-s390x-1
 variable "node_image" {


### PR DESCRIPTION
Current IBM Cloud terraform to create self-managed cluster will always create new VPC and subnet for VSIs.

As a result, it's easy to see vpc quota exceeded errors because by default only 10 VPCs could be created in a region under an account.

In this PR, we introduced 2 new variables to specify existing VPC and subnet names. If they are set, will create VSIs in existing VPC; otherwise, will create new VPC and subnet as usual