### PR TITLE
libvirt/kcli: defaults to Ubuntu 22.04

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -100,11 +100,6 @@ jobs:
           [ -f ~/.ssh/id_rsa ] || \
             ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ""
 
-          # Newest version of kcli does not index old Ubuntu images like 20.04
-          echo "::group::Download Ubuntu 20.04 image"
-          kcli download image -u https://cloud-images.ubuntu.com/releases/20.04/release/ubuntu-20.04-server-cloudimg-amd64.img ubuntu2004
-          echo "::endgroup::"
-
         # This is the key used by cloud-api-adaptor to connect to libvirt
       - name: Generate the SSH key
         run: |


### PR DESCRIPTION
Ubuntu 22.04 packages containerd 1.7 that is the mininum required version as of CoCo 0.8.0. Updated the libvirt/kcli_cluster.sh to install Ubuntu 22.04 instead of 20.04.

There is needed to use a kcli version newer than the build of today (2023/11/21) that contains the fix to [1].

[1] https://github.com/karmab/kcli/issues/619

Fixes #1593
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>