### PR TITLE
test/e22: libvirt: Add delete pod test

### DIFF
--- a/test/e2e/libvirt_test.go
+++ b/test/e2e/libvirt_test.go
@@ -75,6 +75,11 @@ func TestLibvirtCreatePeerPodWithLargeImage(t *testing.T) {
 }
 */
 
+func TestLibvirtDeletePod(t *testing.T) {
+	assert := LibvirtAssert{}
+	doTestDeleteSimplePod(t, assert)
+}
+
 // LibvirtAssert implements the CloudAssert interface for Libvirt.
 type LibvirtAssert struct {
 	// TODO: create the connection once on the initializer.


### PR DESCRIPTION
Add delete pod test to libvirt e2e as part of #1604 libvirt gap closes