### PR TITLE
e2e-test: fix one e2e-test bug

### DIFF
--- a/test/e2e/assessment_runner_test.go
+++ b/test/e2e/assessment_runner_test.go
@@ -321,7 +321,7 @@ func (tc *testCase) run() {
 									t.Fatal(fmt.Errorf("PodVM Created with Differenct Instance Type %v", profile))
 								}
 							}
-
+							break
 						} else {
 							t.Fatal("Pod Not Found...")
 						}
@@ -348,6 +348,7 @@ func (tc *testCase) run() {
 									if !testCommand.testCommandStdoutFn(stdout) {
 										t.Fatal(fmt.Errorf("Command %v running in container %s produced unexpected output on stdout: %s", testCommand.command, testCommand.containerName, stdout.String()))
 									}
+									break
 								}
 							}
 						}

--- a/test/e2e/common_suite_test.go
+++ b/test/e2e/common_suite_test.go
@@ -71,7 +71,7 @@ func doTestCreatePodWithConfigMap(t *testing.T, assert CloudAssert) {
 		},
 	}
 
-	newTestCase(t, "ConfigMapPeerPod", assert, "Configmap is created and contains data").withPod(pod).withConfigMap(configMap).withTestCommands(testCommands).withCustomPodState(v1.PodRunning).run()
+	newTestCase(t, "ConfigMapPeerPod", assert, "Configmap is created and contains data").withPod(pod).withConfigMap(configMap).withTestCommands(testCommands).run()
 }
 
 func doTestCreatePodWithSecret(t *testing.T, assert CloudAssert) {
@@ -121,7 +121,7 @@ func doTestCreatePodWithSecret(t *testing.T, assert CloudAssert) {
 		},
 	}
 
-	newTestCase(t, "SecretPeerPod", assert, "Secret has been created and contains data").withPod(pod).withSecret(secret).withTestCommands(testCommands).withCustomPodState(v1.PodRunning).run()
+	newTestCase(t, "SecretPeerPod", assert, "Secret has been created and contains data").withPod(pod).withSecret(secret).withTestCommands(testCommands).run()
 }
 
 func doTestCreatePeerPodContainerWithExternalIPAccess(t *testing.T, assert CloudAssert) {
@@ -236,7 +236,7 @@ func doTestCreatePeerPodWithPVCAndCSIWrapper(t *testing.T, assert CloudAssert, m
 			},
 		},
 	}
-	newTestCase(t, "PeerPodWithPVCAndCSIWrapper", assert, "PVC is created and mounted as expected").withPod(pod).withPVC(myPVC).withTestCommands(testCommands).withCustomPodState(v1.PodRunning).run()
+	newTestCase(t, "PeerPodWithPVCAndCSIWrapper", assert, "PVC is created and mounted as expected").withPod(pod).withPVC(myPVC).withTestCommands(testCommands).run()
 }
 
 func doTestCreatePeerPodWithAuthenticatedImagewithValidCredentials(t *testing.T, assert CloudAssert) {

--- a/test/provisioner/provision.go
+++ b/test/provisioner/provision.go
@@ -137,7 +137,7 @@ func (p *CloudAPIAdaptor) Delete(ctx context.Context, cfg *envconf.Config) error
 	}
 
 	log.Info("Uninstall CCRuntime CRD")
-	cmd := exec.Command("kubectl", "delete", "-k", "github.com/confidential-containers/operator/config/samples/ccruntime/peer-pods")
+	cmd := exec.Command("kubectl", "delete", "-k", "github.com/confidential-containers/operator/config/samples/ccruntime/peer-pods?ref=v0.8.0")
 	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG="+cfg.KubeconfigFile()))
 	stdoutStderr, err := cmd.CombinedOutput()
 	log.Tracef("%v, output: %s", cmd, stdoutStderr)
@@ -157,7 +157,7 @@ func (p *CloudAPIAdaptor) Delete(ctx context.Context, cfg *envconf.Config) error
 	deployments := &appsv1.DeploymentList{Items: []appsv1.Deployment{*p.controllerDeployment}}
 
 	log.Info("Uninstall the controller manager")
-	cmd = exec.Command("kubectl", "delete", "-k", "github.com/confidential-containers/operator/config/default")
+	cmd = exec.Command("kubectl", "delete", "-k", "github.com/confidential-containers/operator/config/default?ref=v0.8.0")
 	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG="+cfg.KubeconfigFile()))
 	stdoutStderr, err = cmd.CombinedOutput()
 	log.Tracef("%v, output: %s", cmd, stdoutStderr)
@@ -184,7 +184,7 @@ func (p *CloudAPIAdaptor) Deploy(ctx context.Context, cfg *envconf.Config, props
 
 	log.Info("Install the controller manager")
 	// TODO - find go idiomatic way to apply/delete remote kustomize and apply to this file
-	cmd := exec.Command("kubectl", "apply", "-k", "github.com/confidential-containers/operator/config/default")
+	cmd := exec.Command("kubectl", "apply", "-k", "github.com/confidential-containers/operator/config/default?ref=v0.8.0")
 	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG="+cfg.KubeconfigFile()))
 	stdoutStderr, err := cmd.CombinedOutput()
 	log.Tracef("%v, output: %s", cmd, stdoutStderr)
@@ -203,7 +203,7 @@ func (p *CloudAPIAdaptor) Deploy(ctx context.Context, cfg *envconf.Config, props
 		return err
 	}
 
-	cmd = exec.Command("kubectl", "apply", "-k", "github.com/confidential-containers/operator/config/samples/ccruntime/peer-pods")
+	cmd = exec.Command("kubectl", "apply", "-k", "github.com/confidential-containers/operator/config/samples/ccruntime/peer-pods?ref=v0.8.0")
 	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG="+cfg.KubeconfigFile()))
 	stdoutStderr, err = cmd.CombinedOutput()
 	log.Tracef("%v, output: %s", cmd, stdoutStderr)


### PR DESCRIPTION
- fix the e2e-test cases around Annotations for ibmcloud provider
- remove useless withCustomPodState(v1.PodRunning), as by [default all new testcases are with PodRunning status](https://github.com/confidential-containers/cloud-api-adaptor/blob/main/test/e2e/assessment_helpers_test.go#L51).

fixes https://github.com/confidential-containers/cloud-api-adaptor/issues/1613