### PR TITLE
podvm: fix podvm packer image build

### DIFF
--- a/podvm/Dockerfile.podvm_builder
+++ b/podvm/Dockerfile.podvm_builder
@@ -30,7 +30,7 @@ RUN apt-get update -y && \
     apt-get update && apt-get install -y clang-17 && \
     curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
     echo "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee -a /etc/apt/sources.list && \
-    apt-get update && apt-get install --no-install-recommends -y packer && \
+    apt-get update && apt-get install --no-install-recommends -y packer=1.9.4-1 && \
     apt-get clean
 
 ADD https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz go${GO_VERSION}.linux-amd64.tar.gz


### PR DESCRIPTION
- pined the pakcer version to 1.9.4-1 which still in MPL license, and with this old version podvm image build with packer work as expected.

fixes https://github.com/confidential-containers/cloud-api-adaptor/issues/1616