### PR TITLE
WIP: workflows: install docker in e2e_libvirt

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -47,6 +47,11 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Setup docker
+        run: |
+          sudo apt-get install -y docker.io
+          sudo usermod -aG docker "$USER"
+
       - name: Extract qcow2 from ${{ inputs.podvm_image }}
         run: |
            qcow2=$(echo ${{ inputs.podvm_image }} | sed -e "s#.*/\(.*\):.*#\1.qcow2#")


### PR DESCRIPTION
Docker is required to pull and extract the podvm qcow2.

I hope it fixes the problem on https://github.com/confidential-containers/cloud-api-adaptor/pull/1617