### PR TITLE
version: Bump Builder base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILD_TYPE=dev
-ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.20.8-36
+ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.20.12-38
 ARG BASE=registry.fedoraproject.org/fedora:38
 
 # This dockerfile uses Go cross-compilation to build the binary,


### PR DESCRIPTION
- Now we are using fedora 38 and golang 1.20.12, bump the builder base image to pick these up