### PR TITLE
workflows: rebase code on pull_request_target

### DIFF
--- a/.github/workflows/caa_build_and_push.yaml
+++ b/.github/workflows/caa_build_and_push.yaml
@@ -53,6 +53,11 @@ jobs:
           fetch-depth: 0
           ref: "${{ inputs.git_ref }}"
 
+      - name: Rebase the code
+        if: github.event_name == 'pull_request_target'
+        run: |
+          ./hack/ci-helper.sh rebase-atop-of-the-latest-target-branch
+
       - name: Read properties from versions.yaml
         run: |
           go_version="$(yq '.tools.golang' versions.yaml)"

--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -35,6 +35,11 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
 
+      - name: Rebase the code
+        if: github.event_name == 'pull_request_target'
+        run: |
+          ./hack/ci-helper.sh rebase-atop-of-the-latest-target-branch
+
       - name: Read properties from versions.yaml
         run: |
           sudo snap install yq

--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -104,6 +104,11 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
 
+      - name: Rebase the code
+        if: github.event_name == 'pull_request_target'
+        run: |
+          ./hack/ci-helper.sh rebase-atop-of-the-latest-target-branch
+
       - name: Install kustomize
         run: |
           command -v kustomize >/dev/null || \

--- a/.github/workflows/podvm.yaml
+++ b/.github/workflows/podvm.yaml
@@ -46,6 +46,11 @@ jobs:
         fetch-depth: 0
         ref: "${{ inputs.git_ref }}"
 
+    - name: Rebase the code
+      if: github.event_name == 'pull_request_target'
+      run: |
+        ./hack/ci-helper.sh rebase-atop-of-the-latest-target-branch
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/podvm_binaries.yaml
+++ b/.github/workflows/podvm_binaries.yaml
@@ -37,6 +37,11 @@ jobs:
         fetch-depth: 0
         ref: "${{ inputs.git_ref }}"
 
+    - name: Rebase the code
+      if: github.event_name == 'pull_request_target'
+      run: |
+        ./hack/ci-helper.sh rebase-atop-of-the-latest-target-branch
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/podvm_builder.yaml
+++ b/.github/workflows/podvm_builder.yaml
@@ -35,6 +35,11 @@ jobs:
         fetch-depth: 0
         ref: "${{ inputs.git_ref }}"
 
+    - name: Rebase the code
+      if: github.event_name == 'pull_request_target'
+      run: |
+        ./hack/ci-helper.sh rebase-atop-of-the-latest-target-branch
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 

--- a/hack/ci-helper.sh
+++ b/hack/ci-helper.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+TARGET_BRANCH=${TARGET_BRANCH:-main}
+
+function rebase_atop_of_the_latest_target_branch() {
+	if [ -n "${TARGET_BRANCH}" ]; then
+		echo "Rebasing atop of the latest ${TARGET_BRANCH}"
+		# Recover from any previous rebase left halfway
+		git rebase --abort 2> /dev/null || true
+		if ! git rebase "origin/${TARGET_BRANCH}"; then
+			# if GITHUB_WORKSPACE is defined and an architecture is not equal to x86_64
+			# (mostly self-hosted runners), then remove the repository
+			if [ -n "${GITHUB_WORKSPACE:-}" ] && [ "$(uname -m)" != "x86_64" ]; then
+				echo "Rebase failed, cleaning up a repository for self-hosted runners and exiting"
+				cd "${GITHUB_WORKSPACE}"/..
+				sudo rm -rf "${GITHUB_WORKSPACE}"
+			else
+				echo "Rebase failed, exiting"
+			fi
+			exit 1
+		fi
+	fi
+}
+
+function main() {
+    action="${1:-}"
+
+    case "${action}" in
+	rebase-atop-of-the-latest-target-branch) rebase_atop_of_the_latest_target_branch;;
+        *) >&2 echo "Invalid argument"; exit 2 ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
The e2e_on_pull workflow run on pull_request_target event that uses the the merge branch. Unlike the pull_request event, the merge branch is not rebased on top of the target branch (usually 'main'). In simple terms, the e2e_on_pull workflow does not automatically rebase the code so that changes merged on 'main' after the pull request creation are disregarded.

This added a renamed (to ci-helper.sh) and modified version of https://github.com/kata-containers/kata-containers/blob/main/tests/git-helper.sh that's called after 'actions/checkout' step to rebase the code atop of 'main'.

Because the touched workflows may be called on different workflows and events (e.g. release and dispatch_workflow), the rebase step is guarded by `if: github.event_name == 'pull_request_target'` to only run on pull_request_target triggered workflows.