### PR TITLE
e2e-test: grep for container id in nydus test

### DIFF
--- a/test/e2e/assessment_helpers_test.go
+++ b/test/e2e/assessment_helpers_test.go
@@ -131,14 +131,15 @@ func watchImagePullTime(ctx context.Context, client klient.Client, caaPod v1.Pod
 // not
 // <date time> 15:18:43 [adaptor/proxy] CreateContainer: calling PullImage for <image> before CreateContainer (cid: "<cid>")
 // was output
-func IsPulledWithNydusSnapshotter(ctx context.Context, t *testing.T, client klient.Client, nodeName string) (bool, error) {
+func IsPulledWithNydusSnapshotter(ctx context.Context, t *testing.T, client klient.Client, nodeName string, containerId string) (bool, error) {
 	var podlist v1.PodList
 
-	nydusSnapshotterPullRegex, err := regexp.Compile(`.*mount_point:/run/kata-containers.*driver:image_guest_pull.*$`)
+	nydusSnapshotterPullRegex, err := regexp.Compile(`.*mount_point:/run/kata-containers.*` + containerId + `.*driver:image_guest_pull.*$`)
 	if err != nil {
 		return false, err
 	}
-	legacyPullRegex, err := regexp.Compile(`.*CreateContainer: calling PullImage.*before CreateContainer.*$`)
+
+	legacyPullRegex, err := regexp.Compile(`.*CreateContainer: calling PullImage.*before CreateContainer.*` + containerId + `.*$`)
 	if err != nil {
 		return false, err
 	}

--- a/test/e2e/assessment_runner_test.go
+++ b/test/e2e/assessment_runner_test.go
@@ -363,7 +363,14 @@ func (tc *testCase) run() {
 						t.Fatal(err)
 					}
 					log.Tracef("Test pod running on node %s", nodeName)
-					usedNydusSnapshotter, err := IsPulledWithNydusSnapshotter(ctx, t, client, nodeName)
+
+					containerId := tc.pod.Status.ContainerStatuses[0].ContainerID
+					containerId, found := strings.CutPrefix(containerId, "containerd://")
+					if !found {
+						t.Fatal("unexpected container id format")
+					}
+
+					usedNydusSnapshotter, err := IsPulledWithNydusSnapshotter(ctx, t, client, nodeName, containerId)
 					if err != nil {
 						t.Fatal(err)
 					}


### PR DESCRIPTION
when testing in parallel, just listening for the last log won't work, we'll get matches for unrelated peerpod log lines.