### PR TITLE
podvm: revert agent-config path to /etc

### DIFF
--- a/cmd/process-user-data/types.go
+++ b/cmd/process-user-data/types.go
@@ -5,7 +5,7 @@ const (
 	providerAzure = "azure"
 	providerAws   = "aws"
 
-	defaultAgentConfigPath  = "/run/peerpod/agent-config.toml"
+	defaultAgentConfigPath  = "/etc/agent-config.toml"
 	defaultAuthJsonFilePath = "/run/peerpod/auth.json"
 )
 

--- a/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system/kata-agent.service.d/10-override.conf
+++ b/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system/kata-agent.service.d/10-override.conf
@@ -1,0 +1,10 @@
+# On a read-only fs the kata-agent config is created in /run/peerpod, since it contains
+# a parameter that can be set at pod creation time.
+[Unit]
+ConditionKernelCommandLine=
+
+[Service]
+ExecStart=
+ExecStart=/usr/local/bin/kata-agent --config /run/peerpod/agent-config.toml
+ExecStop=
+ExecStopPost=/usr/local/bin/kata-agent-clean --config /run/peerpod/agent-config.toml

--- a/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system/process-user-data.service.d/10-override.conf
+++ b/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system/process-user-data.service.d/10-override.conf
@@ -1,0 +1,5 @@
+# On a read-only fs the kata-agent config is created in /run/peerpod, since it contains
+# a parameter that can be set at pod creation time.
+[Service]
+ExecStart=
+ExecStart=/usr/local/bin/process-user-data update-agent-config --agent-config-file /run/peerpod/agent-config.toml

--- a/podvm/files/etc/systemd/system/kata-agent.service
+++ b/podvm/files/etc/systemd/system/kata-agent.service
@@ -6,9 +6,9 @@ After=netns@podns.service process-user-data.service
 
 [Service]
 ExecStartPre=mkdir -p /run/kata-containers
-ExecStart=/usr/local/bin/kata-agent --config /run/peerpod/agent-config.toml
+ExecStart=/usr/local/bin/kata-agent --config /etc/agent-config.toml
 ExecStartPre=-umount /sys/fs/cgroup/misc
-ExecStopPost=/usr/local/bin/kata-agent-clean --config /run/peerpod/agent-config.toml
+ExecStopPost=/usr/local/bin/kata-agent-clean --config /etc/agent-config.toml
 # Now specified in the agent-config.toml Environment="KATA_AGENT_SERVER_ADDR=unix:///run/kata-containers/agent.sock"
 SyslogIdentifier=kata-agent
 


### PR DESCRIPTION
The ./podvm kata-agent unit has been set to use a config file in /etc. Having the kata-agent config file in /run will break the CAA libvirt tests, since we have dependencies that rely on the config being in /etc. ./podvm-mkosi will override this path to a configuration in /run.

Tested w/ PodVM images built w/ packer + mkosi