### PR TITLE
provider: make existing provider managers can be reused

### DIFF
--- a/pkg/adaptor/cloud/aws/manager.go
+++ b/pkg/adaptor/cloud/aws/manager.go
@@ -53,3 +53,7 @@ func (_ *Manager) LoadEnv() {
 func (_ *Manager) NewProvider() (cloud.Provider, error) {
 	return NewProvider(&awscfg)
 }
+
+func (_ *Manager) GetConfig() (config *Config) {
+	return &awscfg
+}

--- a/pkg/adaptor/cloud/azure/manager.go
+++ b/pkg/adaptor/cloud/azure/manager.go
@@ -54,3 +54,7 @@ func (_ *Manager) LoadEnv() {
 func (_ *Manager) NewProvider() (cloud.Provider, error) {
 	return NewProvider(&azurecfg)
 }
+
+func (_ *Manager) GetConfig() (config *Config) {
+	return &azurecfg
+}

--- a/pkg/adaptor/cloud/ibmcloud-powervs/manager.go
+++ b/pkg/adaptor/cloud/ibmcloud-powervs/manager.go
@@ -61,3 +61,7 @@ func (_ *Manager) LoadEnv() {
 func (_ *Manager) NewProvider() (cloud.Provider, error) {
 	return NewProvider(&ibmcloudPowerVSConfig)
 }
+
+func (_ *Manager) GetConfig() (config *Config) {
+	return &ibmcloudPowerVSConfig
+}

--- a/pkg/adaptor/cloud/ibmcloud/manager.go
+++ b/pkg/adaptor/cloud/ibmcloud/manager.go
@@ -17,7 +17,7 @@ func init() {
 	cloud.AddCloud("ibmcloud", &Manager{})
 }
 
-func (*Manager) ParseCmd(flags *flag.FlagSet) {
+func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 
 	flags.StringVar(&ibmcloudVPCConfig.ApiKey, "api-key", "", "IBM Cloud API key, defaults to `IBMCLOUD_API_KEY`")
 	flags.StringVar(&ibmcloudVPCConfig.IAMProfileID, "iam-profile-id", "", "IBM IAM Profile ID, defaults to `IBMCLOUD_IAM_PROFILE_ID`")
@@ -38,7 +38,7 @@ func (*Manager) ParseCmd(flags *flag.FlagSet) {
 
 }
 
-func (*Manager) LoadEnv() {
+func (_ *Manager) LoadEnv() {
 	// overwrite config set by cmd parameters in oci image with env might come from orchastration platform
 	cloud.DefaultToEnv(&ibmcloudVPCConfig.ApiKey, "IBMCLOUD_API_KEY", "")
 	cloud.DefaultToEnv(&ibmcloudVPCConfig.IAMProfileID, "IBMCLOUD_IAM_PROFILE_ID", "")
@@ -66,6 +66,10 @@ func (*Manager) LoadEnv() {
 	}
 }
 
-func (*Manager) NewProvider() (cloud.Provider, error) {
+func (_ *Manager) NewProvider() (cloud.Provider, error) {
 	return NewProvider(&ibmcloudVPCConfig)
+}
+
+func (_ *Manager) GetConfig() (config *Config) {
+	return &ibmcloudVPCConfig
 }

--- a/pkg/adaptor/cloud/libvirt/manager.go
+++ b/pkg/adaptor/cloud/libvirt/manager.go
@@ -29,7 +29,7 @@ func init() {
 	cloud.AddCloud("libvirt", &Manager{})
 }
 
-func (*Manager) ParseCmd(flags *flag.FlagSet) {
+func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 
 	flags.StringVar(&libvirtcfg.URI, "uri", defaultURI, "libvirt URI")
 	flags.StringVar(&libvirtcfg.PoolName, "pool-name", defaultPoolName, "libvirt storage pool")
@@ -41,7 +41,7 @@ func (*Manager) ParseCmd(flags *flag.FlagSet) {
 
 }
 
-func (*Manager) LoadEnv() {
+func (_ *Manager) LoadEnv() {
 	cloud.DefaultToEnv(&libvirtcfg.URI, "LIBVIRT_URI", defaultURI)
 	cloud.DefaultToEnv(&libvirtcfg.PoolName, "LIBVIRT_POOL", defaultPoolName)
 	cloud.DefaultToEnv(&libvirtcfg.NetworkName, "LIBVIRT_NET", defaultNetworkName)
@@ -50,6 +50,10 @@ func (*Manager) LoadEnv() {
 	cloud.DefaultToEnv(&libvirtcfg.Firmware, "LIBVIRT_FIRMWARE", defaultFirmware)
 }
 
-func (*Manager) NewProvider() (cloud.Provider, error) {
+func (_ *Manager) NewProvider() (cloud.Provider, error) {
 	return NewProvider(&libvirtcfg)
+}
+
+func (_ *Manager) GetConfig() (config *Config) {
+	return &libvirtcfg
 }

--- a/pkg/adaptor/cloud/vsphere/manager.go
+++ b/pkg/adaptor/cloud/vsphere/manager.go
@@ -41,3 +41,7 @@ func (_ *Manager) LoadEnv() {
 func (_ *Manager) NewProvider() (cloud.Provider, error) {
 	return NewProvider(&vspherecfg)
 }
+
+func (_ *Manager) GetConfig() (config *Config) {
+	return &vspherecfg
+}


### PR DESCRIPTION
- Add new GetConfig function

Fixes https://github.com/confidential-containers/cloud-api-adaptor/issues/1628