### PR TITLE
forwarder: update the condition for default route

### DIFF
--- a/pkg/podnetwork/podnetwork_test.go
+++ b/pkg/podnetwork/podnetwork_test.go
@@ -100,7 +100,7 @@ func TestWorkerNode(t *testing.T) {
 			require.Equal(t, mockTunnelType, config.TunnelType, "hostInterface=%q", hostInterface)
 
 			require.Equal(t, len(config.Routes), 1, "hostInterface=%q", hostInterface)
-			require.Empty(t, config.Routes[0].Dst, "hostInterface=%q", hostInterface)
+			require.Equal(t, config.Routes[0].Dst.String(), "0.0.0.0/0", "hostInterface=%q", hostInterface)
 			require.Equal(t, config.Routes[0].GW.String(), "172.16.0.1", "hostInterface=%q", hostInterface)
 			require.Equal(t, config.Routes[0].Dev, "eth0", "hostInterface=%q", hostInterface)
 

--- a/pkg/util/netops/netops.go
+++ b/pkg/util/netops/netops.go
@@ -769,7 +769,7 @@ func toAddr(ip net.IP) netip.Addr {
 func toPrefix(ipnet *net.IPNet) netip.Prefix {
 
 	if ipnet == nil {
-		return netip.Prefix{}
+		return netip.PrefixFrom(netip.IPv4Unspecified(), 0)
 	}
 
 	addr, _ := netip.AddrFromSlice(ipnet.IP)


### PR DESCRIPTION
Fixes #1630

The problem is `r.Destination.Bits()` may return different results if building with different Go versions 

`r.Destination.Bits()` return 0 for go1.20.5, but return -1 for go1.21.1

I tried to change the condition to `!r.Destination.IsValid()` because it returns consistent results.

The code of `IsValid()` for go1.20.5:
```
// IsValid reports whether p.Bits() has a valid range for p.Addr().
// If p.Addr() is the zero Addr, IsValid returns false.
// Note that if p is the zero Prefix, then p.IsValid() == false.
func (p Prefix) IsValid() bool { return !p.ip.isZero() && p.bits >= 0 && int(p.bits) <= p.ip.BitLen() }
```

The code of `IsValid()` for go1.21.1:
```
func (p Prefix) IsValid() bool { return p.bitsPlusOne > 0 }

func PrefixFrom(ip Addr, bits int) Prefix {
	var bitsPlusOne uint8
	if !ip.isZero() && bits >= 0 && bits <= ip.BitLen() {
		bitsPlusOne = uint8(bits) + 1
	}
	return Prefix{
		ip:          ip.withoutZone(),
		bitsPlusOne: bitsPlusOne,
	}
}
```

I think the purpose of the code here is to judge if the route Destination is the default prefix "0.0.0.0/0". However, the route Destination here is `Destination:netip.Prefix{ip:netip.Addr{addr:netip.uint128{hi:0x0, lo:0x0}, z:(*intern.Value)(nil)}, bits:0}` for go1.20.5 and `Destination:netip.Prefix{ip:netip.Addr{addr:netip.uint128{hi:0x0, lo:0x0}, z:(*intern.Value)(nil)}, bitsPlusOne:0x0}` for go1.21.1

Because the **z** is nil, the `Addr.isZero()` returns true, and `Addr.IsUnspecified()` returns false.

The **z** is nil, because the route Destination is from nil. In https://github.com/confidential-containers/cloud-api-adaptor/blob/main/pkg/util/netops/netops.go#L539, the `r.Dst` is nil, because in https://github.com/confidential-containers/cloud-api-adaptor/blob/main/pkg/util/netops/netops.go#L458, we just set Dst if `dst.Bits() > 0`. If change the condition to `if dst.Bits() >= 0`, `ns.handle.RouteListFiltered` will return nil. Not sure why, it's the 3rd party code of "github.com/vishvananda/netlink"