### PR TITLE
azure: fix image reference string

### DIFF
--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -110,7 +110,7 @@ jobs:
 
     - name: Create provisioner file
       env:
-        AZURE_IMAGE_ID: ${{ github.event.inputs.podvm-image-id || format('/CommunityGalleries/{0}/images/{1}/Versions/{2}', secrets.AZURE_COMMUNITY_GALLERY_NAME, secrets.AZURE_PODVM_IMAGE_DEF_NAME, needs.generate-podvm-image-version.outputs.image-version) }}
+        AZURE_IMAGE_ID: ${{ github.event.inputs.podvm-image-id || format('/CommunityGalleries/{0}/images/{1}/Versions/{2}', vars.AZURE_COMMUNITY_GALLERY_NAME, vars.AZURE_PODVM_IMAGE_DEF_NAME, needs.generate-podvm-image-version.outputs.image-version) }}
         CAA_IMAGE: "${{ github.event.inputs.caa-image || needs.build-caa-container-image.outputs.caa-image }}"
       run: |
         cat << EOF > ${{ env.TEST_PROVISION_FILE }}


### PR DESCRIPTION
The community gallery and image definition are supposed to be stored as vars not as secret, reference is usage in the nightly image build.

https://github.com/confidential-containers/cloud-api-adaptor/blob/afe662c4b09f63168e8dae594e67c48871d96c3c/.github/workflows/azure-podvm-image-build.yml#L29-L31