### PR TITLE
process-user-data: process cloud-config yamls

### DIFF
--- a/aws/image/rhel/aws-rhel.pkr.hcl
+++ b/aws/image/rhel/aws-rhel.pkr.hcl
@@ -128,7 +128,6 @@ build {
     environment_vars = [
       "CLOUD_PROVIDER=${var.cloud_provider}",
       "PODVM_DISTRO=${var.podvm_distro}",
-      "DISABLE_CLOUD_CONFIG=${var.disable_cloud_config}",
       "ENABLE_NVIDIA_GPU=${var.enable_nvidia_gpu}"
     ]
     inline = [

--- a/aws/image/ubuntu/aws-ubuntu.pkr.hcl
+++ b/aws/image/ubuntu/aws-ubuntu.pkr.hcl
@@ -114,7 +114,6 @@ build {
     environment_vars = [
       "CLOUD_PROVIDER=${var.cloud_provider}",
       "PODVM_DISTRO=${var.podvm_distro}",
-      "DISABLE_CLOUD_CONFIG=${var.disable_cloud_config}",
       "ENABLE_NVIDIA_GPU=${var.enable_nvidia_gpu}"
     ]
     inline = [

--- a/azure/image/rhel/azure-rhel.pkr.hcl
+++ b/azure/image/rhel/azure-rhel.pkr.hcl
@@ -140,7 +140,6 @@ build {
     environment_vars = [
       "CLOUD_PROVIDER=${var.cloud_provider}",
       "PODVM_DISTRO=${var.podvm_distro}",
-      "DISABLE_CLOUD_CONFIG=${var.disable_cloud_config}",
       "ENABLE_NVIDIA_GPU=${var.enable_nvidia_gpu}"
     ]
     inline = [

--- a/azure/image/ubuntu/azure-ubuntu.pkr.hcl
+++ b/azure/image/ubuntu/azure-ubuntu.pkr.hcl
@@ -120,7 +120,6 @@ build {
     environment_vars = [
       "CLOUD_PROVIDER=${var.cloud_provider}",
       "PODVM_DISTRO=${var.podvm_distro}",
-      "DISABLE_CLOUD_CONFIG=${var.disable_cloud_config}",
       "ENABLE_NVIDIA_GPU=${var.enable_nvidia_gpu}"
     ]
     inline = [

--- a/cmd/process-user-data/main.go
+++ b/cmd/process-user-data/main.go
@@ -41,6 +41,8 @@ var updateAgentConfigCmd = &cobra.Command{
 var cfg Config
 
 func init() {
+	// set a fixed value for authJsonPath
+	cfg.authJsonPath = defaultAuthJsonFilePath
 
 	rootCmd.PersistentFlags().BoolVarP(&versionFlag, "version", "v", false, "Print the version")
 	// Add a flag to specify the daemonConfigPath

--- a/cmd/process-user-data/types.go
+++ b/cmd/process-user-data/types.go
@@ -12,8 +12,8 @@ const (
 type Config struct {
 	daemonConfigPath     string
 	agentConfigPath      string
-	userData             string
 	userDataFetchTimeout int
+	authJsonPath         string
 }
 
 type Endpoints struct {

--- a/cmd/process-user-data/update.go
+++ b/cmd/process-user-data/update.go
@@ -102,7 +102,7 @@ func updateAgentConfig(cmd *cobra.Command, args []string) error {
 	}
 
 	if config.AAKBCParams != "" {
-		fmt.Printf("Updating aa_kbc_params in agent config file")
+		fmt.Printf("Updating aa_kbc_params in agent config file\n")
 		agentConfig.AaKbcParams = config.AAKBCParams
 	}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,7 +50,6 @@ aws() {
     [[ "${USE_PUBLIC_IP}" == "true" ]] && optionals+="-use-public-ip " # Use public IP for pod vm
     [[ "${ROOT_VOLUME_SIZE}" ]] && optionals+="-root-volume-size ${ROOT_VOLUME_SIZE} " # Specify root volume size for pod vm
     [[ "${DISABLECVM}" == "true" ]] && optionals+="-disable-cvm "
-    [[ "${DISABLE_CLOUD_CONFIG}" == "true" ]] && optionals+="-disable-cloud-config "
 
     set -x
     exec cloud-api-adaptor aws \
@@ -67,7 +66,6 @@ azure() {
     [[ "${DISABLECVM}" == "true" ]] && optionals+="-disable-cvm "
     [[ "${AZURE_INSTANCE_SIZES}" ]] && optionals+="-instance-sizes ${AZURE_INSTANCE_SIZES} "
     [[ "${TAGS}" ]] && optionals+="-tags ${TAGS} " # Custom tags applied to pod vm
-    [[ "${DISABLE_CLOUD_CONFIG}" == "true" ]] && optionals+="-disable-cloud-config "
     [[ "${ENABLE_SECURE_BOOT}" == "true" ]] && optionals+="-enable-secure-boot "
 
     set -x

--- a/install/overlays/azure/kustomization.yaml
+++ b/install/overlays/azure/kustomization.yaml
@@ -37,7 +37,6 @@ configMapGenerator:
   #- VXLAN_PORT="" # Uncomment and set if you want to use a specific vxlan port. Defaults to 4789
   #- AZURE_INSTANCE_SIZES="" # comma separated
   #- TAGS="" # Uncomment and add key1=value1,key2=value2 etc if you want to use specific tags for podvm
-  #- DISABLE_CLOUD_CONFIG="" # Uncomment if you want to enable user data for podvm
   #- AA_KBC_PARAMS="" # Uncomment and set if you want to set KBC params for podvm
   #- FORWARDER_PORT="" # Uncomment and set if you want to use a specific port for agent-protocol-forwarder. Defaults to 15150
 ##TLS_SETTINGS

--- a/pkg/adaptor/cloud/aws/manager.go
+++ b/pkg/adaptor/cloud/aws/manager.go
@@ -39,8 +39,6 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	// Default is 30GiBs for free tier. Hence use it as default
 	flags.IntVar(&awscfg.RootVolumeSize, "root-volume-size", 30, "Root volume size (in GiB) for the Pod VMs")
 	flags.BoolVar(&awscfg.DisableCVM, "disable-cvm", false, "Use non-CVMs for peer pods")
-	// Add a flag to disable cloud config and use userdata via metadata service
-	flags.BoolVar(&awscfg.DisableCloudConfig, "disable-cloud-config", false, "Disable cloud config and use userdata via metadata service")
 
 }
 

--- a/pkg/adaptor/cloud/aws/misc.go
+++ b/pkg/adaptor/cloud/aws/misc.go
@@ -41,11 +41,11 @@ func IsAWS(ctx context.Context) bool {
 
 // Method to retrieve userData from the instance metadata service
 // and return it as a string
-func GetUserData(ctx context.Context, url string) (string, error) {
+func GetUserData(ctx context.Context, url string) ([]byte, error) {
 
 	// If url is empty then return empty string
 	if url == "" {
-		return "", fmt.Errorf("url is empty")
+		return nil, fmt.Errorf("url is empty")
 	}
 
 	// Create a new HTTP client
@@ -57,30 +57,30 @@ func GetUserData(ctx context.Context, url string) (string, error) {
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to create request: %s", err)
+		return nil, fmt.Errorf("failed to create request: %s", err)
 
 	}
 
 	// Send the request and retrieve the response
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to send request: %s", err)
+		return nil, fmt.Errorf("failed to send request: %s", err)
 
 	}
 	defer resp.Body.Close()
 
 	// Check if the response was successful
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to retrieve userData: %s", resp.Status)
+		return nil, fmt.Errorf("failed to retrieve userData: %s", resp.Status)
 
 	}
 
 	// Read the response body and return it as a string
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("failed to read response body: %s", err)
+		return nil, fmt.Errorf("failed to read response body: %s", err)
 
 	}
 
-	return string(body), nil
+	return body, nil
 }

--- a/pkg/adaptor/cloud/aws/provider.go
+++ b/pkg/adaptor/cloud/aws/provider.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"log"
 	"net/netip"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -145,8 +144,6 @@ func (p *awsProvider) CreateInstance(ctx context.Context, podName, sandboxID str
 	// Public IP address
 	var publicIPAddr netip.Addr
 
-	var b64EncData string
-
 	instanceName := util.GenerateInstanceName(podName, sandboxID, maxInstanceNameLen)
 
 	cloudConfigData, err := cloudConfig.Generate()
@@ -154,19 +151,8 @@ func (p *awsProvider) CreateInstance(ctx context.Context, podName, sandboxID str
 		return nil, err
 	}
 
-	if !p.serviceConfig.DisableCloudConfig {
-		//Convert userData to base64
-		b64EncData = base64.StdEncoding.EncodeToString([]byte(cloudConfigData))
-	} else {
-		userData := strings.Split(cloudConfigData, "content: |")[1]
-		// Take the data in {} after content: and ignore the rest
-		// ToDo: use a regex
-		userData = strings.Split(userData, "- path")[0]
-		userData = strings.TrimSpace(userData)
-
-		//Convert userData to base64
-		b64EncData = base64.StdEncoding.EncodeToString([]byte(userData))
-	}
+	//Convert userData to base64
+	b64EncData := base64.StdEncoding.EncodeToString([]byte(cloudConfigData))
 
 	instanceType, err := p.selectInstanceType(ctx, spec)
 	if err != nil {

--- a/pkg/adaptor/cloud/aws/types.go
+++ b/pkg/adaptor/cloud/aws/types.go
@@ -55,7 +55,6 @@ type Config struct {
 	RootVolumeSize       int
 	RootDeviceName       string
 	DisableCVM           bool
-	DisableCloudConfig   bool
 }
 
 func (c Config) Redact() Config {

--- a/pkg/adaptor/cloud/azure/manager.go
+++ b/pkg/adaptor/cloud/azure/manager.go
@@ -36,8 +36,6 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	flags.Var(&azurecfg.InstanceSizes, "instance-sizes", "Instance sizes to be used for the Pod VMs, comma separated")
 	// Add a key value list parameter to indicate custom tags to be used for the Pod VMs
 	flags.Var(&azurecfg.Tags, "tags", "Custom tags (key=value pairs) to be used for the Pod VMs, comma separated")
-	// Add a flag to disable cloud config and use userdata via metadata service
-	flags.BoolVar(&azurecfg.DisableCloudConfig, "disable-cloud-config", false, "Disable cloud config and use userdata via metadata service")
 	flags.BoolVar(&azurecfg.EnableSecureBoot, "enable-secure-boot", false, "Enable secure boot for the VMs")
 }
 

--- a/pkg/adaptor/cloud/azure/misc.go
+++ b/pkg/adaptor/cloud/azure/misc.go
@@ -44,11 +44,11 @@ func IsAzure(ctx context.Context) bool {
 
 // Method to retrieve userData from the instance metadata service
 // and return it as a string
-func GetUserData(ctx context.Context, url string) (string, error) {
+func GetUserData(ctx context.Context, url string) ([]byte, error) {
 
 	// If url is empty then return empty string
 	if url == "" {
-		return "", fmt.Errorf("url is empty")
+		return nil, fmt.Errorf("url is empty")
 	}
 
 	// Create a new HTTP client
@@ -60,7 +60,7 @@ func GetUserData(ctx context.Context, url string) (string, error) {
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to create request: %s", err)
+		return nil, fmt.Errorf("failed to create request: %s", err)
 
 	}
 	// Add the required headers to the request
@@ -69,21 +69,21 @@ func GetUserData(ctx context.Context, url string) (string, error) {
 	// Send the request and retrieve the response
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to send request: %s", err)
+		return nil, fmt.Errorf("failed to send request: %s", err)
 
 	}
 	defer resp.Body.Close()
 
 	// Check if the response was successful
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to retrieve userData: %s", resp.Status)
+		return nil, fmt.Errorf("failed to retrieve userData: %s", resp.Status)
 
 	}
 
 	// Read the response body and return it as a string
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("failed to read response body: %s", err)
+		return nil, fmt.Errorf("failed to read response body: %s", err)
 
 	}
 
@@ -125,8 +125,8 @@ func GetUserData(ctx context.Context, url string) (string, error) {
 	// Decode the base64 response
 	decoded, err := base64.StdEncoding.DecodeString(string(body))
 	if err != nil {
-		return "", fmt.Errorf("failed to decode b64 encoded userData: %s", err)
+		return nil, fmt.Errorf("failed to decode b64 encoded userData: %s", err)
 	}
 
-	return string(decoded), nil
+	return decoded, nil
 }

--- a/pkg/adaptor/cloud/azure/types.go
+++ b/pkg/adaptor/cloud/azure/types.go
@@ -44,7 +44,6 @@ type Config struct {
 	InstanceSizes        instanceSizes
 	InstanceSizeSpecList []cloud.InstanceTypeSpec
 	Tags                 cloud.KeyValueFlag
-	DisableCloudConfig   bool
 	// Disabled by default, we want to do measured boot.
 	// Secure boot brings no additional security.
 	EnableSecureBoot bool

--- a/podvm-mkosi/README.md
+++ b/podvm-mkosi/README.md
@@ -73,6 +73,5 @@ Packages=
 The following limitations apply to these images. Notice that the limitations are intentional to
 reduce complexity of configuration and CI and shall not be seen as open to-dos.
 
-- `DISABLE_CLOUD_CONFIG=true` is implied. The mkosi images are using
-    our own mechanism to fetch metadata from the IMDS API. Cloud init is not supported.
-    Ensure that `DISABLE_CLOUD_CONFIG=true` in your `install/overlay/${CSP}/kustomization.yaml`.
+- Deployed images cannot be customized with cloud-init. Runtime configuration data is retrieved
+  from IMDS via the project's `process-user-data` tool.


### PR DESCRIPTION
fixes #1639 

The process-user-data tool is processing cloud-config data now instead of a raw daemon config json file. The latter required setting a parameter on the DaemonSet configuration, depending on whether a PodVM image has been built w/ cloud-config disabled or not.

The support is limited to the `write_files` directive and a subset of properties, specifically `path` and `content`, as those are set by the cloud provider code. Parsing will fail if additional properties are encountered.

In theory provider code can set additional properties, but atm we don't. (we might consider removing the unused props in the cloudconfig code, to avoid confusion)

All `write_files` entries but the one with `path: $daemonConfigPath` will be ignored.

In the CAA code the `DISABLE_CLOUD_CONFIG` flag has been removed and providers will always set cloud-config files as user-data. For packer based builds, the `DISABLE_CLOUD_CONFIG` env is still used to pick process-user-data instead of the system's cloud-init service.

## Testing done

Tested peerpod deployment successfully on Azure with an mkosi-based image (uses process-user-data exclusively) and a CAA daemonset with the `-disable-cloud-config` flag removed.