### PR TITLE
e2e: enable more than one pod in one test case

### DIFF
--- a/test/e2e/ibmcloud_test.go
+++ b/test/e2e/ibmcloud_test.go
@@ -502,6 +502,13 @@ func TestIBMCreateNginxDeployment(t *testing.T) {
 	doTestNginxDeployment(t, assert)
 }
 
+func TestPodToServiceCommunication(t *testing.T) {
+	assert := IBMCloudAssert{
+		vpc: pv.IBMCloudProps.VPC,
+	}
+	doTestPodToServiceCommunication(t, assert)
+}
+
 // IBMCloudAssert implements the CloudAssert interface for ibmcloud.
 type IBMCloudAssert struct {
 	vpc *vpcv1.VpcV1

--- a/test/e2e/libvirt_test.go
+++ b/test/e2e/libvirt_test.go
@@ -85,6 +85,11 @@ func TestLibvirtDeletePod(t *testing.T) {
 	doTestDeleteSimplePod(t, assert)
 }
 
+func TestLibvirtPodToServiceCommunication(t *testing.T) {
+	assert := LibvirtAssert{}
+	doTestPodToServiceCommunication(t, assert)
+}
+
 // LibvirtAssert implements the CloudAssert interface for Libvirt.
 type LibvirtAssert struct {
 	// TODO: create the connection once on the initializer.


### PR DESCRIPTION
Enable test framework to support more than one pod in one test case

Fixes: https://github.com/confidential-containers/cloud-api-adaptor/issues/16