### PR TITLE
peerpod-ctrl: fix Make command docker-buildx

### DIFF
--- a/peerpod-ctrl/Makefile
+++ b/peerpod-ctrl/Makefile
@@ -153,13 +153,10 @@ list-build-args:
 PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 .PHONY: docker-buildx
 docker-buildx: test ## Build and push docker image for the manager for cross-platform support
-	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
-	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} --build-arg CGO_ENABLED=$(CGO_ENABLED) --build-arg GOFLAGS=$(GOFLAGS) -f Dockerfile .
 	- docker buildx rm project-v3-builder
-	rm Dockerfile.cross
 
 ##@ Deployment
 


### PR DESCRIPTION
When I tried to build peerpod-ctrl image locally with command `make docker-buildx`, it failed:
```
docker buildx build --push --platform=linux/arm64,linux/amd64,linux/s390x,linux/ppc64le --tag quay.io/cdlleili/peerpod-ctrl:latest -f Dockerfile.cross
ERROR: "docker buildx build" requires exactly 1 argument.
```

So I tried to fix it:
* `--platform=$TARGETPLATFORM` has been set in Dockerfile, so we don't need to insert `--platform=${BUILDPLATFORM}` for cross-platform support
* add 2 build args
* add `.` as the latest argument