### PR TITLE
e2e-test: fix e2e-test pipelines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ image-with-arch: .git-commit ## Build the per arch image
 .PHONY: deploy
 deploy: ## Deploy cloud-api-adaptor using the operator, according to install/overlays/$(CLOUD_PROVIDER)/kustomization.yaml file.
 ifneq ($(CLOUD_PROVIDER),)
-	kubectl apply -k "github.com/confidential-containers/operator/config/default?ref=v0.8.0"
+	kubectl apply -k "github.com/confidential-containers/operator/config/release?ref=v0.8.0"
 	kubectl apply -k "github.com/confidential-containers/operator/config/samples/ccruntime/peer-pods?ref=v0.8.0"
 	kubectl apply -k install/overlays/$(CLOUD_PROVIDER)
 else

--- a/test/provisioner/provision.go
+++ b/test/provisioner/provision.go
@@ -157,7 +157,7 @@ func (p *CloudAPIAdaptor) Delete(ctx context.Context, cfg *envconf.Config) error
 	deployments := &appsv1.DeploymentList{Items: []appsv1.Deployment{*p.controllerDeployment}}
 
 	log.Info("Uninstall the controller manager")
-	cmd = exec.Command("kubectl", "delete", "-k", "github.com/confidential-containers/operator/config/default?ref=v0.8.0")
+	cmd = exec.Command("kubectl", "delete", "-k", "github.com/confidential-containers/operator/config/release?ref=v0.8.0")
 	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG="+cfg.KubeconfigFile()))
 	stdoutStderr, err = cmd.CombinedOutput()
 	log.Tracef("%v, output: %s", cmd, stdoutStderr)
@@ -184,7 +184,7 @@ func (p *CloudAPIAdaptor) Deploy(ctx context.Context, cfg *envconf.Config, props
 
 	log.Info("Install the controller manager")
 	// TODO - find go idiomatic way to apply/delete remote kustomize and apply to this file
-	cmd := exec.Command("kubectl", "apply", "-k", "github.com/confidential-containers/operator/config/default?ref=v0.8.0")
+	cmd := exec.Command("kubectl", "apply", "-k", "github.com/confidential-containers/operator/config/release?ref=v0.8.0")
 	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG="+cfg.KubeconfigFile()))
 	stdoutStderr, err := cmd.CombinedOutput()
 	log.Tracef("%v, output: %s", cmd, stdoutStderr)


### PR DESCRIPTION
- pin operator manager to use release v0.8.0 tag

From last Saturday, the opensource e2e test pipelines are failed with error:
```
[2024-01-06T00:22:04.027Z] confidential-containers-system   cc-operator-daemon-install-jptsh                          0/1     Error              4 (65s ago)   3m12s
``` 
eg: https://github.com/confidential-containers/cloud-api-adaptor/actions/runs/7429572885/job/20218312686#step:5:1827

Did a dig found that log from the `cc-operator-daemon-install` looks like:
```
kubectl logs -f -n confidential-containers-system   cc-operator-daemon-install-88f4z
/opt/kata-artifacts/scripts/kata-deploy.sh: line 417: SNAPSHOTTER: unbound variable
Environment variables passed to this script
* NODE_NAME: peer-pods-worker-0
* DEBUG: false
* SHIMS: remote
* DEFAULT_SHIM:
* CREATE_RUNTIMECLASSES: true
* CREATE_DEFAULT_RUNTIMECLASS: false
```

This is because the operator change from https://github.com/confidential-containers/operator/pull/303

As we want to keep the operator using v0.8.0:
- https://github.com/confidential-containers/cloud-api-adaptor/blob/main/Makefile#L168
- https://github.com/confidential-containers/cloud-api-adaptor/blob/main/test/provisioner/provision.go#L187
`github.com/confidential-containers/operator/config/default?ref=v0.8.0` is used but the operator image from this url is:
```
kubectl describe po -n confidential-containers-system   cc-operator-controller-manager-68ff8494b7-mqdkb
...
  Normal   Pulled     21m                kubelet  Successfully pulled image "quay.io/confidential-containers/operator:latest" in 7.676360911s (7.676367738s including waiting)
``` 
We should use `github.com/confidential-containers/operator/config/release?ref=v0.8.0`, it pin the operator image to v0.8.0 tag:
https://github.com/confidential-containers/operator/blob/v0.8.0/config/release/kustomization.yaml#L7