### PR TITLE
test/e2e: Switch tests away from default namespace

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -138,6 +138,11 @@ func TestMain(m *testing.M) {
 				return ctx, err
 			}
 		}
+
+		if err = CreateAndWaitForNamespace(ctx, cfg.Client(), E2eNamespace); err != nil {
+			return ctx, err
+		}
+
 		return ctx, nil
 	})
 
@@ -146,6 +151,11 @@ func TestMain(m *testing.M) {
 		if !shouldTeardown {
 			return ctx, nil
 		}
+
+		if err = DeleteAndWaitForNamespace(ctx, cfg.Client(), E2eNamespace); err != nil {
+			return ctx, err
+		}
+
 		if shouldProvisionCluster {
 			if err = provisioner.DeleteCluster(ctx, cfg); err != nil {
 				return ctx, err

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -69,10 +69,10 @@ func TestMain(m *testing.M) {
 	// Cloud API Adaptor is installed by default during e2e test.
 	// In case TEST_INSTALL_CAA is exported as "no", it will skip the installation of
 	// Cloud API Adaptor.
-	// In scenario of teardown, CAA will be cleanup when shouldTeardown is true and shoudlInstallCAA is true.
-	shoudlInstallCAA := true
+	// In scenario of teardown, CAA will be cleanup when shouldTeardown is true and shouldInstallCAA is true.
+	shouldInstallCAA := true
 	if os.Getenv("TEST_INSTALL_CAA") == "no" {
-		shoudlInstallCAA = false
+		shouldInstallCAA = false
 	}
 
 	// The TEST_PODVM_IMAGE is an option variable which specifies the path
@@ -127,7 +127,7 @@ func TestMain(m *testing.M) {
 			}
 		}
 
-		if shoudlInstallCAA {
+		if shouldInstallCAA {
 			log.Info("Install Cloud API Adaptor")
 			relativeInstallDirectory := "../../install"
 			if cloudAPIAdaptor, err = pv.NewCloudAPIAdaptor(cloudProvider, relativeInstallDirectory); err != nil {
@@ -156,7 +156,7 @@ func TestMain(m *testing.M) {
 				return ctx, nil
 			}
 		}
-		if shoudlInstallCAA {
+		if shouldInstallCAA {
 			log.Info("Delete the Cloud API Adaptor installation")
 			if err = cloudAPIAdaptor.Delete(ctx, cfg); err != nil {
 				return ctx, err

--- a/test/e2e/nginx_deployment.go
+++ b/test/e2e/nginx_deployment.go
@@ -93,12 +93,11 @@ func NewDeployment(namespace, deploymentName, containerName, imageName string, o
 }
 
 func DoTestNginxDeployment(t *testing.T, testEnv env.Environment, assert CloudAssert) {
-	namespace := envconf.RandomName("default", 7)
 	deploymentName := "nginx-deployment"
 	containerName := "nginx"
 	imageName := "nginx:latest"
 	replicas := int32(2)
-	deployment := NewDeployment(namespace, deploymentName, containerName, imageName, WithReplicaCount(replicas))
+	deployment := NewDeployment(E2eNamespace, deploymentName, containerName, imageName, WithReplicaCount(replicas))
 
 	nginxImageFeature := features.New("Nginx image deployment test").
 		WithSetup("Create nginx deployment", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {

--- a/test/e2e/rolling_update.go
+++ b/test/e2e/rolling_update.go
@@ -31,7 +31,6 @@ const OLD_VM_DELETION_TIMEOUT = time.Second * 30
 
 func DoTestCaaDaemonsetRollingUpdate(t *testing.T, testEnv env.Environment, assert RollingUpdateAssert) {
 	runtimeClassName := "kata-remote"
-	namespace := envconf.RandomName("default", 7)
 	deploymentName := "webserver-deployment"
 	containerName := "webserver"
 	imageName := "python:3"
@@ -48,7 +47,7 @@ func DoTestCaaDaemonsetRollingUpdate(t *testing.T, testEnv env.Environment, asse
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      deploymentName,
-			Namespace: namespace,
+			Namespace: E2eNamespace,
 			Labels:    labelsMap,
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -100,7 +99,7 @@ func DoTestCaaDaemonsetRollingUpdate(t *testing.T, testEnv env.Environment, asse
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceName,
-			Namespace: namespace,
+			Namespace: E2eNamespace,
 		},
 		Spec: v1.ServiceSpec{
 			Type: v1.ServiceTypeNodePort,
@@ -119,7 +118,7 @@ func DoTestCaaDaemonsetRollingUpdate(t *testing.T, testEnv env.Environment, asse
 	verifyPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      verifyPodName,
-			Namespace: namespace,
+			Namespace: E2eNamespace,
 		},
 		Spec: v1.PodSpec{
 			RestartPolicy: v1.RestartPolicyNever,
@@ -208,7 +207,7 @@ func DoTestCaaDaemonsetRollingUpdate(t *testing.T, testEnv env.Environment, asse
 			// Wait for webserver deployment available again
 			waitForDeploymentAvailable(t, client, deployment, rc)
 
-			if err = client.Resources().Get(ctx, verifyPodName, namespace, verifyPod); err != nil {
+			if err = client.Resources().Get(ctx, verifyPodName, E2eNamespace, verifyPod); err != nil {
 				t.Fatal(err)
 			}
 			log.Printf("verify pod status: %s", verifyPod.Status.Phase)
@@ -217,7 +216,7 @@ func DoTestCaaDaemonsetRollingUpdate(t *testing.T, testEnv env.Environment, asse
 				if err != nil {
 					log.Printf("Failed to new client set: %v", err)
 				} else {
-					req := clientset.CoreV1().Pods(namespace).GetLogs(verifyPodName, &v1.PodLogOptions{})
+					req := clientset.CoreV1().Pods(E2eNamespace).GetLogs(verifyPodName, &v1.PodLogOptions{})
 					podLogs, err := req.Stream(ctx)
 					if err != nil {
 						log.Printf("Failed to get pod logs: %v", err)


### PR DESCRIPTION
- Currently we are run e2e-test cases under a  namespace defined by
```
namespace := envconf.RandomName("default", 7)
```
The way that
[envconf.RandomName](https://pkg.go.dev/sigs.k8s.io/e2e-framework/pkg/envconf#RandomName) works is to add random name after the prefix, up to the specified length. As default is 7 chars long then envconf.RandomName("default", 7) will just return `default`.

- This means that we have a lot of duplicated code in each test case that does nothing, so we should resolved this.

- It's also a good idea to have a single namespace for testing anyway, like we;ve done in kata-containers,  as in case things fail and go wrong it's easier to clean up by deleting the namespace, though obviously `default` shouldn't be that namespace here.

- This PR adds a new e2e-test namespace to address these.

Fixes: #1652