### PR TITLE
podvm-mkosi: override kata-agent config path

### DIFF
--- a/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system/kata-agent.service.d/10-override.conf
+++ b/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system/kata-agent.service.d/10-override.conf
@@ -1,10 +1,8 @@
 # On a read-only fs the kata-agent config is created in /run/peerpod, since it contains
 # a parameter that can be set at pod creation time.
-[Unit]
-ConditionKernelCommandLine=
-
 [Service]
+Environment=KATA_AGENT_CONFIG_PATH=/run/peerpod/agent-config.toml
 ExecStart=
-ExecStart=/usr/local/bin/kata-agent --config /run/peerpod/agent-config.toml
+ExecStart=/usr/local/bin/kata-agent --config ${KATA_AGENT_CONFIG_PATH}
 ExecStop=
-ExecStopPost=/usr/local/bin/kata-agent-clean --config /run/peerpod/agent-config.toml
+ExecStopPost=/usr/local/bin/kata-agent-clean --config ${KATA_AGENT_CONFIG_PATH}

--- a/versions.yaml
+++ b/versions.yaml
@@ -26,7 +26,7 @@ tools:
 git:
   guest-components:
     url: https://github.com/confidential-containers/guest-components
-    reference: dec7f10ec2ab1e715c49741188d48065ab6c0feb
+    reference: f20d4b59aa62032e82bd8d8107e6874d9618db50
   kata-containers:
     url: https://github.com/kata-containers/kata-containers
     reference: d0df91935b8840036c2891b1f93dd8059ebe486a


### PR DESCRIPTION
fixes: #1637

~blocked-by: https://github.com/confidential-containers/guest-components/pull/429~

On a podvm using an guest-components build from the PR, `KATA_AGENT_CONFIG_PATH` is set and picked up by attestation-agent and cdh:

```bash
$ cat /proc/$(pgrep -i attest)/environ | xargs --null echo
LANG=C.UTF-8 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin SYSTEMD_SULOGIN_FORCE=1 INVOCATION_ID=ad04b8c4ff6c4f2c8617dfcfed24c183 JOURNAL_STREAM=8:3090 SYSTEMD_EXEC_PID=552 KATA_AGENT_CONFIG_PATH=/run/peerpod/agent-config.toml RUST_BACKTRACE=full OCICRYPT_KEYPROVIDER_CONFIG=/tmp/ocicrypt_config.json
```

Verified w/ a kbs deployment that the mkosi-podvm performs a remote attestation.

Once this is the guest-components PR is merged, we need to bump its revision in `versions.yaml`