### PR TITLE
e2e: Add support for pods' secure communication

### DIFF
--- a/pkg/util/tlsutil/certgen.go
+++ b/pkg/util/tlsutil/certgen.go
@@ -177,7 +177,7 @@ func generateCertificate(orgName, serverName string, parentCertPEM, parentKeyPEM
 		Subject:               pkix.Name{Organization: []string{orgName}},
 		NotBefore:             notBefore,
 		NotAfter:              notAfter,
-		KeyUsage:              x509.KeyUsageCertSign,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{authType},
 		BasicConstraintsValid: true,
 	}

--- a/test/e2e/assessment_runner.go
+++ b/test/e2e/assessment_runner.go
@@ -65,6 +65,7 @@ type TestCase struct {
 	extraPods            []*ExtraPod
 	configMap            *v1.ConfigMap
 	secret               *v1.Secret
+	extraSecrets         []*v1.Secret
 	pvc                  *v1.PersistentVolumeClaim
 	job                  *batchv1.Job
 	service              *v1.Service
@@ -86,6 +87,11 @@ func (tc *TestCase) WithConfigMap(configMap *v1.ConfigMap) *TestCase {
 
 func (tc *TestCase) WithSecret(secret *v1.Secret) *TestCase {
 	tc.secret = secret
+	return tc
+}
+
+func (tc *TestCase) WithExtraSecrets(secrets []*v1.Secret) *TestCase {
+	tc.extraSecrets = secrets
 	return tc
 }
 
@@ -181,6 +187,14 @@ func (tc *TestCase) Run() {
 			if tc.secret != nil {
 				if err = client.Resources().Create(ctx, tc.secret); err != nil {
 					t.Fatal(err)
+				}
+			}
+
+			if tc.extraSecrets != nil {
+				for _, extraSecret := range tc.extraSecrets {
+					if err = client.Resources().Create(ctx, extraSecret); err != nil {
+						t.Fatal(err)
+					}
 				}
 			}
 
@@ -471,6 +485,17 @@ func (tc *TestCase) Run() {
 				} else {
 					log.Infof("Deleting Secret... %s", tc.secret.Name)
 				}
+			}
+
+			if tc.extraSecrets != nil {
+				for _, extraSecret := range tc.extraSecrets {
+					if err = client.Resources().Delete(ctx, extraSecret); err != nil {
+						t.Fatal(err)
+					} else {
+						log.Infof("Deleting extra Secret... %s", extraSecret.Name)
+					}
+				}
+
 			}
 
 			if tc.job != nil {

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -50,6 +50,13 @@ func WithContainerPort(port int32) PodOption {
 	}
 }
 
+func WithSecureContainerPort(port int32) PodOption {
+	return func(p *corev1.Pod) {
+		p.Spec.Containers[0].Ports = append(p.Spec.Containers[0].Ports,
+			corev1.ContainerPort{Name: "https", ContainerPort: port})
+	}
+}
+
 func WithCommand(command []string) PodOption {
 	return func(p *corev1.Pod) {
 		p.Spec.Containers[0].Command = command
@@ -207,21 +214,14 @@ func NewPVC(namespace, name, storageClassName, diskSize string, accessModel core
 	}
 }
 
-func NewService(namespace, serviceName, portName string, portNumber, targetPort int32, labels map[string]string) *corev1.Service {
+func NewService(namespace, serviceName string, servicePorts []corev1.ServicePort, labels map[string]string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceName,
 			Namespace: namespace,
 		},
 		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{
-				{
-					Name:       portName,
-					Port:       portNumber,
-					TargetPort: intstr.FromInt(int(targetPort)),
-					Protocol:   corev1.ProtocolTCP,
-				},
-			},
+			Ports:    servicePorts,
 			Selector: labels,
 		},
 	}

--- a/test/e2e/ibmcloud_test.go
+++ b/test/e2e/ibmcloud_test.go
@@ -243,3 +243,10 @@ func TestPodToServiceCommunication(t *testing.T) {
 	}
 	DoTestPodToServiceCommunication(t, testEnv, assert)
 }
+
+func TestPodsMTLSCommunication(t *testing.T) {
+	assert := IBMCloudAssert{
+		VPC: pv.IBMCloudProps.VPC,
+	}
+	DoTestPodsMTLSCommunication(t, testEnv, assert)
+}

--- a/test/e2e/libvirt_test.go
+++ b/test/e2e/libvirt_test.go
@@ -91,3 +91,8 @@ func TestLibvirtPodToServiceCommunication(t *testing.T) {
 	assert := LibvirtAssert{}
 	DoTestPodToServiceCommunication(t, testEnv, assert)
 }
+
+func TestLibvirtPodsMTLSCommunication(t *testing.T) {
+	assert := LibvirtAssert{}
+	DoTestPodsMTLSCommunication(t, testEnv, assert)
+}


### PR DESCRIPTION
Export secure port and extra secret for pods' secure communication

fix: https://github.com/confidential-containers/cloud-api-adaptor/issues/1658