### PR TITLE
aws: remove redundant aws-region flag on cloud-api-adaptor invocation

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,7 +53,6 @@ aws() {
 
     set -x
     exec cloud-api-adaptor aws \
-        -aws-region "${AWS_REGION}" \
         -pods-dir /run/peerpod/pods \
         ${optionals} \
         -socket /run/peerpod/hypervisor.sock


### PR DESCRIPTION
Remove redundant `-aws-region` argument.

This arg is processed in the code:

https://github.com/confidential-containers/cloud-api-adaptor/blob/e7bf868a7d2ffcc59c38ed57a5fa2e346cbda4e9/entrypoint.sh#L48

This argument is (also) passed with an empty value if `AWS_REGION` is not specified.
