### PR TITLE
[Draft] Using mkosi to build podvm binaries on s390x architecture

### DIFF
--- a/podvm/Dockerfile.podvm_builder.fedora
+++ b/podvm/Dockerfile.podvm_builder.fedora
@@ -5,13 +5,13 @@
 #
 # Build binaries for mkosi podvm image
 #
-FROM registry.fedoraproject.org/fedora:38
+FROM registry.fedoraproject.org/fedora:39
 
 ARG GO_VERSION="1.20.8"
-ARG PROTOC_VERSION="3.11.4"
+ARG PROTOC_VERSION="25.2"
 ARG RUST_VERSION="1.72.0"
-ARG YQ_VERSION="v4.35.1"
-ARG YQ_CHECKSUM="sha256:bd695a6513f1196aeda17b174a15e9c351843fb1cef5f9be0af170f2dd744f08"
+ARG YQ_VERSION="v4.40.5"
+ARG YQ_CHECKSUM="sha256:45b7000ebe3f52c8b0c8a7ac2b313cb72b30460909cca370d57cd43c6e658f73"
 
 
 RUN dnf groupinstall -y 'Development Tools' && \
@@ -20,11 +20,11 @@ RUN dnf groupinstall -y 'Development Tools' && \
         perl-FindBin openssl-devel tpm2-tss-devel \
 	clang which && \
     dnf clean all && \
-    curl -fsSLO https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
-    rm -rf /usr/local/go && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
-    rm -f go${GO_VERSION}.linux-amd64.tar.gz
+    curl -fsSLO https://dl.google.com/go/go${GO_VERSION}.linux-s390x.tar.gz && \
+    rm -rf /usr/local/go && tar -C /usr/local -xzf go${GO_VERSION}.linux-s390x.tar.gz && \
+    rm -f go${GO_VERSION}.linux-s390x.tar.gz
 
-ADD --checksum=${YQ_CHECKSUM} https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 /usr/local/bin/yq
+ADD --checksum=${YQ_CHECKSUM} https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_s390x /usr/local/bin/yq
 RUN chmod a+x /usr/local/bin/yq
 
 RUN curl -fsSL https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "${RUST_VERSION}"
@@ -33,8 +33,8 @@ ENV PATH "/root/.cargo/bin:/usr/local/go/bin:$PATH"
 
 RUN echo $PATH
 
-RUN curl -fsSLO https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip && \
-    unzip protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local && rm -f protoc-${PROTOC_VERSION}-linux-x86_64.zip
+RUN curl -fsSLO https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-s390_64.zip && \
+    unzip protoc-${PROTOC_VERSION}-linux-s390_64.zip -d /usr/local && rm -f protoc-${PROTOC_VERSION}-linux-s390_64.zip
 
 WORKDIR /src
 

--- a/podvm/Dockerfile.podvm_builder.fedora
+++ b/podvm/Dockerfile.podvm_builder.fedora
@@ -38,8 +38,8 @@ RUN curl -fsSLO https://github.com/protocolbuffers/protobuf/releases/download/v2
 
 WORKDIR /src
 
-ARG CAA_SRC="https://github.com/confidential-containers/cloud-api-adaptor"
-ARG CAA_SRC_REF="main"
+ARG CAA_SRC="https://github.com/lysliu/cloud-api-adaptor"
+ARG CAA_SRC_REF="mkosi-s390x"
 
 ARG KATA_SRC="https://github.com/kata-containers/kata-containers"
 ARG KATA_SRC_BRANCH="CCv0"

--- a/podvm/Dockerfile.podvm_builder.fedora
+++ b/podvm/Dockerfile.podvm_builder.fedora
@@ -17,7 +17,7 @@ ARG YQ_CHECKSUM="sha256:45b7000ebe3f52c8b0c8a7ac2b313cb72b30460909cca370d57cd43c
 RUN dnf groupinstall -y 'Development Tools' && \
     dnf install -y yum-utils gnupg git perl-core pkg-config libseccomp-devel gpgme-devel \
         device-mapper-devel unzip libassuan-devel \
-        perl-FindBin openssl-devel tpm2-tss-devel \
+        perl-FindBin openssl-devel tpm2-tss-devel skopeo \
 	clang which && \
     dnf clean all && \
     curl -fsSLO https://dl.google.com/go/go${GO_VERSION}.linux-s390x.tar.gz && \

--- a/podvm/Makefile.inc
+++ b/podvm/Makefile.inc
@@ -84,7 +84,7 @@ KATA_CONTAINERS_SRC = $(ROOT_DIR)/../kata-containers
 KATA_AGENT_SRC = $(KATA_CONTAINERS_SRC)/src/agent
 KATA_AGENT_BUILD_TYPE = release
 
-SKOPEO_SRC ?= skopeo
+SKOPEO_SRC ?= /usr
 SKOPEO_BIN ?= $(SKOPEO_SRC)/bin/skopeo
 
 UMOCI_SRC   = umoci
@@ -140,12 +140,6 @@ $(STATIC_LIBSECCOMP): $(KATA_CONTAINERS_SRC)
 $(KATA_CONTAINERS_SRC):
 	$(call git_clone_repo_ref,$(KATA_SRC),$(KATA_CONTAINERS_SRC),$(KATA_SRC_REF))
 
-# Skopeo package packages are available in RHEL/CentOS 8 or later and Ubuntu 20.10 or later
-$(SKOPEO_SRC):
-	$(call git_clone_repo_ref,$(SKOPEO_REPO),$(SKOPEO_SRC),$(SKOPEO_VERSION))
-
-$(SKOPEO_BIN): $(SKOPEO_SRC)
-	cd "$(SKOPEO_SRC)" && CC= $(MAKE) bin/skopeo
 
 # The umoci release page only publishes amd64 binaries. https://github.com/opencontainers/umoci/releases
 $(UMOCI_SRC):
@@ -155,7 +149,7 @@ $(UMOCI_SRC)/umoci: $(UMOCI_SRC)
 	cd "$(UMOCI_SRC)" && CC= $(MAKE)
 
 $(PAUSE_SRC): $(SKOPEO_BIN)
-	$(SKOPEO_BIN) --override-arch $(DEB_ARCH) --policy "$(FILES_DIR)/etc/containers/policy.json" copy "$(PAUSE_REPO):$(PAUSE_VERSION)" "oci:$(PAUSE_SRC):$(PAUSE_VERSION)"
+	skopeo --override-arch $(DEB_ARCH) --policy "$(FILES_DIR)/etc/containers/policy.json" copy "$(PAUSE_REPO):$(PAUSE_VERSION)" "oci:$(PAUSE_SRC):$(PAUSE_VERSION)"
 
 $(PAUSE): | $(PAUSE_SRC) $(UMOCI_SRC)/umoci
 	$(UMOCI_SRC)/umoci unpack --rootless --image "$(PAUSE_SRC):$(PAUSE_VERSION)" "${FILES_DIR}/$(PAUSE_BUNDLE)"

--- a/podvm/Makefile.inc
+++ b/podvm/Makefile.inc
@@ -75,7 +75,7 @@ OPA = $(FILES_DIR)/usr/local/bin/opa
 
 # Allow BINARIES to be overriden externally
 
-BINARIES ?= $(AGENT_PROTOCOL_FORWARDER) $(KATA_AGENT) $(PAUSE) $(ATTESTATION_AGENT) $(CONFIDENTIAL_DATA_HUB) $(API_SERVER_REST) $(PROCESS_USER_DATA) \
+BINARIES ?= $(AGENT_PROTOCOL_FORWARDER) $(PAUSE) $(KATA_AGENT) $(ATTESTATION_AGENT) $(CONFIDENTIAL_DATA_HUB) $(API_SERVER_REST) $(PROCESS_USER_DATA) \
 		$(OPA)
 
 $(shell sed -i "s|\(aa_kbc_params = \)\"[^\"]*\"|\1\"${AA_KBC}::${KBC_URI}\"|g" $(FILES_DIR)/etc/agent-config.toml)

--- a/podvm/Makefile.inc
+++ b/podvm/Makefile.inc
@@ -84,7 +84,7 @@ KATA_CONTAINERS_SRC = $(ROOT_DIR)/../kata-containers
 KATA_AGENT_SRC = $(KATA_CONTAINERS_SRC)/src/agent
 KATA_AGENT_BUILD_TYPE = release
 
-SKOPEO_SRC ?= /usr
+SKOPEO_SRC ?= skopeo
 SKOPEO_BIN ?= $(SKOPEO_SRC)/bin/skopeo
 
 UMOCI_SRC   = umoci
@@ -122,6 +122,13 @@ endef
 
 binaries: $(BINARIES)
 
+# Skopeo package packages are available in RHEL/CentOS 8 or later and Ubuntu 20.10 or later
+$(SKOPEO_SRC):
+	$(call git_clone_repo_ref,$(SKOPEO_REPO),$(SKOPEO_SRC),$(SKOPEO_VERSION))
+
+$(SKOPEO_BIN): $(SKOPEO_SRC)
+	cd "$(SKOPEO_SRC)" && CC= $(MAKE) bin/skopeo
+
 $(AGENT_PROTOCOL_FORWARDER): always
 	cd "$(ROOT_DIR)" && ARCH=$(DEB_ARCH) $(MAKE) agent-protocol-forwarder
 	install -D --compare "$(ROOT_DIR)/agent-protocol-forwarder" "$@"
@@ -140,7 +147,6 @@ $(STATIC_LIBSECCOMP): $(KATA_CONTAINERS_SRC)
 $(KATA_CONTAINERS_SRC):
 	$(call git_clone_repo_ref,$(KATA_SRC),$(KATA_CONTAINERS_SRC),$(KATA_SRC_REF))
 
-
 # The umoci release page only publishes amd64 binaries. https://github.com/opencontainers/umoci/releases
 $(UMOCI_SRC):
 	$(call git_clone_repo_ref,$(UMOCI_REPO),$(UMOCI_SRC),$(UMOCI_VERSION))
@@ -149,7 +155,7 @@ $(UMOCI_SRC)/umoci: $(UMOCI_SRC)
 	cd "$(UMOCI_SRC)" && CC= $(MAKE)
 
 $(PAUSE_SRC): $(SKOPEO_BIN)
-	skopeo --override-arch $(DEB_ARCH) --policy "$(FILES_DIR)/etc/containers/policy.json" copy "$(PAUSE_REPO):$(PAUSE_VERSION)" "oci:$(PAUSE_SRC):$(PAUSE_VERSION)"
+	$(SKOPEO_BIN) --override-arch $(DEB_ARCH) --policy "$(FILES_DIR)/etc/containers/policy.json" copy "$(PAUSE_REPO):$(PAUSE_VERSION)" "oci:$(PAUSE_SRC):$(PAUSE_VERSION)"
 
 $(PAUSE): | $(PAUSE_SRC) $(UMOCI_SRC)/umoci
 	$(UMOCI_SRC)/umoci unpack --rootless --image "$(PAUSE_SRC):$(PAUSE_VERSION)" "${FILES_DIR}/$(PAUSE_BUNDLE)"

--- a/versions.yaml
+++ b/versions.yaml
@@ -35,7 +35,7 @@ git:
     reference: v0.4.7
   skopeo:
     url: https://github.com/containers/skopeo
-    reference: v1.5.0
+    reference: v1.14.1
   opa:
     url: https://github.com/open-policy-agent/opa
     reference: v0.58.0


### PR DESCRIPTION
### Goal of the PR:
Using mkosi to build podvm binaries on s390x architecture
### Summary 

1. Some packages are architecture specific, add dependencies for `s390x`
2. Skopeo binary couldn't built out after kata-agent build, change the sequence by moving `skopeo` to the first place to build.