### PR TITLE
libvirt: Fix config_libvirt script

### DIFF
--- a/libvirt/config_libvirt.sh
+++ b/libvirt/config_libvirt.sh
@@ -16,11 +16,11 @@ installGolang() {
     export PATH=/usr/local/go/bin:$PATH
     export GOROOT=/usr/local/go
     export GOPATH=$HOME/go
-    REQUIRED_GO_VERSION="$(yq '.tools.golang' versions.yaml)"
     if ! command -v "yq" >/dev/null; then
         echo "Installing latest yq"
         sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${TARGET_ARCH} -O /usr/bin/yq && sudo chmod a+x /usr/bin/yq
     fi
+    REQUIRED_GO_VERSION="$(yq '.tools.golang' versions.yaml)"
     if [[ -d /usr/local/go ]]; then
         installed_go_version=$(v=$(go version | awk '{print $3}') && echo ${v#go})
         if [[ "$(printf '%s\n' "$REQUIRED_GO_VERSION" "$installed_go_version" | sort -V | head -1)" != "$REQUIRED_GO_VERSION" ]]; then


### PR DESCRIPTION
Sorry, I missed it in my test of the PR yesterday as I already had `yq` installed, but the ordering is incorrect now:
Move the `REQUIRED_GO_VERSION` fetch below the check for whether yq is installed