### PR TITLE
s390x: build fedora binaries for peerpod

### DIFF
--- a/podvm-mkosi/Makefile
+++ b/podvm-mkosi/Makefile
@@ -13,7 +13,7 @@ fedora-binaries-builder:
 	docker buildx build \
 		-t fedora-binaries-builder \
 		--load \
-		- < ../podvm/Dockerfile.podvm_builder.fedora
+		-f ../podvm/Dockerfile.podvm_builder.fedora ../.
 
 PHONY: binaries
 binaries:
@@ -24,7 +24,7 @@ binaries:
 		--build-arg BUILDER_IMG=fedora-binaries-builder \
 		--build-arg AA_KBC=$(AA_KBC) \
 		-o type=local,dest="./resources/binaries-tree" \
-		- < ../podvm/Dockerfile.podvm_binaries.fedora
+		-f ../podvm/Dockerfile.podvm_binaries.fedora ../.
 
 PHONY: image
 image:

--- a/podvm-mkosi/Makefile
+++ b/podvm-mkosi/Makefile
@@ -1,4 +1,6 @@
-AA_KBC ?= offline_fs_kbc
+AA_KBC  ?= offline_fs_kbc
+ARCH    ?= $(subst x86_64,amd64,$(shell uname -m))
+BUILDER = fedora-binaries-builder-$(ARCH)
 
 .DEFAULT_GOAL := all
 .PHONY: all
@@ -9,11 +11,22 @@ debug: fedora-binaries-builder binaries image-debug
 
 PHONY: fedora-binaries-builder
 fedora-binaries-builder:
-	@echo "Building fedora-binaries-builder image..."
+	@echo "Building $(BUILDER) image..."
+ifeq ($(ARCH),s390x)
 	docker buildx build \
-		-t fedora-binaries-builder \
+		-t $(BUILDER) \
+		--build-arg ARCH=s390x \
+		--build-arg PROTOC_ARCH=s390x_64 \
+		--build-arg YQ_ARCH=s390x \
+		--build-arg YQ_CHECKSUM=sha256:4e6324d08630e7df733894a11830412a43703682d65a76f1fc925aac08268a45 \
 		--load \
 		-f ../podvm/Dockerfile.podvm_builder.fedora ../.
+else
+	docker buildx build \
+		-t $(BUILDER) \
+		--load \
+		-f ../podvm/Dockerfile.podvm_builder.fedora ../.
+endif
 
 PHONY: binaries
 binaries:
@@ -21,7 +34,7 @@ binaries:
 	@echo "Building binaries..."
 	rm -rf ./resources/binaries-tree
 	docker buildx build \
-		--build-arg BUILDER_IMG=fedora-binaries-builder \
+		--build-arg BUILDER_IMG=$(BUILDER) \
 		--build-arg AA_KBC=$(AA_KBC) \
 		-o type=local,dest="./resources/binaries-tree" \
 		-f ../podvm/Dockerfile.podvm_binaries.fedora ../.

--- a/podvm/Dockerfile.podvm_binaries.fedora
+++ b/podvm/Dockerfile.podvm_binaries.fedora
@@ -27,8 +27,11 @@ ENV ARCH ${ARCH}
 ENV IMAGE_URL "none"
 ENV IMAGE_CHECKSUM "none"
 
-RUN cd cloud-api-adaptor/podvm && \
-     LIBC=gnu make binaries
+COPY . /src/cloud-api-adaptor
+
+WORKDIR /src/cloud-api-adaptor/podvm
+
+RUN LIBC=gnu make binaries
 
 FROM scratch
 COPY --from=podvm_builder /src/cloud-api-adaptor/podvm/files /

--- a/podvm/Dockerfile.podvm_builder.fedora
+++ b/podvm/Dockerfile.podvm_builder.fedora
@@ -7,49 +7,39 @@
 #
 FROM registry.fedoraproject.org/fedora:38
 
-ARG GO_VERSION="1.20.8"
+ARG ARCH="amd64"
+ARG YQ_ARCH="amd64"
+# PROTOC_ARCH="x86_64" | "s390x_64"
+ARG PROTOC_ARCH="x86_64"
+ARG GO_VERSION="1.20.12"
 ARG PROTOC_VERSION="3.11.4"
 ARG RUST_VERSION="1.72.0"
 ARG YQ_VERSION="v4.35.1"
+# amd64: YQ_CHECKSUM="sha256:bd695a6513f1196aeda17b174a15e9c351843fb1cef5f9be0af170f2dd744f08"
+# s390x: YQ_CHECKSUM="sha256:4e6324d08630e7df733894a11830412a43703682d65a76f1fc925aac08268a45"
 ARG YQ_CHECKSUM="sha256:bd695a6513f1196aeda17b174a15e9c351843fb1cef5f9be0af170f2dd744f08"
-
 
 RUN dnf groupinstall -y 'Development Tools' && \
     dnf install -y yum-utils gnupg git perl-core pkg-config libseccomp-devel gpgme-devel \
         device-mapper-devel unzip libassuan-devel \
         perl-FindBin openssl-devel tpm2-tss-devel \
-	clang which && \
-    dnf clean all && \
-    curl -fsSLO https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
-    rm -rf /usr/local/go && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
-    rm -f go${GO_VERSION}.linux-amd64.tar.gz
+        clang which && \
+    dnf clean all
 
-ADD --checksum=${YQ_CHECKSUM} https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 /usr/local/bin/yq
+ADD https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz go${GO_VERSION}.linux-${ARCH}.tar.gz
+RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go${GO_VERSION}.linux-${ARCH}.tar.gz && rm -f go${GO_VERSION}.linux-${ARCH}.tar.gz
+
+ADD --checksum=${YQ_CHECKSUM} https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${YQ_ARCH} /usr/local/bin/yq
 RUN chmod a+x /usr/local/bin/yq
-
-RUN curl -fsSL https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "${RUST_VERSION}"
 
 ENV PATH "/root/.cargo/bin:/usr/local/go/bin:$PATH"
 
-RUN echo $PATH
+ADD https://sh.rustup.rs rustup
+RUN chmod a+x rustup && ./rustup -y --default-toolchain ${RUST_VERSION}
 
-RUN curl -fsSLO https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip && \
-    unzip protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local && rm -f protoc-${PROTOC_VERSION}-linux-x86_64.zip
+ADD https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip
+RUN unzip protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip -d /usr/local && rm -f protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip
 
 WORKDIR /src
-
-ARG CAA_SRC="https://github.com/confidential-containers/cloud-api-adaptor"
-ARG CAA_SRC_REF="main"
-
-ARG KATA_SRC="https://github.com/kata-containers/kata-containers"
-ARG KATA_SRC_BRANCH="CCv0"
-
-RUN echo $CAA_SRC
-
-RUN echo $CAA_SRC_REF
-
-RUN git clone ${CAA_SRC} -b ${CAA_SRC_REF} cloud-api-adaptor
-RUN git clone ${KATA_SRC} kata-containers
-RUN cd kata-containers && git checkout ${KATA_SRC_BRANCH}
 
 ENV GOPATH /src

--- a/podvm/Makefile.inc
+++ b/podvm/Makefile.inc
@@ -133,7 +133,11 @@ $(SKOPEO_SRC):
 	$(call git_clone_repo_ref,$(SKOPEO_REPO),$(SKOPEO_SRC),$(SKOPEO_VERSION))
 
 $(SKOPEO_BIN): $(SKOPEO_SRC)
+ifeq ($(ARCH),s390x)
+	cd "$(SKOPEO_SRC)" && CC=gcc $(MAKE) bin/skopeo
+else
 	cd "$(SKOPEO_SRC)" && CC= $(MAKE) bin/skopeo
+endif
 
 # The umoci release page only publishes amd64 binaries. https://github.com/opencontainers/umoci/releases
 $(UMOCI_SRC):


### PR DESCRIPTION
Fixes: #1640

As a 1st step to enable mkosi images on s390x on fedora, we'll enable s390x binaries build on fedora with same Dockerfile on a s390x host in this PR.

There are other options to build s390x binaries on fedora like:
- Build the s390x binaries on x86 host and s390x container
- Build the s390x binaries on x86 host and x86 container with compilers cross platform 
But it looks not easy, as we tried, both of the other 2 options failed. We'll track and maybe switch the approach in further PR as investigation move ahead.

In this PR, the fedora Dockerfile is revised following same format as ubuntu. It'll be more easier to maintain the Dockerfile.

To try the changes:
- on s390x
To run the builder build:
```
docker buildx build \
	-t fedora-binaries-builder-s390x \
	--build-arg ARCH=s390x \
	--build-arg PROTOC_ARCH=s390x_64 \
	--build-arg YQ_ARCH=s390x \
	--build-arg YQ_CHECKSUM=sha256:4e6324d08630e7df733894a11830412a43703682d65a76f1fc925aac08268a45 \
	--load \
	-f podvm/Dockerfile.podvm_builder.fedora .
```
To run the binaries build against the builder image
```
docker buildx build \
	--build-arg BUILDER_IMG=fedora-binaries-builder-s390x:latest \
	--build-arg AA_KBC=offline_fs_kbc \
	-o type=local,dest="./resources/binaries-tree" \
	-f podvm/Dockerfile.podvm_binaries.fedora .
```

- on x86

```
docker buildx build \
	-t fedora-binaries-builder-amd64 \
	--load \
	-f podvm/Dockerfile.podvm_builder.fedora .
```
```
docker buildx build \
	--build-arg BUILDER_IMG=fedora-binaries-builder-amd64:latest \
	--build-arg AA_KBC=offline_fs_kbc \
	-o type=local,dest="./resources/binaries-tree" \
	-f podvm/Dockerfile.podvm_binaries.fedora .
```

Note: `BUILDER_IMG` might need be pushed to a registry before use it.