### PR TITLE
doc: Update README.md add YQ_VERSION

### DIFF
--- a/podvm/README.md
+++ b/podvm/README.md
@@ -64,6 +64,7 @@ currently accepted:
 | GO\_VERSION       | 1.20.12                                                      | Go version                                                      |
 | PROTOC\_VERSION   | 3.11.4                                                       | [Protobuf](https://github.com/protocolbuffers/protobuf) version |
 | RUST\_VERSION     | 1.72.0                                                       | Rust version                                                    |
+| YQ\_VERSION       | v4.35.1                                                      | [yq](https://github.com/mikefarah/yq/) version                  |
 
 As it can be noted in the table above the cloud-api-adaptor repository is cloned within the builder image, so rather than
 copying the local source tree, it will be using the upstream source. But if you want to test local changes then you should:


### PR DESCRIPTION
Add YQ_VERSION in `--build-arg`

to resolve the issue below:
```
$ docker build -t podvm_builder \
         --build-arg CAA_SRC=https://github.com/huoqifeng/cloud-api-adaptor \
         --build-arg CAA_SRC_REF=fedora-s390x-build \
         --build-arg GO_VERSION=1.20.12 \
         --build-arg PROTOC_VERSION=3.11.4 \
         --build-arg RUST_VERSION=1.72.0 \
         --build-arg KATA_SRC=https://github.com/kata-containers/kata-containers   \
         -f Dockerfile.podvm_builder .
[+] Building 0.6s (11/20)                                                                                                                                                       docker:default
 => [internal] load .dockerignore                                                                                                                                                         0.0s
 => => transferring context: 2B                                                                                                                                                           0.0s
 => [internal] load build definition from Dockerfile.podvm_builder                                                                                                                        0.0s
 => => transferring dockerfile: 2.38kB                                                                                                                                                    0.0s
 => resolve image config for docker.io/docker/dockerfile:1.5-labs                                                                                                                         0.2s
 => CACHED docker-image://docker.io/docker/dockerfile:1.5-labs@sha256:f2e91734a84c0922ff47aa4098ab775f1dfa932430d2888dd5cad5251fafdac4                                                    0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                                                                                                           0.0s
 => CACHED [ 1/11] FROM docker.io/library/ubuntu:20.04                                                                                                                                    0.0s
 => CANCELED https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-x86_64.zip                                                                         0.2s
 => ERROR https://github.com/mikefarah/yq/releases/download//yq_linux_amd64                                                                                                               0.2s
 => https://sh.rustup.rs                                                                                                                                                                  0.1s
 => CANCELED https://dl.google.com/go/go1.20.12.linux-amd64.tar.gz                                                                                                                        0.2s
 => CANCELED [ 2/11] RUN apt-get update -y &&     apt-get install --no-install-recommends -y build-essential cloud-image-utils curl git gnupg         libdevmapper-dev libgpgme-dev lsb-  0.2s
------
 > https://github.com/mikefarah/yq/releases/download//yq_linux_amd64:
------
ERROR: failed to solve: failed to load cache key: invalid response status 404
```