### PR TITLE
e2e: update PodVM with Authenticated Registry cases

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -24,6 +24,7 @@ import (
 
 const BUSYBOX_IMAGE = "quay.io/prometheus/busybox:latest"
 const WAIT_DEPLOYMENT_AVAILABLE_TIMEOUT = time.Second * 180
+const DEFAULT_AUTH_SECRET = "auth-json-secret-default"
 
 type PodOption func(*corev1.Pod)
 

--- a/test/provisioner/ibmcloud/provision_kustomize.go
+++ b/test/provisioner/ibmcloud/provision_kustomize.go
@@ -168,6 +168,7 @@ func (lio *IBMCloudInstallOverlay) Edit(ctx context.Context, cfg *envconf.Config
 		}
 	}
 	if os.Getenv("REGISTRY_CREDENTIAL_ENCODED") != "" {
+		registryName := "quay.io"
 		client, err := cfg.NewClient()
 		if err != nil {
 			return err
@@ -184,11 +185,13 @@ func (lio *IBMCloudInstallOverlay) Edit(ctx context.Context, cfg *envconf.Config
 				return err
 			}
 		}
-
+		if os.Getenv("AUTHENTICATED_REGISTRY_IMAGE") != "" {
+			registryName = strings.Split(os.Getenv("AUTHENTICATED_REGISTRY_IMAGE"), "/")[0]
+		}
 		log.Info("Setting up auth.json")
 		data := map[string]interface{}{
 			"auths": map[string]interface{}{
-				"quay.io": map[string]interface{}{
+				registryName: map[string]interface{}{
 					"auth": os.Getenv("REGISTRY_CREDENTIAL_ENCODED"),
 				},
 			},


### PR DESCRIPTION
- add ImagePullSecret to default ServiceAccount
- make PodVM with Authenticated Registry cases can be reused by other cloud providers
- support given Authenticated Registry

Fixes https://github.com/confidential-containers/cloud-api-adaptor/issues/1680