### PR TITLE
Misc fixes

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -161,7 +161,7 @@ configMapGenerator:
   literals:
   - CLOUD_PROVIDER="aws"   
   - PODVM_AMI_ID="${PODVM_AMI_ID}"  
-  #- PODVM_INSTANCE_TYPE="t3.small" # default instance type to use
+  #- PODVM_INSTANCE_TYPE="m6a.large" # default instance type to use
   #- PODVM_INSTANCE_TYPES="" # comma separated list of supported instance types
 secretGenerator:
 - name: auth-json-secret

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,17 +37,16 @@ one_of() {
 aws() {
     test_vars AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
 
-
     [[ "${PODVM_LAUNCHTEMPLATE_NAME}" ]] && optionals+="-use-lt -aws-lt-name ${PODVM_LAUNCHTEMPLATE_NAME} " # has precedence if set
     [[ "${AWS_SG_IDS}" ]] && optionals+="-securitygroupids ${AWS_SG_IDS} "                                  # MUST if template is not used
     [[ "${PODVM_AMI_ID}" ]] && optionals+="-imageid ${PODVM_AMI_ID} "                                       # MUST if template is not used
-    [[ "${PODVM_INSTANCE_TYPE}" ]] && optionals+="-instance-type ${PODVM_INSTANCE_TYPE} "                   # default t3.small
+    [[ "${PODVM_INSTANCE_TYPE}" ]] && optionals+="-instance-type ${PODVM_INSTANCE_TYPE} "                   # default m6a.large
     [[ "${PODVM_INSTANCE_TYPES}" ]] && optionals+="-instance-types ${PODVM_INSTANCE_TYPES} "
-    [[ "${SSH_KP_NAME}" ]] && optionals+="-keyname ${SSH_KP_NAME} "      # if not retrieved from IMDS
-    [[ "${AWS_SUBNET_ID}" ]] && optionals+="-subnetid ${AWS_SUBNET_ID} " # if not set retrieved from IMDS
-    [[ "${AWS_REGION}" ]] && optionals+="-aws-region ${AWS_REGION} "     # if not set retrieved from IMDS
-    [[ "${TAGS}" ]] && optionals+="-tags ${TAGS} " # Custom tags applied to pod vm
-    [[ "${USE_PUBLIC_IP}" == "true" ]] && optionals+="-use-public-ip " # Use public IP for pod vm
+    [[ "${SSH_KP_NAME}" ]] && optionals+="-keyname ${SSH_KP_NAME} "                    # if not retrieved from IMDS
+    [[ "${AWS_SUBNET_ID}" ]] && optionals+="-subnetid ${AWS_SUBNET_ID} "               # if not set retrieved from IMDS
+    [[ "${AWS_REGION}" ]] && optionals+="-aws-region ${AWS_REGION} "                   # if not set retrieved from IMDS
+    [[ "${TAGS}" ]] && optionals+="-tags ${TAGS} "                                     # Custom tags applied to pod vm
+    [[ "${USE_PUBLIC_IP}" == "true" ]] && optionals+="-use-public-ip "                 # Use public IP for pod vm
     [[ "${ROOT_VOLUME_SIZE}" ]] && optionals+="-root-volume-size ${ROOT_VOLUME_SIZE} " # Specify root volume size for pod vm
     [[ "${DISABLECVM}" == "true" ]] && optionals+="-disable-cvm "
 

--- a/install/overlays/aws/kustomization.yaml
+++ b/install/overlays/aws/kustomization.yaml
@@ -23,7 +23,7 @@ configMapGenerator:
   #- PODVM_LAUNCHTEMPLATE_NAME="" # Uncomment and set if you want to use launch template
   # Comment out all the following variables if using launch template
   - PODVM_AMI_ID="" #set
-  #- PODVM_INSTANCE_TYPE="t3.small" # caa defaults to t3.small
+  #- PODVM_INSTANCE_TYPE="m6a.large" # caa defaults to m6a.large
   #- PODVM_INSTANCE_TYPES="" # comma separated
   #- AWS_SG_IDS="" # comma separated, if not set all SGs will be retrieved from IMDS
   #- AWS_REGION="" # if not set retrieved from IMDS

--- a/pkg/adaptor/cloud/aws/manager.go
+++ b/pkg/adaptor/cloud/aws/manager.go
@@ -26,7 +26,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	flags.StringVar(&awscfg.LaunchTemplateName, "aws-lt-name", "kata", "AWS Launch Template Name")
 	flags.BoolVar(&awscfg.UseLaunchTemplate, "use-lt", false, "Use EC2 Launch Template for the Pod VMs")
 	flags.StringVar(&awscfg.ImageId, "imageid", "", "Pod VM ami id")
-	flags.StringVar(&awscfg.InstanceType, "instance-type", "t3.small", "Pod VM instance type")
+	flags.StringVar(&awscfg.InstanceType, "instance-type", "m6a.large", "Pod VM instance type")
 	flags.Var(&awscfg.SecurityGroupIds, "securitygroupids", "Security Group Ids to be used for the Pod VM, comma separated")
 	flags.StringVar(&awscfg.KeyName, "keyname", "", "SSH Keypair name to be used with the Pod VM")
 	flags.StringVar(&awscfg.SubnetId, "subnetid", "", "Subnet ID to be used for the Pod VMs")
@@ -45,7 +45,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 func (_ *Manager) LoadEnv() {
 	cloud.DefaultToEnv(&awscfg.AccessKeyId, "AWS_ACCESS_KEY_ID", "")
 	cloud.DefaultToEnv(&awscfg.SecretKey, "AWS_SECRET_ACCESS_KEY", "")
-	cloud.DefaultToEnv(&awscfg.InstanceType, "PODVM_INSTANCE_TYPE", "t3.small")
+	cloud.DefaultToEnv(&awscfg.InstanceType, "PODVM_INSTANCE_TYPE", "m6a.large")
 }
 
 func (_ *Manager) NewProvider() (cloud.Provider, error) {

--- a/pkg/adaptor/cloud/aws/manager_test.go
+++ b/pkg/adaptor/cloud/aws/manager_test.go
@@ -65,7 +65,7 @@ func TestManager_ParseCmd(t *testing.T) {
 				LaunchTemplateName: "kata",
 				UseLaunchTemplate:  false,
 				ImageId:            "",
-				InstanceType:       "t3.small",
+				InstanceType:       "m6a.large",
 				SecurityGroupIds:   securityGroupIds{},
 				KeyName:            "",
 				SubnetId:           "",

--- a/pkg/adaptor/cloud/aws/provider.go
+++ b/pkg/adaptor/cloud/aws/provider.go
@@ -27,7 +27,6 @@ var errNotReady = errors.New("address not ready")
 const (
 	maxInstanceNameLen = 63
 	maxWaitTime        = 120 * time.Second
-	defaultCVMInstance = "m6a.large"
 )
 
 // Make ec2Client a mockable interface
@@ -240,9 +239,6 @@ func (p *awsProvider) CreateInstance(ctx context.Context, podName, sandboxID str
 				// Add AmdSevSnp Cpu options to the instance
 				AmdSevSnp: types.AmdSevSnpSpecificationEnabled,
 			}
-
-			// Change the default instance type to a CVM capable instance type
-			p.serviceConfig.InstanceType = defaultCVMInstance
 		}
 
 	}

--- a/pkg/adaptor/cloud/aws/provider.go
+++ b/pkg/adaptor/cloud/aws/provider.go
@@ -448,15 +448,15 @@ func (p *awsProvider) getDeviceNameAndSize(imageID string) (string, int32, error
 		return "", 0, err
 	}
 
+	if describeImagesOutput == nil || len(describeImagesOutput.Images) == 0 {
+		return "", 0, fmt.Errorf("Unable to get details for the image")
+	}
+
 	// Get the device name
 	deviceName := describeImagesOutput.Images[0].RootDeviceName
 
-	// Check if the device name is nil
-	if deviceName == nil {
-		return "", 0, fmt.Errorf("device name is nil")
-	}
-	// If the device name is empty, return an error
-	if *deviceName == "" {
+	// Check if the device name is empty
+	if deviceName == nil || *deviceName == "" {
 		return "", 0, fmt.Errorf("device name is empty")
 	}
 

--- a/pkg/userdata/provision.go
+++ b/pkg/userdata/provision.go
@@ -18,8 +18,8 @@ import (
 var logger = log.New(log.Writer(), "[userdata/provision] ", log.LstdFlags|log.Lmsgprefix)
 
 type Config struct {
-	daemonConfigPath string
 	authJsonPath     string
+	daemonConfigPath string
 	fetchTimeout     int
 }
 
@@ -154,7 +154,7 @@ func writeFile(path string, bytes []byte) error {
 func processCloudConfig(cfg *Config, cc *CloudConfig) error {
 	daemonConfig, bytes, err := findDaemonConfigEntry(cfg.daemonConfigPath, cc)
 	if err != nil {
-		return fmt.Errorf("failed to process cloud config: %w", err)
+		return fmt.Errorf("failed to process daemon config: %w", err)
 	}
 
 	if err = writeFile(cfg.daemonConfigPath, bytes); err != nil {


### PR DESCRIPTION
1. The provisioning command used a wrong ordering of daemonconfig and authJson files, resulting in startup errors for process-user-data
2. Change AWS default instance type to CVM to align with the default  disable-cvm option
3. Fix handling of describeimages 

