### PR TITLE
s390x: add s390x runner to build fedora binaries

### DIFF
--- a/.github/workflows/podvm_mkosi_image.yaml
+++ b/.github/workflows/podvm_mkosi_image.yaml
@@ -1,0 +1,57 @@
+name: mkosi build podvm builder, binaries and image
+
+on:
+  workflow_dispatch:
+
+
+jobs:
+  build-podvm-image-mkosi:
+    name: Build podvm image via mkosi
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - ubuntu-latest
+          - S390X
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Take a pre-action for self-hosted runner
+        run: |
+          if [ -f ${HOME}/script/pre_action.sh ]; then
+            ${HOME}/script/pre_action.sh cc-caa
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build builder
+        run: make fedora-binaries-builder
+        working-directory: podvm-mkosi
+
+      - name: Build binaries
+        run: make binaries
+        working-directory: podvm-mkosi
+      
+      # TODO - build image via mkosi when s390x is available
+      # TODO - upload the image 
+
+      - name: Take a post-action
+        if: always()
+        run: |
+          if [ -f ${HOME}/script/post_action.sh ]; then
+            ${HOME}/script/post_action.sh cc-caa
+          fi
+


### PR DESCRIPTION
Fixes: #1640 

The code has been tested in personal repo via GHA: https://github.com/huoqifeng/cloud-api-adaptor/actions/runs/7811452618