### PR TITLE
versions: Update guest-components

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -27,7 +27,7 @@ tools:
 git:
   guest-components:
     url: https://github.com/confidential-containers/guest-components
-    reference: f20d4b59aa62032e82bd8d8107e6874d9618db50
+    reference: 480a13fb107a3321327af7082d785d209065857c
   kata-containers:
     url: https://github.com/kata-containers/kata-containers
     reference: d0df91935b8840036c2891b1f93dd8059ebe486a


### PR DESCRIPTION
The guest-components we build with the coco is far outdated with the KBS project. This commit updates the version of the guest-component we ship so that we can use latest KBS image.