### PR TITLE
e2e-test: Add build directive to libvirt code

### DIFF
--- a/test/e2e/libvirt_common.go
+++ b/test/e2e/libvirt_common.go
@@ -1,3 +1,5 @@
+//go:build libvirt && cgo
+
 // (C) Copyright Confidential Containers Contributors
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
fixes #1701

The libvirt go modules require a local installation of libvirt, without it will fail to run:

```bash
go test -c -tags=notlibvirt ./test/e2e
/usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: cannot find -lvirt-lxc
/usr/bin/ld: cannot find -lvirt-lxc
/usr/bin/ld: cannot find -lvirt-qemu
/usr/bin/ld: cannot find -lvirt-qemu
/usr/bin/ld: cannot find -lvirt
collect2: error: ld returned 1 exit status
```

We shouldn't require libvirt to be present on a machine running kubernetes tests, hence the added directive to fix the test build:

```
go test -c -tags=notlibvirt ./test/e2e
```