### PR TITLE
e2e-test: default delete timeout per cloudprovider

### DIFF
--- a/test/e2e/assessment_helpers.go
+++ b/test/e2e/assessment_helpers.go
@@ -60,6 +60,7 @@ func NewTestCase(t *testing.T, e env.Environment, testName string, assert CloudA
 		podState:       v1.PodRunning,
 		imagePullTimer: false,
 		isAuth:         false,
+		deletionWithin: assert.DefaultTimeout(),
 	}
 
 	return testCase

--- a/test/e2e/aws_common.go
+++ b/test/e2e/aws_common.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -23,6 +24,10 @@ func NewAWSAssert() AWSAssert {
 	return AWSAssert{
 		Vpc: pv.AWSProps.Vpc,
 	}
+}
+
+func (aa AWSAssert) DefaultTimeout() time.Duration {
+	return 1 * time.Minute
 }
 
 func (aa AWSAssert) HasPodVM(t *testing.T, id string) {

--- a/test/e2e/azure_common.go
+++ b/test/e2e/azure_common.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	pv "github.com/confidential-containers/cloud-api-adaptor/test/provisioner/azure"
 	log "github.com/sirupsen/logrus"
@@ -37,6 +38,10 @@ func checkVMExistence(resourceGroupName, prefixName string) bool {
 	}
 
 	return false
+}
+
+func (c AzureCloudAssert) DefaultTimeout() time.Duration {
+	return 2 * time.Minute
 }
 
 func (c AzureCloudAssert) HasPodVM(t *testing.T, id string) {

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -255,6 +255,7 @@ func WaitForClusterIP(t *testing.T, client klient.Client, svc *v1.Service) strin
 type CloudAssert interface {
 	HasPodVM(t *testing.T, id string)                             // Assert there is a PodVM with `id`.
 	GetInstanceType(t *testing.T, podName string) (string, error) // Get Instance Type of PodVM
+	DefaultTimeout() time.Duration                                // Default timeout for cloud operations
 }
 
 // RollingUpdateAssert defines assertions for rolling update test

--- a/test/e2e/common_suite.go
+++ b/test/e2e/common_suite.go
@@ -40,7 +40,7 @@ func DoTestCreateSimplePodWithNydusAnnotation(t *testing.T, e env.Environment, a
 
 func DoTestDeleteSimplePod(t *testing.T, e env.Environment, assert CloudAssert) {
 	pod := NewBusyboxPodWithName(E2eNamespace, "deletion-test")
-	duration := 1 * time.Minute
+	duration := assert.DefaultTimeout()
 	NewTestCase(t, e, "DeletePod", assert, "Deletion complete").WithPod(pod).WithDeleteAssertion(&duration).Run()
 }
 

--- a/test/e2e/ibmcloud_common.go
+++ b/test/e2e/ibmcloud_common.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -285,6 +286,10 @@ func NewPodWithPVCFromIBMVPCBlockDriver(namespace, podName, containerName, image
 // IBMCloudAssert implements the CloudAssert interface for ibmcloud.
 type IBMCloudAssert struct {
 	VPC *vpcv1.VpcV1
+}
+
+func (c IBMCloudAssert) DefaultTimeout() time.Duration {
+	return 1 * time.Minute
 }
 
 func (c IBMCloudAssert) HasPodVM(t *testing.T, id string) {

--- a/test/e2e/libvirt_common.go
+++ b/test/e2e/libvirt_common.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"libvirt.org/go/libvirt"
 )
@@ -14,6 +15,10 @@ import (
 type LibvirtAssert struct {
 	// TODO: create the connection once on the initializer.
 	//conn libvirt.Connect
+}
+
+func (c LibvirtAssert) DefaultTimeout() time.Duration {
+	return 1 * time.Minute
 }
 
 func (l LibvirtAssert) HasPodVM(t *testing.T, id string) {


### PR DESCRIPTION
fixes #1704

The Azure tests will not reliably pass the deletion tests within 60s. Added a per-cloudprovider default setting and made the deletionWithin param mandatory for the TestCase struct.