### PR TITLE
ci: add tdx attester to azure podvm image

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -109,7 +109,9 @@ jobs:
         rm -r "${GOPATH}/bin/yq"
 
     - name: Build binaries
-      run: make binaries LIBC=gnu AA_KBC=cc_kbc_az_snp_vtpm
+      run: make binaries \
+        AA_KBC="cc_kbc_az_snp_vtpm,cc_kbc_az_tdx_vtpm" \
+        LIBC=gnu
 
     - uses: azure/login@v1
       name: 'Az CLI login'


### PR DESCRIPTION
fixes #1703 

~draft until #1713 is merged.~

Tested packer-based image successfully with a TDX instance size. Starts and performs remote attestation w/ cc_kbc.