### PR TITLE
policy: fix broken default policy symlink on mkosi

### DIFF
--- a/podvm-mkosi/Makefile
+++ b/podvm-mkosi/Makefile
@@ -36,7 +36,7 @@ binaries:
 	docker buildx build \
 		--build-arg BUILDER_IMG=$(BUILDER) \
 		--build-arg AA_KBC=$(AA_KBC) \
-		--build-arg DEFAULT_AGENT_POLICY_FILE=$(DEFAULT_AGENT_POLICY_FILE) \
+		$(if $(DEFAULT_AGENT_POLICY_FILE),--build-arg DEFAULT_AGENT_POLICY_FILE=$(DEFAULT_AGENT_POLICY_FILE),) \
 		-o type=local,dest="./resources/binaries-tree" \
 		-f ../podvm/Dockerfile.podvm_binaries.fedora ../.
 

--- a/podvm/Makefile.inc
+++ b/podvm/Makefile.inc
@@ -191,7 +191,7 @@ ifeq ($(AGENT_POLICY),yes)
 	cd "$(OPA_SRC)" && $(MAKE) GOARCH=$(DEB_ARCH) GOOS=linux WASM_ENABLED=0 CGO_ENABLED=0 go-build
 	install --compare "$(OPA_SRC)/$(OPA_BUILD_TARGET)" "$@"
 	# Set default policy
-	cd $(AGENT_POLICY_PATH) && ln -s -f $(DEFAULT_AGENT_POLICY_FILE) default-policy.rego
+	cd $(AGENT_POLICY_PATH) && ln -s -f "$(DEFAULT_AGENT_POLICY_FILE)" default-policy.rego
 	# Enable the service
 	cd $(FILES_DIR)/etc/systemd/system/multi-user.target.wants && ln -s -f ../kata-opa.service kata-opa.service
 


### PR DESCRIPTION
The podvm makefile would be invoked with an empty default policy file setting from the mkosi docker build, in which the docker-build arg is set to an empty string. The podvm makefile would hence not pick the default, but attempt to use the empty string in the creation of the symbolic link, resulting in a symbolic link that points to itself.

The change will make sure that the env is only set in the Dockerfile invocation if the variable is set in the mkosi makefile. Also we quote the the source file for the symbolic link creation, so we bail out properly, instead of creating a self-pointing symbolic link.