### PR TITLE
test/e2e: Only check KBS image property if required

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -119,8 +119,10 @@ func TestMain(m *testing.M) {
 
 		// Get properties
 		props := provisioner.GetProperties(ctx, cfg)
-		if props["KBS_IMAGE"] == "" || props["KBS_IMAGE_TAG"] == "" {
-			return ctx, fmt.Errorf("kbs image not provided")
+		if shouldDeployKbs {
+			if props["KBS_IMAGE"] == "" || props["KBS_IMAGE_TAG"] == "" {
+				return ctx, fmt.Errorf("kbs image not provided")
+			}
 		}
 
 		if shouldProvisionCluster {


### PR DESCRIPTION
Skip the kbs image property if we aren't deploying the KBS in the tests

Fixes: #1724