### PR TITLE
podvm: Fix podvm-binaries build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ podvm-binaries:
 	--build-arg PODVM_DISTRO=$(PODVM_DISTRO) \
 	--build-arg ARCH=$(ARCH) \
 	--build-arg AA_KBC=$(AA_KBC) \
-	--build-arg DEFAULT_AGENT_POLICY_FILE=$(DEFAULT_AGENT_POLICY_FILE) \
+	$(if $(DEFAULT_AGENT_POLICY_FILE),--build-arg DEFAULT_AGENT_POLICY_FILE=$(DEFAULT_AGENT_POLICY_FILE),) \
 	$(DOCKER_OPTS) .
 
 podvm-image:


### PR DESCRIPTION
Nightly podvm-binaries build has been failing with:
```
# Set default policy
956.9 cd /src/cloud-api-adaptor/podvm/files/etc/kata-opa && ln -s -f "" default-policy.rego
956.9 ln: failed to create symbolic link 'default-policy.rego' -> '': No such file or directory
```

So port over the mkosi fix for this that Magnus did in #1718