### PR TITLE
ci: update deb sources in azure podvm build

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -79,7 +79,8 @@ jobs:
 
     - name: Install build dependencies
       run: |
-        sudo apt-get install \
+        sudo apt-get update
+        sudo apt-get install -y \
           clang \
           gcc \
           libdevmapper-dev \


### PR DESCRIPTION
There was an apt-get update statement missing that is causing CI failures.