### PR TITLE
podvm: use correct PROTOC_ARCH value for s390x

### DIFF
--- a/podvm-mkosi/Makefile
+++ b/podvm-mkosi/Makefile
@@ -16,7 +16,7 @@ ifeq ($(ARCH),s390x)
 	docker buildx build \
 		-t $(BUILDER) \
 		--build-arg ARCH=s390x \
-		--build-arg PROTOC_ARCH=s390x_64 \
+		--build-arg PROTOC_ARCH=s390x \
 		--build-arg YQ_ARCH=s390x \
 		--build-arg YQ_CHECKSUM=sha256:4e6324d08630e7df733894a11830412a43703682d65a76f1fc925aac08268a45 \
 		--load \


### PR DESCRIPTION
It's related to PR https://github.com/confidential-containers/cloud-api-adaptor/pull/1734.

After updating PROTOC version to v3.15.0, still failed to build s390x fedora-binaries-builder image with following error:
```
 => ERROR https://github.com/protocolbuffers/protobuf/releases/download/v3.15.0/protoc-3.15.0-linux-s390x_64.zip
```

https://github.com/protocolbuffers/protobuf/releases/download/v3.15.0/protoc-3.15.0-linux-s390x_64.zip is not a valid url.

The valid url is: https://github.com/protocolbuffers/protobuf/releases/download/v3.15.0/protoc-3.15.0-linux-s390x.zip

So need revise the value of PROTOC_ARCH