### PR TITLE
set environment variables for mkosi

### DIFF
--- a/podvm-mkosi/mkosi.conf
+++ b/podvm-mkosi/mkosi.conf
@@ -8,3 +8,10 @@ OutputDirectory=build
 
 [Distribution]
 Distribution=fedora
+
+[Host]
+ToolsTree=default
+
+[Config]
+Profile=debug.conf
+#Profile=production.conf

--- a/podvm-mkosi/mkosi.profiles/debug.conf
+++ b/podvm-mkosi/mkosi.profiles/debug.conf
@@ -1,0 +1,2 @@
+[Content]
+Environment=VARIANT_ID=Debug

--- a/podvm-mkosi/mkosi.profiles/production.conf
+++ b/podvm-mkosi/mkosi.profiles/production.conf
@@ -1,0 +1,2 @@
+[Content]
+Environment=VARIANT_ID=Production


### PR DESCRIPTION
fixes: #1746 
use Profile to set extra variable

The issue is fixed as below:

```
mkosi build --profile debug

......


‣  Running postinstall script /root/cloud-api-adaptor/podvm-mkosi/mkosi.postinst…
+ mv /var/tmp/mkosi-workspaceex485y55/root/etc/issue.d /var/tmp/mkosi-workspaceex485y55/root/usr/lib/issue.d
+ echo 'IMAGE_ID="podvm"'
+ echo 'IMAGE_VERSION="v0.0.0"'
+ echo 'VARIANT_ID="Debug"'

```