### PR TITLE
cloud-config: add support for CDH config

### DIFF
--- a/cmd/process-user-data/main.go
+++ b/cmd/process-user-data/main.go
@@ -8,6 +8,7 @@ import (
 
 	cmdUtil "github.com/confidential-containers/cloud-api-adaptor/cmd"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/agent"
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/cdh"
 	daemon "github.com/confidential-containers/cloud-api-adaptor/pkg/forwarder"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/userdata"
 	"github.com/spf13/cobra"
@@ -36,17 +37,18 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	var agentConfigPath, daemonConfigPath string
+	var agentConfigPath, cdhConfigPath, daemonConfigPath string
 	var fetchTimeout int
 
 	rootCmd.PersistentFlags().BoolVarP(&versionFlag, "version", "v", false, "Print the version")
 	rootCmd.PersistentFlags().StringVarP(&daemonConfigPath, "daemon-config-path", "d", daemon.DefaultConfigPath, "Path to a daemon config file")
+	rootCmd.PersistentFlags().StringVarP(&cdhConfigPath, "cdh-config-path", "c", cdh.ConfigFilePath, "Path to a CDH config file")
 
 	var provisionFilesCmd = &cobra.Command{
 		Use:   "provision-files",
 		Short: "Provision required files based on user data",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			cfg := userdata.NewConfig(defaultAuthJsonPath, daemonConfigPath, fetchTimeout)
+			cfg := userdata.NewConfig(defaultAuthJsonPath, daemonConfigPath, cdhConfigPath, fetchTimeout)
 			return userdata.ProvisionFiles(cfg)
 		},
 		SilenceUsage: true, // Silence usage on error

--- a/pkg/adaptor/cloud/cloud.go
+++ b/pkg/adaptor/cloud/cloud.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/k8sops"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/adaptor/proxy"
+	"github.com/confidential-containers/cloud-api-adaptor/pkg/cdh"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/forwarder"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/podnetwork"
 	"github.com/confidential-containers/cloud-api-adaptor/pkg/util"
@@ -279,6 +280,17 @@ func (s *cloudService) CreateVM(ctx context.Context, req *pb.CreateVMRequest) (r
 				Content: string(daemonJSON),
 			},
 		},
+	}
+
+	if s.aaKBCParams != "" {
+		toml, err := cdh.CreateConfigFile(s.aaKBCParams)
+		if err != nil {
+			return nil, fmt.Errorf("creating CDH config: %w", err)
+		}
+		cloudConfig.WriteFiles = append(cloudConfig.WriteFiles, cloudinit.WriteFile{
+			Path:    cdh.ConfigFilePath,
+			Content: toml,
+		})
 	}
 
 	sandbox := &sandbox{

--- a/pkg/cdh/config.go
+++ b/pkg/cdh/config.go
@@ -1,0 +1,48 @@
+package cdh
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+const (
+	ConfigFilePath = "/run/confidential-containers/cdh.toml"
+	Socket         = "unix:///run/confidential-containers/cdh.sock"
+)
+
+type Credential struct{}
+
+type Config struct {
+	Socket      string       `toml:"socket"`
+	KBC         KBCConfig    `toml:"kbc"`
+	Credentials []Credential `toml:"credentials"`
+}
+
+type KBCConfig struct {
+	Name string `toml:"name"`
+	URL  string `toml:"url"`
+}
+
+func parseAAKBCParams(aaKBCParams string) (*Config, error) {
+	parts := strings.SplitN(aaKBCParams, "::", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("Invalid aa-kbs-params input: %s", aaKBCParams)
+	}
+	name, url := parts[0], parts[1]
+	kbcConfig := KBCConfig{name, url}
+	return &Config{Socket, kbcConfig, []Credential{}}, nil
+}
+
+func CreateConfigFile(aaKBCParams string) (string, error) {
+	config, err := parseAAKBCParams(aaKBCParams)
+	if err != nil {
+		return "", err
+	}
+	bytes, err := toml.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}

--- a/pkg/cdh/config_test.go
+++ b/pkg/cdh/config_test.go
@@ -1,0 +1,42 @@
+package cdh
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+func TestCDHConfigFileFromAAKBCParams(t *testing.T) {
+	refdoc := `
+socket = "%s"
+credentials = []
+[kbc]
+name = "cc_kbc"
+url = "http://1.2.3.4:8080"
+`
+	refdoc = fmt.Sprintf(refdoc, Socket)
+	var refcfg Config
+	err := toml.Unmarshal([]byte(refdoc), &refcfg)
+	if err != nil {
+		panic(err)
+	}
+
+	config, err := parseAAKBCParams("cc_kbc::http://1.2.3.4:8080")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if config.KBC.Name != refcfg.KBC.Name {
+		t.Errorf("Expected %s, got %s", refcfg.KBC.Name, config.KBC.Name)
+	}
+	if config.KBC.URL != refcfg.KBC.URL {
+		t.Errorf("Expected %s, got %s", refcfg.KBC.URL, config.KBC.URL)
+	}
+	if config.Socket != refcfg.Socket {
+		t.Errorf("Expected %s, got %s", refcfg.Socket, config.Socket)
+	}
+	if len(config.Credentials) != 0 {
+		t.Errorf("Expected empty credentials array")
+	}
+}

--- a/podvm/files/etc/systemd/system/kata-agent.service
+++ b/podvm/files/etc/systemd/system/kata-agent.service
@@ -5,6 +5,7 @@ Wants=process-user-data.service
 After=netns@podns.service process-user-data.service
 
 [Service]
+Environment=CDH_CONFIG_PATH=/run/confidential-containers/cdh.toml
 ExecStartPre=mkdir -p /run/kata-containers
 ExecStart=/usr/local/bin/kata-agent --config /etc/agent-config.toml
 ExecStartPre=-umount /sys/fs/cgroup/misc

--- a/versions.yaml
+++ b/versions.yaml
@@ -27,7 +27,7 @@ tools:
 git:
   guest-components:
     url: https://github.com/confidential-containers/guest-components
-    reference: 480a13fb107a3321327af7082d785d209065857c
+    reference: 277617af60c32661819c1132ffbf3db8dc6e1b9f
   kata-containers:
     url: https://github.com/kata-containers/kata-containers
     reference: d0df91935b8840036c2891b1f93dd8059ebe486a


### PR DESCRIPTION
fixes #1720

This change will add a write_files entry to the cloud-config file that is produced by CAA. aa-kbc-params are converted into a config file with kbc name and kbc url.

process-user-data has been made more flexible to also support this entry.

guest-components in versions.yaml has been updated to a new revision that requires a cdh config file.

the kata-agent service unit has been extended to have the env `CDH_CONFIG_FILE=/run/confidential-containers/cdh.toml` set, which is the path that we add as a cloud-config directive.