### PR TITLE
podvm: trigger api-server-rest activation by file

### DIFF
--- a/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system-preset/30-coco.preset
+++ b/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system-preset/30-coco.preset
@@ -1,5 +1,5 @@
 enable attestation-protocol-forwarder.service
-enable api-server-rest.service
+enable api-server-rest.path
 enable kata-agent.service
 enable netns@.service
 enable process-user-data.service

--- a/podvm/files/etc/systemd/system/api-server-rest.path
+++ b/podvm/files/etc/systemd/system/api-server-rest.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Monitor for the Confidential Data Hub socket
+
+[Path]
+PathExists=/run/confidential-containers/cdh.sock
+Unit=api-server-rest.service
+
+[Install]
+WantedBy=multi-user.target

--- a/podvm/files/etc/systemd/system/multi-user.target.wants/api-server-rest.path
+++ b/podvm/files/etc/systemd/system/multi-user.target.wants/api-server-rest.path
@@ -1,0 +1,1 @@
+../api-server-rest.path

--- a/podvm/files/etc/systemd/system/multi-user.target.wants/api-server-rest.service
+++ b/podvm/files/etc/systemd/system/multi-user.target.wants/api-server-rest.service
@@ -1,1 +1,0 @@
-../api-server-rest.service


### PR DESCRIPTION
fixes #1695

there will be a race condition when CDH, started by kata-agent doesn't listen on cdh.sock yet, but api-server-rest attempts to use the socket immediately.

This change adds adds a path unit that will activate api-server-rest once the socket is being created and remove it from the default target.

A sophisticated e2e test has scientifically proven that this works reliably:

```bash
$ for i in $(seq 1 7); do k apply -f nginx-caa.yaml; sleep 90; k exec -it deploy/nginx-caa -- curl http://127.0.0.1:8006/cdh/resource/one/two/key; k delete deploy/nginx-caa; done
deployment.apps/nginx-caa created
ohai
deployment.apps "nginx-caa" deleted
deployment.apps/nginx-caa created
ohai
deployment.apps "nginx-caa" deleted
deployment.apps/nginx-caa created
ohai
deployment.apps "nginx-caa" deleted
deployment.apps/nginx-caa created
ohai
deployment.apps "nginx-caa" deleted
deployment.apps/nginx-caa created
ohai
deployment.apps "nginx-caa" deleted
deployment.apps/nginx-caa created
ohai
deployment.apps "nginx-caa" deleted
deployment.apps/nginx-caa created
ohai
deployment.apps "nginx-caa" deleted
```
