### PR TITLE
Resolve kustomize warnings

### DIFF
--- a/src/cloud-api-adaptor/install/overlays/aws/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/aws/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
+resources:
 - ../../yamls
 
 images:

--- a/src/cloud-api-adaptor/install/overlays/azure/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/azure/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
+resources:
 - ../../yamls
 
 images:

--- a/src/cloud-api-adaptor/install/overlays/ibmcloud-powervs/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/ibmcloud-powervs/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
+resources:
 - ../../yamls
 
 images:

--- a/src/cloud-api-adaptor/install/overlays/ibmcloud/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/ibmcloud/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
+resources:
 - ../../yamls
 
 images:

--- a/src/cloud-api-adaptor/install/overlays/libvirt/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/libvirt/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
+resources:
 - ../../yamls
 
 images:

--- a/src/cloud-api-adaptor/install/overlays/vsphere/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/vsphere/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
+resources:
 - ../../yamls
 
 images:

--- a/src/cloud-api-adaptor/install/rbac/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/rbac/kustomization.yaml
@@ -1,2 +1,2 @@
 resources:
-    - peer-pod.yaml
+- peer-pod.yaml

--- a/src/cloud-api-adaptor/install/rbac/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/rbac/kustomization.yaml
@@ -1,2 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - peer-pod.yaml

--- a/src/cloud-api-adaptor/install/yamls/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/yamls/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - caa-pod.yaml
 - ../rbac

--- a/src/cloud-api-adaptor/install/yamls/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/yamls/kustomization.yaml
@@ -1,3 +1,3 @@
 resources:
-    - caa-pod.yaml
-    - ../rbac
+- caa-pod.yaml
+- ../rbac

--- a/src/peerpod-ctrl/config/crd/kustomization.yaml
+++ b/src/peerpod-ctrl/config/crd/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default

--- a/src/peerpod-ctrl/config/default/kustomization.yaml
+++ b/src/peerpod-ctrl/config/default/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # Adds namespace to all resources.
 namespace: confidential-containers-system
 

--- a/src/peerpod-ctrl/config/default/kustomization.yaml
+++ b/src/peerpod-ctrl/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ namePrefix: peerpod-ctrl-
 #commonLabels:
 #  someName: someValue
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager

--- a/src/peerpod-ctrl/config/manifests/kustomization.yaml
+++ b/src/peerpod-ctrl/config/manifests/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
 # These patches remove the unnecessary "cert" volume and its manager container volumeMount.
-#patchesJson6902:
+#patches:
 #- target:
 #    group: apps
 #    version: v1

--- a/src/peerpod-ctrl/config/manifests/kustomization.yaml
+++ b/src/peerpod-ctrl/config/manifests/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
 resources:

--- a/src/peerpod-ctrl/config/prometheus/kustomization.yaml
+++ b/src/peerpod-ctrl/config/prometheus/kustomization.yaml
@@ -1,2 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - monitor.yaml

--- a/src/peerpod-ctrl/config/rbac/kustomization.yaml
+++ b/src/peerpod-ctrl/config/rbac/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 # All RBAC will be applied under this service account in
 # the deployment namespace. You may comment out this resource

--- a/src/peerpod-ctrl/config/samples/kustomization.yaml
+++ b/src/peerpod-ctrl/config/samples/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 ## Append samples you want in your CSV to this file as resources ##
 resources:
 - _v1alpha1_peerpod.yaml

--- a/src/peerpod-ctrl/config/scorecard/kustomization.yaml
+++ b/src/peerpod-ctrl/config/scorecard/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
 - bases/config.yaml
-patchesJson6902:
+patches:
 - path: patches/basic.config.yaml
   target:
     group: scorecard.operatorframework.io

--- a/src/peerpod-ctrl/config/scorecard/kustomization.yaml
+++ b/src/peerpod-ctrl/config/scorecard/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - bases/config.yaml
 patches:

--- a/src/peerpodconfig-ctrl/config/crd/kustomization.yaml
+++ b/src/peerpodconfig-ctrl/config/crd/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default

--- a/src/peerpodconfig-ctrl/config/default/kustomization.yaml
+++ b/src/peerpodconfig-ctrl/config/default/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # Adds namespace to all resources.
 namespace: peerpodconfig-ctrl-system
 

--- a/src/peerpodconfig-ctrl/config/default/kustomization.yaml
+++ b/src/peerpodconfig-ctrl/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ namePrefix: peerpodconfig-ctrl-
 #commonLabels:
 #  someName: someValue
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager

--- a/src/peerpodconfig-ctrl/config/manifests/kustomization.yaml
+++ b/src/peerpodconfig-ctrl/config/manifests/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
 # These patches remove the unnecessary "cert" volume and its manager container volumeMount.
-#patchesJson6902:
+#patches:
 #- target:
 #    group: apps
 #    version: v1

--- a/src/peerpodconfig-ctrl/config/manifests/kustomization.yaml
+++ b/src/peerpodconfig-ctrl/config/manifests/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
 resources:

--- a/src/peerpodconfig-ctrl/config/prometheus/kustomization.yaml
+++ b/src/peerpodconfig-ctrl/config/prometheus/kustomization.yaml
@@ -1,2 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - monitor.yaml

--- a/src/peerpodconfig-ctrl/config/rbac/kustomization.yaml
+++ b/src/peerpodconfig-ctrl/config/rbac/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 # All RBAC will be applied under this service account in
 # the deployment namespace. You may comment out this resource

--- a/src/peerpodconfig-ctrl/config/samples/kustomization.yaml
+++ b/src/peerpodconfig-ctrl/config/samples/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 ## Append samples you want in your CSV to this file as resources ##
 resources:
 - _v1alpha1_peerpodconfig.yaml

--- a/src/peerpodconfig-ctrl/config/scorecard/kustomization.yaml
+++ b/src/peerpodconfig-ctrl/config/scorecard/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
 - bases/config.yaml
-patchesJson6902:
+patches:
 - path: patches/basic.config.yaml
   target:
     group: scorecard.operatorframework.io

--- a/src/peerpodconfig-ctrl/config/scorecard/kustomization.yaml
+++ b/src/peerpodconfig-ctrl/config/scorecard/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - bases/config.yaml
 patches:

--- a/src/webhook/config/certmanager/kustomization.yaml
+++ b/src/webhook/config/certmanager/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - certificate.yaml
 

--- a/src/webhook/config/default/kustomization.yaml
+++ b/src/webhook/config/default/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # Adds namespace to all resources.
 namespace: peer-pods-webhook-system
 

--- a/src/webhook/config/default/kustomization.yaml
+++ b/src/webhook/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ namePrefix: peer-pods-webhook-
 #commonLabels:
 #  someName: someValue
 
-bases:
+resources:
 #- ../crd
 - ../rbac
 - ../manager

--- a/src/webhook/config/prometheus/kustomization.yaml
+++ b/src/webhook/config/prometheus/kustomization.yaml
@@ -1,2 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - monitor.yaml

--- a/src/webhook/config/rbac/kustomization.yaml
+++ b/src/webhook/config/rbac/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 # All RBAC will be applied under this service account in
 # the deployment namespace. You may comment out this resource

--- a/src/webhook/config/webhook/kustomization.yaml
+++ b/src/webhook/config/webhook/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - manifests.yaml
 - service.yaml


### PR DESCRIPTION
While setting-up my libvirt+kcli I noticed a few warnings from kustomize. I used `kustomize edit fix` to learn what to replace and then addressed all places using `sed`. Note the behaviour should not change but I have only tested the default libvirt e2e setup with kcli.