### PR TITLE
podvm-mkosi: support to build s390x fedora image

### DIFF
--- a/hack/build-s390x-image.sh
+++ b/hack/build-s390x-image.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -euo pipefail
+
+pushd ../podvm-mkosi/build
+
+workdir=.
+tmp_img_path="${workdir}/tmp.qcow2"
+tmp_nbd=/dev/nbd1
+dst_mnt=./dst_mnt
+disksize=100G
+
+qemu-img create -f qcow2 "${tmp_img_path}" "${disksize}"
+
+modprobe nbd
+qemu-nbd --connect="${tmp_nbd}" "${tmp_img_path}"
+
+# Partition and format
+parted -a optimal "${tmp_nbd}" mklabel gpt \
+        mkpart boot ext4 1MiB 256MiB \
+        mkpart system 256MiB "${disksize}" \
+        set 1 boot on
+
+echo "Waiting for the two nbd partitions to show up"
+while true; do
+sleep 1
+[[ -e "${tmp_nbd}"p2 ]] && break
+done
+
+mke2fs -t ext4 -L boot "${tmp_nbd}"p1
+boot_uuid=$(blkid "${tmp_nbd}"p1 -s PARTUUID -o value)
+
+mke2fs -t ext4 -L system "${tmp_nbd}"p2
+system_uuid=$(blkid "${tmp_nbd}"p2 -s PARTUUID -o value)
+
+# Copy files
+mkdir -p "${dst_mnt}"
+mount "${tmp_nbd}p2" "${dst_mnt}"
+
+mkdir -p "${dst_mnt}"/boot
+mount -o norecovery "${tmp_nbd}"p1 "${dst_mnt}"/boot
+
+cp initrd.cpio.zst "${dst_mnt}"/boot/initrd.img
+cp system.vmlinuz "${dst_mnt}"/boot/vmlinuz
+
+src_mnt=system
+tar_opts=(--numeric-owner --preserve-permissions --acl --selinux --xattrs --xattrs-include='*' --sparse)
+tar -cf - "${tar_opts[@]}" --sort=none -C "${src_mnt}" . | tar -xf - "${tar_opts[@]}" --preserve-order  -C "${dst_mnt}"
+
+cat <<END > "${dst_mnt}/etc/fstab"
+#This file was auto-generated
+PARTUUID=${system_uuid}   /        ext4  defaults 1 1
+PARTUUID=${boot_uuid}     /boot    ext4  norecovery 1 2
+END
+
+mount -t sysfs sysfs "${dst_mnt}/sys"
+mount -t proc proc "${dst_mnt}/proc"
+mount --bind /dev "${dst_mnt}/dev"
+
+# generate bootloader
+chroot "${dst_mnt}" zipl -V --targetbase "${tmp_nbd}" \
+    --targettype scsi \
+    --targetblocksize 512 \
+    --targetoffset 2048 \
+    --target /boot \
+    --image /boot/vmlinuz \
+    --ramdisk /boot/initrd.img \
+    --parameters "root=LABEL=system selinux=0 enforcing=0 audit=0 systemd.firstboot=off"
+
+umount "${dst_mnt}/dev"
+umount "${dst_mnt}/proc"
+umount "${dst_mnt}/sys"
+
+umount "${dst_mnt}/boot"
+umount "${dst_mnt}"
+
+qemu-nbd --disconnect "${tmp_nbd}"
+
+output_img_name="podvm-s390x.qcow2"
+qemu-img convert -O qcow2 -c "${tmp_img_path}" "${output_img_name}"
+
+output_img_path=$(realpath "${output_img_name}")
+echo "podvm image is generated: ${output_img_path}"
+
+popd

--- a/podvm-mkosi/Makefile
+++ b/podvm-mkosi/Makefile
@@ -46,7 +46,12 @@ image:
 	rm -rf resources/buildDebugImage
 	rm -rf ./build
 	@echo "Building image..."
+ifeq ($(ARCH),s390x)
+	mkosi --profile production.conf
+	../hack/build-s390x-image.sh
+else
 	nix develop ..#podvm-mkosi --command mkosi --environment=VARIANT_ID=production
+endif
 
 PHONY: image-debug
 image-debug:
@@ -54,7 +59,12 @@ image-debug:
 	touch resources/buildDebugImage
 	rm -rf ./build
 	@echo "Building debug image..."
+ifeq ($(ARCH),s390x)
+	mkosi --profile debug.conf
+	../hack/build-s390x-image.sh
+else
 	nix develop ..#podvm-mkosi --command mkosi --environment=VARIANT_ID=debug
+endif
 
 PHONY: clean
 clean:

--- a/podvm-mkosi/README.md
+++ b/podvm-mkosi/README.md
@@ -75,3 +75,27 @@ reduce complexity of configuration and CI and shall not be seen as open to-dos.
 
 - Deployed images cannot be customized with cloud-init. Runtime configuration data is retrieved
   from IMDS via the project's `process-user-data` tool.
+
+## Build s390x image
+Since the [nix OS](https://nixos.org/download/#download-nix) does not support s390x, we can use the mkosi **ToolsTree** feature defined in `mkosi.conf` to download latest tools automatically:
+```
+[Host]
+ToolsTree=default
+```
+And install **mkosi** from the repository:
+```sh
+git clone -b v21 https://github.com/systemd/mkosi
+ln -s $PWD/mkosi/bin/mkosi /usr/local/bin/mkosi
+mkosi --version
+```
+Another issue is s390x does not support UEFI. Instead, we can first use **mkosi** to build non-bootable system files, then use **zipl** to generate the bootloader and finally create the bootable image.
+
+It requires a **s390x host** to build s390x image with make commands:
+```
+make fedora-binaries-builder
+make binaries
+make image
+# make image-debug
+```
+
+The final output is `build/podvm-s390x.qcow2`, which can be used as the Pod VM image in libvirt environment.

--- a/podvm-mkosi/mkosi.presets/initrd/mkosi.conf.d/fedora-s390x.conf
+++ b/podvm-mkosi/mkosi.presets/initrd/mkosi.conf.d/fedora-s390x.conf
@@ -1,0 +1,10 @@
+[Match]
+Distribution=fedora
+
+Architecture=s390x
+
+[Content]
+Packages=kernel-core
+
+[Host]
+ToolsTree=default

--- a/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-bootable.conf
+++ b/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-bootable.conf
@@ -1,0 +1,7 @@
+[Match]
+Distribution=fedora
+
+Architecture=!s390x
+
+[Content]
+Packages=systemd-boot

--- a/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-s390x.conf
+++ b/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-s390x.conf
@@ -1,0 +1,18 @@
+[Match]
+Distribution=fedora
+
+Architecture=s390x
+
+[Content]
+Bootable=no
+Packages=s390utils
+    dhclient
+    NetworkManager
+    cloud-init
+    cloud-utils-growpart
+
+[Output]
+Format=directory
+
+[Host]
+ToolsTree=default

--- a/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora.conf
+++ b/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora.conf
@@ -15,7 +15,6 @@ Packages=
     udev
     util-linux
     systemd
-    systemd-boot
     systemd-networkd
     systemd-resolved
     dbus

--- a/podvm-mkosi/mkosi.presets/system/mkosi.finalize.chroot
+++ b/podvm-mkosi/mkosi.presets/system/mkosi.finalize.chroot
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+if [[ "${ARCHITECTURE}" == "s390x" ]]; then
+	# enable cloud-init services
+        systemctl enable cloud-init-local.service
+        systemctl enable cloud-init.service
+        systemctl enable cloud-config.service
+        systemctl enable cloud-final.service
+
+	# disable this service since we already have "NetworkManager-wait-online.service"
+        systemctl disable systemd-networkd-wait-online.service
+fi

--- a/podvm-mkosi/mkosi.profiles/debug.conf
+++ b/podvm-mkosi/mkosi.profiles/debug.conf
@@ -1,0 +1,2 @@
+[Content]
+Environment=VARIANT_ID=debug

--- a/podvm-mkosi/mkosi.profiles/production.conf
+++ b/podvm-mkosi/mkosi.profiles/production.conf
@@ -1,0 +1,2 @@
+[Content]
+Environment=VARIANT_ID=production


### PR DESCRIPTION
According to #1640 , there are 2 problems for mkosi to build s390x images:

* The [nix OS](https://nixos.org/download/#download-nix) does not support s390x, but we can use the mkosi **ToolsTree** feature defined in `mkosi.conf` to download latest tools automatically:
```
[Host]
ToolsTree=default
```
* s390x does not support UEFI, so mkosi cannot build a bootable s390x image. Instead, we can first use **mkosi** to build non-bootable system files, then use **zipl** to generate the bootloader (podvm-mkosi/build-s390x-image.sh)

We need run **mkosi** from the repository:
```sh
git clone -b v21 https://github.com/systemd/mkosi
ln -s $PWD/mkosi/bin/mkosi /usr/local/bin/mkosi
mkosi --version
```

For the new mkosi release, there is an issue to set environment (#1746). Instead, we try to use profile as suggested in mkosi community (https://github.com/systemd/mkosi/issues/2500).

I tested the s390x qcow2 image in libvirt environment, and it should work.

---------------

I try to avoid impacts to x86 images, which can still be run with nix, and s390x changes will not be picked up for the Match rules.

I also build a new x86 image, but I don't have AWS environment to verify it. Since UEFI is enabled, I can start the VM with following command on ubuntu 22.04 host:
```
virt-install --name podvm --memory 2048 --vcpus 1 --disk path=/var/lib/libvirt/images/podvm.qcow2,device=disk,bus=scsi --import --os-variant fedora38 --network default --graphics none --machine q35 --boot loader=/usr/share/OVMF/OVMF_CODE.secboot.fd,loader.readonly=yes,loader.type=pflash,loader_secure=yes --features smm.state=on
```

However, it seems current libvirt provider cannot support UEFI image on a host with Intel processor. I noticed we can configure `LIBVIRT_LAUNCH_SECURITY` and `LIBVIRT_FIRMWARE` for UEFI, but it requires SEV ([AMD Secure Encrypted Virtualization](https://libvirt.org/kbase/launch_security_sev.html#id1)) support on the host, but I don't have an AMD host.
```
2024/03/19 09:32:37 [adaptor/cloud/libvirt] failed to create an instance : error building the libvirt XML, cause: SEV is not supported for this domain
```