### PR TITLE
peerpod-ctrl: Make undeploy depend on kustomize target

### DIFF
--- a/src/peerpod-ctrl/Makefile
+++ b/src/peerpod-ctrl/Makefile
@@ -178,7 +178,7 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 .PHONY: undeploy
-undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 ##@ Build Dependencies


### PR DESCRIPTION
the `undeploy` target is using the `KUSTOMIZE` binary, but it hasn't necessarily been created so add the kustomize target to it that creates

Fixes: 1755