### PR TITLE
workflow: fix the bad workflows after we are in new file structure

### DIFF
--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -37,13 +37,21 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           tags: ghcr.io/${{ github.repository }}/podvm/builder-fedora:${{ github.sha }}
+          context: src
           file: src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.fedora
           push: true
+
+      # Build binaries need git commit id as part of image name
+      - name: Prepare .git folder
+        working-directory: ./
+        run: |
+          cp -rf .git src/.git
 
       - name: Build binaries
         uses: docker/build-push-action@v5
         with:
           tags: ghcr.io/${{ github.repository }}/podvm/binaries-fedora:${{ github.sha }}
+          context: src
           file: src/cloud-api-adaptor/podvm/Dockerfile.podvm_binaries.fedora
           push: true
           build-args:

--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -68,8 +68,8 @@ jobs:
         tags: |
           quay.io/confidential-containers/test-images:${{env.DOCKER_TAG}}
         push: true
-        context: .
+        context: src/cloud-api-adaptor/
         platforms: linux/s390x,linux/amd64
-        file: ${{matrix.targets}}
+        file: src/cloud-api-adaptor/${{matrix.targets}}
         build-args: |
           "ARCH=${{ matrix.arch }}"

--- a/src/cloud-api-adaptor/test/provisioner/provision.go
+++ b/src/cloud-api-adaptor/test/provisioner/provision.go
@@ -421,7 +421,7 @@ func (p *CloudAPIAdaptor) Delete(ctx context.Context, cfg *envconf.Config) error
 	}
 
 	log.Info("Delete the peerpod-ctrl deployment")
-	cmd = exec.Command("make", "-C", "peerpod-ctrl", "undeploy")
+	cmd = exec.Command("make", "-C", "../peerpod-ctrl", "undeploy")
 	// Run the command from the root src dir
 	cmd.Dir = p.rootSrcDir
 	// Set the KUBECONFIG env var
@@ -522,7 +522,7 @@ func (p *CloudAPIAdaptor) Deploy(ctx context.Context, cfg *envconf.Config, props
 	}
 
 	log.Info("Installing peerpod-ctrl")
-	cmd = exec.Command("make", "-C", "peerpod-ctrl", "deploy")
+	cmd = exec.Command("make", "-C", "../peerpod-ctrl", "deploy")
 	// Run the deployment from the root src dir
 	cmd.Dir = p.rootSrcDir
 	// Set the KUBECONFIG env var


### PR DESCRIPTION
- fix bad docker images build for test images
- the `context` and `file` need be set correctly when using `docker/build-push-action`
- also fix the e2e-test failed at `Installing peerpod-ctrl`

fixes for:
- https://github.com/confidential-containers/cloud-api-adaptor/actions/runs/8385253126
- https://github.com/confidential-containers/cloud-api-adaptor/actions/runs/8385451930/job/22965030759?pr=1757