### PR TITLE
pin packer plugins versions

### DIFF
--- a/src/cloud-api-adaptor/aws/image/rhel/aws-rhel.pkr.hcl
+++ b/src/cloud-api-adaptor/aws/image/rhel/aws-rhel.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     amazon = {
-      version = ">= 0.0.2"
+      version = "= 1.3.1"
       source  = "github.com/hashicorp/amazon"
     }
   }

--- a/src/cloud-api-adaptor/aws/image/ubuntu/aws-ubuntu.pkr.hcl
+++ b/src/cloud-api-adaptor/aws/image/ubuntu/aws-ubuntu.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     amazon = {
-      version = ">= 0.0.2"
+      version = "= 1.3.1"
       source  = "github.com/hashicorp/amazon"
     }
   }

--- a/src/cloud-api-adaptor/azure/image/rhel/azure-rhel.pkr.hcl
+++ b/src/cloud-api-adaptor/azure/image/rhel/azure-rhel.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     azure = {
-      version = ">= 2.0.0"
+      version = "= 2.0.2"
       source  = "github.com/hashicorp/azure"
     }
   }

--- a/src/cloud-api-adaptor/azure/image/ubuntu/azure-ubuntu.pkr.hcl
+++ b/src/cloud-api-adaptor/azure/image/ubuntu/azure-ubuntu.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     azure = {
-      version = ">= 2.0.0"
+      version = "= 2.0.2"
       source  = "github.com/hashicorp/azure"
     }
   }


### PR DESCRIPTION
Reasons:
* avoid unexpected bugs (there's one in latest azure plugin)
* avoid license changes
* packer usage for podvm creation is expected to be deprecated soon
