### PR TITLE
podvm-mkosi: fix Architecture cannot be used in [Match]

### DIFF
--- a/src/cloud-api-adaptor/podvm-mkosi/Makefile
+++ b/src/cloud-api-adaptor/podvm-mkosi/Makefile
@@ -45,26 +45,31 @@ binaries:
 PHONY: image
 image:
 	@echo "Enabling production preset..."
-	rm -rf resources/buildDebugImage
+	rm -rf resources/build*Image
 	rm -rf ./build
 	@echo "Building image..."
 ifeq ($(ARCH),s390x)
+	touch resources/buildS390xImage
 	mkosi --profile production.conf
 	../hack/build-s390x-image.sh
 else
+	touch resources/buildBootableImage
 	nix develop ..#podvm-mkosi --command mkosi --environment=VARIANT_ID=production
 endif
 
 PHONY: image-debug
 image-debug:
 	@echo "Enabling debug preset..."
+	rm -rf resources/build*Image
 	touch resources/buildDebugImage
 	rm -rf ./build
 	@echo "Building debug image..."
 ifeq ($(ARCH),s390x)
+	touch resources/buildS390xImage
 	mkosi --profile debug.conf
 	../hack/build-s390x-image.sh
 else
+	touch resources/buildBootableImage
 	nix develop ..#podvm-mkosi --command mkosi --environment=VARIANT_ID=debug
 endif
 

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/initrd/mkosi.conf.d/fedora-s390x.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/initrd/mkosi.conf.d/fedora-s390x.conf
@@ -1,7 +1,11 @@
 [Match]
 Distribution=fedora
 
-Architecture=s390x
+# mkosi version in nix is 17.1,
+# which doesn't support Architecture in [Match]
+# As a workaround, use a flag file instead.
+#Architecture=s390x
+PathExists=../../resources/buildS390xImage
 
 [Content]
 Packages=kernel-core

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-bootable.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-bootable.conf
@@ -1,7 +1,11 @@
 [Match]
 Distribution=fedora
 
-Architecture=!s390x
+# mkosi version in nix is 17.1,
+# which doesn't support Architecture in [Match]
+# As a workaround, use a flag file instead.
+#Architecture=!s390x
+PathExists=../../resources/buildBootableImage
 
 [Content]
 Packages=systemd-boot

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-s390x.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-s390x.conf
@@ -1,7 +1,11 @@
 [Match]
 Distribution=fedora
 
-Architecture=s390x
+# mkosi version in nix is 17.1,
+# which doesn't support Architecture in [Match]
+# As a workaround, use a flag file instead.
+#Architecture=s390x
+PathExists=../../resources/buildS390xImage
 
 [Content]
 Bootable=no


### PR DESCRIPTION
When build x86 podvm image with mkosi, we may hit following error:
```
Architecture cannot be used in [Match]
```

We depend on nix to setup mkosi build environment. Current mkosi version in nix is `17.1`:
```
# nix develop ..#podvm-mkosi --command mkosi --version
warning: Git tree '/root/cloud-api-adaptor' is dirty
mkosi 17.1
```

According to the v17.1 doc, Architecture in [Match] has not been supported in this version:
https://github.com/systemd/mkosi/blob/v17.1/mkosi/resources/mkosi.md

If upgrading mkosi version in nix, we may hit some other new errors. So I'd like to keep mkosi version and use flag files instead to fix the Architecture error.