### PR TITLE
azure: Comment out service principal env file

### DIFF
--- a/src/cloud-api-adaptor/install/overlays/azure/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/azure/kustomization.yaml
@@ -57,8 +57,8 @@ secretGenerator:
   # AZURE_CLIENT_ID=...
   # AZURE_CLIENT_SECRET=...
   # AZURE_TENANT_ID=...
-  envs:
-  - service-principal.env
+  # envs:
+  # - service-principal.env
 - name: ssh-key-secret
   namespace: confidential-containers-system
   files: # key generation example: ssh-keygen -f ./id_rsa -N ""


### PR DESCRIPTION
The service principal env file was needed when we used to rely on using service principal and its secrets. But we have moved away from using SP and now we use managed identities. So, we don't need this file anymore. But if someone needs it they still have a reference, so this commit comments it out, instead of removing it altogether.

Also another problem with this is that the CI runs fail as this file does not exists and kustomize errors out. In the CI run we don't provide the kustomization file we modify the existing kustomization file.