### PR TITLE
azure-podvm-image-build: Relogin before cleanup

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -142,6 +142,15 @@ jobs:
         echo "successfully built $IMAGE_ID"
         echo "image-id=${IMAGE_ID}" >> "$GITHUB_OUTPUT"
 
+    # Above build can take a > 10 minutes and the login assertion is valid only
+    # for 5 minutes, so re-login before we cleanup the intermediate image.
+    - uses: azure/login@v1
+      name: 'Az CLI login'
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+
     - name: Cleanup intermediate image
       if: always()
       run: |


### PR DESCRIPTION
The packer based build takes more than 10 minutes to cleanup. And after the build if we use az CLI to clean up the intermediate image, it fails because the assertion is valid for 5 minutes only.

So relogin before we move on to cleanup the intermediate image.

Fixes: #1771