### PR TITLE
Build: Update build.sh

### DIFF
--- a/src/cloud-api-adaptor/hack/build.sh
+++ b/src/cloud-api-adaptor/hack/build.sh
@@ -59,10 +59,13 @@ function build_caa_payload_image() {
 		--build-arg COMMIT="${commit}" \
 		--build-arg YQ_VERSION="${YQ_VERSION}" \
 		--build-arg YQ_CHECKSUM="${YQ_CHECKSUM}" \
+		--load \
 		-f cloud-api-adaptor/Dockerfile \
 		${tag_string} \
-		--push \
 		.
+
+	docker push  ${registry}/${name}
+
 	popd
 }
 
@@ -104,10 +107,14 @@ function build_caa_payload_arch_specific() {
 		--build-arg COMMIT="${commit}" \
 		--build-arg YQ_VERSION="${YQ_VERSION}" \
 		--build-arg YQ_CHECKSUM="${YQ_CHECKSUM}" \
+		--load \
 		-f cloud-api-adaptor/Dockerfile \
 		${tag_string} \
 		--push \
 		.
+
+	docker push  ${registry}/${name}
+
 	popd
 }
 


### PR DESCRIPTION
podman does not support a `--push` flag.

Replaces #1739  