### PR TITLE
cloud-api-adaptor: Set dnsPolicy to ClusterFirstWithHostNet

### DIFF
--- a/src/cloud-api-adaptor/install/yamls/caa-pod.yaml
+++ b/src/cloud-api-adaptor/install/yamls/caa-pod.yaml
@@ -60,6 +60,7 @@ spec:
           mountPropagation: HostToContainer
           name: netns
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       nodeSelector:
         node.kubernetes.io/worker: ""
       volumes:


### PR DESCRIPTION
change dns setting of the CAA daemonset's pod-spec

 name: cloud-api-adaptor-daemonset
 namespace: confidential-containers-system
  
 Should use `dnsPolicy: ClusterFirstWithHostNet`