### PR TITLE
0.8.1-alpha: updating go modules

### DIFF
--- a/src/cloud-api-adaptor/go.mod
+++ b/src/cloud-api-adaptor/go.mod
@@ -48,8 +48,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/eks v1.29.5
 	github.com/aws/aws-sdk-go-v2/service/iam v1.22.5
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.38.5
-	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers v0.8.0
-	github.com/confidential-containers/cloud-api-adaptor/src/peerpod-ctrl v0.8.0
+	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers v0.8.1-alpha.1
+	github.com/confidential-containers/cloud-api-adaptor/src/peerpod-ctrl v0.8.1-alpha.1
 	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
 	github.com/moby/sys/mountinfo v0.6.2
 	github.com/pelletier/go-toml/v2 v2.1.0

--- a/src/csi-wrapper/go.mod
+++ b/src/csi-wrapper/go.mod
@@ -3,7 +3,7 @@ module github.com/confidential-containers/cloud-api-adaptor/src/csi-wrapper
 go 1.20
 
 require (
-	github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor v0.8.0
+	github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor v0.8.1-alpha.1
 	github.com/container-storage-interface/spec v1.8.0
 	github.com/containerd/ttrpc v1.1.0
 	github.com/gofrs/uuid v4.4.0+incompatible

--- a/src/peerpod-ctrl/go.mod
+++ b/src/peerpod-ctrl/go.mod
@@ -3,7 +3,7 @@ module github.com/confidential-containers/cloud-api-adaptor/src/peerpod-ctrl
 go 1.20
 
 require (
-	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers v0.8.0
+	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers v0.8.1-alpha.1
 	github.com/onsi/ginkgo/v2 v2.8.1
 	github.com/onsi/gomega v1.27.1
 	k8s.io/api v0.26.0


### PR DESCRIPTION
As part of the 0.8.1-alpha release we need to update the following go modules. make tidy didn't updated anything else.