### PR TITLE
podvm-mkosi: build and push images with s390x runner in workflow

### DIFF
--- a/.github/workflows/podvm_mkosi_image.yaml
+++ b/.github/workflows/podvm_mkosi_image.yaml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - ubuntu-latest
           - S390X
     permissions:
       contents: read
@@ -29,12 +28,26 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Log in to GitHub Container Registry
+      - name: Login to Quay container Registry
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+          logout: false
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y bubblewrap alien dnf qemu-utils uidmap
+          sudo snap install yq
+
+      - name: Install mkosi
+        run: |
+          git clone -b v22 https://github.com/systemd/mkosi
+          sudo rm /usr/local/bin/mkosi | true
+          sudo ln -s $PWD/mkosi/bin/mkosi /usr/local/bin/mkosi
+          mkosi --version
 
       - name: Build builder
         working-directory: src/cloud-api-adaptor/podvm-mkosi
@@ -43,9 +56,14 @@ jobs:
       - name: Build binaries
         working-directory: src/cloud-api-adaptor/podvm-mkosi
         run: make binaries
-      
-      # TODO - build image via mkosi when s390x is available
-      # TODO - upload the image 
+
+      - name: Build image
+        run: make image-debug
+        working-directory: src/cloud-api-adaptor/podvm-mkosi
+
+      - name: Push image
+        run: make push-image
+        working-directory: src/cloud-api-adaptor/podvm-mkosi
 
       - name: Take a post-action
         if: always()

--- a/src/cloud-api-adaptor/hack/build-s390x-image.sh
+++ b/src/cloud-api-adaptor/hack/build-s390x-image.sh
@@ -78,6 +78,7 @@ qemu-nbd --disconnect "${tmp_nbd}"
 
 output_img_name="podvm-s390x.qcow2"
 qemu-img convert -O qcow2 -c "${tmp_img_path}" "${output_img_name}"
+chmod 644 "${output_img_name}"
 
 output_img_path=$(realpath "${output_img_name}")
 echo "podvm image is generated: ${output_img_path}"

--- a/src/cloud-api-adaptor/podvm-mkosi/Makefile
+++ b/src/cloud-api-adaptor/podvm-mkosi/Makefile
@@ -1,6 +1,13 @@
+include ../Makefile.defaults
+
 AA_KBC  ?= offline_fs_kbc
 ARCH    ?= $(subst x86_64,amd64,$(shell uname -m))
 BUILDER = fedora-binaries-builder-$(ARCH)
+
+REGISTRY ?= quay.io/confidential-containers
+PODVM_DISTRO ?= fedora
+PODVM_TAG ?= $(VERSIONS_HASH)
+PODVM_NAME ?= $(REGISTRY)/podvm-generic-$(PODVM_DISTRO)-$(ARCH)
 
 .DEFAULT_GOAL := all
 .PHONY: all
@@ -50,8 +57,8 @@ image:
 	@echo "Building image..."
 ifeq ($(ARCH),s390x)
 	touch resources/buildS390xImage
-	mkosi --profile production.conf
-	../hack/build-s390x-image.sh
+	sudo mkosi --profile production.conf
+	sudo ../hack/build-s390x-image.sh
 else
 	touch resources/buildBootableImage
 	nix develop ..#podvm-mkosi --command mkosi --environment=VARIANT_ID=production
@@ -66,11 +73,22 @@ image-debug:
 	@echo "Building debug image..."
 ifeq ($(ARCH),s390x)
 	touch resources/buildS390xImage
-	mkosi --profile debug.conf
-	../hack/build-s390x-image.sh
+	sudo mkosi --profile debug.conf
+	sudo ../hack/build-s390x-image.sh
 else
 	touch resources/buildBootableImage
 	nix develop ..#podvm-mkosi --command mkosi --environment=VARIANT_ID=debug
+endif
+
+PHONY: push-image
+push-image:
+	@echo "Push podvm image to remote repository..."
+ifeq ($(ARCH),s390x)
+	docker buildx build \
+		-t $(PODVM_NAME):$(PODVM_TAG) \
+		-t $(PODVM_NAME):latest \
+		--load \
+		-f ../podvm/Dockerfile.podvm.fedora .
 endif
 
 PHONY: clean

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm.fedora
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm.fedora
@@ -1,0 +1,13 @@
+# Copyright Confidential Containers Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Place pod vm image built via mkosi
+#
+FROM scratch
+
+ARG ARCH=s390x
+
+ENV ARCH ${ARCH}
+
+COPY build/podvm-${ARCH}.qcow2 /


### PR DESCRIPTION
Update workflow, to build and push s390x Pod VM image with the s390x runner

Build a image including the s390x Pod VM qcow2 image, and push it to Quay container Registry: quay.io/confidential-containers/podvm-generic-fedora-s390x

Succeed to run the workflow in branch: https://github.com/confidential-containers/cloud-api-adaptor/actions/runs/8643044858/job/23695257457

Verify the qcow2 image:
```
docker pull quay.io/confidential-containers/podvm-generic-fedora-s390x:latest
docker create --name "fedora-podvm-exporter" "quay.io/confidential-containers/podvm-generic-fedora-s390x:latest" /bin/sh
docker cp "fedora-podvm-exporter:/podvm-s390x.qcow2" .
docker rm -f "fedora-podvm-exporter" 
```