### PR TITLE
libvirt: fix default IP logic

### DIFF
--- a/src/cloud-api-adaptor/libvirt/README.md
+++ b/src/cloud-api-adaptor/libvirt/README.md
@@ -100,11 +100,14 @@ Allocation:     631.52 MiB
 
 ## Install and configure Confidential Containers and cloud-api-adaptor in the cluster
 
-The easiest way to install the cloud-api-adaptor along with Confidential Containers in the cluster is through the
-Kubernetes operator [`install_operator.sh`](./install_operator.sh) script. Ensure that you have your IP address exported in the environment, as shown below, then run the install script:
+The easiest way to install the cloud-api-adaptor along with Confidential
+Containers in the cluster is through the Kubernetes operator
+[`install_operator.sh`](./install_operator.sh) script.
+
+If you need to set any non-default parameter, please run the script with the
+`--help` option.
 
 ```
-$ export LIBVIRT_IP="192.168.122.1"
 $ export SSH_KEY_FILE="id_rsa"
 $ ./libvirt/install_operator.sh
 ```

--- a/src/cloud-api-adaptor/libvirt/install_operator.sh
+++ b/src/cloud-api-adaptor/libvirt/install_operator.sh
@@ -11,7 +11,6 @@ set -o pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-LIBVIRT_IP="${LIBVIRT_IP:-192.168.122.1}"
 LIBVIRT_USER="${LIBVIRT_USER:-$USER}"
 LIBVIRT_NET="${LIBVIRT_NET:-default}"
 LIBVIRT_POOL="${LIBVIRT_POOL:-default}"
@@ -35,7 +34,7 @@ label_workers() {
 usage() {
 	cat <<-EOF
 	Install cloud-api-adaptor in the Kubernetes cluster.
-	You must have KUBECONFIG and LIBVIRT_IP exported in the environment.
+	You must have at least KUBECONFIG exported in the environment.
 
 	Use: $0 [-h|help]
 


### PR DESCRIPTION
If we have a default IP address the logic that will calculate the IP based on the libvirt network will never be executed.