### PR TITLE
ci: add yq shim for v3/v4 support

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -104,10 +104,7 @@ jobs:
     - name: Build kata-agent
       env:
         GOPATH: /home/runner/go
-      run: |
-        make "$(realpath ../../podvm/files/usr/local/bin/kata-agent)" LIBC=gnu
-        # kata build installs yq v3 as a side effect
-        rm -r "${GOPATH}/bin/yq"
+      run: make "$(realpath ../../podvm/files/usr/local/bin/kata-agent)" LIBC=gnu
 
     - name: Build binaries
       run: make binaries \

--- a/src/cloud-api-adaptor/Dockerfile
+++ b/src/cloud-api-adaptor/Dockerfile
@@ -30,6 +30,7 @@ COPY peerpod-ctrl ./peerpod-ctrl
 WORKDIR /work/cloud-api-adaptor
 RUN go mod download
 COPY cloud-api-adaptor/entrypoint.sh cloud-api-adaptor/Makefile cloud-api-adaptor/Makefile.defaults cloud-api-adaptor/versions.yaml ./
+COPY cloud-api-adaptor/hack  ./hack
 COPY cloud-api-adaptor/cmd   ./cmd
 COPY cloud-api-adaptor/pkg   ./pkg
 COPY cloud-api-adaptor/proto ./proto

--- a/src/cloud-api-adaptor/Makefile.defaults
+++ b/src/cloud-api-adaptor/Makefile.defaults
@@ -1,9 +1,6 @@
-YQ_COMMAND ?= yq
-VERSIONS_SRC := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))/versions.yaml
-
-ifeq (, $(shell command -v $(YQ_COMMAND) 2> /dev/null))
-$(error "$(YQ_COMMAND) not found, consider doing snap install yq")
-endif
+ROOT_PATH := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+VERSIONS_SRC := $(ROOT_PATH)/versions.yaml
+YQ_COMMAND ?= $(ROOT_PATH)/hack/yq-shim.sh
 
 # As we need `yq` to be installed to fetch the values from versions.yaml
 # these values are hardcoded here, all other versions/references should be
@@ -12,16 +9,10 @@ YQ_VERSION := v4.35.1
 YQ_CHECKSUM := "sha256:bd695a6513f1196aeda17b174a15e9c351843fb1cef5f9be0af170f2dd744f08"
 YQ_CHECKSUM_s390x:= "sha256:4e6324d08630e7df733894a11830412a43703682d65a76f1fc925aac08268a45"
 
-MINIMUM_YQ_MAJOR_VERSION := 4
-INSTALLED_YQ_MAJOR_VERSION := $(shell $(YQ_COMMAND) --version | sed -nE 's/.* v?([0-9]+).*/\1/p')
-
-ifneq ($(MINIMUM_YQ_MAJOR_VERSION), $(INSTALLED_YQ_MAJOR_VERSION))
-$(error "yq major version should be $(MINIMUM_YQ_MAJOR_VERSION), is: $(INSTALLED_YQ_MAJOR_VERSION)")
-endif
 VERSIONS_HASH := $(firstword $(shell sha256sum $(VERSIONS_SRC)))
 
 define query
-$(or $(shell $(YQ_COMMAND) '.$(1) | select(. != null)' $(VERSIONS_SRC)), \
+$(or $(shell $(YQ_COMMAND) '.$(1)' $(VERSIONS_SRC)), \
 	$(error $(1) is not set, and could not be automatically set from $(VERSIONS_SRC)))
 endef
 

--- a/src/cloud-api-adaptor/hack/yq-shim.sh
+++ b/src/cloud-api-adaptor/hack/yq-shim.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# This script is a shim to allow yq to be used as a drop-in replacement for jq, abstracting away the differences for simple queries between v3 and v4.
+# This is the output of yq --version for each:
+# yq_v4 --version yq (https://github.com/mikefarah/yq/) version v4.35.1
+# yq_v3 --version yq version 3.4.1
+
+usage() { echo "Usage: $0 <query> <path to yaml>"; }
+
+QUERY="${1-}"
+YAML_PATH="${2-}"
+
+if [ "$QUERY" == "-h" ]; then
+	usage
+	exit 0
+elif [ -z "${QUERY-}" ] || [ -z "${YAML_PATH-}" ]; then
+	usage >&2
+	exit 1
+fi
+
+# does yq exist in the path?
+if ! command -v yq > /dev/null; then
+	echo "yq not found in path" >&2
+	exit 1
+fi
+
+if yq --version | grep '^.* version v4.*$' > /dev/null; then
+	# convert null to empty string
+	QUERY="${QUERY} | select(. != null)"
+	YQ_VERSION=4
+elif yq --version | grep '^.* version 3.*$' > /dev/null; then
+	YQ_VERSION=3
+	# if the query is prefixed with a dot, remove it
+	if [[ "$QUERY" == .?* ]]; then
+		QUERY="${QUERY:1}"
+	fi
+else
+	echo "unsupported yq version" >&2
+	exit 1
+fi
+
+if [ "$YQ_VERSION" -eq 4 ]; then
+	yq "$QUERY" "$YAML_PATH"
+else
+	yq r "$YAML_PATH" "$QUERY"
+fi

--- a/src/cloud-api-adaptor/libvirt/config_libvirt.sh
+++ b/src/cloud-api-adaptor/libvirt/config_libvirt.sh
@@ -20,7 +20,8 @@ installGolang() {
         echo "Installing latest yq"
         sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${TARGET_ARCH} -O /usr/bin/yq && sudo chmod a+x /usr/bin/yq
     fi
-    REQUIRED_GO_VERSION="$(yq '.tools.golang' versions.yaml)"
+    # use yq-shim to work with v3
+    REQUIRED_GO_VERSION="$(./hack/yq-shim.sh '.tools.golang' versions.yaml)"
     if [[ -d /usr/local/go ]]; then
         installed_go_version=$(v=$(go version | awk '{print $3}') && echo ${v#go})
         if [[ "$(printf '%s\n' "$REQUIRED_GO_VERSION" "$installed_go_version" | sort -V | head -1)" != "$REQUIRED_GO_VERSION" ]]; then


### PR DESCRIPTION
yq3 (installed in kata builds as a side effect) and yq4 are different in cli and query syntax. the shim should abstract from those differences