### PR TITLE
podvm-mkosi: sshd failed for s390x fedora image

### DIFF
--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-debug-ssh.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-debug-ssh.conf
@@ -1,0 +1,12 @@
+[Match]
+Distribution=fedora
+
+PathExists=../../resources/buildDebugImage
+
+# Overwrite default ssh config, but conflict with 
+# cloud-init which is installed for s390x.
+#Architecture=!s390x
+PathExists=../../resources/buildBootableImage
+
+[Content]
+ExtraTrees=../../mkosi.skeleton-debug

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-debug.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-debug.conf
@@ -8,7 +8,6 @@ PathExists=../../resources/buildDebugImage
 Autologin=true
 KernelCommandLine=rd.shell
 KernelCommandLine=systemd.setenv=SYSTEMD_SULOGIN_FORCE=1
-ExtraTrees=../../mkosi.skeleton-debug
 Packages=
     nano
     vim


### PR DESCRIPTION
For debug image, sshd service failed to start on s390x:
```
Apr 15 02:35:49 cdlleili-custom sshd[1353]: sshd: no hostkeys available -- exiting.
Apr 15 02:36:31 cdlleili-custom sshd[1395]: Unable to load host key: /run/ssh/ssh_host_rsa_key
Apr 15 02:36:31 cdlleili-custom sshd[1395]: Unable to load host key: /run/ssh/ssh_host_ecdsa_key
Apr 15 02:36:31 cdlleili-custom sshd[1395]: Unable to load host key: /run/ssh/ssh_host_ed25519_key
Apr 15 02:36:31 cdlleili-custom sshd[1395]: sshd: no hostkeys available -- exiting.
```

ssh config is overwritten by extra package: [mkosi.skeleton-debug/etc/ssh/sshd_config](https://github.com/confidential-containers/cloud-api-adaptor/blob/main/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton-debug/etc/ssh/sshd_config)

However, it conflicts with cloud-init on s390x, so failed to generate ssh host keys at `/run/ssh`. cloud-init will generate host keys at `/etc/ssh`.

So just keep the default ssh config for s390x

