### PR TITLE
libvirt: e2e test for attestation for sample tee

### DIFF
--- a/src/cloud-api-adaptor/install/overlays/libvirt/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/libvirt/kustomization.yaml
@@ -24,6 +24,7 @@ configMapGenerator:
   - LIBVIRT_POOL="default" # set
   - DISABLECVM="true" # set as false to enable confidential VM
   - SECURE_COMMS="false" # set as true to enable Secure Comms
+  - AA_KBC_PARAMS="" #set KBC params for podvm
   #- LIBVIRT_LAUNCH_SECURITY="" #sev or s390-pv
   #- LIBVIRT_FIRMWARE="" # Uncomment and set if you want to change the firmware path. Defaults to /usr/share/edk2/ovmf/OVMF_CODE.fd
   #- LIBVIRT_VOL_NAME="" # Uncomment and set if you want to use a specific volume name. Defaults to podvm-base.qcow2

--- a/src/cloud-api-adaptor/libvirt/README.md
+++ b/src/cloud-api-adaptor/libvirt/README.md
@@ -216,7 +216,6 @@ make TEST_PROVISION=no TEST_TEARDOWN=no TEST_PODVM_IMAGE=$PWD/podvm/podvm.qcow2 
 * ``CLOUD_PROVIDER`` - which cloud provider should be used
 * ``TEST_E2E_TIMEOUT`` - test timeout
 * ``DEPLOY_KBS`` - whether to deploy the key-broker-service, which is used to test the attestation flow
-* ``TEE_CUSTOMIZED_OPA`` - specify a customized OPA policy file for KBS service.
 * ``TEST_PROVISION_FILE`` - file specifying the libvirt connection and the ssh key file (created earlier by [config_libvirt.sh](config_libvirt.sh))
 
 # Delete Confidential Containers and cloud-api-adaptor from the cluster

--- a/src/cloud-api-adaptor/libvirt/README.md
+++ b/src/cloud-api-adaptor/libvirt/README.md
@@ -215,6 +215,8 @@ make TEST_PROVISION=no TEST_TEARDOWN=no TEST_PODVM_IMAGE=$PWD/podvm/podvm.qcow2 
 * ``TEST_PODVM_IMAGE`` - image to be used for this testing
 * ``CLOUD_PROVIDER`` - which cloud provider should be used
 * ``TEST_E2E_TIMEOUT`` - test timeout
+* ``DEPLOY_KBS`` - whether to deploy the key-broker-service, which is used to test the attestation flow
+* ``TEE_CUSTOMIZED_OPA`` - specify a customized OPA policy file for KBS service.
 * ``TEST_PROVISION_FILE`` - file specifying the libvirt connection and the ssh key file (created earlier by [config_libvirt.sh](config_libvirt.sh))
 
 # Delete Confidential Containers and cloud-api-adaptor from the cluster

--- a/src/cloud-api-adaptor/podvm/Makefile.inc
+++ b/src/cloud-api-adaptor/podvm/Makefile.inc
@@ -23,7 +23,7 @@ ARCH        := $(or $(ARCH),$(HOST_ARCH))
 # Normalise x86_64 / amd64 for input ARCH
 ARCH        := $(subst amd64,x86_64,$(ARCH))
 DEB_ARCH    := $(subst x86_64,amd64,$(ARCH))
-AA_KBC      ?= offline_fs_kbc
+AA_KBC      ?= cc_kbc
 KBC_URI     ?= null
 LIBC        ?= $(if $(filter $(ARCH),s390x ppc64le),gnu,musl)
 RUST_ARCH   ?= $(subst ppc64le,powerpc64le,$(ARCH))

--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -64,6 +64,14 @@ popd
 popd
 ```
 
+We need build and use the PodVM image with `AA_KBC=cc_kbc` enabled, for example:
+```
+pushd ${cloud-api-adaptor}
+AA_KBC=cc_kbc make podvm-builder podvm-binaries podvm-image
+popd
+```
+Then extract the PodVM image and use it following [extracting-the-qcow2-image](../../podvm/README.md#extracting-the-qcow2-image)
+
 To deploy the KBS service and test attestation related cases, set `export DEPLOY_KBS=yes`.
 
 ## Provision file specifics

--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -53,7 +53,7 @@ To use existing cluster which have already installed Cloud API Adaptor, you shou
 We need artificats from trustee when do attestation test, to prepare trustee, do as following. 
 
 ```
-pushd ${cloud-api-adaptor}/test/e2e
+pushd ${cloud-api-adaptor-repo-dir}/src/cloud-api-adaptor/test/e2e
 git clone https://github.com/confidential-containers/trustee.git
 pushd trustee
 git checkout $(../../../hack/yq-shim.sh '.git.kbs.reference' ../../../versions.yaml)
@@ -72,7 +72,12 @@ popd
 ```
 Then extract the PodVM image and use it following [extracting-the-qcow2-image](../../podvm/README.md#extracting-the-qcow2-image)
 
-To deploy the KBS service and test attestation related cases, set `export DEPLOY_KBS=yes`.
+To deploy the KBS service and test attestation related cases, export following variables like:
+```
+export DEPLOY_KBS=yes
+export KBS_IMAGE=$(./hack/yq-shim.sh '.oci.kbs.registry' ./versions.yaml)
+export KBS_IMAGE_TAG=$(./hack/yq-shim.sh '.oci.kbs.tag' ./versions.yaml)
+````
 
 ## Provision file specifics
 

--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -48,6 +48,26 @@ To leave the cluster untouched by the execution finish you should export `TEST_T
 
 To use existing cluster which have already installed Cloud API Adaptor, you should export `TEST_INSTALL_CAA=no`.
 
+## Attestation and KBS specific
+
+We need artificats from trustee when do attestation test, to prepare trustee, do as following. 
+
+```
+pushd ${cloud-api-adaptor}/test/e2e
+git clone https://github.com/confidential-containers/trustee.git
+pushd trustee
+git checkout $(../../../hack/yq-shim.sh '.git.kbs.reference' ../../../versions.yaml)
+pushd kbs
+make CLI_FEATURES=sample_only cli
+popd
+popd
+popd
+```
+
+To deploy the KBS service and test attestation related cases, set `DEPLOY_KBS=yes`.
+To use a customized OPA policy file in KBS service, specify the OPA file via `TEE_CUSTOMIZED_OPA=/path/policy.rego`.
+For example, we need set `TEE_CUSTOMIZED_OPA=/$trustee_path/kbs/sample_policies/allow_all.rego` when test sample TEE as default policy disabled sample TEE.
+
 ## Provision file specifics
 
 As mentioned on the previous section, a properties file can be passed to the cloud provisioner that will be used to controll the provisioning operations. The properties are specific of each cloud provider though, see on the sections below.

--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -65,8 +65,6 @@ popd
 ```
 
 To deploy the KBS service and test attestation related cases, set `export DEPLOY_KBS=yes`.
-To use a customized OPA policy file in KBS service, specify the OPA file via `export TEE_CUSTOMIZED_OPA=/path/policy.rego`.
-For example, we need set `export TEE_CUSTOMIZED_OPA=/$trustee_path/kbs/sample_policies/allow_all.rego` when test sample TEE as default policy disabled sample TEE.
 
 ## Provision file specifics
 

--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -64,9 +64,9 @@ popd
 popd
 ```
 
-To deploy the KBS service and test attestation related cases, set `DEPLOY_KBS=yes`.
-To use a customized OPA policy file in KBS service, specify the OPA file via `TEE_CUSTOMIZED_OPA=/path/policy.rego`.
-For example, we need set `TEE_CUSTOMIZED_OPA=/$trustee_path/kbs/sample_policies/allow_all.rego` when test sample TEE as default policy disabled sample TEE.
+To deploy the KBS service and test attestation related cases, set `export DEPLOY_KBS=yes`.
+To use a customized OPA policy file in KBS service, specify the OPA file via `export TEE_CUSTOMIZED_OPA=/path/policy.rego`.
+For example, we need set `export TEE_CUSTOMIZED_OPA=/$trustee_path/kbs/sample_policies/allow_all.rego` when test sample TEE as default policy disabled sample TEE.
 
 ## Provision file specifics
 

--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -53,10 +53,10 @@ To use existing cluster which have already installed Cloud API Adaptor, you shou
 We need artificats from trustee when do attestation test, to prepare trustee, do as following. 
 
 ```
-pushd ${cloud-api-adaptor-repo-dir}/src/cloud-api-adaptor/test/e2e
+pushd ${cloud-api-adaptor-repo-dir}/src/cloud-api-adaptor/test
 git clone https://github.com/confidential-containers/trustee.git
 pushd trustee
-git checkout $(../../../hack/yq-shim.sh '.git.kbs.reference' ../../../versions.yaml)
+git checkout $(../../hack/yq-shim.sh '.git.kbs.reference' ../../versions.yaml)
 pushd kbs
 make CLI_FEATURES=sample_only cli
 popd

--- a/src/cloud-api-adaptor/test/e2e/azure_test.go
+++ b/src/cloud-api-adaptor/test/e2e/azure_test.go
@@ -47,4 +47,8 @@ func TestKbsKeyRelease(t *testing.T) {
 	}
 	t.Parallel()
 	DoTestKbsKeyRelease(t, testEnv, assert)
+
+	// @Magnus @Kartik, are you going to enable this negative test for azure?
+	// _ = keyBrokerService.EnableKbsCustomizedPolicy("deny_all.rego")
+	// DoTestKbsKeyReleaseForFailure(t, testEnv, assert)
 }

--- a/src/cloud-api-adaptor/test/e2e/azure_test.go
+++ b/src/cloud-api-adaptor/test/e2e/azure_test.go
@@ -6,7 +6,6 @@
 package e2e
 
 import (
-	"os"
 	"testing"
 
 	_ "github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/test/provisioner/azure"
@@ -43,7 +42,7 @@ func TestCreateNginxDeploymentAzure(t *testing.T) {
 }
 
 func TestKbsKeyRelease(t *testing.T) {
-	if os.Getenv("DEPLOY_KBS") == "false" || os.Getenv("DEPLOY_KBS") == "no" {
+	if !isTestWithKbs() {
 		t.Skip("Skipping kbs related test as kbs is not deployed")
 	}
 	t.Parallel()

--- a/src/cloud-api-adaptor/test/e2e/common.go
+++ b/src/cloud-api-adaptor/test/e2e/common.go
@@ -5,6 +5,7 @@ package e2e
 
 import (
 	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -25,6 +26,14 @@ import (
 const BUSYBOX_IMAGE = "quay.io/prometheus/busybox:latest"
 const WAIT_DEPLOYMENT_AVAILABLE_TIMEOUT = time.Second * 180
 const DEFAULT_AUTH_SECRET = "auth-json-secret-default"
+
+func isTestWithKbs() bool {
+	return os.Getenv("DEPLOY_KBS") == "true" || os.Getenv("DEPLOY_KBS") == "yes"
+}
+
+func isTestWithCustomizedOpa() bool {
+	return os.Getenv("TEE_CUSTOMIZED_OPA") != ""
+}
 
 type PodOption func(*corev1.Pod)
 

--- a/src/cloud-api-adaptor/test/e2e/common.go
+++ b/src/cloud-api-adaptor/test/e2e/common.go
@@ -31,14 +31,6 @@ func isTestWithKbs() bool {
 	return os.Getenv("DEPLOY_KBS") == "true" || os.Getenv("DEPLOY_KBS") == "yes"
 }
 
-func isTestWithCustomizedOpa() bool {
-	if _, err := os.Stat(os.Getenv("TEE_CUSTOMIZED_OPA")); err != nil {
-		log.Printf("Stat TEE_CUSTOMIZED_OPA error: %v", err)
-		return false
-	}
-	return true
-}
-
 type PodOption func(*corev1.Pod)
 
 func WithRestartPolicy(restartPolicy corev1.RestartPolicy) PodOption {

--- a/src/cloud-api-adaptor/test/e2e/common.go
+++ b/src/cloud-api-adaptor/test/e2e/common.go
@@ -32,7 +32,11 @@ func isTestWithKbs() bool {
 }
 
 func isTestWithCustomizedOpa() bool {
-	return os.Getenv("TEE_CUSTOMIZED_OPA") != ""
+	if _, err := os.Stat(os.Getenv("TEE_CUSTOMIZED_OPA")); err != nil {
+		log.Printf("Stat TEE_CUSTOMIZED_OPA error: %v", err)
+		return false
+	}
+	return true
 }
 
 type PodOption func(*corev1.Pod)

--- a/src/cloud-api-adaptor/test/e2e/common_suite.go
+++ b/src/cloud-api-adaptor/test/e2e/common_suite.go
@@ -573,6 +573,8 @@ func DoTestPodsMTLSCommunication(t *testing.T, e env.Environment, assert CloudAs
 
 }
 
+// DoTestKbsKeyRelease and DoTestKbsKeyReleaseForFailure should be run in a single test case if you're chaning opa in kbs
+// as test cases might be run in parallel
 func DoTestKbsKeyRelease(t *testing.T, e env.Environment, assert CloudAssert) {
 
 	log.Info("Do test kbs key release")
@@ -596,6 +598,8 @@ func DoTestKbsKeyRelease(t *testing.T, e env.Environment, assert CloudAssert) {
 	NewTestCase(t, e, "KbsKeyReleasePod", assert, "Kbs key release is successful").WithPod(pod).WithTestCommands(testCommands).Run()
 }
 
+// DoTestKbsKeyRelease and DoTestKbsKeyReleaseForFailure should be run in a single test case if you're chaning opa in kbs
+// as test cases might be run in parallel
 func DoTestKbsKeyReleaseForFailure(t *testing.T, e env.Environment, assert CloudAssert) {
 
 	log.Info("Do test kbs key release failure case")

--- a/src/cloud-api-adaptor/test/e2e/common_suite.go
+++ b/src/cloud-api-adaptor/test/e2e/common_suite.go
@@ -595,3 +595,26 @@ func DoTestKbsKeyRelease(t *testing.T, e env.Environment, assert CloudAssert) {
 
 	NewTestCase(t, e, "KbsKeyReleasePod", assert, "Kbs key release is successful").WithPod(pod).WithTestCommands(testCommands).Run()
 }
+
+func DoTestKbsKeyReleaseForFailure(t *testing.T, e env.Environment, assert CloudAssert) {
+
+	log.Info("Do test kbs key release failure case")
+	pod := NewBusyboxPodWithName(E2eNamespace, "busybox-wget-failure")
+	testCommands := []TestCommand{
+		{
+			Command:       []string{"wget", "-q", "-O-", "http://127.0.0.1:8006/cdh/resource/reponame/workload_key/key.bin"},
+			ContainerName: pod.Spec.Containers[0].Name,
+			TestCommandStdoutFn: func(stdout bytes.Buffer) bool {
+				if strings.Contains(stdout.String(), "request unautorized") {
+					log.Infof("Pass failure case as: %s", stdout.String())
+					return true
+				} else {
+					log.Errorf("Failed to faliure case as: %s", stdout.String())
+					return false
+				}
+			},
+		},
+	}
+
+	NewTestCase(t, e, "DoTestKbsKeyReleaseForFailure", assert, "Kbs key release is failed").WithPod(pod).WithTestCommands(testCommands).Run()
+}

--- a/src/cloud-api-adaptor/test/e2e/libvirt_test.go
+++ b/src/cloud-api-adaptor/test/e2e/libvirt_test.go
@@ -97,26 +97,14 @@ func TestLibvirtPodsMTLSCommunication(t *testing.T) {
 	DoTestPodsMTLSCommunication(t, testEnv, assert)
 }
 
-func TestLibvirtKbsKeyReleaseWithDefaultOpa(t *testing.T) {
+func TestLibvirtKbsKeyRelease(t *testing.T) {
 	if !isTestWithKbs() {
 		t.Skip("Skipping kbs related test as kbs is not deployed")
 	}
-	if !isTestWithCustomizedOpa() {
-		t.Skip("Skipping TestLibvirtKbsKeyReleaseWithCustomizedOpa as default opa is used")
-	}
-	assert := LibvirtAssert{}
-	t.Parallel()
-	DoTestKbsKeyRelease(t, testEnv, assert)
-}
-
-func TestLibvirtKbsKeyReleaseWithCustomizedOpa(t *testing.T) {
-	if !isTestWithKbs() {
-		t.Skip("Skipping kbs related test as kbs is not deployed")
-	}
-	if isTestWithCustomizedOpa() {
-		t.Skip("Skipping TestLibvirtKbsKeyReleaseWithDefaultOpa as customized opa is used")
-	}
+	_ = keyBrokerService.EnableKbsCustomizedPolicy("deny_all.rego")
 	assert := LibvirtAssert{}
 	t.Parallel()
 	DoTestKbsKeyReleaseForFailure(t, testEnv, assert)
+	_ = keyBrokerService.EnableKbsCustomizedPolicy("allow_all.rego")
+	DoTestKbsKeyRelease(t, testEnv, assert)
 }

--- a/src/cloud-api-adaptor/test/e2e/libvirt_test.go
+++ b/src/cloud-api-adaptor/test/e2e/libvirt_test.go
@@ -96,3 +96,27 @@ func TestLibvirtPodsMTLSCommunication(t *testing.T) {
 	assert := LibvirtAssert{}
 	DoTestPodsMTLSCommunication(t, testEnv, assert)
 }
+
+func TestLibvirtKbsKeyReleaseWithDefaultOpa(t *testing.T) {
+	if !isTestWithKbs() {
+		t.Skip("Skipping kbs related test as kbs is not deployed")
+	}
+	if !isTestWithCustomizedOpa() {
+		t.Skip("Skipping TestLibvirtKbsKeyReleaseWithCustomizedOpa as default opa is used")
+	}
+	assert := LibvirtAssert{}
+	t.Parallel()
+	DoTestKbsKeyRelease(t, testEnv, assert)
+}
+
+func TestLibvirtKbsKeyReleaseWithCustomizedOpa(t *testing.T) {
+	if !isTestWithKbs() {
+		t.Skip("Skipping kbs related test as kbs is not deployed")
+	}
+	if isTestWithCustomizedOpa() {
+		t.Skip("Skipping TestLibvirtKbsKeyReleaseWithDefaultOpa as customized opa is used")
+	}
+	assert := LibvirtAssert{}
+	t.Parallel()
+	DoTestKbsKeyReleaseForFailure(t, testEnv, assert)
+}

--- a/src/cloud-api-adaptor/test/e2e/main_test.go
+++ b/src/cloud-api-adaptor/test/e2e/main_test.go
@@ -96,10 +96,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// The DEPLOY_KBS is exported then provisioner will install kbs before installing CAA
-	shouldDeployKbs := false
-	if isTestWithKbs() {
-		shouldDeployKbs = true
-	}
+	shouldDeployKbs := isTestWithKbs()
 
 	// The TEE_CUSTOMIZED_OPA is an optional variable which specifies the opa file path
 	// such as: $HOME/trustee/kbs/sample_policies/allow_all.rego.

--- a/src/cloud-api-adaptor/test/e2e/main_test.go
+++ b/src/cloud-api-adaptor/test/e2e/main_test.go
@@ -98,10 +98,6 @@ func TestMain(m *testing.M) {
 	// The DEPLOY_KBS is exported then provisioner will install kbs before installing CAA
 	shouldDeployKbs := isTestWithKbs()
 
-	// The TEE_CUSTOMIZED_OPA is an optional variable which specifies the opa file path
-	// such as: $HOME/trustee/kbs/sample_policies/allow_all.rego.
-	customizedOpaFile := os.Getenv("TEE_CUSTOMIZED_OPA")
-
 	if !shouldProvisionCluster {
 		// Look for a suitable kubeconfig file in the sequence: --kubeconfig flag,
 		// or KUBECONFIG variable, or $HOME/.kube/config.
@@ -153,17 +149,8 @@ func TestMain(m *testing.M) {
 				return ctx, err
 			}
 
-			kbsparams = "cc_kbc::http://" + kbsEndpoint
+			kbsparams = "cc_kbc::" + kbsEndpoint
 			log.Infof("KBS PARAMS: %s", kbsparams)
-			if customizedOpaFile != "" {
-				log.Info("Enable customized opa file in KBS service.")
-				if _, err := os.Stat(customizedOpaFile); err != nil {
-					return ctx, err
-				}
-				if err = keyBrokerService.EnableKbsCustomizedPolicy("http://"+kbsEndpoint, customizedOpaFile); err != nil {
-					return ctx, err
-				}
-			}
 		}
 
 		if podvmImage != "" {

--- a/src/cloud-api-adaptor/test/provisioner/libvirt/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/libvirt/provision_common.go
@@ -312,12 +312,13 @@ func (lio *LibvirtInstallOverlay) Edit(ctx context.Context, cfg *envconf.Config,
 
 	// Mapping the internal properties to ConfigMapGenerator properties and their default values.
 	mapProps := map[string][2]string{
-		"network":      {"default", "LIBVIRT_NET"},
-		"storage":      {"default", "LIBVIRT_POOL"},
-		"pause_image":  {"", "PAUSE_IMAGE"},
-		"podvm_volume": {"", "LIBVIRT_VOL_NAME"},
-		"uri":          {"qemu+ssh://root@192.168.122.1/system?no_verify=1", "LIBVIRT_URI"},
-		"vxlan_port":   {"", "VXLAN_PORT"},
+		"network":       {"default", "LIBVIRT_NET"},
+		"storage":       {"default", "LIBVIRT_POOL"},
+		"pause_image":   {"", "PAUSE_IMAGE"},
+		"podvm_volume":  {"", "LIBVIRT_VOL_NAME"},
+		"uri":           {"qemu+ssh://root@192.168.122.1/system?no_verify=1", "LIBVIRT_URI"},
+		"vxlan_port":    {"", "VXLAN_PORT"},
+		"AA_KBC_PARAMS": {"", "AA_KBC_PARAMS"},
 	}
 
 	for k, v := range mapProps {

--- a/src/cloud-api-adaptor/test/provisioner/provision.go
+++ b/src/cloud-api-adaptor/test/provisioner/provision.go
@@ -564,7 +564,6 @@ func (p *CloudAPIAdaptor) Deploy(ctx context.Context, cfg *envconf.Config, props
 		fmt.Printf("Wait for the %s DaemonSet be available\n", ds.GetName())
 		if err = wait.For(conditions.New(resources).ResourceMatch(ds, func(object k8s.Object) bool {
 			ds = object.(*appsv1.DaemonSet)
-		
 			return ds.Status.CurrentNumberScheduled > 0
 		}), wait.WithTimeout(time.Minute*5)); err != nil {
 			return err

--- a/src/cloud-api-adaptor/test/provisioner/provision.go
+++ b/src/cloud-api-adaptor/test/provisioner/provision.go
@@ -82,7 +82,7 @@ type InstallOverlay interface {
 const PodWaitTimeout = time.Second * 30
 
 // trustee repo related base path
-const TRUSTEE_REPO_PATH = "trustee"
+const TRUSTEE_REPO_PATH = "../trustee"
 
 func saveToFile(filename string, content []byte) error {
 	// Save contents to file

--- a/src/cloud-api-adaptor/test/tools/provisioner-cli/main.go
+++ b/src/cloud-api-adaptor/test/tools/provisioner-cli/main.go
@@ -109,7 +109,7 @@ func main() {
 				log.Fatal(err)
 			}
 
-			kbsparams := "cc_kbc::http://" + kbsEndpoint
+			kbsparams := "cc_kbc::" + kbsEndpoint
 			log.Infof("KBS PARAMS: %s", kbsparams)
 
 			props = provisioner.GetProperties(context.TODO(), cfg)


### PR DESCRIPTION
Fixes: #1825 

This PR is based on the azure approach: https://github.com/confidential-containers/cloud-api-adaptor/pull/1735

- Add `AA_KBC_PARAMS` in libvirt provider
- Wait kbs deployment ready before retrieve the endpoint from it
- Add test case for attestation secret
- Revise a little for the caa ds waiting, as pod ready is enough as the condition
- Change the KBS opa policy to allow_all