### PR TITLE
libvirt: Fix config_libvirt to not exit

### DIFF
--- a/src/cloud-api-adaptor/libvirt/config_libvirt.sh
+++ b/src/cloud-api-adaptor/libvirt/config_libvirt.sh
@@ -9,11 +9,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+source /etc/os-release || source /usr/lib/os-release
 ARCH=$(uname -m)
 TARGET_ARCH=${ARCH/x86_64/amd64}
 OS_DISTRO=ubuntu
-cat /etc/os-release | grep "^ID=" | grep rhel
-if [ $? == 0 ]; then
+if [[ "$ID" == "rhel" ]]; then
     OS_DISTRO=rhel
 fi
 


### PR DESCRIPTION
https://github.com/confidential-containers/cloud-api-adaptor/pull/1822 broke the e2e libvirt tests jobs (https://github.com/confidential-containers/cloud-api-adaptor/actions/runs/8873277040/job/24359701508). We should have added the test_e2e_libvirt label, so sorry for missing that during the review.

config_libvirt.sh has `set -o errexit`, so we can't use a grep for rhel and test if it fails as this will exit the script. Instead use the ID field from `/etc/os-release` or `/usr/lib/os-release`