### PR TITLE
workflows: e2e: Add the CAA image setup

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -10,6 +10,9 @@ on:
       podvm_image:
         required: true
         type: string
+      caa_image:
+        required: true
+        type: string
       install_directory_artifact:
         description: The archive name of the install directory
         default: ''
@@ -79,6 +82,7 @@ jobs:
       - name: Config Libvirt
         run: |
           ./libvirt/config_libvirt.sh
+          echo "CAA_IMAGE=\"${{ inputs.caa_image }}\"" >> libvirt.properties
           # For debugging
           cat libvirt.properties
 
@@ -105,6 +109,9 @@ jobs:
 
           echo "::group::cloud-api-adaptor logs"
           kubectl logs -l app=cloud-api-adaptor -n confidential-containers-system
+          echo "::endgroup::"
+          echo "::group::peerpodconfig-ctrl-caa-daemon logs"
+          kubectl logs ds/peerpodconfig-ctrl-caa-daemon -n confidential-containers-system
           echo "::endgroup::"
 
           for pod in $(kubectl get pods -o name 2>/dev/null); do

--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -125,7 +125,6 @@ jobs:
           providers=(${{ env.PROVIDERS }})
           # If there aren't providers then something is wrong
           [[ ${#providers[@]} -gt 0 ]] || exit 1
-
           for provider in ${providers[@]}; do
             img="${E2E_IMG_REGISTRY}/cloud-api-adaptor"
             tag="${E2E_IMG_RELEASE_TAG}"
@@ -142,7 +141,8 @@ jobs:
             popd
           done
 
-      - uses: actions/upload-artifact@v3
+      - name: Upload install directory for next test runs
+        uses: actions/upload-artifact@v3
         with:
           name: install_directory
           path: src/cloud-api-adaptor/install/
@@ -167,6 +167,7 @@ jobs:
           - amd64
     uses: ./.github/workflows/e2e_libvirt.yaml
     with:
+      caa_image: ${{ inputs.registry }}/cloud-api-adaptor:${{ inputs.caa_image_tag }}-dev
       podvm_image: ${{ inputs.registry }}/podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ matrix.arch }}:${{ inputs.podvm_image_tag }}
       install_directory_artifact: install_directory
       git_ref: ${{ inputs.git_ref }}


### PR DESCRIPTION
- In preparation for the switch to use the latest operator we need to add code that will pass the CAA Image in to the e2e test properties file and try and work with both the new and old operator so that the workflow tests can pass pulled from main by the `pull_request_target` trigger
- In a future PR we will remove the old kustomize versions