### PR TITLE
test/e2e: Skip unstable libvirt test

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/libvirt_test.go
+++ b/src/cloud-api-adaptor/test/e2e/libvirt_test.go
@@ -55,6 +55,9 @@ func TestLibvirtCreatePeerPodAndCheckWorkDirLogs(t *testing.T) {
 }
 
 func TestLibvirtCreatePeerPodAndCheckEnvVariableLogsWithImageOnly(t *testing.T) {
+	// This test is causing issues on CI with instability, so skip until we can resolve this.
+	// See https://github.com/confidential-containers/cloud-api-adaptor/issues/1831
+	SkipTestOnCI(t)
 	assert := LibvirtAssert{}
 	DoTestCreatePeerPodAndCheckEnvVariableLogsWithImageOnly(t, testEnv, assert)
 }
@@ -65,6 +68,8 @@ func TestLibvirtCreatePeerPodAndCheckEnvVariableLogsWithDeploymentOnly(t *testin
 }
 
 func TestLibvirtCreatePeerPodAndCheckEnvVariableLogsWithImageAndDeployment(t *testing.T) {
+	// This test is causing issues on CI with instability, so skip until we can resolve this.
+	// See https://github.com/confidential-containers/cloud-api-adaptor/issues/1831
 	assert := LibvirtAssert{}
 	DoTestCreatePeerPodAndCheckEnvVariableLogsWithImageAndDeployment(t, testEnv, assert)
 }


### PR DESCRIPTION
The TestLibvirtCreatePeerPodAndCheckEnvVariableLogsWithImageOnly test is failing semi-regularly on the CI, but seems to run okay locally, so skip it until we have a chance to debug. See https://github.com/confidential-containers/cloud-api-adaptor/issues/1831