### PR TITLE
libvirt: use AA_KBC=cc_kbc as default for peerpod binaries

### DIFF
--- a/.github/workflows/podvm_binaries.yaml
+++ b/.github/workflows/podvm_binaries.yaml
@@ -71,7 +71,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push
-      run: make podvm-binaries
+      run: AA_KBC=cc_kbc make podvm-binaries
       env:
           PUSH: true
           REGISTRY: ${{ inputs.registry }}

--- a/src/cloud-api-adaptor/podvm-mkosi/Makefile
+++ b/src/cloud-api-adaptor/podvm-mkosi/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.defaults
 
-AA_KBC  ?= offline_fs_kbc
+AA_KBC  ?= cc_kbc
 ARCH    ?= $(subst x86_64,amd64,$(shell uname -m))
 BUILDER = fedora-binaries-builder-$(ARCH)
 

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_binaries
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_binaries
@@ -12,7 +12,7 @@ ARG CLOUD_PROVIDER
 ARG PODVM_DISTRO=ubuntu
 ARG GUEST_COMPONENTS_VERSION
 ARG GUEST_COMPONENTS_REPO
-ARG AA_KBC="offline_fs_kbc"
+ARG AA_KBC="cc_kbc"
 # If not provided, uses system architecture
 ARG ARCH
 #This is the name of the policy file under

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_binaries.fedora
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_binaries.fedora
@@ -12,7 +12,7 @@ ARG CLOUD_PROVIDER
 ARG PODVM_DISTRO=rhel
 ARG GUEST_COMPONENTS_VERSION
 ARG GUEST_COMPONENTS_REPO
-ARG AA_KBC="offline_fs_kbc"
+ARG AA_KBC="cc_kbc"
 # If not provided, uses system architecture
 ARG ARCH
 #This is the name of the policy file under

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_binaries.rhel
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_binaries.rhel
@@ -9,7 +9,7 @@ ARG BUILDER_IMG
 FROM ${BUILDER_IMG} AS podvm_builder
 
 ARG PODVM_DISTRO=rhel
-ARG AA_KBC="offline_fs_kbc"
+ARG AA_KBC="cc_kbc"
 # If not provided, uses system architecture
 ARG ARCH
 #This is the name of the policy file under


### PR DESCRIPTION
Fixes: #1825