### PR TITLE
cloud-config: streamline credentials provisioning

### DIFF
--- a/src/cloud-api-adaptor/pkg/forwarder/forwarder.go
+++ b/src/cloud-api-adaptor/pkg/forwarder/forwarder.go
@@ -42,8 +42,6 @@ type Config struct {
 	TLSServerKey  string `json:"tls-server-key,omitempty"`
 	TLSServerCert string `json:"tls-server-cert,omitempty"`
 	TLSClientCA   string `json:"tls-client-ca,omitempty"`
-
-	AuthJson string `json:"auth-json,omitempty"`
 }
 
 type Daemon interface {


### PR DESCRIPTION
Instead of nesting it into a daemon.json property for the forwarder the auth file is being moved to its own entry, which will simplify the logic and allow cloud-init based podvms to use authenticated registries without running process-user-data alongside cloud-init.