### PR TITLE
podvm: launch guest-components as systemd units

### DIFF
--- a/src/cloud-api-adaptor/pkg/agent/test-data/sample-agent-config.toml
+++ b/src/cloud-api-adaptor/pkg/agent/test-data/sample-agent-config.toml
@@ -12,6 +12,9 @@ aa_kbc_params = ""
 # This field sets up the container registry auth 
 image_registry_auth_file="file:///etc/attestation-agent/auth.json"
 
+# Do not spawn guest components in kata agent
+guest_components_procs = "none"
+
 # temp workaround for kata-containers/kata-containers#5590
 [endpoints]
 allowed = [

--- a/src/cloud-api-adaptor/pkg/agent/update.go
+++ b/src/cloud-api-adaptor/pkg/agent/update.go
@@ -33,6 +33,7 @@ type AgentConfig struct {
 	AaKbcParams                 string    `toml:"aa_kbc_params"`
 	ImageRegistryAuthFile       string    `toml:"image_registry_auth_file"`
 	Endpoints                   Endpoints `toml:"endpoints"`
+	GuestComponentsProcs        string    `toml:"guest_components_procs"`
 }
 
 // Get daemon.Config from local file

--- a/src/cloud-api-adaptor/pkg/agent/update_test.go
+++ b/src/cloud-api-adaptor/pkg/agent/update_test.go
@@ -43,7 +43,9 @@ func TestUpdateAAKBCParams(t *testing.T) {
 		[endpoints]
 		allowed = [
 		"AddARPNeighborsRequest",
-		]`
+		]
+		guest_components_procs = "none"
+		`
 	if _, err := tmpFile.WriteString(testAgentConfigData); err != nil {
 		t.Fatalf("failed to write test data to file: %v", err)
 	}
@@ -139,6 +141,7 @@ func TestWriteAgentConfig(t *testing.T) {
 		AaKbcParams:                 "cc_kbc::http://192.168.1.2:8080",
 		ImageRegistryAuthFile:       "/etc/attestation-agent/auth.json",
 		Endpoints:                   Endpoints{Allowed: []string{"AddARPNeighborsRequest", "AddSwapRequest"}},
+		GuestComponentsProcs:        "none",
 	}
 
 	// Call the writeAgentConfig function
@@ -190,6 +193,9 @@ func TestParseAgentConfig(t *testing.T) {
 		t.Fatalf("agentConfig.Endpoints does not match test data: expected %v, got %v", "AddSwapRequest", agentConfig.Endpoints.Allowed[1])
 	}
 
+	if agentConfig.GuestComponentsProcs != "none" {
+		t.Fatalf("agentConfig.GuestComponentsProcs does not match test data: expected %v, got %v", "none", agentConfig.GuestComponentsProcs)
+	}
 }
 
 // Test the writeAgentConfig function with non existent toml entry in agent config file

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton-debug/usr/lib/systemd/system/api-server-rest.service.d/20-debug.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton-debug/usr/lib/systemd/system/api-server-rest.service.d/20-debug.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=RUST_LOG=debug

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton-debug/usr/lib/systemd/system/attestation-agent.service.d/20-debug.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton-debug/usr/lib/systemd/system/attestation-agent.service.d/20-debug.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=RUST_LOG=debug

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton-debug/usr/lib/systemd/system/confidential-data-hub.service.d/20-debug.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton-debug/usr/lib/systemd/system/confidential-data-hub.service.d/20-debug.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=RUST_LOG=debug

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system-preset/30-coco.preset
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system-preset/30-coco.preset
@@ -1,5 +1,7 @@
 enable attestation-protocol-forwarder.service
+enable attestation-agent.service
 enable api-server-rest.path
+enable confidential-data-hub.path
 enable kata-agent.service
 enable netns@.service
 enable process-user-data.service

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system/attestation-agent.service.d/10-override.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system/attestation-agent.service.d/10-override.conf
@@ -1,0 +1,4 @@
+# On a read-only fs the kata-agent config is created in /run/peerpod, since it contains
+# a parameter that can be set at pod creation time.
+[Service]
+Environment=KATA_AGENT_CONFIG_PATH=/run/peerpod/agent-config.toml

--- a/src/cloud-api-adaptor/podvm/files/etc/agent-config.toml
+++ b/src/cloud-api-adaptor/podvm/files/etc/agent-config.toml
@@ -9,6 +9,9 @@ server_addr="unix:///run/kata-containers/agent.sock"
 # This is replaced in the makefile steps so do not set it manually
 aa_kbc_params = ""
 
+# prevent the agent from launching coco guest-components
+guest_components_procs = "none"
+
 # temp workaround for kata-containers/kata-containers#5590
 [endpoints]
 allowed = [

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/attestation-agent.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/attestation-agent.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Attestation Agent TTRPC API Server
+After=network.target process-user-data.service
+
+[Service]
+Type=simple
+ExecStartPre=mkdir -p /run/confidential-containers/attestation-agent
+ExecStart=/usr/local/bin/attestation-agent
+RestartSec=1
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/confidential-data-hub.path
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/confidential-data-hub.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Monitor for the Attestation Agent socket
+
+[Path]
+PathExists=/run/confidential-containers/attestation-agent/attestation-agent.sock
+Unit=confidential-data-hub.service
+
+[Install]
+WantedBy=multi-user.target

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/confidential-data-hub.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/confidential-data-hub.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Confidential Data Hub TTRPC API Server
+After=network.target process-user-data.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/confidential-data-hub -c /run/confidential-containers/cdh.toml
+RestartSec=1
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/kata-agent.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/kata-agent.service
@@ -5,7 +5,6 @@ Wants=process-user-data.service
 After=netns@podns.service process-user-data.service
 
 [Service]
-Environment=CDH_CONFIG_PATH=/run/confidential-containers/cdh.toml
 ExecStartPre=mkdir -p /run/kata-containers
 ExecStart=/usr/local/bin/kata-agent --config /etc/agent-config.toml
 ExecStartPre=-umount /sys/fs/cgroup/misc

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/attestation-agent.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/attestation-agent.service
@@ -1,0 +1,1 @@
+../attestation-agent.service

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/confidential-data-hub.path
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/confidential-data-hub.path
@@ -1,0 +1,1 @@
+../confidential-data-hub.path

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -31,7 +31,7 @@ git:
     reference: 277617af60c32661819c1132ffbf3db8dc6e1b9f
   kata-containers:
     url: https://github.com/kata-containers/kata-containers
-    reference: 3.5.0
+    reference: 59ff40f05484da2a462fa44f18fe95e7c8484546
   umoci:
     url: https://github.com/opencontainers/umoci
     reference: v0.4.7


### PR DESCRIPTION
Prior to this change the kata-agent was launching the guest-components programatically as child process. For CAA it is preferable to launch the processes as systemd units for improved reliability and to remove redundancy (due to the network ns requirement api-server-rest was spawned in the root ns by kata and via systemd in the podns ns by systemd)

We need to make the "update" functionality aware of the `guest_components_procs` agent setting, so it will be copied to the destination agent configuration file.

The attestation-agent unit is spawned after process-user-data, because it will consume the templated kata-agent config. The confidential-data-hub and api-server-rest units are activated by the presence of the unix sockets they connect to.

attestation-agent will keep defaulting to the kata agent config for the `aa_kbc_params` config, that's why we need to configure the agent path in the mkosi image.

The process tree on a podvm will look like this after in change:

```bash
$ pstree
systemd-+-agent-protocol----6*[{agent-protocol-}]
        |-api-server-rest---2*[{api-server-rest}]
        |-attestation-age---2*[{attestation-age}]
        |-confidential-da---2*[{confidential-da}]
        |-dbus-broker-lau---dbus-broker
        |-kata-agent-+-nginx---2*[nginx]
        |            |-pause
        |            `-5*[{kata-agent}]
        |-2*[login---bash]
        |-opa---6*[{opa}]
        |-sshd---sshd---sshd---bash---pstree
        |-systemd---(sd-pam)
        |-systemd-homed
        |-systemd-journal
        |-systemd-logind
        |-systemd-network
        |-systemd-oomd
        |-systemd-resolve
        |-systemd-udevd
        `-systemd-userdbd---3*[systemd-userwor]
 ```
 
note: at the moment the kata entry in versions.yaml is pointing at a fork, this will be toggled once the [respective PR](https://github.com/kata-containers/kata-containers/pull/9811) is merged

note 2: at the moment both kata-agent and attestation-agent start after the process-user-data oneshot unit, we'll have to see whether there will be race conditions with encrypted images and tweak the order of those units.