### PR TITLE
versions: Bump fedora base image versions

### DIFF
--- a/hack/Dockerfile.golang
+++ b/hack/Dockerfile.golang
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.5-labs
 
-ARG BASE_IMAGE=registry.fedoraproject.org/fedora:38
+ARG BASE_IMAGE=registry.fedoraproject.org/fedora:39
 FROM --platform=$TARGETPLATFORM ${BASE_IMAGE} as base
 
 # DO NOT UPDATE THIS BY HAND !!

--- a/src/cloud-api-adaptor/Dockerfile
+++ b/src/cloud-api-adaptor/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_TYPE=dev
 ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.21.11-38
-ARG BASE=registry.fedoraproject.org/fedora:38
+ARG BASE=registry.fedoraproject.org/fedora:39
 
 # This dockerfile uses Go cross-compilation to build the binary,
 # we build on the host platform ($BUILDPLATFORM) and then copy the

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.fedora
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.fedora
@@ -5,7 +5,7 @@
 #
 # Build binaries for mkosi podvm image
 #
-FROM registry.fedoraproject.org/fedora:38
+FROM registry.fedoraproject.org/fedora:39
 
 ARG ARCH="amd64"
 ARG YQ_ARCH="amd64"

--- a/src/peerpod-ctrl/Dockerfile
+++ b/src/peerpod-ctrl/Dockerfile
@@ -30,7 +30,7 @@ COPY peerpod-ctrl/controllers/ controllers/
 RUN CC=gcc CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build ${GOFLAGS} -a -o manager main.go
 
 # Target Image
-FROM --platform=$TARGETPLATFORM registry.fedoraproject.org/fedora:38
+FROM --platform=$TARGETPLATFORM registry.fedoraproject.org/fedora:39
 ARG CGO_ENABLED=1
 
 RUN if [ "$CGO_ENABLED" = 1 ] ; then dnf install -y libvirt-libs openssh-clients && dnf clean all; fi


### PR DESCRIPTION
- Fedora 38 has passed EoL 3 weeks ago, so we should try and bump to the next version (or possibly even 40?).
- Once `golang-fedora:1.21.11-39` is built, this will be followed up with a bump of the builder_base we use as well,
but do to the chance of breaking things I'll keep it separate for now.