### PR TITLE
fedora: add dnf and openssh-clients for debug

### DIFF
--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-debug.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-debug.conf
@@ -12,6 +12,8 @@ Packages=
     nano
     vim
     strace
+    dnf
+    openssh-clients
     openssh-server
     file
     iputils


### PR DESCRIPTION
- add dnf to debug image for packages management
- add openssh-clients to  debug image for scp etc