### PR TITLE
Kcli version pinning

### DIFF
--- a/src/cloud-api-adaptor/libvirt/config_libvirt.sh
+++ b/src/cloud-api-adaptor/libvirt/config_libvirt.sh
@@ -73,12 +73,8 @@ installLibvirt() {
 installKcli() {
     if ! command -v kcli >/dev/null; then
         echo "Installing kcli"
-        if [[ ${TARGET_ARCH} == "s390x" ]]; then
-            # Installation of the kcli is supported exclusively for s390x machines using pypi
-            sudo pip3 install kcli
-        else
-            curl https://raw.githubusercontent.com/karmab/kcli/main/install.sh | sudo bash
-        fi
+        kcli_version="$(./hack/yq-shim.sh '.tools.kcli' versions.yaml)"
+        sudo pip3 install kcli==${kcli_version}
     fi
 }
 

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -24,6 +24,7 @@ tools:
   rust: 1.74.0
   protoc: 3.15.0
   packer: v1.9.4
+  kcli: 99.0.202406160824
 # Referenced Git repositories
 git:
   guest-components:


### PR DESCRIPTION
Switch kcli to use pip to install and pin the version we are using to avoid breaking changes