### PR TITLE
ci: fix azure image build

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -108,7 +108,7 @@ jobs:
 
     - name: Build binaries
       run: make binaries \
-        ATTESTER="az_snp_vtpm_attester,az_tdx_vtpm_attester" \
+        ATTESTER="az-snp-vtpm-attester,az-tdx-vtpm-attester" \
         LIBC=gnu
 
     - uses: azure/login@v1


### PR DESCRIPTION
new guest-components feature toggles use hyphens, not underscores