### PR TITLE
ibmse: bump guest components commit to support se-attester

### DIFF
--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -29,7 +29,7 @@ tools:
 git:
   guest-components:
     url: https://github.com/confidential-containers/guest-components
-    reference: 9bcc7c1addcbad1e249a6d870d9df68f2824254b
+    reference: fe9560bb99c0e89c0d81f24f08ac4b63d3e22821
   kata-containers:
     url: https://github.com/kata-containers/kata-containers
     reference: 59ff40f05484da2a462fa44f18fe95e7c8484546


### PR DESCRIPTION
- Bump to commit fe9560bb99c0e89c0d81f24f08ac4b63d3e22821 for se-attester
- cd src/cloud-api-adaptor/podvm-mkosi && ATTESTER=se-attester make binaries