### PR TITLE
azure: set northeurope as default replication loc

### DIFF
--- a/src/cloud-api-adaptor/azure/image/ubuntu/azure-ubuntu.pkr.hcl
+++ b/src/cloud-api-adaptor/azure/image/ubuntu/azure-ubuntu.pkr.hcl
@@ -30,7 +30,7 @@ source "azure-arm" "ubuntu" {
     image_name           = "${var.az_gallery_image_name}"
     image_version        = "${var.az_gallery_image_version}"
     storage_account_type = "Standard_LRS"
-    replication_regions  = ["eastus2", "westeurope"]
+    replication_regions  = ["eastus2", "northeurope"]
   }
 }
 


### PR DESCRIPTION
westeurope may not offer free k8s tiers all the time