### PR TITLE
forwarder: remove aa_kbc_params from daemon.jsom

### DIFF
--- a/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
@@ -239,10 +239,6 @@ func (s *cloudService) CreateVM(ctx context.Context, req *pb.CreateVMRequest) (r
 		daemonConfig.TLSServerKey = string(keyPEM)
 	}
 
-	if s.aaKBCParams != "" {
-		daemonConfig.AAKBCParams = s.aaKBCParams
-	}
-
 	// Check if auth json file is present
 	if authJSON, err := os.ReadFile(cloudinit.DefaultAuthfileSrcPath); err == nil {
 		daemonConfig.AuthJson = string(authJSON)

--- a/src/cloud-api-adaptor/pkg/forwarder/forwarder.go
+++ b/src/cloud-api-adaptor/pkg/forwarder/forwarder.go
@@ -43,8 +43,6 @@ type Config struct {
 	TLSServerCert string `json:"tls-server-cert,omitempty"`
 	TLSClientCA   string `json:"tls-client-ca,omitempty"`
 
-	AAKBCParams string `json:"aa-kbc-params,omitempty"`
-
 	AuthJson string `json:"auth-json,omitempty"`
 }
 

--- a/src/cloud-api-adaptor/pkg/userdata/provision_test.go
+++ b/src/cloud-api-adaptor/pkg/userdata/provision_test.go
@@ -40,7 +40,6 @@ var testDaemonConfig string = `{
 	"tls-server-key": "-----BEGIN PRIVATE KEY-----\n....\n-----END PRIVATE KEY-----\n",
 	"tls-server-cert": "-----BEGIN CERTIFICATE-----\n....\n-----END CERTIFICATE-----\n",
 	"tls-client-ca": "-----BEGIN CERTIFICATE-----\n....\n-----END CERTIFICATE-----\n",
-	"aa-kbc-params": "cc_kbc::http://192.168.100.2:8080",
 	"auth-json": "{\"auths\":{}}"
 }
 `
@@ -376,9 +375,4 @@ func TestParseDaemonConfig(t *testing.T) {
 	if config.PodName != "nginx-866fdb5bfb-b98nw" {
 		t.Fatalf("config.PodName does not match test data: expected %q, got %q", "nginx-866fdb5bfb-b98nw", config.PodName)
 	}
-
-	if config.AAKBCParams != "cc_kbc::http://192.168.100.2:8080" {
-		t.Fatalf("config.AAKBCParams does not match test data: expected %q, got %q", "cc_kbc::http://192.168.100.2:8080", config.AAKBCParams)
-	}
-
 }


### PR DESCRIPTION
This field is not used by the forwarder component or anywhere else, aa-kbc-params is managed as part of AA and CDH, having this field duplicated in daemon.json could produce confusion.