### PR TITLE
doc: Remove references to `CCv0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Introduction
 
 This repository contains all go modules related to Cloud API Adaptor. The Cloud API Adaptor is an implementation of the
-[remote hypervisor interface](https://github.com/kata-containers/kata-containers/blob/CCv0/src/runtime/virtcontainers/remote.go)
+[remote hypervisor interface](https://github.com/kata-containers/kata-containers/blob/main/src/runtime/virtcontainers/remote.go)
 of [Kata Containers](https://github.com/kata-containers/kata-containers)
 
 It enables the creation of Kata Containers VMs on any machines without the need for bare metal worker nodes,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,7 +3,7 @@
 ## Overview
 
 The cloud-api-adaptor is an implementation of the
-[remote hypervisor interface](https://github.com/kata-containers/kata-containers/blob/CCv0/src/runtime/virtcontainers/remote.go)
+[remote hypervisor interface](https://github.com/kata-containers/kata-containers/blob/main/src/runtime/virtcontainers/remote.go)
 of [Kata Containers](https://github.com/kata-containers/kata-containers)
 
 It enables the creation of Kata Containers VMs on any machines without the need for bare metal worker nodes,
@@ -108,7 +108,7 @@ The [cloud-api-adaptor](../src/cloud-api-adaptor/cmd/cloud-api-adaptor) implemen
 each node and is responsible for receiving commands from the `containerd-shim-kata-v2` process and implementing them
 for peer pods. For example, when it receives commands that were related to Pod lifecycle that are traditionally
 serviced by a local hypervisor (like `CreateSandboxRequest` and `StopSandboxRequest`) it will use IaaS APIs (from the
-Cloud Service Provider, or locally for the `libvirt` implementation to creating and deleting the peer pod VMs. 
+Cloud Service Provider, or locally for the `libvirt` implementation to creating and deleting the peer pod VMs.
 
 When the VMs are created they make a CNI compatible network tunnel using VxLAN tunneling, between the worker node and
 peer pods VM to flow other commands like `CreateContainer` through to the the remote sandbox.

--- a/src/cloud-api-adaptor/README.md
+++ b/src/cloud-api-adaptor/README.md
@@ -2,7 +2,8 @@
 
 # Introduction
 
-This repository contains the implementation of Kata [remote hypervisor](https://github.com/kata-containers/kata-containers/tree/CCv0).
+This repository contains the implementation of Kata Containers'
+[remote hypervisor interface](https://github.com/kata-containers/kata-containers/blob/main/src/runtime/virtcontainers/remote.go).
 Kata remote hypervisor enables creation of Kata VMs on any environment without requiring baremetal servers or nested
 virtualization support.
 

--- a/src/cloud-api-adaptor/docs/DEVELOPMENT.md
+++ b/src/cloud-api-adaptor/docs/DEVELOPMENT.md
@@ -9,7 +9,7 @@
 export BUILD_DIR=$HOME/remote-hyp
 mkdir -p $BUILD_DIR && cd $BUILD_DIR
 
-git clone -b CCv0 https://github.com/kata-containers/kata-containers.git
+git clone -b main https://github.com/kata-containers/kata-containers.git
 git clone https://github.com/confidential-containers/cloud-api-adaptor.git
 cd cloud-api-adaptor
 ```
@@ -17,7 +17,7 @@ cd cloud-api-adaptor
 ## Building the binaries
 
 Running `make` builds two binaries.
-- cloud-api-adaptor: This is the main program responsibile for Pod VM lifecycle management. 
+- cloud-api-adaptor: This is the main program responsibile for Pod VM lifecycle management.
 By default this is built as a dynamically linked binary with support for libvirt provider.
 
 - agent-protocol-forwarder: This is the program which runs inside the Pod VM to forward the
@@ -25,7 +25,7 @@ kata-agent protocol over TCP. This is a statically linked binary and is common f
 
 ### Release and Dev builds
 
-This is controlled by the variable `RELEASE_BUILD`. By default this is set to `false` and builds 
+This is controlled by the variable `RELEASE_BUILD`. By default this is set to `false` and builds
 all the providers into the cloud-api-adaptor binary.
 
 Further, note that the dev build is a dynamically linked binary as it includes the `libvirt` provider.

--- a/src/cloud-api-adaptor/docs/tls-proxy-forwarder.md
+++ b/src/cloud-api-adaptor/docs/tls-proxy-forwarder.md
@@ -1,6 +1,6 @@
 # TLS communication between `cloud-api-adaptor` and `agent-protocol-forwarder`
 
-`cloud-api-adaptor` running in a worker node communicates with `agent-protocol-forwarder` running in a peer pod VM using a mutual TLS connection. This mTLS connection is used to transfer TTRPC requests and responses of [agent protocol](https://github.com/kata-containers/kata-containers/blob/CCv0/src/libs/protocols/protos/agent.proto) between `kata-shim` and `kata-agent`.
+`cloud-api-adaptor` running in a worker node communicates with `agent-protocol-forwarder` running in a peer pod VM using a mutual TLS connection. This mTLS connection is used to transfer TTRPC requests and responses of [agent protocol](https://github.com/kata-containers/kata-containers/blob/main/src/libs/protocols/protos/agent.proto) between `kata-shim` and `kata-agent`.
 
 There are two options to configure mTLS connections.
 

--- a/src/cloud-api-adaptor/ibmcloud-powervs/README.md
+++ b/src/cloud-api-adaptor/ibmcloud-powervs/README.md
@@ -11,7 +11,7 @@
 We will be using the tool `pvsadm` to customise and build the VM image. Download or install it using the below instructions.
 
 1. You can download the binary from Github releases [here](https://github.com/ppc64le-cloud/pvsadm/releases)
-   
+
 2. To install from source
    ```
    cd $GOPATH/src/github.com/
@@ -31,13 +31,13 @@ pvsadm image qcow2ova --prep-template-default > image-prep.template
 Add the following snippet to `image-prep.template`
 ```
 yum install -y gcc gcc-c++ git make
-git clone -b CCv0 https://github.com/kata-containers/kata-containers.git
+git clone -b main https://github.com/kata-containers/kata-containers.git
 git clone https://github.com/confidential-containers/cloud-api-adaptor.git
 cd cloud-api-adaptor/ibmcloud-powervs/image
 make build
 ```
 
-> NOTE: 
+> NOTE:
 > 1. If you intend to use DHCP network type for creating peer pod VMs with
 > PowerVS provider, you need to additionally add this to `image-prep.template`
 > ```
@@ -74,7 +74,7 @@ pvsadm image import -n <service-instance-name> -b <bucket-name> -o <file-name> -
 ## Running cloud-api-adaptor
 
 1. Setup necessary cloud resources such as PowerVS Service instance, network, API Key etc..
-   
+
 2. Populate an env file with the IBM Cloud API key
 
    ```bash
@@ -84,5 +84,5 @@ pvsadm image import -n <service-instance-name> -b <bucket-name> -o <file-name> -
    ```
 
 3. Update [kustomization.yaml](../install/overlays/ibmcloud-powervs/kustomization.yaml) with the required details
- 
+
 4. Deploy Cloud API Adaptor by following the [install](../install/README.md) guide

--- a/src/cloud-api-adaptor/podvm/README.md
+++ b/src/cloud-api-adaptor/podvm/README.md
@@ -14,7 +14,7 @@ In order to build locally it requires the source trees and softwares mentioned i
   $ apt-get install -y qemu-kvm cloud-utils qemu-utils protobuf-compiler pkg-config libdevmapper-dev libgpgme-dev
   ```
 
-You may need to link the agent with the musl C library. In this case, you should install the musl-tools (Ubuntu) package and setup the Rust toolchain as explained [here](https://github.com/kata-containers/kata-containers/blob/CCv0/src/agent/README.md#build-with-musl).
+You may need to link the agent with the musl C library. In this case, you should install the musl-tools (Ubuntu) package and setup the Rust toolchain as explained [here](https://github.com/kata-containers/kata-containers/blob/main/src/agent/README.md#build-with-musl).
 
 Finally run the following commands to build the qcow2 image:
 
@@ -57,10 +57,6 @@ currently accepted:
 
 | Argument          | Default value                                                | Description                                                     |
 | ----------------- | ------------------------------------------------------------ | --------------------------------------------------------------- |
-| CAA\_SRC          | https://github.com/confidential-containers/cloud-api-adaptor | The cloud-api-adaptor source repository                         |
-| CAA\_SRC\_REF     | main                                                         | cloud-api-adaptor repository branch or commit                   |
-| KATA\_SRC         | https://github.com/kata-containers/kata-containers           | The Kata Containers source repository                           |
-| KATA\_SRC\_BRANCH | CCv0                                                         | The Kata Containers repository branch                           |
 | GO\_VERSION       | 1.21.11                                                      | Go version                                                      |
 | PROTOC\_VERSION   | 3.15.0                                                       | [Protobuf](https://github.com/protocolbuffers/protobuf) version |
 | RUST\_VERSION     | 1.72.0                                                       | Rust version                                                    |


### PR DESCRIPTION
Now we aren't using the kata-container's `CCv0` branch, remove the references to it and switch them out to `main`, or remove if no longer applicable.

Note: There is more work needed on the documentation to review and update it, but this is out of the current scope of this PR.