### PR TITLE
Enable support for embedding custom pause image from authenticated registry in the pod VM image

### DIFF
--- a/src/cloud-api-adaptor/podvm/Makefile.inc
+++ b/src/cloud-api-adaptor/podvm/Makefile.inc
@@ -67,7 +67,11 @@ IMAGE_FILE = $(IMAGE_NAME)$(IMAGE_SUFFIX)
 
 AGENT_PROTOCOL_FORWARDER = $(FILES_DIR)/usr/local/bin/agent-protocol-forwarder
 KATA_AGENT    = $(FILES_DIR)/usr/local/bin/kata-agent
-PAUSE         = $(FILES_DIR)/$(PAUSE_BUNDLE)/rootfs/pause
+
+# The pause binary can be named differently.
+PAUSE_BIN ?= pause
+PAUSE      = $(FILES_DIR)/$(PAUSE_BUNDLE)/rootfs/$(PAUSE_BIN)
+
 ATTESTATION_AGENT = $(FILES_DIR)/usr/local/bin/attestation-agent
 CONFIDENTIAL_DATA_HUB = $(FILES_DIR)/usr/local/bin/confidential-data-hub
 API_SERVER_REST  = $(FILES_DIR)/usr/local/bin/api-server-rest

--- a/src/cloud-api-adaptor/podvm/Makefile.inc
+++ b/src/cloud-api-adaptor/podvm/Makefile.inc
@@ -27,6 +27,9 @@ LIBC        ?= $(if $(filter $(ARCH),s390x ppc64le),gnu,musl)
 RUST_ARCH   ?= $(subst ppc64le,powerpc64le,$(ARCH))
 RUST_TARGET := $(RUST_ARCH)-unknown-linux-$(LIBC)
 
+# Auth json file for registry access. Used with skopeo
+AUTHFILE ?=
+
 ATTESTER ?= none
 CDH_RESOURCE_PROVIDER ?= kbs
 SEALED_SECRET ?= yes
@@ -152,7 +155,8 @@ $(UMOCI_SRC)/umoci: $(UMOCI_SRC)
 	cd "$(UMOCI_SRC)" && CC= $(MAKE)
 
 $(PAUSE_SRC): $(SKOPEO_BIN)
-	$(SKOPEO_BIN) --override-arch $(DEB_ARCH) --policy "$(FILES_DIR)/etc/containers/policy.json" copy "$(PAUSE_REPO):$(PAUSE_VERSION)" "oci:$(PAUSE_SRC):$(PAUSE_VERSION)"
+	$(SKOPEO_BIN) --override-arch $(DEB_ARCH) --policy "$(FILES_DIR)/etc/containers/policy.json" copy \
+		$(if $(AUTHFILE),--authfile $(AUTHFILE)) "$(PAUSE_REPO):$(PAUSE_VERSION)" "oci:$(PAUSE_SRC):$(PAUSE_VERSION)"
 
 $(PAUSE): | $(PAUSE_SRC) $(UMOCI_SRC)/umoci
 	$(UMOCI_SRC)/umoci unpack --rootless --image "$(PAUSE_SRC):$(PAUSE_VERSION)" "${FILES_DIR}/$(PAUSE_BUNDLE)"


### PR DESCRIPTION
This PR adds two commits
1. Enables downloading pause image from an authenticated registry before embedding
2. Allows overriding the default pause binary name to a custom name if needed.