### PR TITLE
versions: add entry for CoCo operator

### DIFF
--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -46,17 +46,7 @@ and trustee versions were updated when their components released as listed above
 As the [CoCo operator](https://github.com/confidential-containers/operator/) doesn't release until after peer pods,
 the [current plan](https://github.com/confidential-containers/confidential-containers/pull/201#discussion_r1570606331),
 is to pick the latest operator commit to pin that in our released version's instructions of deploying the operator.
-To do this, we should edit the [Makefile](../src/cloud-api-adaptor/Makefile) to replace the
-*github.com/confidential-containers/operator/config/default* and
-*github.com/confidential-containers/operator/config/samples/ccruntime/peer-pods* URLs:
-```
-operator_commit=<latest operator commit sha>
-sed -i "s#\(github.com/confidential-containers/operator/config/default\)#\1?ref=${operator_commit}#" Makefile
-sed -i "s#\(github.com/confidential-containers/operator/config/samples/ccruntime/peer-pods\)#\1?ref=${operator_commit}#" Makefile
-```
-
-<!-- TODO, should we worry about updating the e2e test reference in ../src/cloud-api-adaptor/test/provisioner/provision.go too?
-If so we need to also revert that post-release -->
+To do this, we should update the `git.coco-operator.reference` value in [versions.yaml](../src/cloud-api-adaptor/versions.yaml).
 
 When this change is merged, it triggers the
 [project images publish workflow](../.github/workflows/publish_images_on_push.yaml) to create a new container image in
@@ -221,7 +211,7 @@ confidential-containers release team to let them know it has completed successfu
 
 If the `main` branch was not already unlocked, then ask an admin to do this now.
 
-The CoCo operator URLs on the [Makefile](../src/cloud-api-adaptor/Makefile) should be reverted to use the latest version.
+The CoCo operator reference commit in the [versions.yaml](../src/cloud-api-adaptor/versions.yaml) should be reverted to use the latest version.
 
 The changes on the overlay kustomization files should be reverted to start using the latest cloud-api-adaptor images again:
 ```

--- a/src/cloud-api-adaptor/Makefile
+++ b/src/cloud-api-adaptor/Makefile
@@ -122,8 +122,8 @@ image-with-arch: .git-commit ## Build the per arch image
 .PHONY: deploy
 deploy: ## Deploy cloud-api-adaptor using the operator, according to install/overlays/$(CLOUD_PROVIDER)/kustomization.yaml file.
 ifneq ($(CLOUD_PROVIDER),)
-	kubectl apply -k "github.com/confidential-containers/operator/config/default"
-	kubectl apply -k "github.com/confidential-containers/operator/config/samples/ccruntime/peer-pods"
+	kubectl apply -k "$(COCO_OPERATOR_REPO)/config/default?ref=$(COCO_OPERATOR_REF)"
+	kubectl apply -k "$(COCO_OPERATOR_REPO)/config/samples/ccruntime/peer-pods?ref=$(COCO_OPERATOR_REF)"
 	kubectl apply -k install/overlays/$(CLOUD_PROVIDER)
 else
 	$(error CLOUD_PROVIDER is not set)

--- a/src/cloud-api-adaptor/Makefile.defaults
+++ b/src/cloud-api-adaptor/Makefile.defaults
@@ -28,6 +28,8 @@ rhel_amd64_IMAGE_CHECKSUM := $(call query,cloudimg.rhel.$(rhel_RELEASE).amd64.ch
 rhel_s390x_IMAGE_URL := $(call query,cloudimg.rhel.$(rhel_RELEASE).s390x.url)
 rhel_s390x_IMAGE_CHECKSUM := $(call query,cloudimg.rhel.$(rhel_RELEASE).s390x.checksum)
 
+COCO_OPERATOR_REF := $(or $(COCO_OPERATOR_REF),$(call query,git.coco-operator.reference))
+COCO_OPERATOR_REPO := $(or $(COCO_OPERATOR_REPO),$(call query,git.coco-operator.url))
 KATA_SRC := $(or $(KATA_SRC),$(call query,git.kata-containers.url))
 KATA_SRC_REF := $(or $(KATA_SRC_REF),$(call query,git.kata-containers.reference))
 GO_VERSION := $(or $(GO_VERSION),$(call query,tools.golang))

--- a/src/cloud-api-adaptor/install/README.md
+++ b/src/cloud-api-adaptor/install/README.md
@@ -47,6 +47,7 @@ You can deploy the CoCo operator and cloud-api-adaptor with the `Makefile` by ru
 
 * `make deploy` deploys operator, runtime and cloud-api-adaptor pod in the configured cluster
     * validate kubectl is available in your `$PATH` and `$KUBECONFIG` is set
+    * `yq` tool is available in your `$PATH`
 
 > **Note:** `make delete` deletes the cloud-api-adaptor daemonset from the configured cluster (and peerpod-ctrl if RESOURCE_CTRL=true is set)
 

--- a/src/cloud-api-adaptor/test/utils/versions.go
+++ b/src/cloud-api-adaptor/test/utils/versions.go
@@ -1,0 +1,37 @@
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Relative to test/e2e
+const VersionsFile = "../../versions.yaml"
+
+// Versions represents the project's versions.yaml
+type Versions struct {
+	Git map[string]struct {
+		Url string `yaml:"url"`
+		Ref string `yaml:"reference"`
+	}
+}
+
+// GetVersions unmarshals the project's versions.yaml
+func GetVersions() (*Versions, error) {
+	var versions Versions
+
+	yamlFile, err := os.ReadFile(VersionsFile)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := yaml.Unmarshal(yamlFile, &versions); err != nil {
+		return nil, err
+	}
+
+	return &versions, nil
+}

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -27,6 +27,9 @@ tools:
   kcli: 99.0.202407031308
 # Referenced Git repositories
 git:
+  coco-operator:
+    url: https://github.com/confidential-containers/operator
+    reference: main
   guest-components:
     url: https://github.com/confidential-containers/guest-components
     reference: df60725afe0ba452a25a740cf460c2855442c49a


### PR DESCRIPTION
Added 'git.coco-operator' entry to the project's versions.yaml with information about the repository URL and reference (commit SHA1, tag...etc) as a way to have a single source truth and avoiding the need to update the references in many places at release time (then roll-back after the release).

Now `make deploy` will read the operator's URL and reference from versions.yaml. Likewise, the e2e test's provision.