### PR TITLE
mkosi-podvm: Remove NetworkManager from s390x fedora image

### DIFF
--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-s390x.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-s390x.conf
@@ -10,8 +10,6 @@ PathExists=../../resources/buildS390xImage
 [Content]
 Bootable=no
 Packages=s390utils
-    dhclient
-    NetworkManager
     cloud-init
     cloud-utils-growpart
 


### PR DESCRIPTION
Both NetworkManager and systemd-networkd are currently installed and each tries to obtain an IP address from an DHCP server. This results in two IP addresses assigned to a single network interface of a booted pod VM. The agent-protocol-forwarder process fails to start when multiple IP addresses are assigned.

This patch removes NetworkManager from s390x fedora image, and fix the error of agent-protocol-forwarder.

Fixes #1893