### PR TITLE
test/e2e: misc improvements

### DIFF
--- a/src/cloud-api-adaptor/Makefile
+++ b/src/cloud-api-adaptor/Makefile
@@ -21,6 +21,8 @@ SOURCES     := $(shell find $(SOURCEDIRS) -name '*.go' -print)
 ATTESTER    ?= none
 # End-to-end tests overall run timeout.
 TEST_E2E_TIMEOUT ?= 60m
+# To run a sub-set of tests, set an unanchored regex matching the test's name as in go's test -run option.
+RUN_TESTS ?= ''
 
 RESOURCE_CTRL ?= true
 YQ_CHECKSUM_${ARCH} ?= $(YQ_CHECKSUM)
@@ -93,7 +95,7 @@ test: ## Run tests.
 .PHONY: test-e2e
 test-e2e: ## Run end-to-end tests for single provider.
 ifneq ($(CLOUD_PROVIDER),)
-	go test -v -tags=$(CLOUD_PROVIDER) -timeout $(TEST_E2E_TIMEOUT) -count=1 ./test/e2e
+	go test -v -tags=$(CLOUD_PROVIDER) -timeout $(TEST_E2E_TIMEOUT) -count=1 -run $(RUN_TESTS) ./test/e2e
 else
 	$(error CLOUD_PROVIDER is not set)
 endif

--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -131,6 +131,72 @@ Use the properties on the table below for Libvirt:
 |vxlan_port| VXLAN port number||
 |cluster_name|Cluster Name| "peer-pods"|
 
+## Running tests for PodVM with Authenticated Registry
+
+For running e2e test cases specifically for checking PodVM with Image from Authenticated Registry, we need to export following two variables
+- `AUTHENTICATED_REGISTRY_IMAGE` - Name of the image along with the tag from authenticated registry (example: quay.io/kata-containers/confidential-containers-auth:test)
+- `REGISTRY_CREDENTIAL_ENCODED` - Credentials of registry encrypted as BASE64ENCODED(USERNAME:PASSWORD). If you're using quay registry, we can get the encrypted credentials from Account Settings >> Generate Encrypted Password >> Docker Configuration
+
+## Running the e2e Test Suite on an Existing CAA Deployment
+
+To test local changes the test suite can run without provisioning any infrastructure, CoCo or CAA. Make sure your cluster is configured and available via kubectl. You also might need to set up Cloud Provider-specific API access, since some of tests assert conditions for cloud resources.
+
+### Azure
+
+Fill in `RESOURCE_GROUP` and `AZURE_SUBSCRIPTION_ID` with the values you want to use in your test:
+
+```bash
+cd ../.. # go to project root
+cat <<EOF> skip-provisioning.properties
+RESOURCE_GROUP_NAME="..."
+AZURE_SUBSCRIPTION_ID="..."
+AZURE_CLIENT_ID="unused"
+AZURE_TENANT_ID="unused"
+LOCATION="unused"
+AZURE_IMAGE_ID="unused"
+EOF
+```
+
+Run the test suite with the respective flags:
+
+```bash
+make test-e2e \
+CLOUD_PROVIDER=azure \
+TEST_TEARDOWN=no \
+TEST_PROVISION=no \
+TEST_INSTALL_CAA=no \
+TEST_PROVISION_FILE="${PWD}/skip-provisioning.properties" \
+```
+
+### IBM Cloud
+Take region `jp-tok` for example.
+```
+cd ../.. # go to project root
+cat <<EOF> skip-provisioning.properties
+REGION="jp-tok"
+ZONE="jp-tok-1"
+VPC_ID="<vpc-of-worker>"
+VPC_SUBNET_ID="<subnet-of-worker>"
+VPC_SECURITY_GROUP_ID="<security-group-of-vpc>"
+RESOURCE_GROUP_ID="<resource-group-id>"
+IBMCLOUD_PROVIDER="ibmcloud"
+APIKEY="<your-ibmcloud-apikey>"
+
+IAM_SERVICE_URL="https://iam.cloud.ibm.com/identity/token"
+VPC_SERVICE_URL="https://jp-tok.iaas.cloud.ibm.com/v1"
+IKS_SERVICE_URL="https://containers.cloud.ibm.com/global"
+PODVM_IMAGE_ID="<podvm-image-uploaded-previously>"
+INSTANCE_PROFILE_NAME="bz2-2x8"
+PODVM_IMAGE_ARCH="s390x"
+IMAGE_PULL_API_KEY="<can-be-same-as-apikey>"
+CAA_IMAGE_TAG="<caa-image-tag>"
+EOF
+```
+
+- For `INSTANCE_PROFILE_NAME`, if it's not secure execution, the value is started with "bz2". If it's secure execution, the value is started with 'bz2e'. More values can be found through ibmcloud command `ibmcloud is instance-profiles`.
+- For `PODVM_IMAGE_ID`, the vpc image id uploaded to ibmcloud.
+- For `CAA_IMAGE_TAG`, the commit id of project. The commit id can be found here: https://github.com/confidential-containers/cloud-api-adaptor/commits/main/
+
 # Adding support for a new cloud provider
 
 In order to add a test pipeline for a new cloud provider, you will need to implement some
@@ -162,68 +228,3 @@ func TestCloudProviderCreateSimplePod(t *testing.T) {
     DoTestCreateSimplePod(t, assert)
 }
 ```
-## Running tests for PodVM with Authenticated Registry
-
-For running e2e test cases specifically for checking PodVM with Image from Authenticated Registry, we need to export following two variables
-- `AUTHENTICATED_REGISTRY_IMAGE` - Name of the image along with the tag from authenticated registry (example: quay.io/kata-containers/confidential-containers-auth:test)
-- `REGISTRY_CREDENTIAL_ENCODED` - Credentials of registry encrypted as BASE64ENCODED(USERNAME:PASSWORD). If you're using quay registry, we can get the encrypted credentials from Account Settings >> Generate Encrypted Password >> Docker Configuration
-
-## Running the e2e Test Suite on an Existing CAA Deployment
-
-To test local changes the test suite can run without provisioning any infrastructure, CoCo or CAA. Make sure your cluster is configured and available via kubectl. You also might need to set up Cloud Provider-specific API access, since some of tests assert conditions for cloud resources.
-
-## Azure
-
-Fill in `RESOURCE_GROUP` and `AZURE_SUBSCRIPTION_ID` with the values you want to use in your test:
-
-```bash
-cd ../.. # go to project root
-cat <<EOF> skip-provisioning.properties
-RESOURCE_GROUP_NAME="..."
-AZURE_SUBSCRIPTION_ID="..."
-AZURE_CLIENT_ID="unused"
-AZURE_TENANT_ID="unused"
-LOCATION="unused"
-AZURE_IMAGE_ID="unused"
-EOF
-```
-
-Run the test suite with the respective flags:
-
-```bash
-make test-e2e \
-CLOUD_PROVIDER=azure \
-TEST_TEARDOWN=no \
-TEST_PROVISION=no \
-TEST_INSTALL_CAA=no \
-TEST_PROVISION_FILE="${PWD}/skip-provisioning.properties" \
-```
-
-## IBM Cloud
-Take region `jp-tok` for example.
-```
-cd ../.. # go to project root
-cat <<EOF> skip-provisioning.properties
-REGION="jp-tok"
-ZONE="jp-tok-1"
-VPC_ID="<vpc-of-worker>"
-VPC_SUBNET_ID="<subnet-of-worker>"
-VPC_SECURITY_GROUP_ID="<security-group-of-vpc>"
-RESOURCE_GROUP_ID="<resource-group-id>"
-IBMCLOUD_PROVIDER="ibmcloud"
-APIKEY="<your-ibmcloud-apikey>"
-
-IAM_SERVICE_URL="https://iam.cloud.ibm.com/identity/token"
-VPC_SERVICE_URL="https://jp-tok.iaas.cloud.ibm.com/v1"
-IKS_SERVICE_URL="https://containers.cloud.ibm.com/global"
-PODVM_IMAGE_ID="<podvm-image-uploaded-previously>"
-INSTANCE_PROFILE_NAME="bz2-2x8"
-PODVM_IMAGE_ARCH="s390x"
-IMAGE_PULL_API_KEY="<can-be-same-as-apikey>"
-CAA_IMAGE_TAG="<caa-image-tag>"
-EOF
-```
-
-- For `INSTANCE_PROFILE_NAME`, if it's not secure execution, the value is started with "bz2". If it's secure execution, the value is started with 'bz2e'. More values can be found through ibmcloud command `ibmcloud is instance-profiles`.
-- For `PODVM_IMAGE_ID`, the vpc image id uploaded to ibmcloud.
-- For `CAA_IMAGE_TAG`, the commit id of project. The commit id can be found here: https://github.com/confidential-containers/cloud-api-adaptor/commits/main/

--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -48,6 +48,12 @@ To leave the cluster untouched by the execution finish you should export `TEST_T
 
 To use existing cluster which have already installed Cloud API Adaptor, you should export `TEST_INSTALL_CAA=no`.
 
+While in development and/or debugging it's common that you want to run just a sub-set of tests rather than the entire suite. To accomplish that
+you should export an unanchored regular expression in the `RUN_TESTS` variable that matches the tests names (see `-run` in [go test flags](https://pkg.go.dev/cmd/go#hdr-Testing_flags) for the regular expression format accepted). For example, to run only the simple creation pod test:
+```
+$ RUN_TESTS=CreateSimplePod TEST_PROVISION=yes TEST_PODVM_IMAGE="path/to/podvm-base.qcow2" CLOUD_PROVIDER=libvirt make test-e2e
+```
+
 ## Attestation and KBS specific
 
 We need artificats from trustee when do attestation test, to prepare trustee, do as following. 


### PR DESCRIPTION
While testing https://github.com/confidential-containers/cloud-api-adaptor/pull/1845 I wanted to run only a single test case (the simple pod test) because all tests were failing and I didn't want to wait all to run (or ctrl+C). So here is a small improvement to allow us to run just a sub-set of e2e tests.

Also small improvement on e2e tests README.md