### PR TITLE
Docker hub mirror switch

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/common_suite.go
+++ b/src/cloud-api-adaptor/test/e2e/common_suite.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/tlsutil"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/test/utils"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/e2e-framework/pkg/env"
@@ -486,13 +485,13 @@ func DoTestPodsMTLSCommunication(t *testing.T, e env.Environment, assert CloudAs
 		},
 	}
 	clientPod.WithTestCommands(testCommands)
-	httpsPort := corev1.ServicePort{
+	httpsPort := v1.ServicePort{
 		Name:       "https",
 		Port:       443,
 		TargetPort: intstr.FromInt(int(443)),
-		Protocol:   corev1.ProtocolTCP,
+		Protocol:   v1.ProtocolTCP,
 	}
-	servicePorts := []corev1.ServicePort{httpsPort}
+	servicePorts := []v1.ServicePort{httpsPort}
 	nginxSvc := NewService(E2eNamespace, serviceName, servicePorts, labels)
 	extraPods := []*ExtraPod{clientPod}
 	extraSecrets := []*v1.Secret{clientSecret}

--- a/src/cloud-api-adaptor/test/e2e/common_suite.go
+++ b/src/cloud-api-adaptor/test/e2e/common_suite.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/tlsutil"
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/test/utils"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -359,7 +360,10 @@ func DoTestPodToServiceCommunication(t *testing.T, e env.Environment, assert Clo
 	clientImageName := BUSYBOX_IMAGE
 	serverPodName := "test-server"
 	serverContainerName := "nginx"
-	serverImageName := "nginx:latest"
+	serverImageName, err := utils.GetImage("nginx")
+	if err != nil {
+		t.Fatal(err)
+	}
 	serviceName := "nginx-server"
 	labels := map[string]string{
 		"app": "nginx-server",
@@ -397,10 +401,16 @@ func DoTestPodToServiceCommunication(t *testing.T, e env.Environment, assert Clo
 func DoTestPodsMTLSCommunication(t *testing.T, e env.Environment, assert CloudAssert) {
 	clientPodName := "mtls-client"
 	clientContainerName := "curl"
-	clientImageName := "docker.io/curlimages/curl:8.4.0"
+	clientImageName, err := utils.GetImage("curl")
+	if err != nil {
+		t.Fatal(err)
+	}
 	serverPodName := "mtls-server"
 	serverContainerName := "nginx"
-	serverImageName := "nginx:latest"
+	serverImageName, err := utils.GetImage("nginx")
+	if err != nil {
+		t.Fatal(err)
+	}
 	caService, _ := tlsutil.NewCAService("nginx")
 	serverCACertPEM := caService.RootCertificate()
 	serviceName := "nginx-mtls"

--- a/src/cloud-api-adaptor/test/e2e/ibmcloud_test.go
+++ b/src/cloud-api-adaptor/test/e2e/ibmcloud_test.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
-
 	pv "github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/test/provisioner/ibmcloud"
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/test/utils"
 	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestCreateSimplePod(t *testing.T) {
@@ -130,7 +130,10 @@ func TestCreatePeerPodWithPVC(t *testing.T) {
 		storageClassName := "ibmc-vpc-block-5iops-tier"
 		storageSize := "10Gi"
 		podName := "nginx-pvc-pod"
-		imageName := "nginx:latest"
+		imageName, err := utils.GetImage("nginx")
+		if err != nil {
+			t.Fatal(err)
+		}
 		containerName := "nginx-pvc-container"
 		csiContainerName := "ibm-vpc-block-podvm-node-driver"
 		csiImageName := "gcr.io/k8s-staging-cloud-provider-ibm/ibm-vpc-block-csi-driver:v5.2.0"

--- a/src/cloud-api-adaptor/test/e2e/nginx_deployment.go
+++ b/src/cloud-api-adaptor/test/e2e/nginx_deployment.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/test/utils"
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -93,7 +94,10 @@ func NewDeployment(namespace, deploymentName, containerName, imageName string, o
 func DoTestNginxDeployment(t *testing.T, testEnv env.Environment, assert CloudAssert) {
 	deploymentName := "nginx-deployment"
 	containerName := "nginx"
-	imageName := "nginxinc/nginx-unprivileged"
+	imageName, err := utils.GetImage("unprivileged-nginx")
+	if err != nil {
+		t.Fatal(err)
+	}
 	replicas := int32(2)
 	deployment := NewDeployment(E2eNamespace, deploymentName, containerName, imageName, WithReplicaCount(replicas))
 

--- a/src/cloud-api-adaptor/test/e2e/versions.yaml
+++ b/src/cloud-api-adaptor/test/e2e/versions.yaml
@@ -1,0 +1,13 @@
+test_images:
+  nginx:
+    registry: "quay.io/confidential-containers/test/nginx"
+    tag: "latest"
+  unprivileged-nginx:
+    registry: "quay.io/nginx/nginx-unprivileged"
+    tag: "latest"
+  busybox:
+    registry: "quay.io/prometheus/busybox"
+    tag: "latest"
+  curl:
+    registry: "quay.io/curl/curl"
+    tag: "8.4.0"

--- a/src/cloud-api-adaptor/test/utils/test_versions.go
+++ b/src/cloud-api-adaptor/test/utils/test_versions.go
@@ -1,0 +1,57 @@
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"gopkg.in/yaml.v2"
+)
+
+// TestVersions represents the test versions.yaml
+type TestVersions struct {
+	ContainerImage map[string]ContainerImage `yaml:"test_images"`
+}
+
+type ContainerImage struct {
+	Registry string `yaml:"registry"`
+	Tag      string `yaml:"tag"`
+}
+
+func (c ContainerImage) getImage() string {
+	return c.Registry + ":" + c.Tag
+}
+
+// Use singleton to reduce multiple file reads
+var lock = &sync.Mutex{}
+var testVersions *TestVersions
+
+func getTestVersions() (*TestVersions, error) {
+
+	if testVersions == nil {
+		lock.Lock()
+		defer lock.Unlock()
+		// Relative to test/e2e
+		yamlFile, err := os.ReadFile("versions.yaml")
+		if err != nil {
+			return nil, err
+		}
+
+		if err := yaml.Unmarshal(yamlFile, &testVersions); err != nil {
+			return nil, err
+		}
+	}
+
+	return testVersions, nil
+}
+
+func GetImage(image string) (string, error) {
+	test_versions, err := getTestVersions()
+	if err != nil {
+		return "", fmt.Errorf("getTestImage: failed to read image: %s, with error %v", image, err)
+	}
+	return test_versions.ContainerImage[image].getImage(), nil
+}


### PR DESCRIPTION
In some e2e tests, particularly the docker-provider ones, when you do multiple
runs we are likely to hit the rate limits of docker hub, so try switching to the
official mirrors of nginx and curl container images instead to reduce our usage of docker.io.