### PR TITLE
libvirt: Bump to kcli 99.0.202407031308

### DIFF
--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -24,7 +24,7 @@ tools:
   rust: 1.74.0
   protoc: 3.15.0
   packer: v1.9.4
-  kcli: 99.0.202406160824
+  kcli: 99.0.202407031308
 # Referenced Git repositories
 git:
   guest-components:


### PR DESCRIPTION
This patch bumps the version of kcli to 99.0.202407031308. This version includes a fix https://github.com/karmab/kcli/commit/2babdf6fda2f04a4c1e7a814b89193fdac14f664 for the issue that prevents from creating a cluster with libvirt/kcli_cluster.sh on s390x.

Fixes #1907