### PR TITLE
build: Fix Dockerfile from-as-casing warnings

### DIFF
--- a/hack/Dockerfile.golang
+++ b/hack/Dockerfile.golang
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.5-labs
 
 ARG BASE_IMAGE=registry.fedoraproject.org/fedora:39
-FROM --platform=$TARGETPLATFORM ${BASE_IMAGE} as base
+FROM --platform=$TARGETPLATFORM ${BASE_IMAGE} AS base
 
 # DO NOT UPDATE THIS BY HAND !!
 # Use hack/update-go-container.sh to update the version and hashes.

--- a/src/cloud-api-adaptor/Dockerfile
+++ b/src/cloud-api-adaptor/Dockerfile
@@ -7,10 +7,10 @@ ARG BASE=registry.fedoraproject.org/fedora:39
 # binary into the container image of the target platform ($TARGETPLATFORM)
 # that was specified with --platform. For more details see:
 # https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
-FROM --platform=$BUILDPLATFORM $BUILDER_BASE as builder-release
+FROM --platform=$BUILDPLATFORM $BUILDER_BASE AS builder-release
 # For `dev` builds due to CGO constraints we have to emulate the target platform
 # instead of using Go's cross-compilation
-FROM --platform=$TARGETPLATFORM $BUILDER_BASE as builder-dev
+FROM --platform=$TARGETPLATFORM $BUILDER_BASE AS builder-dev
 
 RUN dnf install -y libvirt-devel && dnf clean all
 
@@ -37,9 +37,9 @@ COPY cloud-api-adaptor/proto ./proto
 
 RUN CC=gcc make ARCH=$TARGETARCH COMMIT=$COMMIT VERSION=$VERSION RELEASE_BUILD=$RELEASE_BUILD cloud-api-adaptor
 
-FROM --platform=$TARGETPLATFORM $BASE as base-release
+FROM --platform=$TARGETPLATFORM $BASE AS base-release
 
-FROM base-release as base-dev
+FROM base-release AS base-dev
 RUN dnf install -y libvirt-libs /usr/bin/ssh && dnf clean all
 
 FROM base-${BUILD_TYPE}

--- a/src/peerpod-ctrl/Dockerfile
+++ b/src/peerpod-ctrl/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$TARGETPLATFORM quay.io/confidential-containers/golang-fedora:1.21.12-39 as builder
+FROM --platform=$TARGETPLATFORM quay.io/confidential-containers/golang-fedora:1.21.12-39 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG CGO_ENABLED=1

--- a/src/peerpodconfig-ctrl/Dockerfile
+++ b/src/peerpodconfig-ctrl/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.20 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/src/webhook/Dockerfile
+++ b/src/webhook/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.20 as builder
+FROM --platform=$BUILDPLATFORM golang:1.20 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
https://docs.docker.com/reference/build-checks/from-as-casing/ states the FROM and AS keywords in Dockerfiles
should match, so some of our jobs and is throwing warnings in our build steps