### PR TITLE
ibmcloud: revise ibmcloud README

### DIFF
--- a/src/cloud-api-adaptor/ibmcloud/README.md
+++ b/src/cloud-api-adaptor/ibmcloud/README.md
@@ -134,6 +134,12 @@ PODVM_IMAGE_ID="$PODVM_IMAGE_ID"
 INSTANCE_PROFILE_NAME="$PODVM_INSTANCE_PROFILE"
 CAA_IMAGE_TAG="$CAA_IMAGE_TAG"
 SSH_KEY_ID="$(terraform output --raw ssh_key_id)"
+REGION="$(terraform output --raw region)"
+RESOURCE_GROUP_ID="$(terraform output --raw resource_group_id)"
+ZONE="$(terraform output --raw zone)"
+VPC_SUBNET_ID="$(terraform output --raw subnet_id)"
+VPC_SECURITY_GROUP_ID="$(terraform output --raw security_group_id)"
+VPC_ID="$(terraform output --raw vpc_id)"
 EOF
 
 popd

--- a/src/cloud-providers/ibmcloud/provider.go
+++ b/src/cloud-providers/ibmcloud/provider.go
@@ -76,7 +76,7 @@ func NewProvider(config *Config) (provider.Provider, error) {
 	if config.VpcServiceURL == "" && ok {
 		// Assume in prod if fetching from labels for now
 		// TODO handle other environments
-		config.VpcServiceURL = fmt.Sprintf("https://%s.iaas.provider.ibm.com/v1", nodeRegion)
+		config.VpcServiceURL = fmt.Sprintf("https://%s.iaas.cloud.ibm.com/v1", nodeRegion)
 	}
 
 	vpcV1, err := vpcv1.NewVpcV1(&vpcv1.VpcV1Options{


### PR DESCRIPTION
I followed the guide to [Deploy the Confidential-containers operator](https://github.com/confidential-containers/cloud-api-adaptor/tree/main/src/cloud-api-adaptor/ibmcloud#deploy-the-confidential-containers-operator) on a self-managed cluster in IBM Cloud VPC. However, it doesn't work as expected. I try to fix 2 problems:

- Fix the default VPC service url, revert it to the value in v0.8.0: https://github.com/confidential-containers/cloud-api-adaptor/blob/v0.8.0/pkg/adaptor/cloud/ibmcloud/provider.go#L79

- Add missing settings in selfmanaged_cluster.properties.  Without those settings, CAA will fail to create instance with errors like below:
```
failed to create an instance : Expected only one oneOf fields to be set: got 0 and the response is {

"code": "validation_failed_oneof",
                "message": "Expected only one oneOf fields to be set: got 0",
                "target": {
                    "name": "InstancePrototype",
                    "type": "field"
                }

"message": "InstanceByImage is invalid: Expected only one oneOf fields to be set: got 0",
```