### PR TITLE
test/e2e: Skip unstable libvirt test

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/libvirt_test.go
+++ b/src/cloud-api-adaptor/test/e2e/libvirt_test.go
@@ -45,6 +45,9 @@ func TestLibvirtCreatePeerPodAndCheckUserLogs(t *testing.T) {
 }
 
 func TestLibvirtCreatePeerPodAndCheckWorkDirLogs(t *testing.T) {
+	// This test is causing issues on CI with instability, so skip until we can resolve this.
+	// See https://github.com/confidential-containers/cloud-api-adaptor/issues/1831
+	SkipTestOnCI(t)
 	assert := LibvirtAssert{}
 	DoTestCreatePeerPodAndCheckWorkDirLogs(t, testEnv, assert)
 }


### PR DESCRIPTION
The TestLibvirtCreatePeerPodAndCheckWorkDirLogs test has failed on a few PRs and the last three nightly test runs, so skip it until we have a chance to debug.
See https://github.com/confidential-containers/cloud-api-adaptor/issues/1831