### PR TITLE
podnetwork: Support CNI plugins like PTP and GKE 

### DIFF
--- a/src/cloud-api-adaptor/pkg/podnetwork/tunneler/routing/podnode.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/tunneler/routing/podnode.go
@@ -21,7 +21,6 @@ func NewPodNodeTunneler() tunneler.Tunneler {
 }
 
 const (
-	podVEthName  = "eth0"
 	hostVEthName = "veth0"
 
 	podTableID          = 45001
@@ -37,6 +36,11 @@ func (t *podNodeTunneler) Setup(nsPath string, podNodeIPs []netip.Addr, config *
 
 	if len(podNodeIPs) != 2 {
 		return errors.New("secondary pod node IP is not available")
+	}
+
+	podVEthName := config.InterfaceName
+	if podVEthName == "" {
+		return errors.New("InterfaceName is not specified")
 	}
 
 	podNodeIP := podNodeIPs[1]

--- a/src/cloud-api-adaptor/pkg/podnetwork/tunneler/routing/podnode.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/tunneler/routing/podnode.go
@@ -101,21 +101,7 @@ func (t *podNodeTunneler) Setup(nsPath string, podNodeIPs []netip.Addr, config *
 
 	var defaultRouteGateway netip.Addr
 
-	// We need to process routes without gateway address first. Processing routes with a gateway causes an error if the gateway is not reachable.
-	// Calico sets up routes with this pattern.
-	// https://github.com/projectcalico/cni-plugin/blob/7495c0279c34faac315b82c1838bca638e23dbbe/pkg/dataplane/linux/dataplane_linux.go#L158-L167
-
-	var first, second []*tunneler.Route
 	for _, route := range config.Routes {
-		if !route.GW.IsValid() {
-			first = append(first, route)
-		} else {
-			second = append(second, route)
-		}
-	}
-	routes := append(first, second...)
-
-	for _, route := range routes {
 		if err := podNS.RouteAdd(&netops.Route{Destination: route.Dst, Gateway: route.GW, Device: podVEthName}); err != nil {
 			return fmt.Errorf("failed to add a route to %s via %s on pod network namespace %s: %w", route.Dst, route.GW, nsPath, err)
 		}

--- a/src/cloud-api-adaptor/pkg/podnetwork/tunneler/tunneler.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/tunneler/tunneler.go
@@ -6,6 +6,8 @@ package tunneler
 import (
 	"fmt"
 	"net/netip"
+
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/netops"
 )
 
 type Tunneler interface {
@@ -28,9 +30,11 @@ type Config struct {
 }
 
 type Route struct {
-	Dst netip.Prefix
-	GW  netip.Addr
-	Dev string
+	Dst      netip.Prefix
+	GW       netip.Addr
+	Dev      string
+	Protocol netops.RouteProtocol
+	Scope    netops.RouteScope
 }
 
 type driver struct {

--- a/src/cloud-api-adaptor/pkg/podnetwork/tunneler/vxlan/podnode.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/tunneler/vxlan/podnode.go
@@ -92,26 +92,6 @@ func (t *podNodeTunneler) Setup(nsPath string, podNodeIPs []netip.Addr, config *
 		return err
 	}
 
-	// We need to process routes without gateway address first. Processing routes with a gateway causes an error if the gateway is not reachable.
-	// Calico sets up routes with this pattern.
-	// https://github.com/projectcalico/cni-plugin/blob/7495c0279c34faac315b82c1838bca638e23dbbe/pkg/dataplane/linux/dataplane_linux.go#L158-L167
-
-	var first, second []*tunneler.Route
-	for _, route := range config.Routes {
-		if !route.GW.IsValid() {
-			first = append(first, route)
-		} else {
-			second = append(second, route)
-		}
-	}
-	routes := append(first, second...)
-
-	for _, route := range routes {
-		if err := podNS.RouteAdd(&netops.Route{Destination: route.Dst, Gateway: route.GW, Device: podVxlanInterface}); err != nil {
-			return fmt.Errorf("failed to add a route to %s via %s on pod network namespace %s: %w", route.Dst, route.GW, nsPath, err)
-		}
-	}
-
 	return nil
 }
 

--- a/src/cloud-api-adaptor/pkg/podnetwork/workernode.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/workernode.go
@@ -164,9 +164,11 @@ func (n *workerNode) Inspect(nsPath string) (*tunneler.Config, error) {
 
 	for _, route := range routes {
 		r := &tunneler.Route{
-			Dst: route.Destination,
-			Dev: route.Device,
-			GW:  route.Gateway,
+			Dst:      route.Destination,
+			Dev:      route.Device,
+			GW:       route.Gateway,
+			Protocol: route.Protocol,
+			Scope:    route.Scope,
 		}
 		config.Routes = append(config.Routes, r)
 	}


### PR DESCRIPTION
CNI plugins like PTP and GKE remove a route that is automatically added by kernel for eth0, and then add another route for the same destination.

This patch changes the code to manipulates routes to support such CNI plugins.

Fixes #1909 
