### PR TITLE
podvm-mkosi: let 'make binaries' works on RHEL with podman

### DIFF
--- a/src/cloud-api-adaptor/podvm-mkosi/Makefile
+++ b/src/cloud-api-adaptor/podvm-mkosi/Makefile
@@ -42,7 +42,6 @@ endif
 
 PHONY: binaries
 binaries:
-	docker buildx use default
 	@echo "Building binaries..."
 	rm -rf ./resources/binaries-tree
 	cp -rf ../../../.git ../../.git


### PR DESCRIPTION
- remove the useless `docker buildx use default` command
- fix Error: unrecognized command `podman buildx use`
- with podman version 4.9.4-rhel on RHEL 9.4