### PR TITLE
podvm:Enable se image build for s390x rhel podvm

### DIFF
--- a/src/cloud-api-adaptor/Makefile
+++ b/src/cloud-api-adaptor/Makefile
@@ -207,5 +207,6 @@ endif
 	--build-arg CLOUD_PROVIDER=$(or $(CLOUD_PROVIDER),generic) \
 	--build-arg IMAGE_URL=$(IMAGE_URL) \
 	--build-arg IMAGE_CHECKSUM=$(IMAGE_CHECKSUM) \
+	--build-arg SE_BOOT=$(SE_BOOT) \
 	$(DOCKER_OPTS) .
 	rm -rf .git

--- a/src/cloud-api-adaptor/ibmcloud/SECURE_EXECUTION.md
+++ b/src/cloud-api-adaptor/ibmcloud/SECURE_EXECUTION.md
@@ -81,7 +81,7 @@ When you obtain the host key document, please copy the downloaded host key docum
 ```bash
 $ docker build -t se_podvm_s390x \
          --build-arg ARCH=s390x \
-         --build-arg SE_BOOT=1 \
+         --build-arg SE_BOOT=true \
          --build-arg BUILDER_IMG=podvm_builder \
          --build-arg BINARIES_IMG=podvm_binaries_s390x \
          --build-arg UBUNTU_IMAGE_URL="" \
@@ -89,7 +89,7 @@ $ docker build -t se_podvm_s390x \
          -f Dockerfile.podvm .
 ```
 > **Note**
-> - You must passing the `SE_BOOT=1`, `ARCH=s390x`,`UBUNTU_IMAGE_URL=""` and `UBUNTU_IMAGE_CHECKSUM=""` build arguments to docker.
+> - You must passing the `SE_BOOT=true`, `ARCH=s390x`,`UBUNTU_IMAGE_URL=""` and `UBUNTU_IMAGE_CHECKSUM=""` build arguments to docker.
 > - Make sure passing the `BINARIES_IMG=podvm_binaries_s390x` build argument to docker, `podvm_binaries_s390x` is the image from the previous step.
 
 #### Upload the Secure Execution enabled peer pod VM image to IBM Cloud

--- a/src/cloud-api-adaptor/ibmcloud/image/build.sh
+++ b/src/cloud-api-adaptor/ibmcloud/image/build.sh
@@ -34,12 +34,12 @@ if [[ -z "${base_img_path-}" || -z "${dst_img_path-}" || -z "${files_dir-}" ]]; 
     exit 1
 fi
 
-SE_BOOT=${SE_BOOT:-0}
+SE_BOOT=${SE_BOOT:-false}
 
-if [ "${SE_BOOT}" = "1" ]; then
+if [ "${SE_BOOT}" = "true" ]; then
     if [[ -z "${HOST_KEYS_DIR-}" ]]; then
         echo "HOST_KEYS_DIR is missed" 1>&2
-        echo "CLOUD_PROVIDER=ibmcloud SE_BOOT=1 HOST_KEYS_DIR=<host keys directory> make build"
+        echo "CLOUD_PROVIDER=ibmcloud SE_BOOT=true HOST_KEYS_DIR=<host keys directory> make build"
         exit 1
     fi
     umount ./rootkeys/ || true
@@ -65,7 +65,7 @@ fi
 
 function cleanup () {
     msg=$1
-    if [ "${SE_BOOT}" = "1" ]; then
+    if [ "${SE_BOOT}" = "true" ]; then
         for mnt in "$dst_mnt/boot-se" "$dst_mnt/etc/keys" "$dst_mnt/sys"; do
             mountpoint -q "$mnt" && umount "$mnt" || true
             [[ -d "$mnt" ]] && rmdir "$mnt" 2> /dev/null || true
@@ -100,7 +100,7 @@ modprobe nbd
 rm -f "$src_img_path" "$tmp_img_path"
 echo "Cleanuping build env"
 cleanup ""
-if [ "${SE_BOOT}" = "1" ]; then
+if [ "${SE_BOOT}" = "true" ]; then
     echo "Finding host key files"
     host_keys=""
     for i in "${HOST_KEYS_DIR}"/*.crt; do

--- a/src/cloud-api-adaptor/ibmcloud/image/push.sh
+++ b/src/cloud-api-adaptor/ibmcloud/image/push.sh
@@ -95,7 +95,7 @@ fi
 image_ref="cos://$location/$cos_bucket/$object_key"
 
 arch=$(uname -m)
-[ "${SE_BOOT:-0}" = "1" ] && os_name="hyper-protect-1-0-s390x" || os_name="ubuntu-20-04-${arch/x86_64/amd64}"
+[ "${SE_BOOT:-false}" = "true" ] && os_name="hyper-protect-1-0-s390x" || os_name="ubuntu-20-04-${arch/x86_64/amd64}"
 
 echo -e "\nCreating image \"$image_name\" with $image_ref\n"
 image_json=$(ibmcloud is image-create "$image_name" --os-name "$os_name" --file "$image_ref" --output json)

--- a/src/cloud-api-adaptor/ibmcloud/image/verify.sh
+++ b/src/cloud-api-adaptor/ibmcloud/image/verify.sh
@@ -37,7 +37,7 @@ case "$image" in
     *)       echo "$0: image for unknown architecture: $image" 1>&2; exit 1 ;;
 esac
 
-[ "${SE_BOOT:-0}" = "1" ] && profile=bz2e-2x8
+[ "${SE_BOOT:-false}" = "true" ] && profile=bz2e-2x8
 
 name=$(printf "imagetest-%.8s-%s" "$(uuidgen)" "$image")
 

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm.rhel
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm.rhel
@@ -24,6 +24,7 @@ ENV PODVM_DISTRO=${PODVM_DISTRO}
 ENV ARCH=${ARCH}
 ENV UEFI=${UEFI}
 
+ARG SE_BOOT
 ARG IMAGE_URL
 ARG IMAGE_CHECKSUM
 
@@ -31,6 +32,7 @@ ADD ${IMAGE_URL} /tmp/rhel.img
 ENV IMAGE_URL=/tmp/rhel.img
 ENV IMAGE_CHECKSUM=${IMAGE_CHECKSUM}
 
+ENV SE_BOOT=${SE_BOOT}
 # workaround to ensure hashicorp packer is called instead
 # of cracklib packer which is installed by default
 ENV PATH="/usr/bin:${PATH}"

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.rhel
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.rhel
@@ -23,7 +23,14 @@ ARG YQ_CHECKSUM="sha256:bd695a6513f1196aeda17b174a15e9c351843fb1cef5f9be0af170f2
 ARG ORG_ID
 ARG ACTIVATION_KEY
 
+# Without setting ENV gh-action is failing to use the correct values
+ENV GO_VERSION=${GO_VERSION}
+ENV RUST_VERSION=${RUST_VERSION}
+ENV PROTOC_VERSION=${PROTOC_VERSION}
+ENV PROTOC_ARCH=${PROTOC_ARCH}
 ENV ARCH=${ARCH}
+ENV YQ_ARCH=${YQ_ARCH}
+ENV YQ_VERSION=${YQ_VERSION}
 
 # This registering RHEL when building on an unsubscribed system
 # If you are running a UBI container on a registered and subscribed RHEL host, the main RHEL Server repository is enabled inside the standard UBI container

--- a/src/cloud-api-adaptor/podvm/Makefile
+++ b/src/cloud-api-adaptor/podvm/Makefile
@@ -53,8 +53,10 @@ else ifeq ($(PODVM_DISTRO),rhel)
 	@echo defined
 	$(eval OPTS := -var disk_size=11144)
 ifeq ($(ARCH),s390x)
+	$(eval OPTS += -var se_boot=${SE_BOOT})
 	$(eval OPTS += -var machine_type=${QEMU_MACHINE_TYPE_${ARCH}})
 	$(eval OPTS += -var cpu_type=max)
+	$(eval OPTS += -var os_arch=s390x)
 ifndef QEMU_BINARY
 	$(eval OPTS += -var qemu_binary=qemu-system-${ARCH})
 endif
@@ -80,14 +82,14 @@ $(IMAGE_FILE): $(BINARIES) $(FILES) setopts
 	rm -f cloud-init.img
 	cloud-localds cloud-init.img qcow2/userdata.cfg
 	mkdir -p toupload
-	if [ "${SE_BOOT}" = "1" ] && [ "${ARCH}" = "s390x" ]; then \
+	if [ "${SE_BOOT}" = "true" ] && [ "${ARCH}" = "s390x" ]; then \
 		qemu-img create -f qcow2 "se-${IMAGE_FILE}" 100G; \
 	fi
 	packer init ./qcow2/${PODVM_DISTRO}
 	if [ "${ARCH}" = "x86_64" ]; then \
 		packer plugins install github.com/hashicorp/qemu v1.1.0; \
 	fi
-	packer build ${PACKER_DEFAULT_OPTS} ${OPTS} qcow2/$(PODVM_DISTRO)
+	packer build ${PACKER_DEFAULT_OPTS} ${OPTS} qcow2/${PODVM_DISTRO}
 	rm -fr toupload
 	rm -f cloud-init.img
 

--- a/src/cloud-api-adaptor/podvm/Makefile
+++ b/src/cloud-api-adaptor/podvm/Makefile
@@ -84,6 +84,13 @@ $(IMAGE_FILE): $(BINARIES) $(FILES) setopts
 	mkdir -p toupload
 	if [ "${SE_BOOT}" = "true" ] && [ "${ARCH}" = "s390x" ]; then \
 		qemu-img create -f qcow2 "se-${IMAGE_FILE}" 100G; \
+		# Temporary workaround for installing cryptsetup on RHEL 9.4 and below s390x base images for enabling se \
+		# Due to issue: https://gitlab.com/qemu-project/qemu/-/issues/2054 \
+		# Remove this if using the latest QEMU version (v9.0.0) \
+		if [ "${PODVM_DISTRO}" = "rhel" ]; then \
+			yum install -y cryptsetup; \
+			cp /usr/sbin/cryptsetup ./files; \
+		fi \
 	fi
 	packer init ./qcow2/${PODVM_DISTRO}
 	if [ "${ARCH}" = "x86_64" ]; then \

--- a/src/cloud-api-adaptor/podvm/README.md
+++ b/src/cloud-api-adaptor/podvm/README.md
@@ -161,7 +161,7 @@ Running below command will build the Secure Execution enabled qcow2 image:
 ```bash
 $ docker build -t se_podvm_s390x \
          --build-arg ARCH=s390x \
-         --build-arg SE_BOOT=1 \
+         --build-arg SE_BOOT=true \
          --build-arg BUILDER_IMG=podvm_builder \
          --build-arg BINARIES_IMG=podvm_binaries_s390x \
          -f Dockerfile.podvm .

--- a/src/cloud-api-adaptor/podvm/qcow2/build-s390x-se-image-post.sh
+++ b/src/cloud-api-adaptor/podvm/qcow2/build-s390x-se-image-post.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "${SE_BOOT:-0}" != "1" ]; then
+if [ "${SE_BOOT:-false}" != "true" ]; then
     exit 0
 elif [ "${ARCH}" != "s390x" ]; then
     echo "Building of SE podvm image is only supported for s390x"

--- a/src/cloud-api-adaptor/podvm/qcow2/build-s390x-se-image.sh
+++ b/src/cloud-api-adaptor/podvm/qcow2/build-s390x-se-image.sh
@@ -19,6 +19,10 @@ done
 
 if [ "${PODVM_DISTRO}" = "rhel" ]; then
     export LANG=C.UTF-8
+    # Below is the tmp work-around to install cryptsetup on rhel9.4 and below s390x version base images,
+    #due to the issue : https://gitlab.com/qemu-project/qemu/-/issues/2054
+    cp /tmp/files/cryptsetup /usr/bin/cryptsetup
+    chmod +x /usr/bin/cryptsetup
     if ! command -v jq &> /dev/null || ! command -v cryptsetup &> /dev/null; then
         if ! command -v jq &> /dev/null; then
             echo >&2 "jq is required but it's not installed. Installing now..."

--- a/src/cloud-api-adaptor/podvm/qcow2/rhel/variables.pkr.hcl
+++ b/src/cloud-api-adaptor/podvm/qcow2/rhel/variables.pkr.hcl
@@ -102,3 +102,13 @@ variable "disable_cloud_config" {
   type    = string
   default = env("DISABLE_CLOUD_CONFIG")
 }
+
+variable "se_boot" {
+  type    = string
+  default = env("SE_BOOT")
+}
+
+variable "output_directory" {
+  type    = string
+  default = "output"
+}

--- a/src/cloud-api-adaptor/podvm/qcow2/ubuntu/qemu-ubuntu.pkr.hcl
+++ b/src/cloud-api-adaptor/podvm/qcow2/ubuntu/qemu-ubuntu.pkr.hcl
@@ -25,7 +25,7 @@ locals {
       ["-serial", "mon:stdio"]
     ]
   )
-  final_qemuargs = "${var.se_boot}" == "1" ? concat(local.qemuargs, local.se_qemuargs) : local.qemuargs
+  final_qemuargs = "${var.se_boot}" == "true" ? concat(local.qemuargs, local.se_qemuargs) : local.qemuargs
 }
 
 source "qemu" "ubuntu" {


### PR DESCRIPTION
This changes help build RHEL Se enabled podvm image with an extra Arg of SE_BOOT=true

Changes Made:-

Updated the build-s390x-se-image.sh script to generate SE PodVM images for both RHEL and Debian.
Used Dracut to update the initramfs on the RHEL machine, incorporating the newly created fstab, crypttab, and keys into the Dracut configuration file.
Revised the Packer configuration file (qemu-rhel.pkr.hcl) to include an additional disk for encryption purposes and to execute a script for enabling SE.
Updated the Makefile, Dockerfile.podvm.rhel, and variables.pkr.hcl to include the SE_BOOT variable option.
Also, as suggested in comments replaced all SE_BOOT=1 with SE_BOOT=true.

Temporary  fix: 

Due to issue https://gitlab.com/qemu-project/qemu/-/issues/2054, we can't install packages on RHEL s390x base machines with packer. As a temporary fix, we're downloading cryptsetup in a container and copying the binaries to the VM image.

Resulting images :- 
```
[root@hpscc02 seeluser]# podman images
REPOSITORY                                                 TAG         IMAGE ID      CREATED       SIZE
quay.io/confidential-containers/podvm-libvirt-rhel-s390x   sl-final    8368079c41af  10 hours ago  3.04 GB
<none>                                                     <none>      55398315189a  10 hours ago  14.5 GB
quay.io/confidential-containers/podvm-binaries-rhel-s390x  sl-final    da36a893ed7e  10 hours ago  396 MB
<none>                                                     <none>      84685cf5f221  10 hours ago  15.4 GB
quay.io/confidential-containers/podvm-builder-rhel         sl-final    109f2a1c4338  11 hours ago  7.1 GB
registry.access.redhat.com/ubi9/ubi                        9.4         c78647ae33b8  11 days ago   217 MB

```

se-enabled podvm qcow2 image was able to bring up workload on OCP 

```
[root@bastion-sl ~]# oc get pods -n default
NAME             READY   STATUS    RESTARTS   AGE
osc-caa-commit   1/1     Running   0          20m
[root@bastion-sl ~]# 

```

below are the logs from libvirt peerpod deamon for reference which says LaunchSecurityType: S390PV

```
2024/07/30 03:28:43 [adaptor/cloud/libvirt] LaunchSecurityType: S390PV
2024/07/30 03:28:43 [adaptor/cloud/libvirt] Checking if instance (podvm-osc-caa-commit-3c11b24d) exists
2024/07/30 03:28:43 [adaptor/cloud/libvirt] Uploaded volume key /var/lib/libvirt/images/test-se-anj-dir/podvm-osc-caa-commit-3c11b24d-root.qcow2
2024/07/30 03:28:43 [adaptor/cloud/libvirt] Create cloudInit iso
2024/07/30 03:28:43 [adaptor/cloud/libvirt] Uploading iso file: podvm-osc-caa-commit-3c11b24d-cloudinit.iso
2024/07/30 03:28:43 [adaptor/cloud/libvirt] 47104 bytes uploaded
2024/07/30 03:28:43 [adaptor/cloud/libvirt] Volume ID: /var/lib/libvirt/images/test-se-anj-dir/podvm-osc-caa-commit-3c11b24d-cloudinit.iso
2024/07/30 03:28:43 [adaptor/cloud/libvirt] Create XML for 'podvm-osc-caa-commit-3c11b24d'
2024/07/30 03:28:43 [adaptor/cloud/libvirt] Creating VM 'podvm-osc-caa-commit-3c11b24d'
2024/07/30 03:28:43 [adaptor/cloud/libvirt] Starting VM 'podvm-osc-caa-commit-3c11b24d'
2024/07/30 03:28:43 [adaptor/cloud/libvirt] VM id 1070
2024/07/30 03:29:05 [adaptor/cloud/libvirt] Instance created successfully
2024/07/30 03:29:05 [adaptor/cloud/libvirt] created an instance podvm-osc-caa-commit-3c11b24d for sandbox 3c11b24dca6d9ca7076eed23915ec8a1b15eb4b2a3d5f992b40ad2a5ec9c462c
2024/07/30 03:29:05 [util/k8sops] osc-caa-commit is now owning a PeerPod object
```

