### PR TITLE
azure: remove fed cred in e2e test cleanup

### DIFF
--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -165,6 +165,7 @@ jobs:
           KBS_IMAGE_TAG="${KBS_IMAGE_TAG}"
           AZURE_INSTANCE_SIZE="${AZURE_INSTANCE_SIZE}"
           TAGS="${{ env.TEST_TAGS }}"
+          FEDERATED_CREDENTIAL_NAME="${{ env.CLUSTER_NAME }}"
         EOF
         cat "$TEST_PROVISION_FILE"
         # assert that no variable is unset
@@ -356,4 +357,11 @@ jobs:
           --name "${{ format(env.CLUSTER_NAME_TEMPLATE, matrix.parameters.id) }}" \
           --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
           --no-wait \
+          --yes || true
+    - name: Remove federated credential
+      run: |
+        az identity federated-credential delete \
+          --identity-name "${{ secrets.AZURE_MANAGED_IDENTITY_NAME }}" \
+          --name "${{ format(env.CLUSTER_NAME_TEMPLATE, matrix.parameters.id) }}" \
+          --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
           --yes || true

--- a/src/cloud-api-adaptor/test/provisioner/azure/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/azure/provision_common.go
@@ -174,13 +174,12 @@ func (p *AzureCloudProvisioner) DeleteVPC(ctx context.Context, cfg *envconf.Conf
 func createFederatedIdentityCredential(aksOIDCIssuer string) error {
 	namespace := "confidential-containers-system"
 	serviceAccountName := "cloud-api-adaptor"
-	log.Infof("Successfully created federated identity credential %q in resource group %q", AzureProps.federatedIdentityCredentialName, AzureProps.ResourceGroupName)
 
 	if _, err := AzureProps.FederatedIdentityCredentialsClient.CreateOrUpdate(
 		context.Background(),
 		AzureProps.ResourceGroupName,
 		AzureProps.ManagedIdentityName,
-		AzureProps.federatedIdentityCredentialName,
+		AzureProps.FederatedCredentialName,
 		armmsi.FederatedIdentityCredential{
 			Properties: &armmsi.FederatedIdentityCredentialProperties{
 				Audiences: []*string{to.Ptr("api://AzureADTokenExchange")},
@@ -193,7 +192,7 @@ func createFederatedIdentityCredential(aksOIDCIssuer string) error {
 		return fmt.Errorf("creating federated identity credential: %w", err)
 	}
 
-	log.Infof("Successfully created federated identity credential %q in resource group %q", AzureProps.federatedIdentityCredentialName, AzureProps.ResourceGroupName)
+	log.Infof("Successfully created federated identity credential %q in resource group %q", AzureProps.FederatedCredentialName, AzureProps.ResourceGroupName)
 
 	return nil
 }
@@ -203,13 +202,13 @@ func deleteFederatedIdentityCredential() error {
 		context.Background(),
 		AzureProps.ResourceGroupName,
 		AzureProps.ManagedIdentityName,
-		AzureProps.federatedIdentityCredentialName,
+		AzureProps.FederatedCredentialName,
 		nil,
 	); err != nil {
 		return fmt.Errorf("deleting federated identity credential: %w", err)
 	}
 
-	log.Infof("Successfully deleted federated identity credential %q in resource group %q", AzureProps.federatedIdentityCredentialName, AzureProps.ResourceGroupName)
+	log.Infof("Successfully deleted federated identity credential %q in resource group %q", AzureProps.FederatedCredentialName, AzureProps.ResourceGroupName)
 
 	return nil
 }

--- a/src/cloud-api-adaptor/test/provisioner/azure/provision_initializer.go
+++ b/src/cloud-api-adaptor/test/provisioner/azure/provision_initializer.go
@@ -47,7 +47,7 @@ type AzureProperties struct {
 	ManagedAksClient                   *armcontainerservice.ManagedClustersClient
 	ManagedVmClient                    *armcompute.VirtualMachinesClient
 	FederatedIdentityCredentialsClient *armmsi.FederatedIdentityCredentialsClient
-	federatedIdentityCredentialName    string
+	FederatedCredentialName            string
 }
 
 var AzureProps = &AzureProperties{}
@@ -56,21 +56,22 @@ func initAzureProperties(properties map[string]string) error {
 	log.Trace("initAzureProperties()")
 
 	AzureProps = &AzureProperties{
-		SubscriptionID:      properties["AZURE_SUBSCRIPTION_ID"],
-		ClientID:            properties["AZURE_CLIENT_ID"],
-		ResourceGroupName:   properties["RESOURCE_GROUP_NAME"],
-		ClusterName:         properties["CLUSTER_NAME"],
-		Location:            properties["LOCATION"],
-		SSHKeyID:            properties["SSH_KEY_ID"],
-		ImageID:             properties["AZURE_IMAGE_ID"],
-		SubnetID:            properties["AZURE_SUBNET_ID"],
-		SshUserName:         properties["SSH_USERNAME"],
-		ManagedIdentityName: properties["MANAGED_IDENTITY_NAME"],
-		CaaImage:            properties["CAA_IMAGE"],
-		KbsImage:            properties["KBS_IMAGE"],
-		KbsImageTag:         properties["KBS_IMAGE_TAG"],
-		InstanceSize:        properties["AZURE_INSTANCE_SIZE"],
-		Tags:                properties["TAGS"],
+		SubscriptionID:          properties["AZURE_SUBSCRIPTION_ID"],
+		ClientID:                properties["AZURE_CLIENT_ID"],
+		ResourceGroupName:       properties["RESOURCE_GROUP_NAME"],
+		ClusterName:             properties["CLUSTER_NAME"],
+		Location:                properties["LOCATION"],
+		SSHKeyID:                properties["SSH_KEY_ID"],
+		ImageID:                 properties["AZURE_IMAGE_ID"],
+		SubnetID:                properties["AZURE_SUBNET_ID"],
+		SshUserName:             properties["SSH_USERNAME"],
+		ManagedIdentityName:     properties["MANAGED_IDENTITY_NAME"],
+		CaaImage:                properties["CAA_IMAGE"],
+		KbsImage:                properties["KBS_IMAGE"],
+		KbsImageTag:             properties["KBS_IMAGE_TAG"],
+		InstanceSize:            properties["AZURE_INSTANCE_SIZE"],
+		Tags:                    properties["TAGS"],
+		FederatedCredentialName: properties["FEDERATED_CREDENTIAL_NAME"],
 	}
 
 	CIManagedStr := properties["IS_CI_MANAGED_CLUSTER"]
@@ -119,7 +120,9 @@ func initAzureProperties(properties map[string]string) error {
 		return fmt.Errorf("initializing managed clients: %w", err)
 	}
 
-	AzureProps.federatedIdentityCredentialName = fmt.Sprintf("%sFederatedIdentityCredential", AzureProps.ClusterName)
+	if AzureProps.FederatedCredentialName == "" {
+		AzureProps.FederatedCredentialName = fmt.Sprintf("%sFederatedIdentityCredential", AzureProps.ClusterName)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Added option to specify a federated credential name so we can remove it together with other resources (outside of the deprovisioner).