### PR TITLE
Kata 3.7.0 release bump

### DIFF
--- a/src/cloud-api-adaptor/go.mod
+++ b/src/cloud-api-adaptor/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/coreos/go-iptables v0.6.0
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0
-	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240617195946-7df221a8f968
+	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240717205640-6aff5f300a98
 	github.com/opencontainers/runtime-spec v1.1.1-0.20230922153023-c0e90434df2a
 	github.com/stretchr/testify v1.9.0
 	github.com/vishvananda/netlink v1.2.1-beta.2

--- a/src/cloud-api-adaptor/go.sum
+++ b/src/cloud-api-adaptor/go.sum
@@ -367,8 +367,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240617195946-7df221a8f968 h1:SR1rJt+026XbUlkjw4SbQvE7eL1S1fSC3EqdxBTl7D8=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240617195946-7df221a8f968/go.mod h1:E4YBwwlTgi4TmfBfGDbMRhVaD6iHRaMLM7v8g1reHT8=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240717205640-6aff5f300a98 h1:fejtO8zU3QZq8eEl4i1Vuc1gizjjL5jDhzPV1xqXxgk=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240717205640-6aff5f300a98/go.mod h1:E4YBwwlTgi4TmfBfGDbMRhVaD6iHRaMLM7v8g1reHT8=
 github.com/kdomanski/iso9660 v0.4.0 h1:BPKKdcINz3m0MdjIMwS0wx1nofsOjxOq8TOr45WGHFg=
 github.com/kdomanski/iso9660 v0.4.0/go.mod h1:OxUSupHsO9ceI8lBLPJKWBTphLemjrCQY8LPXM7qSzU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -21,7 +21,7 @@ cloudimg:
 tools:
   bats: 1.10.0
   golang: 1.21.12
-  rust: 1.74.0
+  rust: 1.75.0
   protoc: 3.15.0
   packer: v1.9.4
   kcli: 99.0.202407031308
@@ -32,10 +32,10 @@ git:
     reference: main
   guest-components:
     url: https://github.com/confidential-containers/guest-components
-    reference: df60725afe0ba452a25a740cf460c2855442c49a
+    reference: v0.9.0
   kata-containers:
     url: https://github.com/kata-containers/kata-containers
-    reference: 3.6.0
+    reference: 3.7.0
   umoci:
     url: https://github.com/opencontainers/umoci
     reference: v0.4.7
@@ -44,11 +44,11 @@ git:
     reference: v1.5.0
   kbs:
     url: https://github.com/confidential-containers/trustee
-    reference: dc01f454264fb4350e5f69eba05683a9a1882c41
+    reference: e890fc90c384207668fa3a4d6a2f2a2d652797ee
 oci:
   pause:
     registry: docker://registry.k8s.io/pause
-    tag: 3.6
+    tag: 3.9
   kbs:
     registry: ghcr.io/confidential-containers/staged-images/kbs
-    tag: dc01f454264fb4350e5f69eba05683a9a1882c41
+    tag: e890fc90c384207668fa3a4d6a2f2a2d652797ee

--- a/src/csi-wrapper/go.mod
+++ b/src/csi-wrapper/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang/glog v1.1.2
 	github.com/golang/protobuf v1.5.4
-	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240617195946-7df221a8f968
+	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240717205640-6aff5f300a98
 	golang.org/x/net v0.26.0
 	google.golang.org/grpc v1.61.2
 	k8s.io/apimachinery v0.26.2

--- a/src/csi-wrapper/go.sum
+++ b/src/csi-wrapper/go.sum
@@ -70,8 +70,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240617195946-7df221a8f968 h1:SR1rJt+026XbUlkjw4SbQvE7eL1S1fSC3EqdxBTl7D8=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240617195946-7df221a8f968/go.mod h1:E4YBwwlTgi4TmfBfGDbMRhVaD6iHRaMLM7v8g1reHT8=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240717205640-6aff5f300a98 h1:fejtO8zU3QZq8eEl4i1Vuc1gizjjL5jDhzPV1xqXxgk=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240717205640-6aff5f300a98/go.mod h1:E4YBwwlTgi4TmfBfGDbMRhVaD6iHRaMLM7v8g1reHT8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=


### PR DESCRIPTION
- Bump the kata-runtime go module to the 3.7.0 version in the csi-wrapper and cloud-api-adaptor modules
- Bump dependencies to match the versions used in the [Kata 3.7.0 release](https://github.com/kata-containers/kata-containers/blob/3.7.0/versions.yaml) to minimise the chances of incompatibilities and unstable code