### PR TITLE
workflow: Install packages for KBS client

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -98,6 +98,8 @@ jobs:
 
       - name: Checkout kbs Repository and build kbs-client
         run: |
+          sudo apt-get update -y
+          sudo apt-get install -y build-essential pkg-config libssl-dev
           git clone "${KBS_REPO}" test/trustee
           pushd test/trustee
           git checkout "${KBS_VERSION}"


### PR DESCRIPTION
- The new version of the KBS client is failing the build in https://github.com/confidential-containers/cloud-api-adaptor/pull/1929
```
The file `openssl.pc` needs to be installed and the
PKG_CONFIG_PATH environment variable must contain its parent directory.
```
so install packages to get it building