### PR TITLE
workflow: Add auth test secrets

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -112,6 +112,9 @@ jobs:
 
       - name: run tests
         id: runTests
+        env:
+          AUTHENTICATED_REGISTRY_IMAGE: ${{ vars.AUTHENTICATED_REGISTRY_IMAGE }}
+          REGISTRY_CREDENTIAL_ENCODED: ${{ secrets.REGISTRY_CREDENTIAL_ENCODED }}
         run: |
           export CLOUD_PROVIDER=libvirt
           export DEPLOY_KBS=true

--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -171,3 +171,4 @@ jobs:
       podvm_image: ${{ inputs.registry }}/podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ matrix.arch }}:${{ inputs.podvm_image_tag }}
       install_directory_artifact: install_directory
       git_ref: ${{ inputs.git_ref }}
+    secrets: inherit


### PR DESCRIPTION
Set the `AUTHENTICATED_REGISTRY_IMAGE` and
`REGISTRY_CREDENTIAL_ENCODED` secrets as environment variables in preparation for adding libvirt auth registry tests