### PR TITLE
auth: allow specifying auth.json for guest-pull

### DIFF
--- a/src/cloud-api-adaptor/cmd/process-user-data/main.go
+++ b/src/cloud-api-adaptor/cmd/process-user-data/main.go
@@ -8,6 +8,7 @@ import (
 
 	cmdUtil "github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/cmd"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/aa"
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/agent"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/cdh"
 	daemon "github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/forwarder"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/userdata"
@@ -19,7 +20,8 @@ const (
 	providerAzure = "azure"
 	providerAws   = "aws"
 
-	defaultAuthJsonPath = "/run/peerpod/auth.json"
+	defaultAuthJsonPath    = "/run/peerpod/auth.json"
+	defaultAgentConfigPath = "/run/peerpod/agent-config.toml"
 )
 
 var versionFlag bool
@@ -36,19 +38,20 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	var aaConfigPath, cdhConfigPath, daemonConfigPath string
+	var aaConfigPath, agentConfigPath, cdhConfigPath, daemonConfigPath string
 	var fetchTimeout int
 
 	rootCmd.PersistentFlags().BoolVarP(&versionFlag, "version", "v", false, "Print the version")
 	rootCmd.PersistentFlags().StringVarP(&daemonConfigPath, "daemon-config-path", "d", daemon.DefaultConfigPath, "Path to a daemon config file")
 	rootCmd.PersistentFlags().StringVarP(&aaConfigPath, "aa-config-path", "a", aa.DefaultAaConfigPath, "Path to a AA config file")
+	rootCmd.PersistentFlags().StringVarP(&agentConfigPath, "agent-config-path", "k", agent.ConfigFilePath, "Path to a kata agent config file")
 	rootCmd.PersistentFlags().StringVarP(&cdhConfigPath, "cdh-config-path", "c", cdh.ConfigFilePath, "Path to a CDH config file")
 
 	var provisionFilesCmd = &cobra.Command{
 		Use:   "provision-files",
 		Short: "Provision required files based on user data",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			cfg := userdata.NewConfig(aaConfigPath, defaultAuthJsonPath, daemonConfigPath, cdhConfigPath, fetchTimeout)
+			cfg := userdata.NewConfig(aaConfigPath, agentConfigPath, defaultAuthJsonPath, daemonConfigPath, cdhConfigPath, fetchTimeout)
 			return userdata.ProvisionFiles(cfg)
 		},
 		SilenceUsage: true, // Silence usage on error

--- a/src/cloud-api-adaptor/docs/registries-authentication.md
+++ b/src/cloud-api-adaptor/docs/registries-authentication.md
@@ -1,35 +1,14 @@
-## Container Image Registries Authentication
+# Container Image Registries Authentication
 
 To authenticate with private container image registry you are required to provide
-[registry authentication file](https://github.com/containers/image/blob/main/docs/containers-auth.json.5.md) to your podvm in order
-to allow the image to be pulled directly.
+[registry authentication file](https://github.com/containers/image/blob/main/docs/containers-auth.json.5.md) to your podvm in order to allow the image to be pulled directly.
 
-Registry authentication file can be provided either statically or at runtime.
+## Pull Secrets on the Worker Node
 
-### Understanding workflow
+Even though in the current CoCo configuration the images are being pulled on the pod, the pod spec still needs to have the pull secret defined. This is because metadata of an OCI image is still being accessed on the worker node, even if kata-agent pulls an image in the podvm. Please refer to the kubernetes docs to learn more about [pull secrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod).
 
-- For pulling images from authenticated registries you need the [**attestation-agent**](https://github.com/confidential-containers/guest-components/tree/main/attestation-agent) in the podvm. The role of the attestation-agent is to provide the registry credentials to the `kata-agent`. The podvm image that you are using should be built with `AA_KBC="offline_fs_kbc`. This ensures that [agent-config.toml](../podvm/files/etc/agent-config.toml) in podVM should have `aa_kbc_params = "offline_fs_kbc::null"` set.
-- The registry credentials also need to be available in a file inside the Pod VM image. The config `aa_kbc_params = "offline_fs_kbc::null` tells the attestation-agent to retrieve secrets from the **local filesystem**. The registry credentials are embedded in a resources file on a fixed path on the local filesystem: `/etc/aa-offline_fs_kbc-resources.json`.
+## Deploy auth.json along with cloud-api-adaptor deployment
 
-### Statically embed authentication file in podvm image
-
-- `cd ~/cloud-api-adaptor/podvm/files/etc`
-- Base64 your [auth.json](https://github.com/containers/image/blob/main/docs/containers-auth.json.5.md), this can be done by doing `cat auth.json | base64 -w 0`
-- Export the base64 encoded file `export AUTHFILE=<base64-encoded-auth.json>`
-- Create and Add the base64 encoded auth file into the `aa-offline_fs_kbc-resources.json` like so:
-```
-cat <<EOF | tee aa-offline_fs_kbc-resources.json
-{
-  "default/credential/test": "${AUTHFILE}"
-}
-EOF
-```
-- **Important:** Make sure to build image with `AA_KBC="offline_fs_kbc" make image`.
-
-### Deploy authentication file along with cloud-api-adaptor deployment
-
-- The cloud-api-adaptor (CAA) provides the secret to the local fs in the podvm image by attaching it. This secret is converted and copied using `cloud-init` to `/etc/aa-offline_fs_kbc-resources.json` on the podvm.
-- CAA gets the secret from the auth-json-secret secret that is mounted inside the CAA pod using `install/overlays/$(CLOUD_PROVIDER)/kustomization.yaml`.
-- **Important:** Make sure to build image with `AA_KBC="offline_fs_kbc" make image`.
-- Make sure you set [auth.json](https://github.com/containers/image/blob/main/docs/containers-auth.json.5.md) file for the `auth-json-secret`
-when you configure `install/overlays/$(CLOUD_PROVIDER)/kustomization.yaml` prior to `make deploy`
+- CAA receives a registry auth file from the `auth-json-secret` secret that is mounted in the CAA pod using `install/overlays/$(CLOUD_PROVIDER)/kustomization.yaml`.
+- Make sure you do set a valid [auth.json](https://github.com/containers/image/blob/main/docs/containers-auth.json.5.md) as an entry for `auth-json-secret` when you configure `install/overlays/$(CLOUD_PROVIDER)/kustomization.yaml` prior to `make deploy`
+- If CAA encounters an auth.json file, it will configure kata-agent to use it.

--- a/src/cloud-api-adaptor/ibmcloud-powervs/image/copy-files.sh
+++ b/src/cloud-api-adaptor/ibmcloud-powervs/image/copy-files.sh
@@ -6,7 +6,6 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
 PODVM_DIR=${REPO_ROOT}/podvm
 
 sudo mkdir -p /etc/containers
-sudo cp ${PODVM_DIR}/files/etc/agent-config.toml /etc/agent-config.toml
 sudo cp /tmp/files/etc/aa-offline_fs_kbc-keys.json /etc/aa-offline_fs_kbc-keys.json
 
 if [ -n "${FORWARDER_PORT}" ]; then

--- a/src/cloud-api-adaptor/pkg/agent/config.go
+++ b/src/cloud-api-adaptor/pkg/agent/config.go
@@ -1,0 +1,36 @@
+package agent
+
+import (
+	"github.com/pelletier/go-toml/v2"
+)
+
+const (
+	ConfigFilePath       = "/run/peerpod/agent-config.toml"
+	ServerAddr           = "unix:///run/kata-containers/agent.sock"
+	GuestComponentsProcs = "none"
+)
+
+type agentConfig struct {
+	ServerAddr           string `toml:"server_addr"`
+	GuestComponentsProcs string `toml:"guest_components_procs"`
+	ImageRegistryAuth    string `toml:"image_registry_auth,omitempty"`
+}
+
+func CreateConfigFile(authJsonPath string) (string, error) {
+	var imageRegistryAuth string
+	if authJsonPath != "" {
+		imageRegistryAuth = "file://" + authJsonPath
+	}
+
+	config := agentConfig{
+		ServerAddr:           ServerAddr,
+		GuestComponentsProcs: GuestComponentsProcs,
+		ImageRegistryAuth:    imageRegistryAuth,
+	}
+
+	bytes, err := toml.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}

--- a/src/cloud-api-adaptor/pkg/agent/config_test.go
+++ b/src/cloud-api-adaptor/pkg/agent/config_test.go
@@ -1,0 +1,59 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+func TestAgentConfigFile(t *testing.T) {
+	refdoc := `server_addr = 'unix:///run/kata-containers/agent.sock'
+guest_components_procs = 'none'
+`
+	var refcfg agentConfig
+	err := toml.Unmarshal([]byte(refdoc), &refcfg)
+	if err != nil {
+		panic(err)
+	}
+
+	if refcfg.ServerAddr != ServerAddr {
+		t.Errorf("Expected %s, got %s", ServerAddr, refcfg.ServerAddr)
+	}
+	if refcfg.GuestComponentsProcs != GuestComponentsProcs {
+		t.Errorf("Expected %s, got %s", GuestComponentsProcs, refcfg.GuestComponentsProcs)
+	}
+
+	configstr, err := CreateConfigFile("")
+	if err != nil {
+		panic(err)
+	}
+	if refdoc != string(configstr) {
+		t.Errorf("Expected %s, got %s", refdoc, configstr)
+	}
+}
+
+func TestAgentConfigFileWithAuthJsonFile(t *testing.T) {
+	refdoc := `server_addr = 'unix:///run/kata-containers/agent.sock'
+guest_components_procs = 'none'
+image_registry_auth = 'file:///run/peerpod/auth.json'
+`
+	authJsonFile := "/run/peerpod/auth.json"
+
+	configstr, err := CreateConfigFile(authJsonFile)
+	if err != nil {
+		panic(err)
+	}
+	if refdoc != string(configstr) {
+		t.Errorf("Expected %s, got %s", refdoc, configstr)
+	}
+
+	var config agentConfig
+	err = toml.Unmarshal([]byte(configstr), &config)
+	if err != nil {
+		panic(err)
+	}
+
+	if config.ImageRegistryAuth != "file://"+authJsonFile {
+		t.Errorf("Expected %s, got %s", config.ImageRegistryAuth, authJsonFile)
+	}
+}

--- a/src/cloud-api-adaptor/pkg/userdata/provision.go
+++ b/src/cloud-api-adaptor/pkg/userdata/provision.go
@@ -24,6 +24,7 @@ type paths struct {
 	authJson     string
 	cdhConfig    string
 	daemonConfig string
+	agentConfig  string
 }
 
 type Config struct {
@@ -31,8 +32,8 @@ type Config struct {
 	paths        paths
 }
 
-func NewConfig(aaConfigPath, authJsonPath, daemonConfigPath, cdhConfig string, fetchTimeout int) *Config {
-	cfgPaths := paths{aaConfigPath, authJsonPath, cdhConfig, daemonConfigPath}
+func NewConfig(aaConfigPath, agentConfig, authJsonPath, daemonConfigPath, cdhConfig string, fetchTimeout int) *Config {
+	cfgPaths := paths{aaConfigPath, agentConfig, authJsonPath, cdhConfig, daemonConfigPath}
 	return &Config{fetchTimeout, cfgPaths}
 }
 
@@ -176,7 +177,15 @@ func writeFile(path string, bytes []byte) error {
 }
 
 func processCloudConfig(cfg *Config, cc *CloudConfig) error {
-	bytes := findConfigEntry(cfg.paths.daemonConfig, cc)
+	bytes := findConfigEntry(cfg.paths.agentConfig, cc)
+	if bytes == nil {
+		return fmt.Errorf("failed to find agent config entry in cloud config")
+	}
+	if err := writeFile(cfg.paths.agentConfig, bytes); err != nil {
+		return fmt.Errorf("failed to write daemon config file: %w", err)
+	}
+
+	bytes = findConfigEntry(cfg.paths.daemonConfig, cc)
 	if bytes == nil {
 		return fmt.Errorf("failed to find daemon config entry in cloud config")
 	}

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system/kata-agent.service.d/10-override.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system/kata-agent.service.d/10-override.conf
@@ -1,8 +1,0 @@
-# On a read-only fs the kata-agent config is created in /run/peerpod, since it contains
-# a parameter that can be set at pod creation time.
-[Service]
-Environment=KATA_AGENT_CONFIG_PATH=/run/peerpod/agent-config.toml
-ExecStart=
-ExecStart=/usr/local/bin/kata-agent --config ${KATA_AGENT_CONFIG_PATH}
-ExecStop=
-ExecStopPost=/usr/local/bin/kata-agent-clean --config ${KATA_AGENT_CONFIG_PATH}

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/tmpfiles.d/peerpods.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/tmpfiles.d/peerpods.conf
@@ -1,2 +1,0 @@
-#Type   Path                            Mode User Group Age     Argument
-C       /run/peerpod/agent-config.toml   -    -    -     -       /etc/agent-config.toml

--- a/src/cloud-api-adaptor/podvm/files/etc/agent-config.toml
+++ b/src/cloud-api-adaptor/podvm/files/etc/agent-config.toml
@@ -1,3 +1,0 @@
-server_addr = "unix:///run/kata-containers/agent.sock"
-# prevent the agent from launching coco guest-components
-guest_components_procs = "none"

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/kata-agent.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/kata-agent.service
@@ -1,14 +1,14 @@
 [Unit]
 Description=Kata Agent
 BindsTo=netns@podns.service
-Wants=process-user-data.service
-After=netns@podns.service process-user-data.service
+Wants=process-user-data.service attestation-agent.service
+After=netns@podns.service process-user-data.service attestation-agent.service
 
 [Service]
 ExecStartPre=mkdir -p /run/kata-containers
-ExecStart=/usr/local/bin/kata-agent --config /etc/agent-config.toml
+ExecStart=/usr/local/bin/kata-agent --config /run/peerpod/agent-config.toml
 ExecStartPre=-umount /sys/fs/cgroup/misc
-ExecStopPost=/usr/local/bin/kata-agent-clean --config /etc/agent-config.toml
+ExecStopPost=/usr/local/bin/kata-agent-clean --config /run/peerpod/agent-config.toml
 SyslogIdentifier=kata-agent
 
 [Install]

--- a/src/cloud-api-adaptor/podvm/qcow2/copy-files.sh
+++ b/src/cloud-api-adaptor/podvm/qcow2/copy-files.sh
@@ -3,7 +3,6 @@
 # the correct location on the podvm image
 
 sudo mkdir -p /etc/containers
-sudo cp /tmp/files/etc/agent-config.toml /etc/agent-config.toml
 sudo cp /tmp/files/etc/aa-offline_fs_kbc-keys.json /etc/aa-offline_fs_kbc-keys.json
 sudo cp -a /tmp/files/etc/containers/* /etc/containers/
 sudo cp -a /tmp/files/etc/systemd/* /etc/systemd/

--- a/src/cloud-providers/util/cloudinit/cloudconfig.go
+++ b/src/cloud-providers/util/cloudinit/cloudconfig.go
@@ -12,10 +12,6 @@ import (
 )
 
 const (
-	DefaultAuthfileSrcPath = "/root/containers/auth.json"
-
-	// Location of the container registry auth json file
-	DefaultAuthfileDstPath = "/etc/attestation-agent/auth.json"
 	DefaultAuthfileLimit   = 12288 // TODO: use a whole userdata limit mechanism instead of limiting authfile
 	DefaultAAKBCParamsPath = "/etc/attestation-agent/kbc-params.json"
 )

--- a/src/cloud-providers/util/cloudinit/cloudconfig_test.go
+++ b/src/cloud-providers/util/cloudinit/cloudconfig_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 const forwarderConfigPath = "/peerpod/daemon.json"
+const authJSONPath = "/run/peerpod/auth.json"
 
 func TestUserData(t *testing.T) {
 	cloudConfig := &CloudConfig{
@@ -92,7 +93,7 @@ func TestUserDataWithDaemonAndAuth(t *testing.T) {
 	cloudConfig := &CloudConfig{
 		WriteFiles: []WriteFile{
 			{Path: forwarderConfigPath, Content: string(testDaemonConfigJson)},
-			{Path: DefaultAuthfileDstPath, Content: testResourcesJson},
+			{Path: authJSONPath, Content: testResourcesJson},
 		},
 	}
 
@@ -111,8 +112,8 @@ func TestUserDataWithDaemonAndAuth(t *testing.T) {
 		t.Fatalf("Expect %q, got %q", forwarderConfigPath, userData)
 	}
 
-	if !strings.Contains(userData, DefaultAuthfileDstPath) {
-		t.Fatalf("Expect %q, got %q", DefaultAuthfileDstPath, userData)
+	if !strings.Contains(userData, authJSONPath) {
+		t.Fatalf("Expect %q, got %q", authJSONPath, userData)
 	}
 
 	var output CloudConfig
@@ -185,7 +186,7 @@ func TestUserDataWithDaemonAndAuthAndAAKBCParams(t *testing.T) {
 	cloudConfig := &CloudConfig{
 		WriteFiles: []WriteFile{
 			{Path: forwarderConfigPath, Content: string(testDaemonConfigJson)},
-			{Path: DefaultAuthfileDstPath, Content: testResourcesJson},
+			{Path: authJSONPath, Content: testResourcesJson},
 		},
 	}
 
@@ -204,8 +205,8 @@ func TestUserDataWithDaemonAndAuthAndAAKBCParams(t *testing.T) {
 		t.Fatalf("Expect %q, got %q", forwarderConfigPath, userData)
 	}
 
-	if !strings.Contains(userData, DefaultAuthfileDstPath) {
-		t.Fatalf("Expect %q, got %q", DefaultAuthfileDstPath, userData)
+	if !strings.Contains(userData, authJSONPath) {
+		t.Fatalf("Expect %q, got %q", authJSONPath, userData)
 	}
 
 	var output CloudConfig


### PR DESCRIPTION
Kata introduced a flag to specify `image-registry-auth` which we can in guest pull. Since our agent-configuration is mostly static and we want to avoid brittle templating we provision the full kata-agent config from the CAA application like other config files.

If an auth secret is present in a CAA deployment, CAA will embed it in the agent config and provision it to the guest. The static agent-configuration has been removed and the configuration is pointing to `/run/peerpod/agent-config.toml` now, since it is a resource that changes at runtime.