### PR TITLE
process-user-data: Fix the assignment of config filenames

### DIFF
--- a/src/cloud-api-adaptor/pkg/userdata/provision.go
+++ b/src/cloud-api-adaptor/pkg/userdata/provision.go
@@ -33,7 +33,8 @@ type Config struct {
 }
 
 func NewConfig(aaConfigPath, agentConfig, authJsonPath, daemonConfigPath, cdhConfig string, fetchTimeout int) *Config {
-	cfgPaths := paths{aaConfigPath, agentConfig, authJsonPath, cdhConfig, daemonConfigPath}
+	cfgPaths := paths{aaConfig: aaConfigPath, agentConfig: agentConfig, authJson: authJsonPath,
+		cdhConfig: cdhConfig, daemonConfig: daemonConfigPath}
 	return &Config{fetchTimeout, cfgPaths}
 }
 


### PR DESCRIPTION
The config files were incorrectly assigned resulting in agent-config.toml not being created.