### PR TITLE
IBMCloud-Powervs docs and pre-req update

### DIFF
--- a/src/cloud-api-adaptor/ibmcloud-powervs/README.md
+++ b/src/cloud-api-adaptor/ibmcloud-powervs/README.md
@@ -30,31 +30,36 @@ pvsadm image qcow2ova --prep-template-default > image-prep.template
 
 Add the following snippet to `image-prep.template`
 ```
-yum install -y gcc gcc-c++ git make
-git clone -b main https://github.com/kata-containers/kata-containers.git
+yum install -y gcc gcc-c++ git make wget perl
+wget https://github.com/mikefarah/yq/releases/download/v4.42.1/yq_linux_ppc64le
+chmod +x yq_linux_ppc64le && mv yq_linux_ppc64le /usr/local/bin/yq
 git clone https://github.com/confidential-containers/cloud-api-adaptor.git
-cd cloud-api-adaptor/ibmcloud-powervs/image
+cd cloud-api-adaptor/src/cloud-api-adaptor/ibmcloud-powervs/image
 make build
 ```
 
 > NOTE:
 > 1. If you intend to use DHCP network type for creating peer pod VMs with
-> PowerVS provider, you need to additionally add this to `image-prep.template`
+> PowerVS provider, you need to additionally add this to `image-prep.template` and setup a DHCP server.
 > ```
 > mkdir -p /etc/cloud/cloud.cfg.d
 > cat <<EOF >> /etc/cloud/cloud.cfg.d/99-custom-networking.cfg
 > network: {config: disabled}
 > EOF
 > ```
-> 2. To use a specific port or address for agent-protocol-forwarder, pass `FORWARDER_PORT=<port-number>` to the `make` command.
+> 2. Setup a DHCP server using pvsadm
+> ```
+> pvsadm dhcpserver create --workspace-id <workspace-id> -k  <api-key>
+> ```
+> 3. To use a specific port or address for agent-protocol-forwarder, pass `FORWARDER_PORT=<port-number>` to the `make` command.
 
 2. Download the qcow2 image and converts into ova type
 ```
-pvsadm image qcow2ova --image-name <name> --image-dist centos --image-url https://cloud.centos.org/centos/8-stream/ppc64le/images/CentOS-Stream-GenericCloud-8-latest.ppc64le.qcow2 --prep-template image-prep.template
+pvsadm image qcow2ova --image-name <name> --image-dist centos --image-url https://cloud.centos.org/centos/9-stream/ppc64le/images/CentOS-Stream-GenericCloud-9-latest.ppc64le.qcow2 --prep-template image-prep.template --image-size 20
 ```
 
 
-> Qcow2 CentOS images for ppc64le can be found [here](https://cloud.centos.org/centos/8-stream/ppc64le/images/)
+> Qcow2 CentOS images for ppc64le can be found [here](https://cloud.centos.org/centos/9-stream/ppc64le/images/)
 
 ## Import image to PowerVS
 

--- a/src/cloud-api-adaptor/ibmcloud-powervs/image/prereq.sh
+++ b/src/cloud-api-adaptor/ibmcloud-powervs/image/prereq.sh
@@ -3,10 +3,15 @@
 # FIXME to pickup these values from versions.yaml
 GO_VERSION="1.21.12"
 RUST_VERSION="1.75.0"
-SKOPEO_VERSION="1.5.0"
 
 # Install dependencies
-yum install -y curl protobuf-compiler libseccomp-devel openssl openssl-devel perl skopeo-${SKOPEO_VERSION}
+yum install -y curl libseccomp-devel openssl openssl-devel skopeo clang clang-devel
+
+wget https://rpmfind.net/linux/centos-stream/9-stream/CRB/ppc64le/os/Packages/protobuf-compiler-3.14.0-13.el9.ppc64le.rpm
+yum install -y protobuf-compiler-3.14.0-13.el9.ppc64le.rpm
+
+wget https://www.rpmfind.net/linux/centos-stream/9-stream/CRB/ppc64le/os/Packages/device-mapper-devel-1.02.197-2.el9.ppc64le.rpm
+yum install -y device-mapper-devel-1.02.197-2.el9.ppc64le.rpm
 
 # Install Golang
 curl https://dl.google.com/go/go${GO_VERSION}.linux-ppc64le.tar.gz -o go${GO_VERSION}.linux-ppc64le.tar.gz && \


### PR DESCRIPTION
Changes:
1. Moving from centos 8-stream to centos 9-stream for qcow2ova image.
2. Adding additional steps to setup a DHCP server
3. Updating pre-req.sh for installing additional packages `protobuf-compiler` and `device-mapper-devel`