### PR TITLE
e2e: improve test cases for ibmcloud provider

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/assessment_runner.go
+++ b/src/cloud-api-adaptor/test/e2e/assessment_runner.go
@@ -422,7 +422,7 @@ func (tc *TestCase) Run() {
 					tc.assert.HasPodVM(t, tc.pod.Name)
 				}
 
-				if tc.podState != v1.PodRunning {
+				if tc.podState != v1.PodRunning && tc.podState != v1.PodSucceeded {
 					profile, error := tc.assert.GetInstanceType(t, tc.pod.Name)
 					if error != nil {
 						if error.Error() == "Failed to Create PodVM Instance" {

--- a/src/cloud-api-adaptor/test/e2e/common_suite.go
+++ b/src/cloud-api-adaptor/test/e2e/common_suite.go
@@ -211,7 +211,12 @@ func DoTestCreatePeerPodAndCheckEnvVariableLogsWithImageAndDeployment(t *testing
 func DoTestCreatePeerPodWithLargeImage(t *testing.T, e env.Environment, assert CloudAssert) {
 	podName := "largeimage-pod"
 	imageName := "quay.io/confidential-containers/test-images:largeimage"
-	pod := NewPod(E2eNamespace, podName, podName, imageName, WithRestartPolicy(v1.RestartPolicyOnFailure))
+	// Need more timeout to pull large image data
+	timeout := "300"
+	annotationData := map[string]string{
+		"io.katacontainers.config.runtime.create_container_timeout": timeout,
+	}
+	pod := NewPod(E2eNamespace, podName, podName, imageName, WithRestartPolicy(v1.RestartPolicyOnFailure), WithAnnotations(annotationData))
 	NewTestCase(t, e, "LargeImagePeerPod", assert, "Peer pod with Large Image has been created").WithPod(pod).WithPodWatcher().Run()
 }
 

--- a/src/cloud-api-adaptor/test/e2e/ibmcloud_test.go
+++ b/src/cloud-api-adaptor/test/e2e/ibmcloud_test.go
@@ -30,7 +30,7 @@ func TestCaaDaemonsetRollingUpdate(t *testing.T) {
 		}
 		DoTestCaaDaemonsetRollingUpdate(t, testEnv, &assert)
 	} else {
-		log.Infof("Ignore CAA DaemonSet upgrade  test")
+		t.Skip("Ignore CAA DaemonSet upgrade  test")
 	}
 }
 
@@ -44,7 +44,7 @@ func TestCreateConfidentialPod(t *testing.T) {
 		testCommands := CreateConfidentialPodCheckIBMSECommands()
 		DoTestCreateConfidentialPod(t, testEnv, assert, testCommands)
 	} else {
-		log.Infof("Ignore SE test for simple pod")
+		t.Skip("Ignore SE test for simple pod")
 	}
 
 }
@@ -139,7 +139,7 @@ func TestCreatePeerPodWithPVC(t *testing.T) {
 		myPodwithPVC := NewPodWithPVCFromIBMVPCBlockDriver(nameSpace, podName, containerName, imageName, csiContainerName, csiImageName, WithPVCBinding(mountPath, pvcName))
 		DoTestCreatePeerPodWithPVCAndCSIWrapper(t, testEnv, assert, myPVC, myPodwithPVC, mountPath)
 	} else {
-		log.Infof("Ignore PeerPod with PVC (CSI wrapper) test")
+		t.Skip("Ignore PeerPod with PVC (CSI wrapper) test")
 	}
 }
 


### PR DESCRIPTION
- Skip fail reason check for Completed pod. Refer to issue: https://github.com/confidential-containers/cloud-api-adaptor/issues/1938

- Set more timeout to recreate container by annotation. The default timeout 60 sec is too short to pull large image data

- Use `t.Skip` instead of `log.Infof` for skip cases