### PR TITLE
ci: Enable exhaustruct linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -227,6 +227,7 @@ linters:
     - unused
     # Additional linters.
     - gofmt
+    - exhaustruct
 
   # Enable all available linters.
   # Default: false


### PR DESCRIPTION
exhaustruct "Checks if all structure fields are initialized". This should help us avoid issues with the order of fields in structures going wrong which has happened a couple of times.