### PR TITLE
podvm-mkosi: Add support for Debian and Fedora variants

### DIFF
--- a/src/cloud-api-adaptor/podvm-mkosi/Makefile
+++ b/src/cloud-api-adaptor/podvm-mkosi/Makefile
@@ -4,6 +4,7 @@ ATTESTER  ?= none
 ARCH      ?= $(subst x86_64,amd64,$(shell uname -m))
 BUILDER   = fedora-binaries-builder-$(ARCH)
 SEDEBUG   ?= false
+IS_DEBIAN := $(shell if grep -q 'ID_LIKE=debian' /etc/os-release; then echo "true"; else echo "false"; fi)
 
 REGISTRY ?= quay.io/confidential-containers
 PODVM_DISTRO ?= fedora
@@ -46,6 +47,9 @@ binaries:
 	@echo "Building binaries..."
 	rm -rf ./resources/binaries-tree
 	cp -rf ../../../.git ../../.git
+ifeq ($(IS_DEBIAN),true)
+	docker buildx use default
+endif
 	docker buildx build \
 		--build-arg BUILDER_IMG=$(BUILDER) \
 		--build-arg ATTESTER=$(ATTESTER) \


### PR DESCRIPTION
Since #1923 was merged, the CI job using podvm_mkosi_image.yaml has been failing.

It turns out `docker buildx use default` needs to be run in the GHA environment where the Ubuntu self-hosted runner is running.

This PR adds support for both Debian and Fedora variants.

Fixes: #1949

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>