### PR TITLE
readme: add fossa badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fconfidential-containers%2Fcloud-api-adaptor.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fconfidential-containers%2Fcloud-api-adaptor?ref=badge_shield&issueType=license)
+
 [![daily e2e tests for libvirt](https://github.com/confidential-containers/cloud-api-adaptor/actions/workflows/daily-e2e-tests-libvirt.yaml/badge.svg)](https://github.com/confidential-containers/cloud-api-adaptor/actions/workflows/daily-e2e-tests-libvirt.yaml)
 
 [![daily e2e tests for azure](https://github.com/confidential-containers/cloud-api-adaptor/actions/workflows/azure-e2e-test.yml/badge.svg)](https://github.com/confidential-containers/cloud-api-adaptor/actions/workflows/azure-e2e-test.yml)


### PR DESCRIPTION
fossa license issues are resolved, we can have a badge now.