### PR TITLE
kata-agent: set ocicrypt environment variable

### DIFF
--- a/src/cloud-api-adaptor/podvm/files/etc/ocicrypt_config.json
+++ b/src/cloud-api-adaptor/podvm/files/etc/ocicrypt_config.json
@@ -1,0 +1,7 @@
+{
+	"key-providers": {
+		"attestation-agent": {
+			"ttrpc": "unix:///run/confidential-containers/cdh.sock"
+		}
+	}
+}

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/kata-agent.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/kata-agent.service
@@ -5,6 +5,7 @@ Wants=process-user-data.service attestation-agent.service
 After=netns@podns.service process-user-data.service attestation-agent.service
 
 [Service]
+Environment=OCICRYPT_KEYPROVIDER_CONFIG=/etc/ocicrypt_config.json
 ExecStartPre=mkdir -p /run/kata-containers
 ExecStart=/usr/local/bin/kata-agent --config /run/peerpod/agent-config.toml
 ExecStartPre=-umount /sys/fs/cgroup/misc


### PR DESCRIPTION
this will (re-)enable support for encrypted images on kata#main

kata uses image-rs, which in turn uses ocicrypt-rs. the latter requires the env OCICRYPT_KEYPROVIDER_CONFIG to point to a file which defines how decryption keys can be retrieved from CDH. (note: it's called attestation-agent here, but that's a misnomer for historical reasons)

kata-agent is only setting this env in process and writing the file to a /tmp location, if it is actively managing the guest-component processes.

We start those processes as service units, so we have to take care of it on the podvm manually. the ocicrypt file is static and writing to /tmp wouldn't work well with a read-only rootfs anyway, so we can just include in the podvm image and referene the path in the env.