### PR TITLE
test-e2e: Allow agent policy override

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -89,6 +89,29 @@ export KBS_IMAGE=$(./hack/yq-shim.sh '.oci.kbs.registry' ./versions.yaml)
 export KBS_IMAGE_TAG=$(./hack/yq-shim.sh '.oci.kbs.tag' ./versions.yaml)
 ````
 
+# Running end-to-end tests against pre-configured cluster
+
+Let's say you want to run the e2e tests against a pre-configured cluster in Azure:
+
+```sh
+TEST_PROVISION=no TEST_INSTALL_CAA=no make CLOUD_PROVIDER=azure TEST_PROVISION_FILE=azure_test.properties test-e2e
+```
+
+If your environment already has [Trustee operator](https://github.com/confidential-containers/trustee-operator) configured for attestation, then you can run e2e with the following command:
+
+```sh
+TEST_TRUSTEE_OPERATOR=yes TEST_PROVISION=no TEST_INSTALL_CAA=no make CLOUD_PROVIDER=azure TEST_PROVISION_FILE=azure_test.properties test-e2e
+```
+
+If your environment uses a pod VM image with restrict agent policy, then some of the e2e tests may fail.
+You can use the following command to override the test pods with a relaxed agent policy allowing all APIs.
+
+```sh
+POD_ALLOW_ALL_POLICY_OVERRIDE=yes TEST_PROVISION=no TEST_INSTALL_CAA=no make CLOUD_PROVIDER=azure TEST_PROVISION_FILE=azure_test.properties test-e2e
+```
+
+The `POD_ALLOW_ALL_POLICY_OVERRIDE` variable will not override the policy for a test pod if the `io.katacontainers.config.agent.policy` already exists in the pod spec.
+
 ## Provision file specifics
 
 As mentioned on the previous section, a properties file can be passed to the cloud provisioner that will be used to control the provisioning operations. The properties are specific of each cloud provider though, see on the sections below.

--- a/src/cloud-api-adaptor/test/e2e/common.go
+++ b/src/cloud-api-adaptor/test/e2e/common.go
@@ -43,6 +43,18 @@ func isTestOnCrio() bool {
 	return os.Getenv("CONTAINER_RUNTIME") == "crio"
 }
 
+func enableAllowAllPodPolicyOverride() bool {
+	return os.Getenv("POD_ALLOW_ALL_POLICY_OVERRIDE") == "yes"
+}
+
+func encodePolicyFile(policyFilePath string) string {
+	policyString, err := os.ReadFile(policyFilePath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return b64.StdEncoding.EncodeToString([]byte(policyString))
+}
+
 type PodOption func(*corev1.Pod)
 
 func WithRestartPolicy(restartPolicy corev1.RestartPolicy) PodOption {
@@ -147,8 +159,12 @@ func WithInitContainers(initContainers []corev1.Container) PodOption {
 
 func NewPod(namespace string, podName string, containerName string, imageName string, options ...PodOption) *corev1.Pod {
 	runtimeClassName := "kata-remote"
+	annotationData := map[string]string{}
+
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: podName,
+			Namespace:   namespace,
+			Annotations: annotationData},
 		Spec: corev1.PodSpec{
 			Containers:       []corev1.Container{{Name: containerName, Image: imageName, ImagePullPolicy: corev1.PullAlways}},
 			RuntimeClassName: &runtimeClassName,
@@ -157,6 +173,14 @@ func NewPod(namespace string, podName string, containerName string, imageName st
 
 	for _, option := range options {
 		option(pod)
+	}
+
+	// Don't override the policy annotation if it's already set
+	if enableAllowAllPodPolicyOverride() {
+		allowAllPolicyFilePath := "fixtures/policies/allow-all.rego"
+		if _, ok := pod.ObjectMeta.Annotations["io.katacontainers.config.agent.policy"]; !ok {
+			pod.ObjectMeta.Annotations["io.katacontainers.config.agent.policy"] = encodePolicyFile(allowAllPolicyFilePath)
+		}
 	}
 
 	return pod
@@ -196,16 +220,10 @@ func NewBusyboxPodWithName(namespace, podName string) *corev1.Pod {
 }
 
 func NewPodWithPolicy(namespace, podName, policyFilePath string) *corev1.Pod {
-	policyString, err := os.ReadFile(policyFilePath)
-	if err != nil {
-		log.Fatal(err)
-	}
-	encodedPolicy := b64.StdEncoding.EncodeToString([]byte(policyString))
-
 	containerName := "busybox"
 	imageName := BUSYBOX_IMAGE
 	annotationData := map[string]string{
-		"io.katacontainers.config.agent.policy": encodedPolicy,
+		"io.katacontainers.config.agent.policy": encodePolicyFile(policyFilePath),
 	}
 	return NewPod(namespace, podName, containerName, imageName, WithCommand([]string{"/bin/sh", "-c", "sleep 3600"}), WithAnnotations(annotationData))
 }


### PR DESCRIPTION
If your pre-configured environment uses a pod VM image with restrict agent policy, then some of the e2e tests may fail.  This commit introduces a variable to override the test pods with a relaxed agent policy allowing all APIs.

`POD_ALLOW_ALL_POLICY_OVERRIDE=yes`

Also updating the README with instructions on how to execute e2e tests against a pre-configured cluster