### PR TITLE
e2e-test: use t.Log functions in tests

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/assessment_helpers.go
+++ b/src/cloud-api-adaptor/test/e2e/assessment_helpers.go
@@ -172,7 +172,6 @@ func IsPulledWithNydusSnapshotter(ctx context.Context, t *testing.T, client klie
 			podLogSlice := reverseSlice(strings.Split(podLogString, "\n"))
 			for _, line := range podLogSlice {
 				if nydusSnapshotterPullRegex.MatchString(line) {
-					t.Log("Pulled with nydus-snapshotter driver:" + line)
 					return true, nil
 				}
 			}

--- a/src/cloud-api-adaptor/test/e2e/assessment_runner.go
+++ b/src/cloud-api-adaptor/test/e2e/assessment_runner.go
@@ -243,11 +243,11 @@ func (tc *TestCase) Run() {
 				}
 				_, err = clientSet.CoreV1().Secrets(E2eNamespace).Get(ctx, DEFAULT_AUTH_SECRET, metav1.GetOptions{})
 				if err == nil {
-					log.Infof("Deleting pre-existing %v...", DEFAULT_AUTH_SECRET)
+					t.Logf("Deleting pre-existing %v...", DEFAULT_AUTH_SECRET)
 					if err = clientSet.CoreV1().Secrets(E2eNamespace).Delete(ctx, DEFAULT_AUTH_SECRET, metav1.DeleteOptions{}); err != nil {
 						t.Fatal(err)
 					}
-					log.Infof("Creating empty %v...", DEFAULT_AUTH_SECRET)
+					t.Logf("Creating empty %v...", DEFAULT_AUTH_SECRET)
 					if err = client.Resources().Create(ctx, &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: DEFAULT_AUTH_SECRET, Namespace: E2eNamespace}, Type: v1.SecretTypeOpaque}); err != nil {
 						t.Fatal(err)
 					}
@@ -413,7 +413,7 @@ func (tc *TestCase) Run() {
 					if len(tc.testCommands) > 0 {
 						if len(tc.testCommands) > 0 {
 							logString, err := AssessPodTestCommands(ctx, client, tc.pod, tc.testCommands)
-							t.Logf("Output when execute test commands:%s", logString)
+							t.Logf("Output when execute test commands: %s", logString)
 							if err != nil {
 								t.Fatal(err)
 							}
@@ -449,9 +449,9 @@ func (tc *TestCase) Run() {
 								}
 							}
 							if strings.Contains(podLogString, tc.FailReason) {
-								log.Infof("failed due to expected reason %s", tc.FailReason)
+								t.Logf("failed due to expected reason %s", tc.FailReason)
 							} else {
-								log.Infof("cloud-api-adaptor pod logs: %s", podLogString)
+								t.Logf("cloud-api-adaptor pod logs: %s", podLogString)
 								yamlData, err := yaml.Marshal(tc.pod.Status)
 								if err != nil {
 									log.Errorf("Error marshaling pod.Status to JSON: %s", err.Error())
@@ -461,7 +461,7 @@ func (tc *TestCase) Run() {
 								t.Fatal("failed due to unknown reason")
 							}
 						} else {
-							log.Infof("Pod Failed If you want to cross check please give .WithFailReason(error string)")
+							t.Logf("Pod Failed If you want to cross check please give .WithFailReason(error string)")
 						}
 					}
 				}
@@ -542,14 +542,14 @@ func (tc *TestCase) Run() {
 					t.Fatal(err)
 				}
 
-				log.Infof("Deleting Configmap... %s", tc.configMap.Name)
+				t.Logf("Deleting Configmap... %s", tc.configMap.Name)
 			}
 
 			if tc.secret != nil {
 				if err = client.Resources().Delete(ctx, tc.secret); err != nil {
 					t.Fatal(err)
 				} else {
-					log.Infof("Deleting Secret... %s", tc.secret.Name)
+					t.Logf("Deleting Secret... %s", tc.secret.Name)
 				}
 			}
 
@@ -568,7 +568,7 @@ func (tc *TestCase) Run() {
 					if err = client.Resources().Delete(ctx, extraSecret); err != nil {
 						t.Fatal(err)
 					} else {
-						log.Infof("Deleting extra Secret... %s", extraSecret.Name)
+						t.Logf("Deleting extra Secret... %s", extraSecret.Name)
 					}
 				}
 
@@ -582,14 +582,14 @@ func (tc *TestCase) Run() {
 				if err = client.Resources().Delete(ctx, tc.job); err != nil {
 					t.Fatal(err)
 				} else {
-					log.Infof("Deleting Job... %s", tc.job.Name)
+					t.Logf("Deleting Job... %s", tc.job.Name)
 				}
 				for _, pod := range podlist.Items {
 					if pod.ObjectMeta.Labels["job-name"] == tc.job.Name {
 						if err = client.Resources().Delete(ctx, &pod); err != nil {
 							t.Fatal(err)
 						}
-						log.Infof("Deleting pods created by job... %s", pod.ObjectMeta.Name)
+						t.Logf("Deleting pods created by job... %s", pod.ObjectMeta.Name)
 
 					}
 				}
@@ -599,14 +599,14 @@ func (tc *TestCase) Run() {
 				if err = client.Resources().Delete(ctx, tc.pod); err != nil {
 					t.Fatal(err)
 				}
-				log.Infof("Deleting pod %s...", tc.pod.Name)
+				t.Logf("Deleting pod %s...", tc.pod.Name)
 				if err = wait.For(conditions.New(
 					client.Resources()).ResourceDeleted(tc.pod),
 					wait.WithInterval(5*time.Second),
 					wait.WithTimeout(tc.deletionWithin)); err != nil {
 					t.Fatal(err)
 				}
-				log.Infof("Pod %s has been successfully deleted within %.0fs", tc.pod.Name, tc.deletionWithin.Seconds())
+				t.Logf("Pod %s has been successfully deleted within %.0fs", tc.pod.Name, tc.deletionWithin.Seconds())
 			}
 
 			if tc.extraPods != nil {
@@ -623,7 +623,7 @@ func (tc *TestCase) Run() {
 				if err = client.Resources().Delete(ctx, tc.pvc); err != nil {
 					t.Fatal(err)
 				} else {
-					log.Infof("Deleting PVC... %s", tc.pvc.Name)
+					t.Logf("Deleting PVC... %s", tc.pvc.Name)
 				}
 			}
 
@@ -631,7 +631,7 @@ func (tc *TestCase) Run() {
 				if err = client.Resources().Delete(ctx, tc.service); err != nil {
 					t.Fatal(err)
 				} else {
-					log.Infof("Deleting Service... %s", tc.service.Name)
+					t.Logf("Deleting Service... %s", tc.service.Name)
 				}
 			}
 

--- a/src/cloud-api-adaptor/test/e2e/azure_common.go
+++ b/src/cloud-api-adaptor/test/e2e/azure_common.go
@@ -57,9 +57,9 @@ func (c AzureCloudAssert) HasPodVM(t *testing.T, id string) {
 	pod_vm_prefix := "podvm-" + id
 	rg := pv.AzureProps.ResourceGroupName
 	if checkVMExistence(rg, pod_vm_prefix) {
-		log.Infof("VM found in resource group")
+		t.Logf("VM %s found in resource group", id)
 	} else {
-		log.Infof("Virtual machine %s not found in resource group %s", id, rg)
+		t.Logf("Virtual machine %s not found in resource group %s", id, rg)
 		t.Error("PodVM was not created")
 	}
 }
@@ -70,14 +70,14 @@ func (c AzureCloudAssert) GetInstanceType(t *testing.T, podName string) (string,
 	prefixName := "podvm-" + podName
 	vm, err := findVM(pv.AzureProps.ResourceGroupName, prefixName)
 	if err != nil {
-		log.Infof("Virtual machine %s not found in resource group %s", podName, pv.AzureProps.ResourceGroupName)
+		t.Logf("Virtual machine %s not found in resource group %s", podName, pv.AzureProps.ResourceGroupName)
 		return "", err
 	}
 
 	// VM found
 	// Extract the VM size
 	if vm != nil && vm.Properties != nil && vm.Properties.HardwareProfile != nil {
-		log.Infof("The VM size for VM '%s' is: %s\n", podName, *vm.Properties.HardwareProfile.VMSize)
+		t.Logf("The VM size for VM '%s' is: %s\n", podName, *vm.Properties.HardwareProfile.VMSize)
 		return string(*vm.Properties.HardwareProfile.VMSize), nil
 	} else {
 		log.Errorf("Failed to get VM size for VM '%s'", podName)

--- a/src/cloud-api-adaptor/test/e2e/common_suite.go
+++ b/src/cloud-api-adaptor/test/e2e/common_suite.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/tlsutil"
-	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -58,10 +57,10 @@ func DoTestCreatePodWithConfigMap(t *testing.T, e env.Environment, assert CloudA
 			ContainerName: pod.Spec.Containers[0].Name,
 			TestCommandStdoutFn: func(stdout bytes.Buffer) bool {
 				if stdout.String() == configMapContents {
-					log.Infof("Data Inside Configmap: %s", stdout.String())
+					t.Logf("Data Inside Configmap: %s", stdout.String())
 					return true
 				} else {
-					log.Errorf("Configmap has invalid Data: %s", stdout.String())
+					t.Errorf("Configmap has invalid Data: %s", stdout.String())
 					return false
 				}
 			},
@@ -95,10 +94,10 @@ func DoTestCreatePodWithSecret(t *testing.T, e env.Environment, assert CloudAsse
 			ContainerName: pod.Spec.Containers[0].Name,
 			TestCommandStdoutFn: func(stdout bytes.Buffer) bool {
 				if stdout.String() == username {
-					log.Infof("Username from secret inside pod: %s", stdout.String())
+					t.Logf("Username from secret inside pod: %s", stdout.String())
 					return true
 				} else {
-					log.Errorf("Username value from secret inside pod unexpected. Expected %s, got %s", username, stdout.String())
+					t.Errorf("Username value from secret inside pod unexpected. Expected %s, got %s", username, stdout.String())
 					return false
 				}
 			},
@@ -109,10 +108,10 @@ func DoTestCreatePodWithSecret(t *testing.T, e env.Environment, assert CloudAsse
 			ContainerName: pod.Spec.Containers[0].Name,
 			TestCommandStdoutFn: func(stdout bytes.Buffer) bool {
 				if stdout.String() == password {
-					log.Infof("Password from secret inside pod: %s", stdout.String())
+					t.Logf("Password from secret inside pod: %s", stdout.String())
 					return true
 				} else {
-					log.Errorf("Password value from secret inside pod unexpected. Expected %s, got %s", password, stdout.String())
+					t.Errorf("Password value from secret inside pod unexpected. Expected %s, got %s", password, stdout.String())
 					return false
 				}
 			},
@@ -135,10 +134,10 @@ func DoTestCreatePeerPodContainerWithExternalIPAccess(t *testing.T, e env.Enviro
 			ContainerName: pod.Spec.Containers[0].Name,
 			TestCommandStdoutFn: func(stdout bytes.Buffer) bool {
 				if stdout.String() != "" {
-					log.Infof("Output of ping command in busybox : %s", stdout.String())
+					t.Logf("Output of ping command in busybox : %s", stdout.String())
 					return true
 				} else {
-					log.Info("No output from ping command")
+					t.Log("No output from ping command")
 					return false
 				}
 			},
@@ -227,10 +226,10 @@ func DoTestCreatePeerPodWithPVCAndCSIWrapper(t *testing.T, e env.Environment, as
 			ContainerName: pod.Spec.Containers[2].Name,
 			TestCommandStdoutFn: func(stdout bytes.Buffer) bool {
 				if strings.Contains(stdout.String(), mountPath) {
-					log.Infof("PVC volume is mounted correctly: %s", stdout.String())
+					t.Logf("PVC volume is mounted correctly: %s", stdout.String())
 					return true
 				} else {
-					log.Errorf("PVC volume failed to be mounted at target path: %s", stdout.String())
+					t.Errorf("PVC volume failed to be mounted at target path: %s", stdout.String())
 					return false
 				}
 			},
@@ -297,10 +296,10 @@ func DoTestPodVMwithNoAnnotations(t *testing.T, e env.Environment, assert CloudA
 	testInstanceTypes := InstanceValidatorFunctions{
 		testSuccessfn: func(instance string) bool {
 			if instance == expectedType {
-				log.Infof("PodVM Created with %s Instance type successfully...", instance)
+				t.Logf("PodVM Created with %s Instance type successfully...", instance)
 				return true
 			} else {
-				log.Infof("Failed to Create PodVM with %s Instance type", expectedType)
+				t.Logf("Failed to Create PodVM with %s Instance type", expectedType)
 				return false
 			}
 		},
@@ -321,10 +320,10 @@ func DoTestPodVMwithAnnotationsInstanceType(t *testing.T, e env.Environment, ass
 	testInstanceTypes := InstanceValidatorFunctions{
 		testSuccessfn: func(instance string) bool {
 			if instance == expectedType {
-				log.Infof("PodVM Created with %s Instance type successfully...", instance)
+				t.Logf("PodVM Created with %s Instance type successfully...", instance)
 				return true
 			} else {
-				log.Infof("Failed to Create PodVM with %s Instance type", expectedType)
+				t.Logf("Failed to Create PodVM with %s Instance type", expectedType)
 				return false
 			}
 		},
@@ -346,10 +345,10 @@ func DoTestPodVMwithAnnotationsCPUMemory(t *testing.T, e env.Environment, assert
 	testInstanceTypes := InstanceValidatorFunctions{
 		testSuccessfn: func(instance string) bool {
 			if instance == expectedType {
-				log.Infof("PodVM Created with %s Instance type successfully...", instance)
+				t.Logf("PodVM Created with %s Instance type successfully...", instance)
 				return true
 			} else {
-				log.Infof("Failed to Create PodVM with %s Instance type", expectedType)
+				t.Logf("Failed to Create PodVM with %s Instance type", expectedType)
 				return false
 			}
 		},
@@ -371,10 +370,10 @@ func DoTestPodVMwithAnnotationsInvalidInstanceType(t *testing.T, e env.Environme
 		testSuccessfn: IsStringEmpty,
 		testFailurefn: func(errorMsg error) bool {
 			if strings.Contains(errorMsg.Error(), expectedErrorMessage) {
-				log.Infof("Got Expected Error: %v", errorMsg.Error())
+				t.Logf("Got Expected Error: %v", errorMsg.Error())
 				return true
 			} else {
-				log.Infof("Failed to Get Expected Error: %v", errorMsg.Error())
+				t.Logf("Failed to Get Expected Error: %v", errorMsg.Error())
 				return false
 			}
 		},
@@ -396,10 +395,10 @@ func DoTestPodVMwithAnnotationsLargerMemory(t *testing.T, e env.Environment, ass
 		testSuccessfn: IsStringEmpty,
 		testFailurefn: func(errorMsg error) bool {
 			if strings.Contains(errorMsg.Error(), expectedErrorMessage) {
-				log.Infof("Got Expected Error: %v", errorMsg.Error())
+				t.Logf("Got Expected Error: %v", errorMsg.Error())
 				return true
 			} else {
-				log.Infof("Failed to Get Expected Error: %v", errorMsg.Error())
+				t.Logf("Failed to Get Expected Error: %v", errorMsg.Error())
 				return false
 			}
 		},
@@ -425,11 +424,11 @@ func DoTestPodVMwithAnnotationsLargerCPU(t *testing.T, e env.Environment, assert
 		testFailurefn: func(errorMsg error) bool {
 			for _, i := range expectedErrorMessage {
 				if strings.Contains(errorMsg.Error(), i) {
-					log.Infof("Got Expected Error: %v", errorMsg.Error())
+					t.Logf("Got Expected Error: %v", errorMsg.Error())
 					return true
 				}
 			}
-			log.Infof("Failed to Get Expected Error: %v", errorMsg.Error())
+			t.Logf("Failed to Get Expected Error: %v", errorMsg.Error())
 			return false
 		},
 	}
@@ -455,10 +454,10 @@ func DoTestPodToServiceCommunication(t *testing.T, e env.Environment, assert Clo
 			ContainerName: clientPod.pod.Spec.Containers[0].Name,
 			TestCommandStdoutFn: func(stdout bytes.Buffer) bool {
 				if strings.Contains(stdout.String(), "Thank you for using nginx") {
-					log.Infof("Success to access nginx service. %s", stdout.String())
+					t.Logf("Success to access nginx service. %s", stdout.String())
 					return true
 				} else {
-					log.Errorf("Failed to access nginx service: %s", stdout.String())
+					t.Errorf("Failed to access nginx service: %s", stdout.String())
 					return false
 				}
 			},
@@ -548,10 +547,10 @@ func DoTestPodsMTLSCommunication(t *testing.T, e env.Environment, assert CloudAs
 			ContainerName: clientPod.pod.Spec.Containers[0].Name,
 			TestCommandStdoutFn: func(stdout bytes.Buffer) bool {
 				if strings.Contains(stdout.String(), "Thank you for using nginx") {
-					log.Infof("Success to access nginx service. %s", stdout.String())
+					t.Logf("Success to access nginx service. %s", stdout.String())
 					return true
 				} else {
-					log.Errorf("Failed to access nginx service: %s", stdout.String())
+					t.Errorf("Failed to access nginx service: %s", stdout.String())
 					return false
 				}
 			},
@@ -576,8 +575,7 @@ func DoTestPodsMTLSCommunication(t *testing.T, e env.Environment, assert CloudAs
 // DoTestKbsKeyRelease and DoTestKbsKeyReleaseForFailure should be run in a single test case if you're chaning opa in kbs
 // as test cases might be run in parallel
 func DoTestKbsKeyRelease(t *testing.T, e env.Environment, assert CloudAssert) {
-
-	log.Info("Do test kbs key release")
+	t.Log("Do test kbs key release")
 	pod := NewBusyboxPodWithName(E2eNamespace, "busybox-wget")
 	testCommands := []TestCommand{
 		{
@@ -585,10 +583,10 @@ func DoTestKbsKeyRelease(t *testing.T, e env.Environment, assert CloudAssert) {
 			ContainerName: pod.Spec.Containers[0].Name,
 			TestCommandStdoutFn: func(stdout bytes.Buffer) bool {
 				if strings.Contains(stdout.String(), "This is my cluster name") {
-					log.Infof("Success to get key.bin: %s", stdout.String())
+					t.Logf("Success to get key.bin: %s", stdout.String())
 					return true
 				} else {
-					log.Errorf("Failed to access key.bin: %s", stdout.String())
+					t.Errorf("Failed to access key.bin: %s", stdout.String())
 					return false
 				}
 			},
@@ -601,8 +599,7 @@ func DoTestKbsKeyRelease(t *testing.T, e env.Environment, assert CloudAssert) {
 // DoTestKbsKeyRelease and DoTestKbsKeyReleaseForFailure should be run in a single test case if you're chaning opa in kbs
 // as test cases might be run in parallel
 func DoTestKbsKeyReleaseForFailure(t *testing.T, e env.Environment, assert CloudAssert) {
-
-	log.Info("Do test kbs key release failure case")
+	t.Log("Do test kbs key release failure case")
 	pod := NewBusyboxPodWithName(E2eNamespace, "busybox-wget-failure")
 	testCommands := []TestCommand{
 		{
@@ -612,16 +609,16 @@ func DoTestKbsKeyReleaseForFailure(t *testing.T, e env.Environment, assert Cloud
 				if strings.Contains(err.Error(), "command terminated with exit code 1") {
 					return true
 				} else {
-					log.Errorf("Got unexpected error: %s", err.Error())
+					t.Errorf("Got unexpected error: %s", err.Error())
 					return false
 				}
 			},
 			TestCommandStdoutFn: func(stdout bytes.Buffer) bool {
 				if strings.Contains(stdout.String(), "This is my cluster name") {
-					log.Errorf("FAIL as successed to get key.bin: %s", stdout.String())
+					t.Errorf("FAIL as successed to get key.bin: %s", stdout.String())
 					return false
 				} else {
-					log.Infof("PASS as failed to access key.bin: %s", stdout.String())
+					t.Logf("PASS as failed to access key.bin: %s", stdout.String())
 					return true
 				}
 			},
@@ -633,8 +630,7 @@ func DoTestKbsKeyReleaseForFailure(t *testing.T, e env.Environment, assert Cloud
 
 // Test to check for specific key value from Trustee Operator Deployment
 func DoTestTrusteeOperatorKeyReleaseForSpecificKey(t *testing.T, e env.Environment, assert CloudAssert) {
-
-	log.Info("Do test Trustee operator key release for specific key")
+	t.Log("Do test Trustee operator key release for specific key")
 	pod := NewBusyboxPodWithName(E2eNamespace, "busybox-wget")
 	testCommands := []TestCommand{
 		{
@@ -642,10 +638,10 @@ func DoTestTrusteeOperatorKeyReleaseForSpecificKey(t *testing.T, e env.Environme
 			ContainerName: pod.Spec.Containers[0].Name,
 			TestCommandStdoutFn: func(stdout bytes.Buffer) bool {
 				if strings.Contains(stdout.String(), "res1val1") {
-					log.Infof("Success to get key %s", stdout.String())
+					t.Logf("Success to get key %s", stdout.String())
 					return true
 				} else {
-					log.Errorf("Failed to access key: %s", stdout.String())
+					t.Errorf("Failed to access key: %s", stdout.String())
 					return false
 				}
 			},
@@ -666,10 +662,10 @@ func DoTestRestrictivePolicyBlocksExec(t *testing.T, e env.Environment, assert C
 			ContainerName: pod.Spec.Containers[0].Name,
 			TestErrorFn: func(err error) bool {
 				if strings.Contains(err.Error(), "failed to exec in container") && strings.Contains(err.Error(), "ExecProcessRequest is blocked by policy") {
-					log.Infof("Exec process was blocked %s", err.Error())
+					t.Logf("Exec process was blocked %s", err.Error())
 					return true
 				} else {
-					log.Errorf("Exec process was allowed: %s", err.Error())
+					t.Errorf("Exec process was allowed: %s", err.Error())
 					return false
 				}
 			},
@@ -713,10 +709,10 @@ func DoTestPodWithCrioDeviceAnnotation(t *testing.T, e env.Environment, assert C
 			ContainerName: pod.Spec.Containers[0].Name,
 			TestCommandStdoutFn: func(stdout bytes.Buffer) bool {
 				if strings.Contains(stdout.String(), "/dev/fuse") {
-					log.Infof("Device /dev/fuse is created in the pod")
+					t.Logf("Device /dev/fuse is created in the pod")
 					return true
 				} else {
-					log.Errorf("Device /dev/fuse is not created in the pod")
+					t.Errorf("Device /dev/fuse is not created in the pod")
 					return false
 				}
 			},
@@ -744,10 +740,10 @@ func DoTestPodWithIncorrectCrioDeviceAnnotation(t *testing.T, e env.Environment,
 			TestCommandStdoutFn: IsBufferEmpty,
 			TestCommandStderrFn: func(stderr bytes.Buffer) bool {
 				if strings.Contains(stderr.String(), "No such file or directory") {
-					log.Infof("Device /dev/fuse is not created in the pod")
+					t.Logf("Device /dev/fuse is not created in the pod")
 					return true
 				} else {
-					log.Errorf("Device /dev/fuse is created in the pod")
+					t.Errorf("Device /dev/fuse is created in the pod")
 					return false
 				}
 			},
@@ -755,10 +751,10 @@ func DoTestPodWithIncorrectCrioDeviceAnnotation(t *testing.T, e env.Environment,
 			// "command terminated with exit code 1"
 			TestErrorFn: func(err error) bool {
 				if strings.Contains(err.Error(), "command terminated with exit code 1") {
-					log.Infof("Command terminated with exit code 1")
+					t.Logf("Command terminated with exit code 1")
 					return true
 				} else {
-					log.Errorf("Command did not terminate with exit code 1")
+					t.Errorf("Command did not terminate with exit code 1")
 					return false
 				}
 

--- a/src/cloud-api-adaptor/test/e2e/rolling_update.go
+++ b/src/cloud-api-adaptor/test/e2e/rolling_update.go
@@ -143,17 +143,17 @@ func DoTestCaaDaemonsetRollingUpdate(t *testing.T, testEnv env.Environment, asse
 				t.Fatal(err)
 			}
 
-			log.Info("Creating webserver deployment...")
+			t.Log("Creating webserver deployment...")
 			if err = client.Resources().Create(ctx, deployment); err != nil {
 				t.Fatal(err)
 			}
 			waitForDeploymentAvailable(t, client, deployment, rc)
-			log.Info("webserver deployment is available now")
+			t.Log("webserver deployment is available now")
 
 			// Cache Pod VM instance IDs before upgrade
 			assert.CachePodVmIDs(t, deploymentName)
 
-			log.Info("Creating webserver Service")
+			t.Log("Creating webserver Service")
 			if err = client.Resources().Create(ctx, svc); err != nil {
 				t.Fatal(err)
 			}
@@ -196,7 +196,7 @@ func DoTestCaaDaemonsetRollingUpdate(t *testing.T, testEnv env.Environment, asse
 			if err = client.Resources().Get(ctx, caaDaemonSetName, caaNamespace, ds); err != nil {
 				t.Fatal(err)
 			}
-			log.Info("Force to update CAA pods by increasing StartupProbe.FailureThreshold")
+			t.Log("Force to update CAA pods by increasing StartupProbe.FailureThreshold")
 			ds.Spec.Template.Spec.Containers[0].StartupProbe.FailureThreshold += 1
 			if err = client.Resources().Update(ctx, ds); err != nil {
 				t.Fatal(err)
@@ -236,7 +236,7 @@ func DoTestCaaDaemonsetRollingUpdate(t *testing.T, testEnv env.Environment, asse
 			}
 
 			time.Sleep(OLD_VM_DELETION_TIMEOUT)
-			log.Info("Verify old VM instances have been deleted:")
+			t.Log("Verify old VM instances have been deleted:")
 			assert.VerifyOldVmDeleted(t)
 
 			return ctx
@@ -247,17 +247,17 @@ func DoTestCaaDaemonsetRollingUpdate(t *testing.T, testEnv env.Environment, asse
 				t.Fatal(err)
 			}
 
-			log.Info("Deleting verify pod...")
+			t.Log("Deleting verify pod...")
 			if err = client.Resources().Delete(ctx, verifyPod); err != nil {
 				t.Fatal(err)
 			}
 
-			log.Info("Deleting webserver service...")
+			t.Log("Deleting webserver service...")
 			if err = client.Resources().Delete(ctx, svc); err != nil {
 				t.Fatal(err)
 			}
 
-			log.Info("Deleting webserver deployment...")
+			t.Log("Deleting webserver deployment...")
 			if err = client.Resources().Delete(ctx, deployment); err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
we are using fmt and log calls to produce log output in tests. This will mess up the formatting of go test, especially when running tests in parallel. t.Log/f will wrap the relevant log lines in their correct test context.

```
=== NAME  TestCreatePodWithConfigMapAzure/ConfigMapPeerPod_test/Configmap_is_created_and_contains_data
    assessment_runner.go:416: Output when execute test commands:
time="2024-07-29T00:55:42Z" level=info msg="VM found in resource group"
time="2024-07-29T00:55:42Z" level=info msg="Deleting Configmap... busybox-configmap"
time="2024-07-29T00:55:42Z" level=info msg="Deleting pod busybox-configmap-pod..."
=== RUN   TestCreatePodWithSecretAzure/SecretPeerPod_test/Secret_has_been_created_and_contains_data
    assessment_runner.go:416: Output when execute test commands:
time="2024-07-29T00:55:52Z" level=info msg="VM found in resource group"
time="2024-07-29T00:55:52Z" level=info msg="Deleting Secret... busybox-secret"
```

vs

```
=== NAME  TestCreateSimplePodAzure/SimplePeerPod_test
    assessment_runner.go:602: Deleting pod simple-test...
=== NAME  TestKbsKeyRelease
    common_suite.go:586: Success to get key.bin: This is my cluster name: caa-mgns
=== NAME  TestKbsKeyRelease/KbsKeyReleasePod_test/Kbs_key_release_is_successful
    assessment_runner.go:416: Output when execute test commands: This is my cluster name: caa-mgns
    azure_common.go:60: VM busybox-wget found in resource group
```        

