### PR TITLE
podvm: Disable sshd service

### DIFF
--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/remove-ssh.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/remove-ssh.service
@@ -1,0 +1,1 @@
+../remove-ssh.service

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/remove-ssh.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/remove-ssh.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Remove SSH server on shutdown
+DefaultDependencies=no
+Before=shutdown.target reboot.target halt.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/remove-ssh.sh
+
+[Install]
+WantedBy=halt.target reboot.target shutdown.target
+

--- a/src/cloud-api-adaptor/podvm/files/usr/local/bin/remove-ssh.sh
+++ b/src/cloud-api-adaptor/podvm/files/usr/local/bin/remove-ssh.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Function to remove SSH server on Ubuntu
+remove_ssh_ubuntu() {
+    echo "Detected Ubuntu. Removing openssh-server using apt-get."
+    apt-get remove -y openssh-server
+}
+
+# Function to remove SSH server on RHEL
+remove_ssh_rhel() {
+    echo "Detected RHEL. Removing openssh-server using dnf."
+    dnf remove -y openssh-server
+}
+
+# Detect the operating system
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    case "$ID" in
+        ubuntu)
+            remove_ssh_ubuntu
+            ;;
+        rhel | centos | fedora)
+            remove_ssh_rhel
+            ;;
+        *)
+            echo "Unsupported OS: $ID"
+            exit 1
+            ;;
+    esac
+else
+    echo "Cannot detect the operating system. /etc/os-release not found."
+    exit 1
+fi
+


### PR DESCRIPTION
If using packer based images, ssh service is enabled by default. Coupled this with config-drive based ssh key injection, this allows any infra admin to SSH to the pod VM.
This is unlike the mkosi image where ssh is disabled or uses only user specific public key for login.

This commit removes the SSH package from the podvm image during image generation.

It uses a oneshot service to remove the package during shutdown as part of image generation. This is because SSH is used by packer for configuring the initial image.