### PR TITLE
tests/e2e: fix TestLibvirtKbsKeyRelease skip

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/common.go
+++ b/src/cloud-api-adaptor/test/e2e/common.go
@@ -29,7 +29,7 @@ const WAIT_DEPLOYMENT_AVAILABLE_TIMEOUT = time.Second * 180
 const DEFAULT_AUTH_SECRET = "auth-json-secret-default"
 
 func isTestWithKbs() bool {
-	return os.Getenv("TEST_KBS") == "yes"
+	return os.Getenv("TEST_KBS") == "yes" || os.Getenv("TEST_KBS") == "true"
 }
 
 // Setup of Trustee Operator is required for this test


### PR DESCRIPTION
make align with [test/e2e/main_test.go#L106](https://github.com/confidential-containers/cloud-api-adaptor/blob/main/src/cloud-api-adaptor/test/e2e/main_test.go#L106)

to fix the e2e testcase skipped
```
19:47:32  === RUN   TestLibvirtKbsKeyRelease
19:47:32      libvirt_test.go:109: Skipping kbs related test as kbs is not deployed
19:47:32  --- SKIP: TestLibvirtKbsKeyRelease (0.00s)
19:47:32  PASS
```