### PR TITLE
CI: run e2e tests for docker provider

### DIFF
--- a/.github/workflows/e2e_docker.yaml
+++ b/.github/workflows/e2e_docker.yaml
@@ -39,6 +39,8 @@ defaults:
 jobs:
   test-docker:
     runs-on: ubuntu-22.04
+    # TODO: remove this when the job gets stable
+    continue-on-error: true
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/e2e_docker.yaml
+++ b/.github/workflows/e2e_docker.yaml
@@ -1,0 +1,98 @@
+# (C) Copyright Confidential Containers Contributors 2024.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run docker e2e tests.
+name: (Callable) docker e2e tests
+
+on:
+  workflow_call:
+    inputs:
+      podvm_image:
+        required: true
+        type: string
+      caa_image:
+        required: true
+        type: string
+      caa_image_tag:
+        required: false
+        default: "latest"
+        type: string
+      install_directory_artifact:
+        description: The archive name of the install directory
+        default: ''
+        required: false
+        type: string
+      git_ref:
+        default: 'main'
+        description: Git ref to checkout the cloud-api-adaptor repository. Defaults to main.
+        required: false
+        type: string
+
+env:
+  CLOUD_PROVIDER: docker
+  DEBIAN_FRONTEND: noninteractive
+
+defaults:
+  run:
+    working-directory: src/cloud-api-adaptor
+
+jobs:
+  test-docker:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+
+      - name: Rebase the code
+        if: github.event_name == 'pull_request_target'
+        working-directory: ./
+        run: |
+          ./hack/ci-helper.sh rebase-atop-of-the-latest-target-branch
+
+      - name: Read properties from versions.yaml
+        run: |
+          sudo snap install yq
+          go_version="$(yq '.tools.golang' versions.yaml)"
+          [ -n "$go_version" ]
+          echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"
+
+      - name: Setup Golang version ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Get the install directory
+        if: ${{ inputs.install_directory_artifact != '' }}
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.install_directory_artifact }}
+          path: src/cloud-api-adaptor/install
+
+      - name: Config docker
+        run: |
+          cat <<- EOF > docker.properties
+          CAA_IMAGE="${{ inputs.caa_image }}"
+          CAA_IMAGE_TAG="${{ inputs.caa_image_tag }}"
+          CLUSTER_NAME="peer-pods"
+          DOCKER_PODVM_IMAGE="${{ inputs.podvm_image }}"
+          DOCKER_HOST="unix:///var/run/docker.sock"
+          DOCKER_NETWORK_NAME="kind"
+          EOF
+          # For debugging
+          cat docker.properties
+
+      - name: run tests
+        id: runTests
+        run: |
+          export CLOUD_PROVIDER=docker
+          export DEPLOY_KBS=false
+          export TEST_PROVISION=yes
+          export TEST_TEARDOWN=no
+          export TEST_PROVISION_FILE="$PWD/docker.properties"
+          export TEST_PODVM_IMAGE="${{ inputs.podvm_image }}"
+          export TEST_E2E_TIMEOUT="50m"
+
+          make test-e2e

--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -100,7 +100,7 @@ jobs:
     needs: [image]
     runs-on: ubuntu-latest
     env:
-      PROVIDERS: "libvirt"
+      PROVIDERS: "docker libvirt"
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -169,6 +169,31 @@ jobs:
     with:
       caa_image: ${{ inputs.registry }}/cloud-api-adaptor:${{ inputs.caa_image_tag }}-dev
       podvm_image: ${{ inputs.registry }}/podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ matrix.arch }}:${{ inputs.podvm_image_tag }}
+      install_directory_artifact: install_directory
+      git_ref: ${{ inputs.git_ref }}
+    secrets: inherit
+
+  # Run docker e2e tests if pull request labeled 'test_e2e_docker'
+  docker:
+    name: docker
+    if: |
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
+    needs: [podvm, image, prep_install]
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - fedora
+        provider:
+          - docker
+        arch:
+          - amd64
+    uses: ./.github/workflows/e2e_docker.yaml
+    with:
+      caa_image: ${{ inputs.registry }}/cloud-api-adaptor
+      caa_image_tag: ${{ inputs.caa_image_tag }}
+      podvm_image: ${{ inputs.registry }}/podvm-${{ matrix.provider }}-image:${{ inputs.podvm_image_tag }}
       install_directory_artifact: install_directory
       git_ref: ${{ inputs.git_ref }}
     secrets: inherit

--- a/.github/workflows/podvm.yaml
+++ b/.github/workflows/podvm.yaml
@@ -30,6 +30,8 @@ jobs:
           - ubuntu
         arch: [amd64, s390x]
         provider: [generic, vsphere]
+        tool:
+          - packer
         include:
           - os: ubuntu
         exclude:
@@ -76,3 +78,9 @@ jobs:
         PODVM_TAG: ${{ inputs.image_tag }}
         PODVM_DISTRO: ${{ matrix.os }}
         CLOUD_PROVIDER: ${{ matrix.provider }}
+
+  build-mkosi:
+    name: Build mkosi
+    uses: ./.github/workflows/podvm_mkosi.yaml
+    with:
+      binaries-image: ${{ inputs.registry }}/podvm-binaries-fedora-amd64:${{ inputs.image_tag }}

--- a/.github/workflows/podvm_binaries.yaml
+++ b/.github/workflows/podvm_binaries.yaml
@@ -26,10 +26,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu]
-        arch: [amd64, s390x]
+        os:
+          - ubuntu
+        arch:
+          - amd64
+          - s390x
         include:
-          - os: ubuntu
+          - os: fedora
+            arch: amd64
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3

--- a/.github/workflows/podvm_builder.yaml
+++ b/.github/workflows/podvm_builder.yaml
@@ -28,6 +28,7 @@ jobs:
       matrix:
         os:
           # Please keep this list in alphabetical order.
+          - fedora
           - ubuntu
         runner:
           - ubuntu-latest

--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -84,6 +84,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install Nix
         uses: cachix/install-nix-action@v22
 
@@ -135,3 +142,12 @@ jobs:
         with:
           name: podvm-mkosi-${{ github.sha }}
           path: src/cloud-api-adaptor/podvm-mkosi/build/system.raw
+
+      - name: Build and push image for docker provider
+        working-directory: src/cloud-api-adaptor/podvm-mkosi
+        run: |
+          make image-container
+          make push-image-container
+        env:
+          REGISTRY: ghcr.io/${{ github.repository }}
+          PODVM_TAG: ${{ github.sha }}

--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -75,6 +75,8 @@ jobs:
           )
       )
     runs-on: ubuntu-latest
+    # TODO: remove this when the job gets stable
+    continue-on-error: true
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -7,6 +7,13 @@ on:
         description: "Prebuild fedora binaries image, as produced by this workflow under ghcr.io/confidential-containers/cloud-api-adaptor/podvm/binaries-fedora"
         required: false
 
+  workflow_call:
+    inputs:
+      binaries-image:
+        description: "Prebuild fedora binaries image, as produced by this workflow under ghcr.io/confidential-containers/cloud-api-adaptor/podvm/binaries-fedora"
+        required: false
+        type: string
+
 defaults:
   run:
     working-directory: src/cloud-api-adaptor
@@ -14,7 +21,7 @@ defaults:
 jobs:
   build-binaries:
     name: Build binaries
-    if : ${{ github.event.inputs.binaries-image == '' }}
+    if : ${{ inputs.binaries-image == '' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -58,13 +65,13 @@ jobs:
             "BUILDER_IMG=ghcr.io/${{ github.repository }}/podvm/builder-fedora:${{ github.sha }}"
 
   build-image:
-    name: Build image
+    name: Build mkosi image
     needs: [build-binaries]
     if: |
       always() && (
           needs.build-binaries.result == 'success' || (
               needs.build-binaries.result == 'skipped' &&
-              github.event.inputs.binaries-image != ''
+              inputs.binaries-image != ''
           )
       )
     runs-on: ubuntu-latest
@@ -102,10 +109,10 @@ jobs:
       - name: Decide on image to use
         id: binaries-image
         run: |
-          if [ -z "${{ github.event.inputs.binaries-image }}" ]; then
+          if [ -z "${{ inputs.binaries-image }}" ]; then
             echo "image=ghcr.io/${{ github.repository }}/podvm/binaries-fedora:${{ github.sha }}" | tee -a "$GITHUB_OUTPUT"
           else
-            echo "image=${{ github.event.inputs.binaries-image }}" | tee -a "$GITHUB_OUTPUT"
+            echo "image=${{ inputs.binaries-image }}" | tee -a "$GITHUB_OUTPUT"
           fi
 
       - name: Download binaries and unpack into binaries-tree
@@ -117,7 +124,7 @@ jobs:
           tar xf podvm-binaries.tar -C podvm-mkosi/resources/binaries-tree
           rm podvm-binaries.tar
 
-      - name: Build image
+      - name: Build mkosi image
         working-directory: src/cloud-api-adaptor/podvm-mkosi
         run: make image-debug
 


### PR DESCRIPTION
This adds an initial version of CI for docker provider.

It was created a new workflow (e2e_docker.yaml) that run the e2e tests for docker on x86_64. In order to keep this implementation simple, it isn't installed KBS. Also the tests will be executed only alongside the [libvirt nightly job](https://github.com/confidential-containers/cloud-api-adaptor/actions/workflows/daily-e2e-tests-libvirt.yaml), so not triggered on pull requests. The final status of libvirt nightly job shouldn't change if the docker tests fail because the jobs were marked continue-on-error, this way we will be able to proper test these changes on "production" (reason why I also didn't rename `daily e2e tests for libvirt` to something generic).

As a pre-req to run the e2e tests for docker, I had to ensure the podvm image for docker is built and pushed to the registry. So the very first commits changes the podvm_builder, podvm_binaries, podvm_mkosi, and podvm workflows to reuse existing code. Here I am trying really hard to not introduce new workflows. However, I will need to change further those workflows (on a respin PR) to make them more flexible to allow, for example, run the docker e2e tests on pull requests.

I managed to tests these changes on my forked tree, being the last execution https://github.com/wainersm/cc-cloud-api-adaptor/actions/runs/10171362457 .  From that link you will notice that `Build mkosi image` passed but `test-docker` failed, the error being:

```
# github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/test/e2e [github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/test/e2e.test]
Error: test/e2e/docker_test.go:104:23: keyBrokerService.EnableKbsCustomizedPolicy undefined (type *provisioner.KeyBrokerService has no field or method EnableKbsCustomizedPolicy)
Error: test/e2e/docker_test.go:108:23: keyBrokerService.EnableKbsCustomizedPolicy undefined (type *provisioner.KeyBrokerService has no field or method EnableKbsCustomizedPolicy)
``` 

@bpradipt ^^^ I need help to understand what's going on.


Fixes: #1946