### PR TITLE
GHA: Remove {pre,post}-action steps for self-hosted runners

### DIFF
--- a/.github/workflows/podvm_mkosi_image.yaml
+++ b/.github/workflows/podvm_mkosi_image.yaml
@@ -16,12 +16,6 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Take a pre-action for self-hosted runner
-        run: |
-          if [ -f ${HOME}/script/pre_action.sh ]; then
-            ${HOME}/script/pre_action.sh cc-caa
-          fi
-
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -64,11 +58,3 @@ jobs:
       - name: Push image
         run: make push-image
         working-directory: src/cloud-api-adaptor/podvm-mkosi
-
-      - name: Take a post-action
-        if: always()
-        run: |
-          if [ -f ${HOME}/script/post_action.sh ]; then
-            ${HOME}/script/post_action.sh cc-caa
-          fi
-


### PR DESCRIPTION
The following hooks:

- ACTIONS_RUNNER_HOOK_JOB_STARTED
- ACTIONS_RUNNER_HOOK_JOB_COMPLETED

could perfectly replace the existing {pre,post}-action scripts and will make a workflow independent of the runner context. This PR wipes out all GHA steps where the actions are triggered.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>