### PR TITLE
e2e-tests: add option to deploy kbs with custom pccs_url

### DIFF
--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -264,6 +264,7 @@ jobs:
       env:
         TEST_PROVISION: "no"
         DEPLOY_KBS: "yes"
+        CUSTOM_PCCS_URL: "https://global.acccache.azure.net/sgx/certification/v4"
       run: |
         # Since we install the cluster in parallel, we need to get the credentials here.
         echo "running e2e test for ${{ matrix.parameters.id }} machine"


### PR DESCRIPTION
TDX attestation requires a pccs_url to be set. we'll introduce a flag CUSTOM_PCCS_URL that will configure kbs to use the it.