### PR TITLE
e2e-test: assert job condition on job tests

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/assessment_runner.go
+++ b/src/cloud-api-adaptor/test/e2e/assessment_runner.go
@@ -314,6 +314,11 @@ func (tc *TestCase) Run() {
 			var podlist v1.PodList
 
 			if tc.job != nil {
+				conditions := tc.job.Status.Conditions
+				if len(conditions) == 1 && conditions[0].Type == batchv1.JobFailed {
+					t.Errorf("Job failed")
+				}
+
 				if err := client.Resources(tc.job.Namespace).List(ctx, &podlist); err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
We have elaborate condition checks on a job's pods, but we do not test the job status itself, which will produce wrong test results. A test for job that always fails (cmd: /bin/false) will pass.

This keeps the current assertions in-place, but makes the test fail on a failed job status