### PR TITLE
release: prepare for v0.9.0 alpha.4

### DIFF
--- a/src/cloud-api-adaptor/go.mod
+++ b/src/cloud-api-adaptor/go.mod
@@ -47,8 +47,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/eks v1.29.5
 	github.com/aws/aws-sdk-go-v2/service/iam v1.22.5
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.38.5
-	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers v0.9.0-alpha.3
-	github.com/confidential-containers/cloud-api-adaptor/src/peerpod-ctrl v0.9.0-alpha.3
+	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers v0.9.0-alpha.4
+	github.com/confidential-containers/cloud-api-adaptor/src/peerpod-ctrl v0.9.0-alpha.4
 	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
 	github.com/docker/docker v25.0.5+incompatible
 	github.com/golang-jwt/jwt/v5 v5.2.1

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -29,7 +29,7 @@ tools:
 git:
   coco-operator:
     url: https://github.com/confidential-containers/operator
-    reference: 23aeb68d289041aafe4d6ecdf4601d9b96b7acbf
+    reference: v0.9.0
   guest-components:
     url: https://github.com/confidential-containers/guest-components
     reference: v0.9.0

--- a/src/csi-wrapper/go.mod
+++ b/src/csi-wrapper/go.mod
@@ -3,7 +3,7 @@ module github.com/confidential-containers/cloud-api-adaptor/src/csi-wrapper
 go 1.21
 
 require (
-	github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor v0.9.0-alpha.3
+	github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor v0.9.0-alpha.4
 	github.com/container-storage-interface/spec v1.8.0
 	github.com/containerd/ttrpc v1.2.3
 	github.com/gofrs/uuid v4.4.0+incompatible

--- a/src/peerpod-ctrl/go.mod
+++ b/src/peerpod-ctrl/go.mod
@@ -3,7 +3,7 @@ module github.com/confidential-containers/cloud-api-adaptor/src/peerpod-ctrl
 go 1.21
 
 require (
-	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers v0.9.0-alpha.3
+	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers v0.9.0-alpha.4
 	github.com/onsi/ginkgo/v2 v2.8.1
 	github.com/onsi/gomega v1.27.1
 	k8s.io/api v0.26.0


### PR DESCRIPTION
Updated the go.mod files and pinned to the CoCo operator v0.9.0.

### Changelog from v0.9.0-alpha.3
$ git log --pretty=oneline v0.9.0-alpha.3...origin/main
142e772769db5bac7f9febf8825f64b13c3f53cd (origin/main, origin/HEAD) GHA: Remove {pre,post}-action steps for self-hosted runners
34b2c1c500fe5d06fa5e16d1a5b2e24a9a489d88 e2e-tests: use t.Log instead of fmt/log
9e6a4a760ed6112a64854d6fc770cd36ff66d67d libvirt-e2e: create auth.json file
c7c2a93501edf9bd469b5d4736301c6cfd7b3f0b tests/e2e: fix TestLibvirtKbsKeyRelease skip make align with test/e2e/main_test.go#L106
18b1d7d13ef2e75d165af5a348f1d790b9857567 e2e-test: use t.Log functions in tests
7f2ecddcce1c5e17b675f3d4fd8fef31585e0a63 test-e2e: Allow agent policy override
3f67b4e7deef4469f9997dc6380d3082691b4921 aws: Update docs
ee70b253776936d64a1a8b8b6440a160791ed156 podvm: Remove image mount point
ef5392dc47f33996f4b0434fb83dbae67fba82a1 kata-agent: set ocicrypt environment variable
44cecf6bdf09d6ab38b6bc21a764aaee94f675a3 podvm-mkosi: refine podvm-mkosi s390x se image build logical - Update podvm-mkosi s390x podvm image build logical - Use `SE_BOOT=true` to enable se image build - support push fedora s390x-se image
af5f446de6133c198b182861aa2064dbc02ee2a3 e2e-test: update kbs test case to support kbs with ibmse verifier
0215eb1346763cb85d72eade7105a899d2d2f965 readme: add fossa badge
b635ef3ee81aa8d20d0574bc5459144a949a3684 deps: Remove circular dep from cloud-providers
b52a95608fb47cc49854c15221689d858d1c2324 go.mod: Update go-urn to v1.2.4
b8730a4e44e9a905c353ef99f47e587576585d63 cloud-config: provision auth.json directly
e9d0039d7483c4e7545196620dc457d3988bdd3f azure-e2e: External ping connectivity test
3d6a09375bdcc410e743e0f2c6a9c478a25a73f8 azure-e2e: Add test to download an external file
dc108e99269c21fc1a52023ce1d4e3bd218abcfa test-e2e: Add test case with init container
f49681c9616ea5e0aa81eca591e821d909a9a660 azure-e2e: Add crio tests for device annotation
dcd87db5b0cb19df8ee0f827e64958f0f0d7e8ff azure-e2e: Add InstanceType Annotation tests
cf7b6d9e24495ab8e1bbc440a4246413e70280bc azure-e2e: Add PodToService and PodsMTLSCommunication tests
c15a519d56442952a77b8ec2689d80cc56888b4d test-e2e: Add KBS test with Trustee Operator
2bb986285e930e7d31df029e95bbff689f38ef37 azure-e2e: Implement GetInstanceType method
12d6d03951898dfa9114111cbefaf99cc278ae6d azure-e2e: Add support for crio container runtime
2fed4fa5e0dea20faa2f9a6c5c8734c149d5105d test-e2e: Use unprivileged nginx image
bd4a5ada268b23cc9dcff115bf24150de111b9b7 test-e2e: Decouple isTestWithKbs from KBS provisioning
56196d8ffb738d20d5b0ecdf671ac8ee0782307f e2e: improve test cases for ibmcloud provider
310e22732bbeaea12c87e287b3d745b0135ed0fa podvm-mkosi: Add support for Debian and Fedora variants
9d0aad78a0fc9c57bc498d1cea16755dc1e5b252 workflow: Add auth test secrets
9365f66de6bc423bdec63be97dc8ccc436da09cb doc: Release process re-work
f66b88d4d8b6ee7b4f2021f38e1de91bfc19551e fix: typo in README.md
f8e7ce3d75ef25e40c5dd5eefe9a18b2c6c094d5 podvm: Add attester build deps to RHEL Dockerfile