### PR TITLE
release: preparing for v0.9.0

### DIFF
--- a/src/cloud-api-adaptor/go.mod
+++ b/src/cloud-api-adaptor/go.mod
@@ -47,8 +47,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/eks v1.29.5
 	github.com/aws/aws-sdk-go-v2/service/iam v1.22.5
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.38.5
-	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers v0.9.0-alpha.4
-	github.com/confidential-containers/cloud-api-adaptor/src/peerpod-ctrl v0.9.0-alpha.4
+	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers v0.9.0
+	github.com/confidential-containers/cloud-api-adaptor/src/peerpod-ctrl v0.9.0
 	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
 	github.com/docker/docker v25.0.5+incompatible
 	github.com/golang-jwt/jwt/v5 v5.2.1

--- a/src/cloud-api-adaptor/install/overlays/aws/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/aws/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 images:
 - name: cloud-api-adaptor
   newName: quay.io/confidential-containers/cloud-api-adaptor # change image if needed
-  newTag: latest
+  newTag: 05d8f49c1d24f5c0a130db1e551a90fefabb0dee
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/src/cloud-api-adaptor/install/overlays/azure/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/azure/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 images:
 - name: cloud-api-adaptor
   newName: quay.io/confidential-containers/cloud-api-adaptor # change image if needed
-  newTag: latest
+  newTag: 05d8f49c1d24f5c0a130db1e551a90fefabb0dee
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/src/cloud-api-adaptor/install/overlays/docker/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/docker/kustomization.yaml
@@ -7,7 +7,7 @@ bases:
 images:
   - name: cloud-api-adaptor
     newName: quay.io/confidential-containers/cloud-api-adaptor # change image if needed
-    newTag: latest
+    newTag: 05d8f49c1d24f5c0a130db1e551a90fefabb0dee
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/src/cloud-api-adaptor/install/overlays/ibmcloud-powervs/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/ibmcloud-powervs/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 images:
 - name: cloud-api-adaptor
   newName: quay.io/confidential-containers/cloud-api-adaptor # change image if needed
-  newTag: latest
+  newTag: 05d8f49c1d24f5c0a130db1e551a90fefabb0dee
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/src/cloud-api-adaptor/install/overlays/ibmcloud/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/ibmcloud/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 images:
 - name: cloud-api-adaptor
   newName: quay.io/confidential-containers/cloud-api-adaptor # change image if needed
-  newTag: latest
+  newTag: 05d8f49c1d24f5c0a130db1e551a90fefabb0dee
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/src/cloud-api-adaptor/install/overlays/libvirt/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/libvirt/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 images:
 - name: cloud-api-adaptor
   newName: quay.io/confidential-containers/cloud-api-adaptor # change image if needed
-  newTag: latest
+  newTag: dev-05d8f49c1d24f5c0a130db1e551a90fefabb0dee
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/src/cloud-api-adaptor/install/overlays/vsphere/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/vsphere/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 images:
 - name: cloud-api-adaptor
   newName: quay.io/confidential-containers/cloud-api-adaptor # change image if needed
-  newTag: latest
+  newTag: 05d8f49c1d24f5c0a130db1e551a90fefabb0dee
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/src/csi-wrapper/go.mod
+++ b/src/csi-wrapper/go.mod
@@ -3,7 +3,7 @@ module github.com/confidential-containers/cloud-api-adaptor/src/csi-wrapper
 go 1.21
 
 require (
-	github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor v0.9.0-alpha.4
+	github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor v0.9.0
 	github.com/container-storage-interface/spec v1.8.0
 	github.com/containerd/ttrpc v1.2.3
 	github.com/gofrs/uuid v4.4.0+incompatible

--- a/src/peerpod-ctrl/go.mod
+++ b/src/peerpod-ctrl/go.mod
@@ -3,7 +3,7 @@ module github.com/confidential-containers/cloud-api-adaptor/src/peerpod-ctrl
 go 1.21
 
 require (
-	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers v0.9.0-alpha.4
+	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers v0.9.0
 	github.com/onsi/ginkgo/v2 v2.8.1
 	github.com/onsi/gomega v1.27.1
 	k8s.io/api v0.26.0


### PR DESCRIPTION
These are the last code changes before we create tags and cut the v0.9.0 release. 