### PR TITLE
e2e-tests: remove service naming conflicts

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/assessment_helpers.go
+++ b/src/cloud-api-adaptor/test/e2e/assessment_helpers.go
@@ -459,14 +459,12 @@ func DeletePod(ctx context.Context, client klient.Client, pod *v1.Pod, tcDelDura
 	if err := client.Resources().Delete(ctx, pod); err != nil {
 		return err
 	}
-	log.Infof("Deleting pod %s...", pod.Name)
 	if err := wait.For(conditions.New(
 		client.Resources()).ResourceDeleted(pod),
 		wait.WithInterval(5*time.Second),
 		wait.WithTimeout(*tcDelDuration)); err != nil {
 		return err
 	}
-	log.Infof("Pod %s has been successfully deleted within %.0fs", pod.Name, tcDelDuration.Seconds())
 	return nil
 }
 

--- a/src/cloud-api-adaptor/test/e2e/assessment_runner.go
+++ b/src/cloud-api-adaptor/test/e2e/assessment_runner.go
@@ -611,11 +611,14 @@ func (tc *TestCase) Run() {
 
 			if tc.extraPods != nil {
 				for _, extraPod := range tc.extraPods {
-					err := DeletePod(ctx, client, extraPod.pod, &tc.deletionWithin)
+					pod := extraPod.pod
+					t.Logf("Deleting pod %s...", pod.Name)
+					err := DeletePod(ctx, client, pod, &tc.deletionWithin)
 					if err != nil {
 						t.Logf("Error occurs when delete pod: %s", extraPod.pod.Name)
 						t.Fatal(err)
 					}
+					t.Logf("Pod %s has been successfully deleted within %.0fs", pod.Name, tc.deletionWithin.Seconds())
 				}
 			}
 


### PR DESCRIPTION
tests will run into into race conditions without a unique name when they run in parallel.

drive-by fix: use t.Logf when deleting pods