### PR TITLE
e2e-tests: resolve ambiguous service labels

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/common_suite.go
+++ b/src/cloud-api-adaptor/test/e2e/common_suite.go
@@ -445,7 +445,7 @@ func DoTestPodToServiceCommunication(t *testing.T, e env.Environment, assert Clo
 	serverImageName := "nginx:latest"
 	serviceName := "nginx-server"
 	labels := map[string]string{
-		"app": "nginx",
+		"app": "nginx-server",
 	}
 	clientPod := NewExtraPod(E2eNamespace, clientPodName, clientContainerName, clientImageName, WithCommand([]string{"/bin/sh", "-c", "sleep 3600"}), WithRestartPolicy(v1.RestartPolicyNever))
 	serverPod := NewPod(E2eNamespace, serverPodName, serverContainerName, serverImageName, WithContainerPort(80), WithRestartPolicy(v1.RestartPolicyNever), WithLabel(labels))
@@ -537,7 +537,7 @@ func DoTestPodsMTLSCommunication(t *testing.T, e env.Environment, assert CloudAs
 			`,
 	}
 	labels := map[string]string{
-		"app": "nginx",
+		"app": "mtls-server",
 	}
 	serverPod := NewPod(E2eNamespace, serverPodName, serverContainerName, serverImageName, WithSecureContainerPort(443), WithSecretBinding(serverSecretDir, serverSecretName), WithLabel(labels), WithConfigMapBinding(podKubeConfigmapDir, configMapName))
 	configMap := NewConfigMap(E2eNamespace, configMapName, configMapData)


### PR DESCRIPTION
Sorry about the barrage of e2e PRs, but I keep stumbling over race conditions.

the nginx server/client tests use the same app= labels to pick a service, this will create problems when running both tests in parallel.