### PR TITLE
Support EKS CNI plugin

### DIFF
--- a/src/cloud-api-adaptor/pkg/podnetwork/podnode.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/podnode.go
@@ -138,6 +138,19 @@ func (n *podNode) Setup() error {
 		}
 	}
 
+	for _, neighbor := range n.config.Neighbors {
+		nNeigh := netops.Neighbor{
+			IP:           neighbor.IP,
+			Dev:          neighbor.Dev,
+			HardwareAddr: neighbor.HardwareAddr,
+			State:        neighbor.State,
+		}
+		if err := podNS.NeighborAdd(&nNeigh); err != nil {
+			return fmt.Errorf("failed to add an ARP entry: %s dev %s lladdr %s %s on pod network namespace %s: %w",
+				neighbor.IP, neighbor.Dev, neighbor.HardwareAddr, neighbor.State, podNS.Path(), err)
+		}
+	}
+
 	return nil
 }
 

--- a/src/cloud-api-adaptor/pkg/podnetwork/tunneler/tunneler.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/tunneler/tunneler.go
@@ -22,6 +22,7 @@ type Config struct {
 	WorkerNodeIP  netip.Prefix `json:"worker-node-ip"`
 	TunnelType    string       `json:"tunnel-type"`
 	Routes        []*Route     `json:"routes"`
+	Neighbors     []*Neighbor  `json:"neighbors"`
 	MTU           int          `json:"mtu"`
 	Index         int          `json:"index"`
 	VXLANPort     int          `json:"vxlan-port,omitempty"`
@@ -35,6 +36,13 @@ type Route struct {
 	Dev      string               `json:"dev,omitempty"`
 	Protocol netops.RouteProtocol `json:"protocol,omitempty"`
 	Scope    netops.RouteScope    `json:"scope,omitempty"`
+}
+
+type Neighbor struct {
+	IP           netip.Addr           `json:"ip,omitempty"`
+	HardwareAddr string               `json:"hw-addr,omitempty"`
+	Dev          string               `json:"dev,omitempty"`
+	State        netops.NeighborState `json:"state,omitempty"`
 }
 
 type driver struct {

--- a/src/cloud-api-adaptor/pkg/podnetwork/tunneler/tunneler.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/tunneler/tunneler.go
@@ -30,11 +30,11 @@ type Config struct {
 }
 
 type Route struct {
-	Dst      netip.Prefix
-	GW       netip.Addr
-	Dev      string
-	Protocol netops.RouteProtocol
-	Scope    netops.RouteScope
+	Dst      netip.Prefix         `json:"dst,omitempty"`
+	GW       netip.Addr           `json:"gw,omitempty"`
+	Dev      string               `json:"dev,omitempty"`
+	Protocol netops.RouteProtocol `json:"protocol,omitempty"`
+	Scope    netops.RouteScope    `json:"scope,omitempty"`
 }
 
 type driver struct {

--- a/src/cloud-api-adaptor/pkg/podnetwork/workernode.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/workernode.go
@@ -162,6 +162,11 @@ func (n *workerNode) Inspect(nsPath string) (*tunneler.Config, error) {
 	}
 	config.MTU = mtu
 
+	neighbors, err := podNS.NeighborList(&netops.Neighbor{Dev: podInterface, State: netops.NEIGHBOR_STATE_PERMANENT})
+	if err != nil {
+		return nil, err
+	}
+
 	for _, route := range routes {
 		r := &tunneler.Route{
 			Dst:      route.Destination,
@@ -171,6 +176,16 @@ func (n *workerNode) Inspect(nsPath string) (*tunneler.Config, error) {
 			Scope:    route.Scope,
 		}
 		config.Routes = append(config.Routes, r)
+	}
+
+	for _, neighbor := range neighbors {
+		n := &tunneler.Neighbor{
+			IP:           neighbor.IP,
+			Dev:          neighbor.Dev,
+			HardwareAddr: neighbor.HardwareAddr,
+			State:        neighbor.State,
+		}
+		config.Neighbors = append(config.Neighbors, n)
 	}
 
 	if n.tunnelType == "vxlan" {

--- a/src/cloud-api-adaptor/pkg/util/netops/netops.go
+++ b/src/cloud-api-adaptor/pkg/util/netops/netops.go
@@ -14,6 +14,8 @@ import (
 	"runtime"
 	"sort"
 
+	"golang.org/x/exp/maps"
+
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
@@ -33,6 +35,8 @@ type Namespace interface {
 	RuleAdd(rule *Rule) error
 	RuleDel(rule *Rule) error
 	RuleList(rule *Rule) ([]*Rule, error)
+	NeighborAdd(neighbor *Neighbor) error
+	NeighborList(filters ...*Neighbor) ([]*Neighbor, error)
 	Run(fn func() error) error
 }
 
@@ -774,6 +778,147 @@ func (ns *namespace) RuleList(rule *Rule) ([]*Rule, error) {
 	}
 
 	return rules, nil
+}
+
+type Neighbor struct {
+	IP           netip.Addr
+	HardwareAddr string
+	Dev          string
+	State        NeighborState
+}
+
+type NeighborState uint16
+
+const NEIGHBOR_STATE_PERMANENT = netlink.NUD_PERMANENT
+
+var neighorStateMap = map[NeighborState]string{
+	netlink.NUD_NONE:       "none",
+	netlink.NUD_INCOMPLETE: "incomplete",
+	netlink.NUD_REACHABLE:  "reachable",
+	netlink.NUD_STALE:      "stale",
+	netlink.NUD_DELAY:      "delay",
+	netlink.NUD_PROBE:      "probe",
+	netlink.NUD_FAILED:     "failed",
+	netlink.NUD_NOARP:      "noarp",
+	netlink.NUD_PERMANENT:  "permanent",
+}
+
+func (s NeighborState) String() string {
+
+	str, ok := neighorStateMap[s]
+	if !ok {
+		return "unknown"
+	}
+	return str
+}
+
+var neighborStates = initLookupTable(maps.Keys(neighorStateMap))
+
+func (s NeighborState) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}
+
+func (s *NeighborState) UnmarshalJSON(data []byte) error {
+
+	v, err := unmarshalJSON("neighbor state", data, neighborStates)
+	if err != nil {
+		return err
+	}
+	*s = v
+	return nil
+}
+
+// NeighborAdd adds a new neighbor entry
+func (ns *namespace) NeighborAdd(neighbor *Neighbor) error {
+
+	if !neighbor.IP.IsValid() {
+		return fmt.Errorf("failed to add a new neighbor entry: invalid IP address %q", neighbor.IP)
+	}
+
+	if neighbor.Dev == "" {
+		return fmt.Errorf("failed to add a new neighbor entry: no device name")
+	}
+
+	link, err := ns.handle.LinkByName(neighbor.Dev)
+	if err != nil {
+		return fmt.Errorf("failed to add a new neighbor entry: device %s not found: %w", neighbor.Dev, err)
+	}
+
+	hwAddr, err := net.ParseMAC(neighbor.HardwareAddr)
+	if err != nil {
+		return fmt.Errorf("failed to add a new neighbor entry: invalid hardware address %q", neighbor.HardwareAddr)
+	}
+
+	state := neighbor.State
+	if state.String() == "none" || state.String() == "unknown" {
+		return fmt.Errorf("failed to add a new neighbor entry: invalid neighbor state %q", state.String())
+	}
+
+	nlNeigh := &netlink.Neigh{
+		IP:           toIP(neighbor.IP),
+		LinkIndex:    link.Attrs().Index,
+		HardwareAddr: hwAddr,
+		State:        int(state),
+	}
+
+	if err := ns.handle.NeighAdd(nlNeigh); err != nil {
+		return fmt.Errorf("failed to add a new neighbor entry %q: %w", nlNeigh, err)
+	}
+
+	return nil
+}
+
+// NeighborList gets a list of neighbors
+func (ns *namespace) NeighborList(filters ...*Neighbor) ([]*Neighbor, error) {
+
+	var neighbors []*Neighbor
+	for _, filter := range filters {
+
+		if filter.State.String() == "unknown" {
+			return nil, fmt.Errorf("unknown neighbor state 0x%x is specified", filter.State)
+		}
+
+		msg := netlink.Ndmsg{
+			Family: netlink.FAMILY_V4,
+			State:  uint16(filter.State),
+		}
+
+		if filter.Dev != "" {
+			link, err := ns.handle.LinkByName(filter.Dev)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get a dev link named %s on network namespace %s: %w", filter.Dev, ns.Path(), err)
+			}
+			msg.Index = uint32(link.Attrs().Index)
+		}
+		nlNeighbors, err := ns.handle.NeighListExecute(msg)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, nlNeigh := range nlNeighbors {
+
+			link, err := ns.handle.LinkByIndex(nlNeigh.LinkIndex)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get a link with index %d of neighbor %s: %w", nlNeigh.LinkIndex, nlNeigh.String(), err)
+			}
+			dev := link.Attrs().Name
+
+			state := NeighborState(nlNeigh.State)
+			if state.String() == "unknown" {
+				return nil, fmt.Errorf("unknown neighbor state 0x%x found in entry %q", nlNeigh.State, nlNeigh.String())
+			}
+
+			n := &Neighbor{
+				IP:           toAddr(nlNeigh.IP),
+				Dev:          dev,
+				HardwareAddr: nlNeigh.HardwareAddr.String(),
+				State:        state,
+			}
+			neighbors = append(neighbors, n)
+		}
+	}
+
+	return neighbors, nil
 }
 
 // RedirectAdd adds a tc ingress qdisc and redirect filter that redirects all traffic from src to dst


### PR DESCRIPTION
Permanent ARP entries that are explicitly set in the network namespace for a pod in a worker node are propagated to
the podns network namespace in a peer pod VM.

The EKS CNI plugin sets such a permanent ARP entry, and this patch is necessary for peer pods to work with EKS networks.

Fixes https://github.com/confidential-containers/cloud-api-adaptor/issues/1966

I tested this change with Flannel and Calico.

