### PR TITLE
docs: redirect users to use make targets on builds

### DIFF
--- a/src/cloud-api-adaptor/podvm/README.md
+++ b/src/cloud-api-adaptor/podvm/README.md
@@ -77,31 +77,23 @@ $ docker build -t podvm_builder \
 
 ## Building the image containing the podvm binaries
 
-In order to build the binaries you should be using the corresponding dockerfile
-of the Linux distro for which the builder image was built.
-For example, if the builder image was built with *Dockerfile.podvm_builder.DISTRO* then
-you should use the *Dockerfile.podvm_binaries.DISTRO* to build the image with podvm binaries.
+We have make targets handy for you. Make sure you are under the
+`src/cloud-api-adaptor` folder.
 
-Assuming you have built the podvm_builder image for Ubuntu as explained in the previous step,
-running the following command will build the image with the podvm binaries.
+> **Note:** The `BUILDER_IMG` environment variable is crucial as it specifies
+> the builder image, which is the result of the previous step build. Ensure you
+> have built the builder image before proceeding.
+
+To build the binaries image, use the following command:
 
 ```bash
-$ docker build -t podvm_binaries \
-         --build-arg BUILDER_IMG=podvm_builder \
-         -f Dockerfile.podvm_binaries .
-
+$ BUILDER_IMG=<your_builder_image> make podvm-binaries
 ```
+
 The build process can take significant time.
 
-The binaries can be built for other architectures than `x86_64` by passing the `ARCH` build
-argument to docker. Currently this is only supported for Ubuntu `s390x` as shown below:
-
-```bash
-$ docker build -t podvm_binaries_s390x \
-         --build-arg BUILDER_IMG=podvm_builder \
-         --build-arg ARCH=s390x \
-         -f Dockerfile.podvm_binaries .
-```
+You can customize the build, by using some environment variables like ARCH,
+PODVM_DISTRO, and other things. For details visit the Makefile.
 
 ## Building the podvm qcow2 image
 


### PR DESCRIPTION
Current dockerfiles are not ready to build directly from the folder. Builder is broken as also depends on .git and .hack folders. Make targets are working, so lets redirect our readers to use those targets.

We can improve the targets as needed and this will be transparant for the readers.