### PR TITLE
initdata: don't fail process-user-data if absent

### DIFF
--- a/src/cloud-api-adaptor/pkg/userdata/provision.go
+++ b/src/cloud-api-adaptor/pkg/userdata/provision.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha512"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -207,11 +208,17 @@ func processCloudConfig(cfg *Config, cc *CloudConfig) error {
 }
 
 func extractInitdataAndHash(cfg *Config) error {
-	if _, err := os.Stat(cfg.initdataPath); err != nil {
+	path := cfg.initdataPath
+	_, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			logger.Printf("File %s not found, skipped initdata processing.\n", path)
+			return nil
+		}
 		return fmt.Errorf("Error stat initdata file: %w", err)
 	}
 
-	dataBytes, err := os.ReadFile(cfg.initdataPath)
+	dataBytes, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("Error read initdata file: %w", err)
 	}

--- a/src/cloud-api-adaptor/pkg/userdata/provision_test.go
+++ b/src/cloud-api-adaptor/pkg/userdata/provision_test.go
@@ -614,6 +614,22 @@ func TestExtractInitdataAndHash(t *testing.T) {
 	}
 }
 
+func TestWithoutInitdata(t *testing.T) {
+	cfg := Config{
+		fetchTimeout:  0,
+		digestPath:    "",
+		initdataPath:  "/does/not/exist",
+		parentPath:    "",
+		writeFiles:    nil,
+		initdataFiles: []string{},
+	}
+
+	err := extractInitdataAndHash(&cfg)
+	if err != nil {
+		t.Fatalf("extractInitdataAndHash returned err: %v", err)
+	}
+}
+
 func TestExtractInitdataWithMalicious(t *testing.T) {
 	tempDir, _ := os.MkdirTemp("", "tmp_initdata_root")
 	defer os.RemoveAll(tempDir)


### PR DESCRIPTION
currently the process-user-data unit will fail because process-user-data will exit with a non-zero exit code if there is no initdata file on the file system. this PR will skip the initdata processing with a log message and exit successfully in such a case.