### PR TITLE
policy: symlink default policy to /run/peerpod

### DIFF
--- a/src/cloud-api-adaptor/podvm/files/etc/kata-opa/default-policy.rego
+++ b/src/cloud-api-adaptor/podvm/files/etc/kata-opa/default-policy.rego
@@ -1,1 +1,1 @@
-allow-all.rego
+/run/peerpod/policy.rego

--- a/src/cloud-api-adaptor/podvm/files/etc/tmpfiles.d/policy.conf
+++ b/src/cloud-api-adaptor/podvm/files/etc/tmpfiles.d/policy.conf
@@ -1,0 +1,2 @@
+#Type   Path                            Mode User Group Age     Argument
+C       /run/peerpod/policy.rego        -    -    -     -       /etc/kata-opa/allow-all.rego

--- a/src/cloud-api-adaptor/podvm/qcow2/copy-files.sh
+++ b/src/cloud-api-adaptor/podvm/qcow2/copy-files.sh
@@ -29,3 +29,4 @@ sudo cp -a /tmp/files/pause_bundle /
 # Copy the kata-agent OPA policy files
 sudo mkdir -p /etc/kata-opa
 sudo cp -a /tmp/files/etc/kata-opa/* /etc/kata-opa/
+sudo cp -a /tmp/files/etc/tmpfiles.d/policy.conf /etc/tmpfiles.d/


### PR DESCRIPTION
Since policy is provisioned by initdata to /run/peerpod/policy.rego we need to point the symlink to that file.

In case no init-data is provided allow-all.rego is copied by systemd to /run/peerpod/policy.rego