### PR TITLE
initdata: measure initdata digest into rt register

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![daily e2e tests for libvirt](https://github.com/confidential-containers/cloud-api-adaptor/actions/workflows/daily-e2e-tests-libvirt.yaml/badge.svg)](https://github.com/confidential-containers/cloud-api-adaptor/actions/workflows/daily-e2e-tests-libvirt.yaml)
 
-[![daily e2e tests for azure](https://github.com/confidential-containers/cloud-api-adaptor/actions/workflows/azure-e2e-test.yml/badge.svg)](https://github.com/confidential-containers/cloud-api-adaptor/actions/workflows/azure-e2e-test.yml)
+[![nightly build for azure](https://github.com/confidential-containers/cloud-api-adaptor/actions/workflows/azure-nightly-build.yml/badge.svg)](https://github.com/confidential-containers/cloud-api-adaptor/actions/workflows/azure-nightly-build.yml)
 
 # Introduction
 

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system/process-user-data.service.d/10-override.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system/process-user-data.service.d/10-override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStartPost=-/bin/bash -c 'tpm2_pcrextend 8:sha256=$(cat /run/peerpod/initdata.digest)'
+ExecStartPost=-/bin/bash -c 'tpm2_pcrextend 8:sha384=$(cat /run/peerpod/initdata.digest)'


### PR DESCRIPTION
This adds two post exec directives for process-user-data in the mkosi to extend PCR 8 (grub, which we don't use it mkosi podvms: https://uapi-group.org/specifications/specs/linux_tpm_pcr_registry/) with the digest of initdata. Sha256 and Sha384 banks are attempted. initdata.digest contains a hex value that will fit only in one of those. A failure of either post exec step will be ignored and do not turn the unit status into a failure.

This is a bit provisional, but since things with init-data and runtime measurement are a bit in flux still, which doesn't warrant to put such logic in code yet.