### PR TITLE
podvm: allow only safe cloud-init modules

### DIFF
--- a/src/cloud-api-adaptor/aws/image/Makefile
+++ b/src/cloud-api-adaptor/aws/image/Makefile
@@ -5,7 +5,7 @@ ROOT_DIR := $(dir $(lastword $(MAKEFILE_LIST)))../../
 include $(ROOT_DIR)podvm/Makefile.inc
 
 
-.PHONY: image clean default-vpc
+.PHONY: image clean default-vpc image-debug
 
 INSTANCE_TYPE ?= c4.xlarge
 
@@ -14,9 +14,13 @@ VOLUME_SIZE ?= 30
 ENABLE_NVIDIA_GPU ?= yes
 export ENABLE_NVIDIA_GPU
 
+
 image: $(IMAGE_FILE)
 
-$(IMAGE_FILE): setopts $(BINARIES) $(FILES)
+image-debug: DEBUG=true
+image-debug: image
+
+$(IMAGE_FILE): prepare setopts $(BINARIES) $(FILES)
 	mkdir -p toupload
 	packer init ./${PODVM_DISTRO}/
 	packer build ${OPTS} \

--- a/src/cloud-api-adaptor/azure/image/Makefile
+++ b/src/cloud-api-adaptor/azure/image/Makefile
@@ -5,13 +5,16 @@
 ROOT_DIR := $(dir $(lastword $(MAKEFILE_LIST)))../../
 include $(ROOT_DIR)podvm/Makefile.inc
 
-.PHONY: image clean
+.PHONY: image clean image-debug
 
 ENABLE_NVIDIA_GPU ?= yes
 
+image-debug: DEBUG=true
+image-debug: image
+
 image: $(IMAGE_FILE)
 
-$(IMAGE_FILE): $(BINARIES) $(FILES)
+$(IMAGE_FILE): prepare $(BINARIES) $(FILES)
 	mkdir -p toupload
 	# export the required packer variables as PKR_VAR_<var_name>
 	# export PKR_VAR_client_id="${AZURE_CLIENT_ID}"

--- a/src/cloud-api-adaptor/podvm/Makefile
+++ b/src/cloud-api-adaptor/podvm/Makefile
@@ -6,7 +6,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
 include $(SELF_DIR)Makefile.inc
 
-.PHONY: image clean clean_sources
+.PHONY: image image-debug clean clean_sources
 
 IMAGE_SUFFIX := .qcow2
 PODVM_DISTRO ?= ubuntu
@@ -31,12 +31,16 @@ UEFI_FIRMWARE_LOCATION ?=
 
 SE_BOOT ?= 0
 
+
 # Env variable for default qemu builder options across distros/arch
 PACKER_DEFAULT_OPTS ?= -var qemu_image_name=${IMAGE_FILE} \
 	-var cloud_image_url=${IMAGE_URL} \
 	-var cloud_image_checksum=${IMAGE_CHECKSUM}
 
 image: $(IMAGE_FILE)
+
+image-debug: DEBUG=true
+image-debug: image
 
 setopts:
 ifeq ($(PODVM_DISTRO),ubuntu)
@@ -77,7 +81,7 @@ ifdef UEFI_FIRMWARE_LOCATION
 endif
 endif
 
-$(IMAGE_FILE): $(BINARIES) $(FILES) setopts
+$(IMAGE_FILE): prepare $(BINARIES) $(FILES) setopts
 	rm -fr output
 	rm -f cloud-init.img
 	cloud-localds cloud-init.img qcow2/userdata.cfg

--- a/src/cloud-api-adaptor/podvm/Makefile.inc
+++ b/src/cloud-api-adaptor/podvm/Makefile.inc
@@ -119,6 +119,13 @@ define git_clone_repo_ref
 		git reset --hard FETCH_HEAD
 endef
 
+prepare:
+ifdef DEBUG
+	rm -f "$(FILES_DIR)/etc/cloud/cloud.cfg.d/99_allowed_modules.cfg"
+else
+	ln -s -f "99_allowed_modules.cfg.template" "$(FILES_DIR)/etc/cloud/cloud.cfg.d/99_allowed_modules.cfg"
+endif
+
 binaries: $(BINARIES)
 
 $(AGENT_PROTOCOL_FORWARDER): always
@@ -191,5 +198,5 @@ clean_sources:
 	[ -d "$(UMOCI_SRC)" ] && cd "$(UMOCI_SRC)" && git clean -xfd -e umoci
 	[ -d "$(KATA_CONTAINERS_SRC)" ] && cd "$(KATA_CONTAINERS_SRC)" && git clean -xfd
 
-.PHONY: force always
+.PHONY: force always prepare
 always force:

--- a/src/cloud-api-adaptor/podvm/files/etc/cloud/cloud.cfg.d/99_allowed_modules.cfg.template
+++ b/src/cloud-api-adaptor/podvm/files/etc/cloud/cloud.cfg.d/99_allowed_modules.cfg.template
@@ -1,0 +1,16 @@
+cloud_init_modules:
+  - migrator
+  - set_hostname
+  - update_hostname
+
+cloud_config_modules:
+  - locale
+  - rh_subscription
+  - ntp
+  - timezone
+  - disable_ec2_metadata
+
+cloud_final_modules:
+  - phone_home
+  - final_message
+  - power_state_change

--- a/src/cloud-api-adaptor/podvm/qcow2/copy-files.sh
+++ b/src/cloud-api-adaptor/podvm/qcow2/copy-files.sh
@@ -30,3 +30,8 @@ sudo cp -a /tmp/files/pause_bundle /
 sudo mkdir -p /etc/kata-opa
 sudo cp -a /tmp/files/etc/kata-opa/* /etc/kata-opa/
 sudo cp -a /tmp/files/etc/tmpfiles.d/policy.conf /etc/tmpfiles.d/
+
+# Copy cloud-init config
+if [ -d /tmp/files/etc/cloud/cloud.cfg.d/ ] && [ -n "$(ls /tmp/files/etc/cloud/cloud.cfg.d/*.cfg)" ]; then
+	sudo cp /tmp/files/etc/cloud/cloud.cfg.d/*.cfg /etc/cloud/cloud.cfg.d/
+fi


### PR DESCRIPTION
Usually ssh and scripts injection modules are enabled by default, with this patch we allow only subset of modules that are considered safe or essential for cloud-providers.
Makefiles reverts back to the original distribution cloud-init settings when DEBUG is set or by running make image-debug




**This was tested on AWS and Azure with rhel podvm only as i failed to build working Ubuntu podvm from upstream (also with main) due to unrelated issue.**
This is related also to https://github.com/confidential-containers/cloud-api-adaptor/pull/1962 , as a main goal is to disable ssh