### PR TITLE
libvirt: Support Ubuntu 23.04+

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -121,6 +121,8 @@ jobs:
           echo "container_runtime=\"${{ inputs.container_runtime }}\"" >> libvirt.properties
           # For debugging
           cat libvirt.properties
+          # Add the kcli install directory to PATH for later steps
+          echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install gh cli
         run: |

--- a/src/cloud-api-adaptor/libvirt/config_libvirt.sh
+++ b/src/cloud-api-adaptor/libvirt/config_libvirt.sh
@@ -80,7 +80,17 @@ installKcli() {
     if ! command -v kcli >/dev/null; then
         echo "Installing kcli"
         kcli_version="$(./hack/yq-shim.sh '.tools.kcli' versions.yaml)"
-        sudo pip3 install kcli==${kcli_version}
+        if [ $OS_DISTRO == "ubuntu" ]; then
+            # Work around newer Ubuntu's python venv errors by using pipx to install kcli
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install pipx -y
+            # export PATH="$PATH:$HOME/.local/bin"
+            pipx install kcli==${kcli_version}
+            pipx ensurepath
+            # Reload shell so that pipx install PATH is available
+            exec $SHELL
+        else
+            sudo pip3 install kcli==${kcli_version}
+        fi
     fi
 }
 


### PR DESCRIPTION
In newer versions of Ubuntu running `pip3 install kcli` results in the following error:
```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
...
```
Solutions seem to be either use a virtual environment, install the package with apt (which isn't available for us as we need), or use pipx if installing an application, which we are.

This attempts to use the logic to install with pipx, including a shell reload at the end of the script to force the PATH to be updated