### PR TITLE
Explicitly set proxy dialer timeout

### DIFF
--- a/src/cloud-api-adaptor/pkg/adaptor/proxy/proxy.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/proxy/proxy.go
@@ -54,7 +54,6 @@ type agentProxy struct {
 }
 
 func NewAgentProxy(serverName, socketPath, pauseImage string, tlsConfig *tlsutil.TLSConfig, caService tlsutil.CAService, proxyTimeout time.Duration) AgentProxy {
-
 	return &agentProxy{
 		serverName:   serverName,
 		socketPath:   socketPath,
@@ -68,7 +67,6 @@ func NewAgentProxy(serverName, socketPath, pauseImage string, tlsConfig *tlsutil
 }
 
 func (p *agentProxy) dial(ctx context.Context, address string) (net.Conn, error) {
-
 	var conn net.Conn
 
 	var dialer interface {
@@ -116,7 +114,6 @@ func (p *agentProxy) dial(ctx context.Context, address string) (net.Conn, error)
 		retry.Context(ctx),
 		retry.MaxDelay(5*time.Second),
 	)
-
 	if err != nil {
 		err = fmt.Errorf("failed to establish agent proxy connection to %s: %w", address, err)
 		logger.Print(err)
@@ -128,7 +125,6 @@ func (p *agentProxy) dial(ctx context.Context, address string) (net.Conn, error)
 }
 
 func (p *agentProxy) Start(ctx context.Context, serverURL *url.URL) error {
-
 	if err := os.MkdirAll(filepath.Dir(p.socketPath), os.ModePerm); err != nil {
 		return fmt.Errorf("failed to create parent directories for socket: %s", p.socketPath)
 	}
@@ -215,7 +211,6 @@ func (p *agentProxy) CAService() tlsutil.CAService {
 }
 
 func (p *agentProxy) ClientCA() (certPEM []byte) {
-
 	if p.tlsConfig == nil {
 		return nil
 	}

--- a/src/cloud-api-adaptor/pkg/adaptor/proxy/proxy.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/proxy/proxy.go
@@ -73,6 +73,8 @@ func (p *agentProxy) dial(ctx context.Context, address string) (net.Conn, error)
 		DialContext(ctx context.Context, network, address string) (net.Conn, error)
 	}
 
+	netDialer := &net.Dialer{Timeout: p.proxyTimeout}
+
 	if p.tlsConfig != nil {
 
 		// Create a TLS configuration object
@@ -94,10 +96,11 @@ func (p *agentProxy) dial(ctx context.Context, address string) (net.Conn, error)
 		}
 
 		dialer = &tls.Dialer{
-			Config: config,
+			NetDialer: netDialer,
+			Config:    config,
 		}
 	} else {
-		dialer = &net.Dialer{}
+		dialer = netDialer
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, p.proxyTimeout)


### PR DESCRIPTION
Use proxy timeout value to set dialer timeout. Default for TCP connections is documented as ~3 minutes, which has proven to be insufficient on AWS.

The proxy timeout value is set through `peer-pods-cm` ConfigMap as `PROXY_TIMEOUT`.