### PR TITLE
Install iptables in cloud-api-adaptor daemonset

### DIFF
--- a/src/cloud-api-adaptor/Dockerfile
+++ b/src/cloud-api-adaptor/Dockerfile
@@ -8,10 +8,14 @@ ARG BASE=registry.fedoraproject.org/fedora:39
 # that was specified with --platform. For more details see:
 # https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
 FROM --platform=$BUILDPLATFORM $BUILDER_BASE AS builder-release
+ARG YQ_VERSION
+RUN go install github.com/mikefarah/yq/v4@$YQ_VERSION
+
 # For `dev` builds due to CGO constraints we have to emulate the target platform
 # instead of using Go's cross-compilation
 FROM --platform=$TARGETPLATFORM $BUILDER_BASE AS builder-dev
-
+ARG YQ_VERSION
+RUN go install github.com/mikefarah/yq/v4@$YQ_VERSION
 RUN dnf install -y libvirt-devel && dnf clean all
 
 FROM builder-${BUILD_TYPE} AS builder
@@ -19,9 +23,6 @@ ARG RELEASE_BUILD
 ARG COMMIT
 ARG VERSION
 ARG TARGETARCH
-ARG YQ_VERSION
-
-RUN go install github.com/mikefarah/yq/v4@$YQ_VERSION
 
 WORKDIR /work
 COPY cloud-api-adaptor/go.mod cloud-api-adaptor/go.sum ./cloud-api-adaptor/
@@ -37,7 +38,24 @@ COPY cloud-api-adaptor/proto ./proto
 
 RUN CC=gcc make ARCH=$TARGETARCH COMMIT=$COMMIT VERSION=$VERSION RELEASE_BUILD=$RELEASE_BUILD cloud-api-adaptor
 
+FROM builder-release AS iptables
+
+ARG TARGETARCH
+
+WORKDIR /iptables
+RUN --mount=type=bind,target=/versions.yaml,source=cloud-api-adaptor/versions.yaml,readonly \
+    version=$(yq -r .tools.iptables-wrapper /versions.yaml) && \
+    GOARCH=$TARGETARCH go install "github.com/kubernetes-sigs/iptables-wrappers@$version" && \
+    shopt -s globstar && \
+    cp /go/bin/**/iptables-wrappers ./iptables-wrapper && \
+    curl -L -o iptables-wrapper-installer.sh "https://raw.githubusercontent.com/kubernetes-sigs/iptables-wrappers/${version#v*-*-}/iptables-wrapper-installer.sh" && \
+    chmod 755 iptables-wrapper-installer.sh
+
 FROM --platform=$TARGETPLATFORM $BASE AS base-release
+
+RUN dnf install -y iptables iptables-legacy iptables-nft nftables && dnf clean all
+RUN --mount=type=cache,target=/iptables,from=iptables,source=/iptables,readonly \
+    cd /iptables && ./iptables-wrapper-installer.sh --no-sanity-check --no-cleanup
 
 FROM base-release AS base-dev
 RUN dnf install -y libvirt-libs /usr/bin/ssh && dnf clean all

--- a/src/cloud-api-adaptor/install/yamls/caa-pod.yaml
+++ b/src/cloud-api-adaptor/install/yamls/caa-pod.yaml
@@ -59,6 +59,11 @@ spec:
         - mountPath: /run/netns
           mountPropagation: HostToContainer
           name: netns
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
         # # setting for cloud provider external plugin
         # - mountPath: /cloud-providers
         #   name: provider-dir
@@ -83,6 +88,14 @@ spec:
       - hostPath:
           path: /run/netns
         name: netns
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: xtables-lock
+      - hostPath:
+          path: /lib/modules
+          type: ""
+        name: lib-modules
       # # setting for cloud provider external plugin
       # - hostPath:
       #     path: /opt/cloud-api-adaptor/plugins

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -25,6 +25,7 @@ tools:
   protoc: 3.15.0
   packer: v1.9.4
   kcli: 99.0.202407031308
+  iptables-wrapper: v0.0.0-20240819165702-06cad2ec6cb5
 # Referenced Git repositories
 git:
   coco-operator:


### PR DESCRIPTION
This PR is a prerequisite to fix https://github.com/confidential-containers/cloud-api-adaptor/issues/2015

To run the iptables command within the cloud-api-adaptor container, we need a wrapper command for iptables, and volumes for accessing a lock file and kernel modules in the host side.

https://github.com/kubernetes-sigs/iptables-wrappers

Network-related projects such as [kube-proxy](https://github.com/kubernetes/release/blob/54644168fde905d452980d0d34984a993e6b24a5/images/build/distroless-iptables/distroless-bullseye/Dockerfile#L45-L47) and [flannel](https://github.com/flannel-io/flannel/blob/bb077808679ff71527d5a9a0ff7ffbf7d108dad4/images/Dockerfile#L20)  use this wrapper to manipulate netfilter on worker nodes.

Another PR that actually fixes the issue using iptables will follow after this PR gets merged.
