### PR TITLE
Kata 3.8.0 versions bump

### DIFF
--- a/src/cloud-api-adaptor/go.mod
+++ b/src/cloud-api-adaptor/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/coreos/go-iptables v0.6.0
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0
-	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240717205640-6aff5f300a98
+	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240821155010-09a13da8ece6
 	github.com/opencontainers/runtime-spec v1.1.1-0.20230922153023-c0e90434df2a
 	github.com/stretchr/testify v1.9.0
 	github.com/vishvananda/netlink v1.2.1-beta.2

--- a/src/cloud-api-adaptor/go.sum
+++ b/src/cloud-api-adaptor/go.sum
@@ -379,8 +379,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240717205640-6aff5f300a98 h1:fejtO8zU3QZq8eEl4i1Vuc1gizjjL5jDhzPV1xqXxgk=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240717205640-6aff5f300a98/go.mod h1:E4YBwwlTgi4TmfBfGDbMRhVaD6iHRaMLM7v8g1reHT8=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240821155010-09a13da8ece6 h1:7EVhWhFf+7grtLTuNI3zXjKSui7Y35F1DAjJ/XfhSQQ=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240821155010-09a13da8ece6/go.mod h1:E4YBwwlTgi4TmfBfGDbMRhVaD6iHRaMLM7v8g1reHT8=
 github.com/kdomanski/iso9660 v0.4.0 h1:BPKKdcINz3m0MdjIMwS0wx1nofsOjxOq8TOr45WGHFg=
 github.com/kdomanski/iso9660 v0.4.0/go.mod h1:OxUSupHsO9ceI8lBLPJKWBTphLemjrCQY8LPXM7qSzU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -34,10 +34,10 @@ git:
     reference: main
   guest-components:
     url: https://github.com/confidential-containers/guest-components
-    reference: v0.9.0
+    reference: d996c692207a983426ae0043952d15ed18e84f66
   kata-containers:
     url: https://github.com/kata-containers/kata-containers
-    reference: a113fc93c8fe75cf58b9b6edadd07a3ebfd665f3
+    reference: 3.8.0
   umoci:
     url: https://github.com/opencontainers/umoci
     reference: v0.4.7

--- a/src/csi-wrapper/go.mod
+++ b/src/csi-wrapper/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang/glog v1.1.2
 	github.com/golang/protobuf v1.5.4
-	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240717205640-6aff5f300a98
+	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240821155010-09a13da8ece6
 	golang.org/x/net v0.26.0
 	google.golang.org/grpc v1.61.2
 	k8s.io/apimachinery v0.26.2

--- a/src/csi-wrapper/go.sum
+++ b/src/csi-wrapper/go.sum
@@ -70,8 +70,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240717205640-6aff5f300a98 h1:fejtO8zU3QZq8eEl4i1Vuc1gizjjL5jDhzPV1xqXxgk=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240717205640-6aff5f300a98/go.mod h1:E4YBwwlTgi4TmfBfGDbMRhVaD6iHRaMLM7v8g1reHT8=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240821155010-09a13da8ece6 h1:7EVhWhFf+7grtLTuNI3zXjKSui7Y35F1DAjJ/XfhSQQ=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240821155010-09a13da8ece6/go.mod h1:E4YBwwlTgi4TmfBfGDbMRhVaD6iHRaMLM7v8g1reHT8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=


### PR DESCRIPTION
Bump components to sync with kata v3.8.0 release to try and ensure we stay up-to-date (ish)