### PR TITLE
ibmcloud: Fix slow VM startup

### DIFF
--- a/src/cloud-providers/ibmcloud/provider.go
+++ b/src/cloud-providers/ibmcloud/provider.go
@@ -173,6 +173,10 @@ func (p *ibmcloudVPCProvider) getInstancePrototype(instanceName, userData, insta
 				&vpcv1.SecurityGroupIdentityByID{ID: &p.serviceConfig.PrimarySecurityGroupID},
 			},
 		},
+		MetadataService: &vpcv1.InstanceMetadataServicePrototype{
+			Enabled:  core.BoolPtr(true),
+			Protocol: core.StringPtr(vpcv1.InstanceMetadataServicePatchProtocolHTTPConst),
+		},
 	}
 
 	if p.serviceConfig.KeyID != "" {


### PR DESCRIPTION
This PR enables the VM metadata service to avoid the timeouts when starting up.

Fixes: #2021