### PR TITLE
podnetwork: Disable connection tracking of VXLAN UDP packets

### DIFF
--- a/src/cloud-api-adaptor/pkg/podnetwork/tunneler/vxlan/iptables.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/tunneler/vxlan/iptables.go
@@ -1,0 +1,149 @@
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package vxlan
+
+import (
+	"fmt"
+	"net/netip"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/coreos/go-iptables/iptables"
+
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/netops"
+)
+
+const (
+	iptablesOutputChainName     = "peerpod-OUTPUT"
+	iptablesPreRoutingChainName = "peerpod-PREROUTING"
+)
+
+type iptablesRule struct {
+	table string
+	base  string
+	chain string
+	spec  []string
+}
+
+func iptablesRules(addr, port, id string) []*iptablesRule {
+
+	comment := fmt.Sprintf("peerpod [vni:%s]", id)
+
+	return []*iptablesRule{
+		{
+			table: "raw",
+			base:  "OUTPUT",
+			chain: iptablesOutputChainName,
+			spec: []string{
+				"-m", "comment", "--comment", comment,
+				"-d", addr,
+				"-p", "udp", "-m", "udp", "--dport", port,
+				"-j", "NOTRACK",
+			},
+		},
+		{
+			table: "raw",
+			base:  "PREROUTING",
+			chain: iptablesPreRoutingChainName,
+			spec: []string{
+				"-m", "comment", "--comment", comment,
+				"-s", addr,
+				"-p", "udp", "-m", "udp", "--dport", port,
+				"-j", "NOTRACK",
+			},
+		},
+	}
+}
+
+var iptablesMutex sync.Mutex
+
+func iptablesSetup(ns netops.Namespace, dstAddr netip.Addr, dstPort, vxlanID int) error {
+
+	iptablesMutex.Lock()
+	defer iptablesMutex.Unlock()
+
+	addr := dstAddr.String()
+	port := strconv.Itoa(dstPort)
+	id := strconv.Itoa(vxlanID)
+
+	return ns.Run(func() error {
+
+		ipt, err := iptables.New(iptables.IPFamily(iptables.ProtocolIPv4))
+		if err != nil {
+			return fmt.Errorf("failed to initialize iptables: %w", err)
+		}
+
+		for _, rule := range iptablesRules(addr, port, id) {
+
+			exists, err := ipt.ChainExists(rule.table, rule.chain)
+			if err != nil {
+				return fmt.Errorf("failed to check the existence of iptables chain %q: %w", rule.chain, err)
+			}
+
+			if !exists {
+				// Add "-N <chain>"
+				if err := ipt.NewChain(rule.table, rule.chain); err != nil {
+					return fmt.Errorf("failed to create iptables chain %s on table %s: %w", rule.chain, rule.table, err)
+				}
+				// Add "-A <base> -j <chain>"
+				if err := ipt.AppendUnique(rule.table, rule.base, "-j", rule.chain); err != nil {
+					return fmt.Errorf("failed to add iptables rule \"-t %s -A %s -j %s\": %w", rule.table, rule.chain, rule.chain, err)
+				}
+			}
+
+			if err := ipt.AppendUnique(rule.table, rule.chain, rule.spec...); err != nil {
+				return fmt.Errorf("failed to add iptables rule \"-t %s -A %s %s\": %w", rule.table, rule.chain, strings.Join(rule.spec, " "), err)
+			}
+		}
+
+		return nil
+	})
+}
+
+func iptablesTeardown(ns netops.Namespace, dstAddr netip.Addr, dstPort, vxlanID int) error {
+
+	iptablesMutex.Lock()
+	defer iptablesMutex.Unlock()
+
+	addr := dstAddr.String()
+	port := strconv.Itoa(dstPort)
+	id := strconv.Itoa(vxlanID)
+
+	return ns.Run(func() error {
+
+		ipt, err := iptables.New(iptables.IPFamily(iptables.ProtocolIPv4))
+		if err != nil {
+			return fmt.Errorf("failed to initialize iptables: %w", err)
+		}
+
+		for _, rule := range iptablesRules(addr, port, id) {
+
+			if err := ipt.Delete(rule.table, rule.chain, rule.spec...); err != nil {
+				return fmt.Errorf("failed to delete iptables rule \"-t %s -A %s %s\": %w", rule.table, rule.chain, strings.Join(rule.spec, " "), err)
+			}
+
+			list, err := ipt.List(rule.table, rule.chain)
+			if err != nil {
+				return fmt.Errorf("failed to list rules in chain %s on table %s: %w", rule.chain, rule.table, err)
+			}
+
+			if len(list) > 1 {
+				// There are remaining rules other than "-N <chain>"
+				continue
+			}
+
+			// Delete "-A <base> -j <chain>"
+			if err := ipt.DeleteIfExists(rule.table, rule.base, "-j", rule.chain); err != nil {
+				return fmt.Errorf("failed to delete iptables rule \"-t %s -A %s -j %s\": %w", rule.table, rule.chain, rule.chain, err)
+			}
+			// Delete "-N <chain>"
+			if err := ipt.DeleteChain(rule.table, rule.chain); err != nil {
+				return fmt.Errorf("failed to delete iptables chain %s on table %s: %w", rule.chain, rule.table, err)
+			}
+		}
+
+		return nil
+	})
+}

--- a/src/cloud-api-adaptor/pkg/util/netops/netops.go
+++ b/src/cloud-api-adaptor/pkg/util/netops/netops.go
@@ -186,6 +186,7 @@ type Link interface {
 	SetHardwareAddr(hwAddr string) error
 	GetMTU() (int, error)
 	SetMTU(mtu int) error
+	GetDevice() (Device, error)
 
 	SetMaster(master Link) error
 	SetNamespace(target Namespace) error
@@ -314,6 +315,22 @@ func (l *link) Delete() error {
 		return fmt.Errorf("failed to delete an interface of %s: %s:  %w", l.Name(), l.Type(), err)
 	}
 	return nil
+}
+
+func (l *link) GetDevice() (dev Device, err error) {
+
+	switch v := l.nlLink.(type) {
+	case *netlink.Vxlan:
+		dev = &VXLAN{
+			Group: toAddr(v.Group),
+			ID:    v.VxlanId,
+			Port:  v.Port,
+		}
+	default:
+		// TODO: Support Bridge, VXLAN, ...
+		return nil, fmt.Errorf("device info is not available: %s", l.nlLink.Type())
+	}
+	return dev, nil
 }
 
 type Device interface {


### PR DESCRIPTION
This patch disables connection tracking of VXLAN UDP packets to prevent the conntrack table from filing up.

The Linux connection tracking system (conntrack) always tracks UDP packets as connections by default. This is OK for usual UDP communications, but does not work with VXLAN UDP packets, since a destination port of each VXLAN UDP packet is fixed (4789) in both directions, and a source port of each packet is randomly selected. This UDP packet flow does not creates a connection flow, and every UDP packet of a VXLAN tunnel is recognized as a first packet of a new UDP  sream.

If conntrack table fills up, it may affect other network connections that needs NAT. This patch will alleviate such problems.

Fixes #2015

We can confirm necessary iptable rules are added in a worker node as follows.

```
# iptables -t raw -S
-P PREROUTING ACCEPT
-P OUTPUT ACCEPT
-N peerpod-OUTPUT
-N peerpod-PREROUTING
-A PREROUTING -j peerpod-PREROUTING
-A OUTPUT -j peerpod-OUTPUT
-A peerpod-OUTPUT -d 192.168.122.181/32 -p udp -m comment --comment "peerpod [vni:555001]" -m udp --dport 4789 -j NOTRACK
-A peerpod-PREROUTING -s 192.168.122.181/32 -p udp -m comment --comment "peerpod [vni:555001]" -m udp --dport 4789 -j NOTRACK
```

We can confirm that no conntrack entries are created for VXLAN as follows.
```
# conntrack -L | grep "udp" | grep "UNREPLIED" | grep "dport=4789"
conntrack v1.4.6 (conntrack-tools): 171 flow entries have been shown.
```

