### PR TITLE
Add support to use public IP for the pod VM in Azure

### DIFF
--- a/src/cloud-api-adaptor/entrypoint.sh
+++ b/src/cloud-api-adaptor/entrypoint.sh
@@ -72,6 +72,7 @@ azure() {
     [[ "${AZURE_INSTANCE_SIZES}" ]] && optionals+="-instance-sizes ${AZURE_INSTANCE_SIZES} "
     [[ "${TAGS}" ]] && optionals+="-tags ${TAGS} " # Custom tags applied to pod vm
     [[ "${ENABLE_SECURE_BOOT}" == "true" ]] && optionals+="-enable-secure-boot "
+    [[ "${USE_PUBLIC_IP}" == "true" ]] && optionals+="-use-public-ip " # Use public IP for pod vm
 
     set -x
     exec cloud-api-adaptor azure \

--- a/src/cloud-api-adaptor/install/overlays/azure/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/azure/kustomization.yaml
@@ -40,6 +40,7 @@ configMapGenerator:
   #- AZURE_INSTANCE_SIZES="" # comma separated
   #- TAGS="" # Uncomment and add key1=value1,key2=value2 etc if you want to use specific tags for podvm
   #- FORWARDER_PORT="" # Uncomment and set if you want to use a specific port for agent-protocol-forwarder. Defaults to 15150
+  #- USE_PUBLIC_IP="true" # Uncomment if you want to use public ip for podvm
   #- PEERPODS_LIMIT_PER_NODE="10" # Max number of peer pods that can be created per node. Default is 10
 ##TLS_SETTINGS
   #- CACERT_FILE="/etc/certificates/ca.crt" # for TLS

--- a/src/cloud-providers/azure/manager.go
+++ b/src/cloud-providers/azure/manager.go
@@ -32,11 +32,12 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	flags.StringVar(&azurecfg.SSHKeyPath, "ssh-key-path", "$HOME/.ssh/id_rsa.pub", "Path to SSH public key")
 	flags.StringVar(&azurecfg.SSHUserName, "ssh-username", "peerpod", "SSH User Name")
 	flags.BoolVar(&azurecfg.DisableCVM, "disable-cvm", false, "Use non-CVMs for peer pods")
-	// Add a List parameter to indicate differet type of instance sizes to be used for the Pod VMs
+	// Add a List parameter to indicate different type of instance sizes to be used for the Pod VMs
 	flags.Var(&azurecfg.InstanceSizes, "instance-sizes", "Instance sizes to be used for the Pod VMs, comma separated")
 	// Add a key value list parameter to indicate custom tags to be used for the Pod VMs
 	flags.Var(&azurecfg.Tags, "tags", "Custom tags (key=value pairs) to be used for the Pod VMs, comma separated")
 	flags.BoolVar(&azurecfg.EnableSecureBoot, "enable-secure-boot", false, "Enable secure boot for the VMs")
+	flags.BoolVar(&azurecfg.UsePublicIP, "use-public-ip", false, "Use Public IP for connecting to the kata-agent inside the Pod VM")
 }
 
 func (_ *Manager) LoadEnv() {

--- a/src/cloud-providers/azure/types.go
+++ b/src/cloud-providers/azure/types.go
@@ -48,6 +48,7 @@ type Config struct {
 	// Disabled by default, we want to do measured boot.
 	// Secure boot brings no additional security.
 	EnableSecureBoot bool
+	UsePublicIP      bool
 }
 
 func (c Config) Redact() Config {


### PR DESCRIPTION
This is useful for environments where the K8s cluster is run on a developer workstation and peer pod is created in Azure. Useful for testing, working on AI models requiring large VMs etc.
Similar functionality also exists for the AWS provider. So this PR also brings functional parity.
