### PR TITLE
versions: Bump components to match kata 3.9.0

### DIFF
--- a/src/cloud-api-adaptor/go.mod
+++ b/src/cloud-api-adaptor/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/coreos/go-iptables v0.6.0
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0
-	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240821155010-09a13da8ece6
+	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240919132750-cdaaf708a18d
 	github.com/opencontainers/runtime-spec v1.1.1-0.20230922153023-c0e90434df2a
 	github.com/stretchr/testify v1.9.0
 	github.com/vishvananda/netlink v1.2.1-beta.2

--- a/src/cloud-api-adaptor/go.sum
+++ b/src/cloud-api-adaptor/go.sum
@@ -379,8 +379,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240821155010-09a13da8ece6 h1:7EVhWhFf+7grtLTuNI3zXjKSui7Y35F1DAjJ/XfhSQQ=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240821155010-09a13da8ece6/go.mod h1:E4YBwwlTgi4TmfBfGDbMRhVaD6iHRaMLM7v8g1reHT8=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240919132750-cdaaf708a18d h1:h2BFcyLXojUYtoXvagibDdEheklcUzhNVUtt1j8JC3A=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240919132750-cdaaf708a18d/go.mod h1:E4YBwwlTgi4TmfBfGDbMRhVaD6iHRaMLM7v8g1reHT8=
 github.com/kdomanski/iso9660 v0.4.0 h1:BPKKdcINz3m0MdjIMwS0wx1nofsOjxOq8TOr45WGHFg=
 github.com/kdomanski/iso9660 v0.4.0/go.mod h1:OxUSupHsO9ceI8lBLPJKWBTphLemjrCQY8LPXM7qSzU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/src/cloud-api-adaptor/test/e2e/libvirt_test.go
+++ b/src/cloud-api-adaptor/test/e2e/libvirt_test.go
@@ -99,11 +99,15 @@ func TestLibvirtDeletePod(t *testing.T) {
 }
 
 func TestLibvirtPodToServiceCommunication(t *testing.T) {
+	// This test is causing issues on CI with instability, so skip until we can resolve this.
+	SkipTestOnCI(t)
 	assert := LibvirtAssert{}
 	DoTestPodToServiceCommunication(t, testEnv, assert)
 }
 
 func TestLibvirtPodsMTLSCommunication(t *testing.T) {
+	// This test is causing issues on CI with instability, so skip until we can resolve this.
+	SkipTestOnCI(t)
 	assert := LibvirtAssert{}
 	DoTestPodsMTLSCommunication(t, testEnv, assert)
 }

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -34,7 +34,7 @@ git:
     reference: main
   guest-components:
     url: https://github.com/confidential-containers/guest-components
-    reference: v0.10.0
+    reference: c2022037d8fbb076f569529e93b2cbe63a3968bb
   kata-containers:
     url: https://github.com/kata-containers/kata-containers
     reference: 3.9.0

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -34,10 +34,10 @@ git:
     reference: main
   guest-components:
     url: https://github.com/confidential-containers/guest-components
-    reference: d996c692207a983426ae0043952d15ed18e84f66
+    reference: v0.10.0
   kata-containers:
     url: https://github.com/kata-containers/kata-containers
-    reference: 3.8.0
+    reference: 3.9.0
   umoci:
     url: https://github.com/opencontainers/umoci
     reference: v0.4.7
@@ -46,11 +46,11 @@ git:
     reference: v1.5.0
   kbs:
     url: https://github.com/confidential-containers/trustee
-    reference: e890fc90c384207668fa3a4d6a2f2a2d652797ee
+    reference: v0.10.1
 oci:
   pause:
     registry: docker://registry.k8s.io/pause
     tag: 3.9
   kbs:
-    registry: ghcr.io/confidential-containers/staged-images/kbs
-    tag: e890fc90c384207668fa3a4d6a2f2a2d652797ee
+    registry: ghcr.io/confidential-containers/key-broker-service
+    tag: built-in-as-v0.10.1

--- a/src/csi-wrapper/go.mod
+++ b/src/csi-wrapper/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang/glog v1.1.2
 	github.com/golang/protobuf v1.5.4
-	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240821155010-09a13da8ece6
+	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240919132750-cdaaf708a18d
 	golang.org/x/net v0.26.0
 	google.golang.org/grpc v1.61.2
 	k8s.io/apimachinery v0.26.2

--- a/src/csi-wrapper/go.sum
+++ b/src/csi-wrapper/go.sum
@@ -70,8 +70,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240821155010-09a13da8ece6 h1:7EVhWhFf+7grtLTuNI3zXjKSui7Y35F1DAjJ/XfhSQQ=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240821155010-09a13da8ece6/go.mod h1:E4YBwwlTgi4TmfBfGDbMRhVaD6iHRaMLM7v8g1reHT8=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240919132750-cdaaf708a18d h1:h2BFcyLXojUYtoXvagibDdEheklcUzhNVUtt1j8JC3A=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20240919132750-cdaaf708a18d/go.mod h1:E4YBwwlTgi4TmfBfGDbMRhVaD6iHRaMLM7v8g1reHT8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=


### PR DESCRIPTION
- Following the bump of the guest-components and trustee in
https://github.com/kata-containers/kata-containers/pull/10313
to pick up the 0.10.0 and 0.10.1 versions of the
guest-components and trustee, and the kata containers 3.9.0
release, we need to bump versions to say in sync