### PR TITLE
libvirt: support aarch64 arch VM

### DIFF
--- a/src/cloud-api-adaptor/libvirt/config_libvirt.sh
+++ b/src/cloud-api-adaptor/libvirt/config_libvirt.sh
@@ -11,7 +11,13 @@ set -o pipefail
 
 source /etc/os-release || source /usr/lib/os-release
 ARCH=$(uname -m)
-TARGET_ARCH=${ARCH/x86_64/amd64}
+if [[ "${ARCH}" == "x86_64" ]]; then
+    TARGET_ARCH=amd64
+elif [[ "${ARCH}" == "aarch64" ]]; then
+    TARGET_ARCH=arm64
+else
+    TARGET_ARCH=${ARCH}
+fi
 OS_DISTRO=ubuntu
 if [[ "$ID" == "rhel" || "$ID" == "centos" || "$ID" == "fedora" ]]; then
     OS_DISTRO=rhel

--- a/src/cloud-api-adaptor/libvirt/kcli_cluster.sh
+++ b/src/cloud-api-adaptor/libvirt/kcli_cluster.sh
@@ -61,6 +61,10 @@ create () {
 			-P arch=$ARCH \
 			-P multus=false \
 			-P autolabeller=false "
+	elif [[ ${TARGET_ARCH} == "aarch64" ]]; then
+		parameters="$parameters \
+			-P arch=$ARCH \
+			-P machine=virt"
 	fi
 	echo "Download $CLUSTER_IMAGE ${TARGET_ARCH} image"
 	# kcli support download image with archs: 'x86_64', 'aarch64', 'ppc64le', 's390x'


### PR DESCRIPTION
Get correct yq package name and specify virt machine type for aarch64 instead of relying on kcli (https://github.com/karmab/kcli/commit/7cad52ce9774ffc05b86ce2c127429345ee851fa won't override the machine type from user's input for aarch64 any more).

Also sent some minor `kcli` changes here: https://github.com/karmab/kcli/pull/718

With above changes, `kcli_cluster.sh create` can successfully create k8s cluster on aarch64.

```
$ ./libvirt/kcli_cluster.sh create
...
$ export KUBECONFIG=~/.kcli/clusters/peer-pods/auth/kubeconfig 
$ kubectl get nodes
NAME                   STATUS   ROLES           AGE    VERSION
peer-pods-ctlplane-0   Ready    control-plane   3m6s   v1.30.0
peer-pods-worker-0     Ready    worker          92s    v1.30.0
$ kubectl get pods -A
NAMESPACE       NAME                                           READY   STATUS      RESTARTS   AGE
autorules       autoruler-5ff4dbbf7-fqtz7                      1/1     Running     0          2m51s
ingress-nginx   ingress-nginx-admission-create-kjq68           0/1     Completed   0          2m51s
ingress-nginx   ingress-nginx-admission-patch-thzcq            0/1     Completed   1          2m51s
ingress-nginx   ingress-nginx-controller-54cf9c8856-nzxww      1/1     Running     0          2m51s
kube-flannel    kube-flannel-ds-shvsz                          1/1     Running     0          95s
kube-flannel    kube-flannel-ds-szhwj                          1/1     Running     0          2m51s
kube-system     coredns-7db6d8ff4d-b4pjx                       1/1     Running     0          2m51s
kube-system     coredns-7db6d8ff4d-j7dxt                       1/1     Running     0          2m51s
kube-system     etcd-peer-pods-ctlplane-0                      1/1     Running     0          3m7s
kube-system     kube-apiserver-peer-pods-ctlplane-0            1/1     Running     0          3m5s
kube-system     kube-controller-manager-peer-pods-ctlplane-0   1/1     Running     0          3m5s
kube-system     kube-multus-ds-qf2g7                           1/1     Running     0          95s
kube-system     kube-multus-ds-t6dww                           1/1     Running     0          2m51s
kube-system     kube-proxy-mm2gk                               1/1     Running     0          2m51s
kube-system     kube-proxy-pnwdr                               1/1     Running     0          95s
kube-system     kube-scheduler-peer-pods-ctlplane-0            1/1     Running     0          3m5s
```