### PR TITLE
podvm: Attempt to fix missing policy

### DIFF
--- a/src/cloud-api-adaptor/podvm/Makefile.inc
+++ b/src/cloud-api-adaptor/podvm/Makefile.inc
@@ -129,11 +129,15 @@ $(PROCESS_USER_DATA): always
 	cd "$(ROOT_DIR)" && ARCH=$(DEB_ARCH) $(MAKE) process-user-data
 	install -D --compare "$(ROOT_DIR)/process-user-data" "$@"
 
-$(KATA_AGENT): $(FORCE_TARGET)
+$(KATA_AGENT): $(FORCE_TARGET) | default-policy
 	$(eval $(call generate_tag,tag,$(KATA_SRC_REF)))
 	oras pull ghcr.io/kata-containers/cached-artefacts/agent:${tag}
 	tar xvJpf kata-static-agent.tar.xz
 	install -D --compare "./usr/bin/kata-agent" "$@"
+
+default-policy:
+	cd $(AGENT_POLICY_PATH) && ln -s -f $(DEFAULT_AGENT_POLICY_FILE) /run/peerpod/policy.rego
+
 
 # Skopeo package packages are available in RHEL/CentOS 8 or later and Ubuntu 20.10 or later
 $(SKOPEO_SRC):


### PR DESCRIPTION
WIP: Can we even write to `/run/` during podvm build? Since #1998 the default-policy.rego has been symlinked to point to `/run/peerpod/policy.rego`, but if you aren't using init data then this file doesn't exist. In this we try and make that file point to our default policy file to cover this case.

Note: I don't understand how this works for packer images at the moment, so I'm clearly missing something.