### PR TITLE
ci: set initdata in remote-attestation test

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/azure_test.go
+++ b/src/cloud-api-adaptor/test/e2e/azure_test.go
@@ -7,6 +7,7 @@ package e2e
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 
@@ -135,10 +136,15 @@ func TestKbsKeyRelease(t *testing.T) {
 
 func TestRemoteAttestation(t *testing.T) {
 	t.Parallel()
-	if !isTestWithKbs() {
-		t.Skip("Skipping kbs related test as kbs is not deployed")
+	var kbsEndpoint string
+	if ep := os.Getenv("KBS_ENDPOINT"); ep != "" {
+		kbsEndpoint = ep
+	} else if keyBrokerService == nil {
+		t.Skip("Skipping because KBS config is missing")
+	} else {
+		kbsEndpoint, _ = keyBrokerService.GetCachedKbsEndpoint()
 	}
-	DoTestRemoteAttestation(t, testEnv, assert)
+	DoTestRemoteAttestation(t, testEnv, assert, kbsEndpoint)
 }
 
 func TestTrusteeOperatorKeyReleaseForSpecificKey(t *testing.T) {

--- a/src/cloud-api-adaptor/test/e2e/remote_attestation.go
+++ b/src/cloud-api-adaptor/test/e2e/remote_attestation.go
@@ -1,16 +1,24 @@
 package e2e
 
 import (
+	b64 "encoding/base64"
+	"fmt"
 	"testing"
 
 	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
 // the test will retrieve a kbs token to verify a successful remote attestation
-func DoTestRemoteAttestation(t *testing.T, e env.Environment, assert CloudAssert) {
+func DoTestRemoteAttestation(t *testing.T, e env.Environment, assert CloudAssert, kbsEndpoint string) {
 	name := "remote-attestation"
 	image := "quay.io/curl/curl:latest"
 	// fail on non 200 code, silent, but output on failure
-	job := NewJob(E2eNamespace, name, 0, image, "curl", "-f", "-s", "-S", "-o", "/dev/null", "http://127.0.0.1:8006/aa/token?token_type=kbs")
+	cmd := []string{"curl", "-f", "-s", "-S", "-o", "/dev/null", "http://127.0.0.1:8006/aa/token?token_type=kbs"}
+	initdata := fmt.Sprintf(testInitdata, kbsEndpoint, kbsEndpoint, kbsEndpoint)
+	b64Data := b64.StdEncoding.EncodeToString([]byte(initdata))
+	annotations := map[string]string{
+		"io.katacontainers.config.runtime.cc_init_data": b64Data,
+	}
+	job := NewJob(E2eNamespace, name, 0, image, WithJobCommand(cmd), WithJobAnnotations(annotations))
 	NewTestCase(t, e, "RemoteAttestation", assert, "Received KBS token").WithJob(job).Run()
 }


### PR DESCRIPTION
Set initdata for remote attestation. allow kbs endpoint to be specified for manual test runs.

edit: tested on a [fork](https://github.com/mkulke/cloud-api-adaptor/actions/runs/10883561900/job/30197561320)