### PR TITLE
test/e2e: improve nginx deployment test

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/nginx_deployment.go
+++ b/src/cloud-api-adaptor/test/e2e/nginx_deployment.go
@@ -183,10 +183,14 @@ func waitForNginxDeploymentAvailable(ctx context.Context, t *testing.T, client k
 					t.Logf("Current Pod State: %v", string(yamlData))
 				}
 				if pod.Status.Phase == v1.PodRunning {
-					t.Logf("Log of the pod %.v", pod.Name)
+					t.Logf("Log of the pod %v", pod.Name)
 					t.Logf("===================")
 					podLogString, _ := GetPodLog(ctx, client, &pod)
-					t.Logf(podLogString)
+					if podLogString != "" {
+						t.Logf(podLogString)
+					} else {
+						t.Logf("No logs found")
+					}
 					t.Logf("===================")
 				}
 			}


### PR DESCRIPTION
The nginx deployment test isn't completely stable. Sometimes it fails and we don't know yet whether it's a legit bug on peer pods or not. With this PR I don't solve that problem either, as I still don't know the roots of the problem, however, it improves the test that it will run the `Teardown()` function even when `WithSetup()` failed. We have this suspect that the left nginx deployment might be messing with the next tests, so this change will at least solve that problem (if it's really a problem). Regardless, tests should always delete their resources at the execution end.

There is one thing that I'd like to implement, which is, do not run Teardown() if not running on CI. In other words, if I'm running the test locally and it fails I want to have the deployment running so I can inspect. I may be sending this on another PR or maybe even on this one....depending on the reviews.