### PR TITLE
test/e2e: Skip nginx deployment test

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/libvirt_test.go
+++ b/src/cloud-api-adaptor/test/e2e/libvirt_test.go
@@ -77,6 +77,9 @@ func TestLibvirtCreatePeerPodAndCheckEnvVariableLogsWithImageAndDeployment(t *te
 }
 
 func TestLibvirtCreateNginxDeployment(t *testing.T) {
+	// This test is causing issues on CI with instability, so skip until we can resolve this.
+	// See https://github.com/confidential-containers/cloud-api-adaptor/issues/2046
+	SkipTestOnCI(t)
 	assert := LibvirtAssert{}
 	DoTestNginxDeployment(t, testEnv, assert)
 }


### PR DESCRIPTION
This test is causing lots of delays in merging PRs pre 0.10.0 release, so let's skip it for now.