### PR TITLE
Kbs key release rework

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/assessment_runner.go
+++ b/src/cloud-api-adaptor/test/e2e/assessment_runner.go
@@ -393,11 +393,9 @@ func (tc *TestCase) Run() {
 
 				if tc.podState == v1.PodRunning {
 					if len(tc.testCommands) > 0 {
-						if len(tc.testCommands) > 0 {
-							logString, err := AssessPodTestCommands(ctx, client, tc.pod, tc.testCommands)
-							if err != nil {
-								t.Errorf("AssessPodTestCommands failed, with output: %s and error: %v", logString, err)
-							}
+						logString, err := AssessPodTestCommands(ctx, client, tc.pod, tc.testCommands)
+						if err != nil {
+							t.Errorf("AssessPodTestCommands failed, with output: %s and error: %v", logString, err)
 						}
 					}
 

--- a/src/cloud-api-adaptor/test/e2e/azure_test.go
+++ b/src/cloud-api-adaptor/test/e2e/azure_test.go
@@ -135,6 +135,9 @@ func TestKbsKeyRelease(t *testing.T) {
 	testSecret := envconf.RandomName("coco-pp-e2e-secret", 25)
 	resourcePath := "caa/workload_key/test_key.bin"
 	err := keyBrokerService.SetSecret(resourcePath, []byte(testSecret))
+	if err != nil {
+		t.Fatalf("SetSecret failed with: %v", err)
+	}
 	DoTestKbsKeyRelease(t, testEnv, assert, kbsEndpoint, resourcePath, testSecret)
 }
 
@@ -146,7 +149,11 @@ func TestRemoteAttestation(t *testing.T) {
 	} else if keyBrokerService == nil {
 		t.Skip("Skipping because KBS config is missing")
 	} else {
-		kbsEndpoint, _ = keyBrokerService.GetCachedKbsEndpoint()
+		var err error
+		kbsEndpoint, err = keyBrokerService.GetCachedKbsEndpoint()
+		if err != nil {
+			t.Fatalf("GetCachedKbsEndpoint failed with: %v", err)
+		}
 	}
 	DoTestRemoteAttestation(t, testEnv, assert, kbsEndpoint)
 }
@@ -156,7 +163,10 @@ func TestTrusteeOperatorKeyReleaseForSpecificKey(t *testing.T) {
 		t.Skip("Skipping kbs related test as Trustee Operator is not deployed")
 	}
 	t.Parallel()
-	kbsEndpoint, _ := keyBrokerService.GetCachedKbsEndpoint()
+	kbsEndpoint, err := keyBrokerService.GetCachedKbsEndpoint()
+	if err != nil {
+		t.Fatalf("GetCachedKbsEndpoint failed with: %v", err)
+	}
 	DoTestKbsKeyRelease(t, testEnv, assert, kbsEndpoint, "default/kbsres1/key1", "res1val1")
 }
 

--- a/src/cloud-api-adaptor/test/e2e/azure_test.go
+++ b/src/cloud-api-adaptor/test/e2e/azure_test.go
@@ -157,7 +157,7 @@ func TestTrusteeOperatorKeyReleaseForSpecificKey(t *testing.T) {
 	}
 	t.Parallel()
 	kbsEndpoint, _ := keyBrokerService.GetCachedKbsEndpoint()
-	DoTestTrusteeOperatorKeyReleaseForSpecificKey(t, testEnv, assert, kbsEndpoint)
+	DoTestKbsKeyRelease(t, testEnv, assert, kbsEndpoint, "default/kbsres1/key1", "res1val1")
 }
 
 func TestAzureImageDecryption(t *testing.T) {

--- a/src/cloud-api-adaptor/test/e2e/azure_test.go
+++ b/src/cloud-api-adaptor/test/e2e/azure_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	_ "github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/test/provisioner/azure"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
 func TestDeletePodAzure(t *testing.T) {
@@ -131,7 +132,10 @@ func TestKbsKeyRelease(t *testing.T) {
 	}
 	t.Parallel()
 	kbsEndpoint, _ := keyBrokerService.GetCachedKbsEndpoint()
-	DoTestKbsKeyRelease(t, testEnv, assert, kbsEndpoint)
+	testSecret := envconf.RandomName("coco-pp-e2e-secret", 25)
+	resourcePath := "caa/workload_key/test_key.bin"
+	err := keyBrokerService.SetSecret(resourcePath, []byte(testSecret))
+	DoTestKbsKeyRelease(t, testEnv, assert, kbsEndpoint, resourcePath, testSecret)
 }
 
 func TestRemoteAttestation(t *testing.T) {

--- a/src/cloud-api-adaptor/test/e2e/common.go
+++ b/src/cloud-api-adaptor/test/e2e/common.go
@@ -29,7 +29,6 @@ import (
 
 const WAIT_DEPLOYMENT_AVAILABLE_TIMEOUT = time.Second * 180
 const DEFAULT_AUTH_SECRET = "auth-json-secret-default"
-const KBS_SECRET = "reponame/workload_key/key.bin"
 
 var testInitdata string = `algorithm = "sha384"
 version = "0.1.0"

--- a/src/cloud-api-adaptor/test/e2e/common_suite.go
+++ b/src/cloud-api-adaptor/test/e2e/common_suite.go
@@ -616,29 +616,6 @@ func DoTestKbsKeyReleaseForFailure(t *testing.T, e env.Environment, assert Cloud
 	NewTestCase(t, e, "DoTestKbsKeyReleaseForFailure", assert, "Kbs key release is failed").WithPod(pod).WithTestCommands(testCommands).Run()
 }
 
-// Test to check for specific key value from Trustee Operator Deployment
-func DoTestTrusteeOperatorKeyReleaseForSpecificKey(t *testing.T, e env.Environment, assert CloudAssert, kbsEndpoint string) {
-	t.Log("Do test Trustee operator key release for specific key")
-	pod := NewBusyboxPodWithNameWithInitdata(E2eNamespace, "op-key-release", kbsEndpoint).GetPodOrFatal(t)
-	testCommands := []TestCommand{
-		{
-			Command:       []string{"wget", "-q", "-O-", "http://127.0.0.1:8006/cdh/resource/default/kbsres1/key1"},
-			ContainerName: pod.Spec.Containers[0].Name,
-			TestCommandStdoutFn: func(stdout bytes.Buffer) bool {
-				if strings.Contains(stdout.String(), "res1val1") {
-					t.Logf("Success to get key %s", stdout.String())
-					return true
-				} else {
-					t.Errorf("Failed to access key: %s", stdout.String())
-					return false
-				}
-			},
-		},
-	}
-
-	NewTestCase(t, e, "KbsKeyReleasePod", assert, "Kbs key release from Trustee Operator is successful").WithPod(pod).WithTestCommands(testCommands).Run()
-}
-
 func DoTestRestrictivePolicyBlocksExec(t *testing.T, e env.Environment, assert CloudAssert) {
 	allowAllExceptExecPolicyFilePath := "fixtures/policies/allow-all-except-exec-process.rego"
 	podName := "policy-exec-rejected"

--- a/src/cloud-api-adaptor/test/e2e/docker_test.go
+++ b/src/cloud-api-adaptor/test/e2e/docker_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	_ "github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/test/provisioner/docker"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
 func TestDockerCreateSimplePod(t *testing.T) {
@@ -102,14 +103,16 @@ func TestDockerKbsKeyRelease(t *testing.T) {
 	if !isTestWithKbs() {
 		t.Skip("Skipping kbs related test as kbs is not deployed")
 	}
-	keyBrokerService.SetSampleSecretKey()
+	testSecret := envconf.RandomName("coco-pp-e2e-secret", 25)
+	resourcePath := "caa/workload_key/test_key.bin"
+	keyBrokerService.SetSecret(resourcePath, []byte(testSecret))
 	keyBrokerService.EnableKbsCustomizedResourcePolicy("deny_all.rego")
 	kbsEndpoint, _ := keyBrokerService.GetCachedKbsEndpoint()
 	assert := DockerAssert{}
 	t.Parallel()
-	DoTestKbsKeyReleaseForFailure(t, testEnv, assert, kbsEndpoint)
+	DoTestKbsKeyReleaseForFailure(t, testEnv, assert, kbsEndpoint, resourcePath, testSecret)
 	keyBrokerService.EnableKbsCustomizedResourcePolicy("allow_all.rego")
-	DoTestKbsKeyRelease(t, testEnv, assert, kbsEndpoint)
+	DoTestKbsKeyRelease(t, testEnv, assert, kbsEndpoint, resourcePath, testSecret)
 }
 
 func TestDockerCreatePeerPodWithAuthenticatedImageWithoutCredentials(t *testing.T) {

--- a/src/cloud-api-adaptor/test/e2e/docker_test.go
+++ b/src/cloud-api-adaptor/test/e2e/docker_test.go
@@ -105,13 +105,25 @@ func TestDockerKbsKeyRelease(t *testing.T) {
 	}
 	testSecret := envconf.RandomName("coco-pp-e2e-secret", 25)
 	resourcePath := "caa/workload_key/test_key.bin"
-	keyBrokerService.SetSecret(resourcePath, []byte(testSecret))
-	keyBrokerService.EnableKbsCustomizedResourcePolicy("deny_all.rego")
-	kbsEndpoint, _ := keyBrokerService.GetCachedKbsEndpoint()
+	err := keyBrokerService.SetSecret(resourcePath, []byte(testSecret))
+	if err != nil {
+		t.Fatalf("SetSecret failed with: %v", err)
+	}
+	err = keyBrokerService.EnableKbsCustomizedResourcePolicy("deny_all.rego")
+	if err != nil {
+		t.Fatalf("EnableKbsCustomizedResourcePolicy failed with: %v", err)
+	}
+	kbsEndpoint, err := keyBrokerService.GetCachedKbsEndpoint()
+	if err != nil {
+		t.Fatalf("GetCachedKbsEndpoint failed with: %v", err)
+	}
 	assert := DockerAssert{}
 	t.Parallel()
 	DoTestKbsKeyReleaseForFailure(t, testEnv, assert, kbsEndpoint, resourcePath, testSecret)
-	keyBrokerService.EnableKbsCustomizedResourcePolicy("allow_all.rego")
+	err = keyBrokerService.EnableKbsCustomizedResourcePolicy("allow_all.rego")
+	if err != nil {
+		t.Fatalf("EnableKbsCustomizedResourcePolicy failed with: %v", err)
+	}
 	DoTestKbsKeyRelease(t, testEnv, assert, kbsEndpoint, resourcePath, testSecret)
 }
 

--- a/src/cloud-api-adaptor/test/e2e/libvirt_test.go
+++ b/src/cloud-api-adaptor/test/e2e/libvirt_test.go
@@ -141,10 +141,22 @@ func TestLibvirtSealedSecret(t *testing.T) {
 
 	testSecret := envconf.RandomName("coco-pp-e2e-secret", 25)
 	resourcePath := "caa/workload_key/test_key.bin"
-	_ = keyBrokerService.SetSecret(resourcePath, []byte(testSecret))
-	_ = keyBrokerService.EnableKbsCustomizedResourcePolicy("allow_all.rego")
-	_ = keyBrokerService.EnableKbsCustomizedAttestationPolicy("allow_all.rego")
-	kbsEndpoint, _ := keyBrokerService.GetCachedKbsEndpoint()
+	err := keyBrokerService.SetSecret(resourcePath, []byte(testSecret))
+	if err != nil {
+		t.Fatalf("SetSecret failed with: %v", err)
+	}
+	err = keyBrokerService.EnableKbsCustomizedResourcePolicy("allow_all.rego")
+	if err != nil {
+		t.Fatalf("EnableKbsCustomizedResourcePolicy failed with: %v", err)
+	}
+	err = keyBrokerService.EnableKbsCustomizedAttestationPolicy("allow_all.rego")
+	if err != nil {
+		t.Fatalf("EnableKbsCustomizedAttestationPolicy failed with: %v", err)
+	}
+	kbsEndpoint, err := keyBrokerService.GetCachedKbsEndpoint()
+	if err != nil {
+		t.Fatalf("GetCachedKbsEndpoint failed with: %v", err)
+	}
 	assert := LibvirtAssert{}
 	DoTestSealedSecret(t, testEnv, assert, kbsEndpoint, resourcePath, testSecret)
 }
@@ -156,10 +168,22 @@ func TestLibvirtKbsKeyRelease(t *testing.T) {
 
 	testSecret := envconf.RandomName("coco-pp-e2e-secret", 25)
 	resourcePath := "caa/workload_key/test_key.bin"
-	_ = keyBrokerService.SetSecret(resourcePath, []byte(testSecret))
-	_ = keyBrokerService.EnableKbsCustomizedResourcePolicy("allow_all.rego")
-	_ = keyBrokerService.EnableKbsCustomizedAttestationPolicy("deny_all.rego")
-	kbsEndpoint, _ := keyBrokerService.GetCachedKbsEndpoint()
+	err := keyBrokerService.SetSecret(resourcePath, []byte(testSecret))
+	if err != nil {
+		t.Fatalf("SetSecret failed with: %v", err)
+	}
+	err = keyBrokerService.EnableKbsCustomizedResourcePolicy("allow_all.rego")
+	if err != nil {
+		t.Fatalf("EnableKbsCustomizedResourcePolicy failed with: %v", err)
+	}
+	err = keyBrokerService.EnableKbsCustomizedAttestationPolicy("deny_all.rego")
+	if err != nil {
+		t.Fatalf("EnableKbsCustomizedAttestationPolicy failed with: %v", err)
+	}
+	kbsEndpoint, err := keyBrokerService.GetCachedKbsEndpoint()
+	if err != nil {
+		t.Fatalf("GetCachedKbsEndpoint failed with: %v", err)
+	}
 	assert := LibvirtAssert{}
 	t.Parallel()
 	DoTestKbsKeyReleaseForFailure(t, testEnv, assert, kbsEndpoint, resourcePath, testSecret)
@@ -167,13 +191,22 @@ func TestLibvirtKbsKeyRelease(t *testing.T) {
 		t.Log("KBS with ibmse cases")
 		// the allow_*_.rego file is created by follow document
 		// https://github.com/confidential-containers/trustee/blob/main/deps/verifier/src/se/README.md#set-attestation-policy
-		_ = keyBrokerService.EnableKbsCustomizedAttestationPolicy("allow_with_wrong_image_tag.rego")
+		err = keyBrokerService.EnableKbsCustomizedAttestationPolicy("allow_with_wrong_image_tag.rego")
+		if err != nil {
+			t.Fatalf("EnableKbsCustomizedAttestationPolicy failed with: %v", err)
+		}
 		DoTestKbsKeyReleaseForFailure(t, testEnv, assert, kbsEndpoint, resourcePath, testSecret)
-		_ = keyBrokerService.EnableKbsCustomizedAttestationPolicy("allow_with_correct_claims.rego")
+		err = keyBrokerService.EnableKbsCustomizedAttestationPolicy("allow_with_correct_claims.rego")
+		if err != nil {
+			t.Fatalf("EnableKbsCustomizedAttestationPolicy failed with: %v", err)
+		}
 		DoTestKbsKeyRelease(t, testEnv, assert, kbsEndpoint, resourcePath, testSecret)
 	} else {
 		t.Log("KBS normal cases")
-		_ = keyBrokerService.EnableKbsCustomizedAttestationPolicy("allow_all.rego")
+		err = keyBrokerService.EnableKbsCustomizedAttestationPolicy("allow_all.rego")
+		if err != nil {
+			t.Fatalf("EnableKbsCustomizedAttestationPolicy failed with: %v", err)
+		}
 		DoTestKbsKeyRelease(t, testEnv, assert, kbsEndpoint, resourcePath, testSecret)
 	}
 }


### PR DESCRIPTION
The KbsKeyRelease tests have had errors setting the secret key, which are revealed when trace is on:
```
=== RUN   TestLibvirtKbsKeyRelease
time="2024-09-24T13:53:12Z" level=info msg="set key resource: ../../kbs/config/kubernetes/overlays/x86_64/key.bin"
time="2024-09-24T13:53:12Z" level=trace msg="./kbs-client --url http://192.168.122.140:31680 config --auth-private-key ../../kbs/config/kubernetes/base/kbs.key set-resource --path reponame/workload_key/key.bin --resource-file ../../kbs/config/kubernetes/overlays/x86_64/key.bin, output: Error: Request Failed, Response: \"{\\\"type\\\":\\\"https://github.com/confidential-containers/kbs/errors/SetSecretFailed\\\",\\\"detail\\\":\\\"Set secret failed: write local fs\\\"}\"\n"
```
I believe this is base the `reponame/workload_key` directory is created by the KBS at start-up, so it owns the resource. It also leads to error is the KBS log:
```
[2024-09-24T11:11:40Z INFO  kbs] Using config file /etc/kbs/kbs-config.toml
[2024-09-24T11:11:40Z WARN  attestation_service::rvps] No RVPS address provided and will launch a built-in rvps
[2024-09-24T11:11:40Z INFO  attestation_service::token::simple] No Token Signer key in config file, create an ephemeral key and without CA pubkey cert
[2024-09-24T11:11:40Z INFO  kbs] Starting HTTP server at [0.0.0.0:8080]
[2024-09-24T11:11:40Z INFO  actix_server::builder] starting 4 workers
[2024-09-24T11:11:40Z INFO  actix_server::server] Tokio runtime found; starting in existing Tokio runtime
[2024-09-24T13:07:50Z ERROR kbs::http::error] Set secret failed: write local fs
```
which isn't helpful when debugging.

This PR changes the secret to be in a different directory and also does some refactoring so that a more dynamic secret can be set to avoid use finding errors late and reduce duplication.