### PR TITLE
test/e2e: Provisioning logging

### DIFF
--- a/src/cloud-api-adaptor/test/provisioner/provision.go
+++ b/src/cloud-api-adaptor/test/provisioner/provision.go
@@ -239,6 +239,7 @@ func (p *CloudAPIAdaptor) Deploy(ctx context.Context, cfg *envconf.Config, props
 	stdoutStderr, err := cmd.CombinedOutput()
 	log.Tracef("%v, output: %s", cmd, stdoutStderr)
 	if err != nil {
+		log.Errorf("Operator apply failed with err %v, stdout & stdErr: %s", err, stdoutStderr)
 		return err
 	}
 

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -24,7 +24,7 @@ tools:
   rust: 1.75.0
   protoc: 3.15.0
   packer: v1.9.4
-  kcli: 99.0.202407031308
+  kcli: 99.0.202409251101
   iptables-wrapper: v0.0.0-20240819165702-06cad2ec6cb5
   oras: 1.2.0
 # Referenced Git repositories


### PR DESCRIPTION
Add extra logging in case the operator apply fails for debug