### PR TITLE
podvm: Update hardcoded value for oras on podvm-builder

### DIFF
--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.rhel
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.rhel
@@ -81,7 +81,7 @@ ENV PATH="/root/.cargo/bin:/usr/local/go/bin:$PATH"
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip && \
     unzip protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip -d /usr/local && rm -f protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip
 
-ADD https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${ARCH}.tar.gz oras_${ORAS_VERSION}_linux_amd64.tar.gz
+ADD https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${ARCH}.tar.gz oras_${ORAS_VERSION}_linux_${ARCH}.tar.gz
 RUN rm -rf /usr/local/bin/oras && tar -C /usr/local/bin -xzf oras_${ORAS_VERSION}_linux_${ARCH}.tar.gz && rm -f oras_${ORAS_VERSION}_linux_${ARCH}.tar.gz
 
 WORKDIR /src


### PR DESCRIPTION
Updating the ARCH value on podvm-builder, so that it can pick up the respective architecture while it's being built.

Fixes https://github.com/confidential-containers/cloud-api-adaptor/issues/2059