### PR TITLE
libvirt: Enable multiple PodVM image scenario

### DIFF
--- a/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
@@ -203,11 +203,15 @@ func (s *cloudService) CreateVM(ctx context.Context, req *pb.CreateVMRequest) (r
 	// Get Pod VM cpu and memory from annotations
 	vcpus, memory := util.GetCPUAndMemoryFromAnnotation(req.Annotations)
 
+	// Get Pod VM image from annotations
+	image := util.GetImageFromAnnotation(req.Annotations)
+
 	// Pod VM spec
 	vmSpec := provider.InstanceTypeSpec{
 		InstanceType: instanceType,
 		VCPUs:        vcpus,
 		Memory:       memory,
+		Image:        image,
 	}
 
 	// TODO: server name is also generated in each cloud provider, and possibly inconsistent

--- a/src/cloud-api-adaptor/pkg/util/cloud.go
+++ b/src/cloud-api-adaptor/pkg/util/cloud.go
@@ -35,6 +35,14 @@ func GetInstanceTypeFromAnnotation(annotations map[string]string) string {
 	return annotations[hypannotations.MachineType]
 }
 
+// Method to get image from annotation
+func GetImageFromAnnotation(annotations map[string]string) string {
+	// The image annotation in Kata refers to image path
+	// For example image for Kata/Qemu refers to /hypervisor/image.img etc.
+	// We use the same annotation for Kata/remote to refer to image name
+	return annotations[hypannotations.ImagePath]
+}
+
 // Method to get vCPU and memory from annotations
 func GetCPUAndMemoryFromAnnotation(annotations map[string]string) (int64, int64) {
 

--- a/src/cloud-api-adaptor/pkg/util/cloud_test.go
+++ b/src/cloud-api-adaptor/pkg/util/cloud_test.go
@@ -114,3 +114,42 @@ func TestGetInstanceTypeFromAnnotation(t *testing.T) {
 		})
 	}
 }
+
+func TestGetImageFromAnnotation(t *testing.T) {
+	type args struct {
+		annotations map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		// Add test cases with annotations for only image name
+		{
+			name: "image name only",
+			args: args{
+				annotations: map[string]string{
+					hypannotations.ImagePath: "rhel9-os",
+				},
+			},
+			want: "rhel9-os",
+		},
+		// Add test cases with annotations for only image name with empty value
+		{
+			name: "image name only with empty value",
+			args: args{
+				annotations: map[string]string{
+					hypannotations.ImagePath: "",
+				},
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetImageFromAnnotation(tt.args.annotations); got != tt.want {
+				t.Errorf("GetImageFromAnnotation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/src/cloud-api-adaptor/test/e2e/assessment_helpers.go
+++ b/src/cloud-api-adaptor/test/e2e/assessment_helpers.go
@@ -525,3 +525,20 @@ func AddImagePullSecretToDefaultServiceAccount(ctx context.Context, client klien
 	}
 	return nil
 }
+
+func GetPodNamesByLabel(ctx context.Context, client klient.Client, t *testing.T, namespace string, labelName string, labelValue string) (*v1.PodList, error) {
+
+	clientset, err := kubernetes.NewForConfig(client.RESTConfig())
+	if err != nil {
+		t.Fatal(err)
+		return nil, err
+	}
+
+	pods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelName + "=" + labelValue})
+	if err != nil {
+		t.Fatal(err)
+		return nil, err
+	}
+
+	return pods, nil
+}

--- a/src/cloud-api-adaptor/test/e2e/libvirt_test.go
+++ b/src/cloud-api-adaptor/test/e2e/libvirt_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	_ "github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/test/provisioner/libvirt"
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/test/provisioner/libvirt"
 )
 
 func TestLibvirtCreateSimplePod(t *testing.T) {
@@ -33,6 +33,16 @@ func TestLibvirtCreatePeerPodContainerWithExternalIPAccess(t *testing.T) {
 	assert := LibvirtAssert{}
 	DoTestCreatePeerPodContainerWithExternalIPAccess(t, testEnv, assert)
 
+}
+
+func TestLibvirtCreatePeerPodContainerWithValidAlternateImage(t *testing.T) {
+	assert := LibvirtAssert{}
+	DoTestCreatePeerPodContainerWithValidAlternateImage(t, testEnv, assert, libvirt.AlternateVolumeName)
+}
+
+func TestLibvirtCreatePeerPodContainerWithInvalidAlternateImage(t *testing.T) {
+	assert := LibvirtAssert{}
+	DoTestCreatePeerPodContainerWithInvalidAlternateImage(t, testEnv, assert)
 }
 
 func TestLibvirtCreatePeerPodWithJob(t *testing.T) {

--- a/src/cloud-providers/libvirt/provider.go
+++ b/src/cloud-providers/libvirt/provider.go
@@ -79,6 +79,14 @@ func (p *libvirtProvider) CreateInstance(ctx context.Context, podName, sandboxID
 	}
 	logger.Printf("LaunchSecurityType: %s", vm.launchSecurityType.String())
 
+	if spec.Image != "" {
+		logger.Printf("Choosing %s as libvirt volume for the PodVM image", spec.Image)
+		p.libvirtClient.volName = spec.Image
+	} else if spec.Image == "" && p.serviceConfig.VolName != p.libvirtClient.volName {
+		logger.Printf("Choosing the default %s as libvirt volume for the PodVM image", p.serviceConfig.VolName)
+		p.libvirtClient.volName = p.serviceConfig.VolName
+	}
+
 	result, err := CreateDomain(ctx, p.libvirtClient, vm)
 	if err != nil {
 		logger.Printf("failed to create an instance : %v", err)

--- a/src/cloud-providers/types.go
+++ b/src/cloud-providers/types.go
@@ -66,4 +66,5 @@ type InstanceTypeSpec struct {
 	Memory       int64
 	Arch         string
 	GPUs         int64
+	Image        string
 }


### PR DESCRIPTION
Enable support for multiple PodVM images for libvirt provider with the merge of https://github.com/kata-containers/kata-containers/pull/10274

Fixes https://github.com/confidential-containers/cloud-api-adaptor/issues/1282

**Working Scenario:**
Tried with the following busybox manifest:
```
apiVersion: v1
kind: Pod
metadata:
  name: busybox
  namespace: openshift-sandboxed-containers-operator
  labels:
    app: busybox
  annotations:
    io.katacontainers.config.hypervisor.image: "pppvm-nov-vol.qcow2"
spec:
  containers:
  - image: quay.io/prometheus/busybox
    imagePullPolicy: Always
    name: busybox-container
    ports:
    - containerPort: 80
      protocol: TCP
  restartPolicy: Always
  runtimeClassName: kata-remote
```
Here the `pppvm-nov-vol.qcow2` is a valid libvirt volume and a podvm image is uploaded there.

CAA logs:
```
2024/09/26 09:20:17 [adaptor/cloud] initdata in Pod annotation:
2024/09/26 09:20:17 [adaptor/cloud] initdata in pod annotation is empty, use global initdata:
2024/09/26 09:20:17 [adaptor/cloud] create a sandbox 20a284a33e1e6222844abd4f92bda5ee7b897d752f2b3a505f4f32b5ef5eb33e for pod busybox in namespace openshift-sandboxed-containers-operator (netns: /var/run/netns/7745570f-3b24-4f0e-a623-e060ded3f3db)
2024/09/26 09:20:17 [adaptor/cloud/libvirt] LaunchSecurityType: None
2024/09/26 09:20:17 [adaptor/cloud/libvirt] Choosing pppvm-nov-vol.qcow2 as libvirt volume for the PodVM image
2024/09/26 09:20:17 [adaptor/cloud/libvirt] Checking if instance (podvm-busybox-20a284a3) exists
2024/09/26 09:20:17 [adaptor/cloud/libvirt] Uploaded volume key /var/lib/libvirt/images/kata-pod-vms/podvm-busybox-20a284a3-root.qcow2
2024/09/26 09:20:17 [adaptor/cloud/libvirt] Create cloudInit iso
2024/09/26 09:20:17 [adaptor/cloud/libvirt] Uploading iso file: podvm-busybox-20a284a3-cloudinit.iso
......
......
2024/09/26 09:21:28 [adaptor/proxy]         io.katacontainers.pkg.oci.container_type: pod_container
2024/09/26 09:21:28 [adaptor/proxy]         io.kubernetes.cri-o.Image: quay.io/prometheus/busybox@sha256:59d0ed3060aef57d1b23bc353a2223af24a6e1d035486647eb599a77ff2d446e
2024/09/26 09:21:28 [adaptor/proxy]         io.kubernetes.cri-o.Labels: {"io.kubernetes.container.name":"busybox-container","io.kubernetes.pod.name":"busybox","io.kubernetes.pod.namespace":"openshift-sandboxed-containers-operator","io.kubernetes.pod.uid":"ff0368c7-c9f1-4c2f-9c95-3a8a168c6ed8"}
2024/09/26 09:21:28 [adaptor/proxy]         io.katacontainers.config.hypervisor.image: pppvm-nov-vol.qcow2
2024/09/26 09:21:28 [adaptor/proxy]         io.kubernetes.container.restartCount: 0
```

**Failure Scenario:**
Tried with the following busybox manifest:
```
apiVersion: v1
kind: Pod
metadata:
  name: busybox
  namespace: openshift-sandboxed-containers-operator
  labels:
    app: busybox
  annotations:
    io.katacontainers.config.hypervisor.image: "rhel9-os"
spec:
  containers:
  - image: quay.io/prometheus/busybox
    imagePullPolicy: Always
    name: busybox-container
    ports:
    - containerPort: 80
      protocol: TCP
  restartPolicy: Always
  runtimeClassName: kata-remote
```
Here the `rhel9-os` is a dummy variable and not an actual libvirt volume.

CAA logs:
```
2024/09/26 09:29:09 [adaptor/cloud] create a sandbox 57bbf987d92ff21b508adddff69ef36a400f6ba7e9dfaabf13c1b54897aca0d3 for pod busybox in namespace openshift-sandboxed-containers-operator (netns: /var/run/netns/dd971e3c-d1e8-4156-8832-35ead351c3b0)
2024/09/26 09:29:09 [adaptor/cloud/libvirt] LaunchSecurityType: None
2024/09/26 09:29:09 [adaptor/cloud/libvirt] Choosing rhel9-os as libvirt volume for the PodVM image
2024/09/26 09:29:09 [adaptor/cloud/libvirt] Checking if instance (podvm-busybox-57bbf987) exists
2024/09/26 09:29:09 [adaptor/cloud/libvirt] failed to create an instance : Error in creating volume: Can't retrieve volume rhel9-os
2024/09/26 09:29:09 [adaptor/cloud] error starting instance: creating an instance : Error in creating volume: Can't retrieve volume rhel9-os
2024/09/26 09:29:09 [adaptor/proxy] shutting down socket forwarder
```