### PR TITLE
workflow/libvirt: improve debug step post-failure

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -147,6 +147,13 @@ jobs:
             done
           done
 
+          for worker in $(kubectl get node -o name -l node.kubernetes.io/worker 2>/dev/null); do
+            echo "::group::journalctl -t kata ($worker)"
+            kubectl debug --image quay.io/prometheus/busybox -q -i \
+              "$worker" -- chroot /host journalctl -x -t kata --no-pager
+            echo "::endgroup::"
+          done
+
           echo "::group::Libvirt domains"
           sudo virsh list
           echo "::endgroup::"

--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -139,10 +139,12 @@ jobs:
           kubectl logs -l app=cloud-api-adaptor -n confidential-containers-system
           echo "::endgroup::"
 
-          for pod in $(kubectl get pods -o name 2>/dev/null); do
-            echo "::group::Describe $pod"
-            kubectl describe "$pod"
-            echo "::endgroup::"
+          for ns in $(kubectl get ns -o name 2>/dev/null | sed 's#namespace/##' | grep "^coco-pp-"); do
+            for pod in $(kubectl get pods -o name -n "$ns" 2>/dev/null); do
+              echo "::group::Describe $pod (namespace/$ns)"
+              kubectl describe "$pod" -n "$ns"
+              echo "::endgroup::"
+            done
           done
 
           echo "::group::Libvirt domains"


### PR DESCRIPTION
This contain a fix for when printing the description of any test pod left on k8s. Also it will start collecting the journal messages from the workers (although I'm not sure yet how github will handle the many lines of logs....). Usually those log messages are useful to debug; not sure if it will for the peer pods case...I hope it helps.