### PR TITLE
APF: Rename KataAgentNamespace

### DIFF
--- a/src/cloud-api-adaptor/docs/SecureComms.md
+++ b/src/cloud-api-adaptor/docs/SecureComms.md
@@ -56,7 +56,7 @@ kubectl -n kbs-operator-system get cm resource-policy -o yaml | sed "s/default a
 
 Change the `src/cloud-api-adaptor/podvm/files/etc/systemd/system/agent-protocol-forwarder.service` to include:
 ```sh
-ExecStart=/usr/local/bin/agent-protocol-forwarder -kata-agent-namespace /run/netns/podns -secure-comms -kata-agent-socket /run/kata-containers/agent.sock $TLS_OPTIONS $OPTIONS
+ExecStart=/usr/local/bin/agent-protocol-forwarder -pod-namespace /run/netns/podns -secure-comms -kata-agent-socket /run/kata-containers/agent.sock $TLS_OPTIONS $OPTIONS
 ```
 
 You may also include additional Inbounds and Outbounds configurations to the Forwarder using the `-secure-comms-inbounds` and `-secure-comms-outbounds` flags. See more details regarding Inbounds and Outbounds below.

--- a/src/cloud-api-adaptor/pkg/forwarder/forwarder.go
+++ b/src/cloud-api-adaptor/pkg/forwarder/forwarder.go
@@ -30,7 +30,7 @@ const (
 	DefaultConfigPath          = "/run/peerpod/daemon.json"
 	DefaultPodNetworkSpecPath  = "/run/peerpod/podnetwork.json"
 	DefaultKataAgentSocketPath = "/run/kata-containers/agent.sock"
-	DefaultKataAgentNamespace  = "/run/netns/podns"
+	DefaultPodNamespace        = "/run/netns/podns"
 	AgentURLPath               = "/agent"
 )
 

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/agent-protocol-forwarder.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/agent-protocol-forwarder.service
@@ -8,7 +8,7 @@ DefaultDependencies=no
 [Service]
 Type=notify
 EnvironmentFile=-/etc/default/agent-protocol-forwarder
-ExecStart=/usr/local/bin/agent-protocol-forwarder -kata-agent-namespace /run/netns/podns -kata-agent-socket /run/kata-containers/agent.sock $TLS_OPTIONS $OPTIONS
+ExecStart=/usr/local/bin/agent-protocol-forwarder -pod-namespace /run/netns/podns -kata-agent-socket /run/kata-containers/agent.sock $TLS_OPTIONS $OPTIONS
 Restart=on-failure
 RestartSec=5s
 


### PR DESCRIPTION
KataAgentNamespace parameter is controlling the namespace in which the pod runs (not the namespace in which the Kata Agent runs)

To make the code readable, it is renamed to PodNamespace