### PR TITLE
CI: run e2e tests for libvirt with CRI-O

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -38,6 +38,11 @@ on:
         default: false
         required: false
         type: boolean
+      container_runtime:
+        default: 'containerd'
+        description: Name of the container runtime. Either containerd or crio.
+        required: false
+        type: string
 
 env:
   CLOUD_PROVIDER: libvirt
@@ -111,6 +116,7 @@ jobs:
         run: |
           export TEST_E2E_SECURE_COMMS="${{ inputs.secure_comms }}"
           ./libvirt/config_libvirt.sh
+          echo "container_runtime=\"${{ inputs.container_runtime }}\"" >> libvirt.properties
           # For debugging
           cat libvirt.properties
 
@@ -163,6 +169,7 @@ jobs:
           REGISTRY_CREDENTIAL_ENCODED: ${{ secrets.REGISTRY_CREDENTIAL_ENCODED }}
         run: |
           export CLOUD_PROVIDER=libvirt
+          export CONTAINER_RUNTIME="${{ inputs.container_runtime }}"
           export DEPLOY_KBS=true
           export TEST_PROVISION="yes"
           export TEST_TEARDOWN="no"

--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -55,6 +55,8 @@ defaults:
 jobs:
   test:
     runs-on: ${{ inputs.runner }}
+    # TODO: remove this when the crio job gets stable
+    continue-on-error: ${{ inputs.container_runtime == 'crio' && true || false }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -188,6 +188,7 @@ jobs:
     uses: ./.github/workflows/e2e_libvirt.yaml
     with:
       caa_image: ${{ inputs.registry }}/cloud-api-adaptor:${{ inputs.caa_image_tag }}-dev
+      container_runtime: ${{ matrix.container_runtime }}
       podvm_image: ${{ inputs.registry }}/podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ matrix.arch }}:${{ inputs.podvm_image_tag }}
       install_directory_artifact: install_directory
       git_ref: ${{ inputs.git_ref }}

--- a/src/cloud-api-adaptor/libvirt/e2e_matrix_libvirt.json
+++ b/src/cloud-api-adaptor/libvirt/e2e_matrix_libvirt.json
@@ -1,4 +1,5 @@
 {
+    "container_runtime": ["containerd", "crio"],
     "secure_comms": ["none"],
     "os": ["ubuntu"],
     "provider": ["generic"],

--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -144,6 +144,7 @@ Use the properties on the table below for Libvirt:
 
 |Property|Description|Default|
 |---|---|---|
+|container_runtime|Test cluster configured container runtime. Either **containerd** or **crio** |containerd|
 |libvirt_network|Libvirt Network|"default"|
 |libvirt_storage|Libvirt storage pool|"default"|
 |libvirt_vol_name|Volume name|"podvm-base.qcow2"|

--- a/src/cloud-api-adaptor/test/e2e/common_suite.go
+++ b/src/cloud-api-adaptor/test/e2e/common_suite.go
@@ -632,8 +632,10 @@ func DoTestRestrictivePolicyBlocksExec(t *testing.T, e env.Environment, assert C
 			Command:       []string{"ls"},
 			ContainerName: pod.Spec.Containers[0].Name,
 			TestErrorFn: func(err error) bool {
-				if strings.Contains(err.Error(), "failed to exec in container") && strings.Contains(err.Error(), "ExecProcessRequest is blocked by policy") {
-					t.Logf("Exec process was blocked %s", err.Error())
+				if (strings.Contains(err.Error(), "failed to exec in container") || // containerd
+					strings.Contains(err.Error(), "error executing command in container")) && // cri-o
+					strings.Contains(err.Error(), "ExecProcessRequest is blocked by policy") {
+					t.Logf("Exec process was blocked: %s", err.Error())
 					return true
 				} else {
 					t.Errorf("Exec process was allowed: %s", err.Error())

--- a/src/cloud-api-adaptor/test/e2e/libvirt_test.go
+++ b/src/cloud-api-adaptor/test/e2e/libvirt_test.go
@@ -31,6 +31,9 @@ func TestLibvirtCreatePodWithSecret(t *testing.T) {
 
 func TestLibvirtCreatePeerPodContainerWithExternalIPAccess(t *testing.T) {
 	SkipTestOnCI(t)
+	if isTestOnCrio() {
+		t.Skip("Fails with CRI-O (confidential-containers/cloud-api-adaptor#2100)")
+	}
 	assert := LibvirtAssert{}
 	DoTestCreatePeerPodContainerWithExternalIPAccess(t, testEnv, assert)
 
@@ -114,6 +117,9 @@ func TestLibvirtDeletePod(t *testing.T) {
 func TestLibvirtPodToServiceCommunication(t *testing.T) {
 	// This test is causing issues on CI with instability, so skip until we can resolve this.
 	SkipTestOnCI(t)
+	if isTestOnCrio() {
+		t.Skip("Fails with CRI-O (confidential-containers/cloud-api-adaptor#2100)")
+	}
 	assert := LibvirtAssert{}
 	DoTestPodToServiceCommunication(t, testEnv, assert)
 }
@@ -121,6 +127,9 @@ func TestLibvirtPodToServiceCommunication(t *testing.T) {
 func TestLibvirtPodsMTLSCommunication(t *testing.T) {
 	// This test is causing issues on CI with instability, so skip until we can resolve this.
 	SkipTestOnCI(t)
+	if isTestOnCrio() {
+		t.Skip("Fails with CRI-O (confidential-containers/cloud-api-adaptor#2100)")
+	}
 	assert := LibvirtAssert{}
 	DoTestPodsMTLSCommunication(t, testEnv, assert)
 }
@@ -128,6 +137,10 @@ func TestLibvirtPodsMTLSCommunication(t *testing.T) {
 func TestLibvirtImageDecryption(t *testing.T) {
 	if !isTestWithKbs() {
 		t.Skip("Skipping kbs related test as kbs is not deployed")
+	}
+
+	if isTestOnCrio() {
+		t.Skip("Image decryption not supported with CRI-O")
 	}
 
 	assert := LibvirtAssert{}

--- a/src/cloud-api-adaptor/test/provisioner/libvirt/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/libvirt/provision_common.go
@@ -23,14 +23,15 @@ const AlternateVolumeName = "another-podvm-base.qcow2"
 
 // LibvirtProvisioner implements the CloudProvisioner interface for Libvirt.
 type LibvirtProvisioner struct {
-	conn         *libvirt.Connect // Libvirt connection
-	network      string           // Network name
-	ssh_key_file string           // SSH key file used to connect to Libvirt
-	storage      string           // Storage pool name
-	uri          string           // Libvirt URI
-	wd           string           // libvirt's directory path on this repository
-	volumeName   string           // Podvm volume name
-	clusterName  string           // Cluster name
+	conn             *libvirt.Connect // Libvirt connection
+	containerRuntime string           // Name of the container runtime
+	network          string           // Network name
+	ssh_key_file     string           // SSH key file used to connect to Libvirt
+	storage          string           // Storage pool name
+	uri              string           // Libvirt URI
+	wd               string           // libvirt's directory path on this repository
+	volumeName       string           // Podvm volume name
+	clusterName      string           // Cluster name
 }
 
 // LibvirtInstallOverlay implements the InstallOverlay interface
@@ -84,14 +85,15 @@ func NewLibvirtProvisioner(properties map[string]string) (pv.CloudProvisioner, e
 
 	// TODO: Check network and storage are not nil?
 	return &LibvirtProvisioner{
-		conn:         conn,
-		network:      network,
-		ssh_key_file: ssh_key_file,
-		storage:      storage,
-		uri:          uri,
-		wd:           wd,
-		volumeName:   vol_name,
-		clusterName:  clusterName,
+		conn:             conn,
+		containerRuntime: properties["container_runtime"],
+		network:          network,
+		ssh_key_file:     ssh_key_file,
+		storage:          storage,
+		uri:              uri,
+		wd:               wd,
+		volumeName:       vol_name,
+		clusterName:      clusterName,
 	}, nil
 }
 
@@ -196,11 +198,12 @@ func (l *LibvirtProvisioner) DeleteVPC(ctx context.Context, cfg *envconf.Config)
 
 func (l *LibvirtProvisioner) GetProperties(ctx context.Context, cfg *envconf.Config) map[string]string {
 	return map[string]string{
-		"network":      l.network,
-		"podvm_volume": l.volumeName,
-		"ssh_key_file": l.ssh_key_file,
-		"storage":      l.storage,
-		"uri":          l.uri,
+		"CONTAINER_RUNTIME": l.containerRuntime,
+		"network":           l.network,
+		"podvm_volume":      l.volumeName,
+		"ssh_key_file":      l.ssh_key_file,
+		"storage":           l.storage,
+		"uri":               l.uri,
 	}
 }
 

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -23,7 +23,7 @@ tools:
   golang: 1.22.7
   protoc: 3.15.0
   packer: v1.9.4
-  kcli: 99.0.202407031308
+  kcli: 99.0.202408152044
   iptables-wrapper: v0.0.0-20240819165702-06cad2ec6cb5
   oras: 1.2.0
 # Referenced Git repositories


### PR DESCRIPTION
This is the minimum required to run e2e tests for libvirt on k8s configured with CRI-O.

* libvirt/kcli_cluster.sh can now provision k8s configured with CRI-O. Just need to export `CONTAINER_RUNTIME=crio`
* The e2e framework will handle the `container_runtime=crio` property in libvirt.properties
* Finally the changes on workflows to add a new job were made. Notice that the CRI-O will run with `continue-on-error` enabled for a while as we will be to fully check its stability by running on CI env.

Fixes #1981 