### PR TITLE
podvm: Make download-image.sh always pull

### DIFF
--- a/src/cloud-api-adaptor/podvm/hack/download-image.sh
+++ b/src/cloud-api-adaptor/podvm/hack/download-image.sh
@@ -47,7 +47,7 @@ else
 fi
 
 # Create a non-running container to extract image
-$container_binary create --platform="$platform" --name "$container_name" "$image" /bin/sh >/dev/null 2>&1;
+$container_binary create --pull=always --platform="$platform" --name "$container_name" "$image" /bin/sh >/dev/null 2>&1;
 # Destory container after use
 rm-container(){
     $container_binary rm -f "$container_name" >/dev/null 2>&1;


### PR DESCRIPTION
During some recent testing of bug fixes I spent quite a lot of time trying to understand why the fixes weren't having any effect on peer pods. After a while I found it was because although the registry version of the podvm image had been updated, when running `download-image.sh` it was just using the version I'd previously downloaded.

If we pass `--pull=always`, in the container create command, this should resolve that problem and it looks to be supported on docker and podman clis