### PR TITLE
caa: fixing toolchain not available

### DIFF
--- a/src/cloud-api-adaptor/go.mod
+++ b/src/cloud-api-adaptor/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1

--- a/src/cloud-api-adaptor/podvm/go.mod
+++ b/src/cloud-api-adaptor/podvm/go.mod
@@ -4,4 +4,4 @@
 
 module github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/podvm
 
-go 1.22
+go 1.22.0

--- a/src/cloud-providers/go.mod
+++ b/src/cloud-providers/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers
 
-go 1.22
+go 1.22.0
 
 require (
 	cloud.google.com/go/compute v1.23.3

--- a/src/csi-wrapper/go.mod
+++ b/src/csi-wrapper/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/csi-wrapper
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor v0.10.0-alpha1

--- a/src/peerpod-ctrl/go.mod
+++ b/src/peerpod-ctrl/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/peerpod-ctrl
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers v0.10.0-alpha1

--- a/src/webhook/go.mod
+++ b/src/webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/webhook
 
-go 1.22
+go 1.22.0
 
 require (
 	k8s.io/api v0.29.6


### PR DESCRIPTION
make here is returning the following error:

go: download go1.22 for linux/amd64: toolchain not available

This change specifies the exact toolchain version (1.22.7) instead of
the language family version (1.22), a feature introduced in Go 1.21. It
ensures more precise toolchain resolution, improves reproducibility, and
avoids potential automatic upgrades to future versions.

Updating go.mod to use 1.22.7 instead.