### PR TITLE
Revert upload artifacts bump

### DIFF
--- a/.github/workflows/caa_build_and_push_per_arch.yaml
+++ b/.github/workflows/caa_build_and_push_per_arch.yaml
@@ -115,7 +115,7 @@ jobs:
             cd src/cloud-api-adaptor && ARCHES=${{matrix.arches}} RELEASE_BUILD=true RELEASE_TAGS=${{ inputs.release_tags}} make image-with-arch registry=${{ inputs.registry }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: image-artifacts
           retention-days: 1
@@ -135,7 +135,7 @@ jobs:
           ref: "${{ inputs.git_ref }}"
 
       - name: Download release commits file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: image-artifacts
           path: src/cloud-api-adaptor


### PR DESCRIPTION
workflow: Partially revert actions/upload-artifact bump

The breaking change is causing problems for the multi-arch CAA
image build, so revert the bump from v2 to v4 there until we fix
the break this causes.

Signed-off-by: stevenhorsman <steven@uk.ibm.com>