### PR TITLE
checklinks: add link to exclude

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,1 +1,2 @@
 https://github.com/\$USER/cloud-api-adaptor/tree/my-changes-in-a-branch
+https://github.com/confidential-containers/cloud-api-adaptor/commits/main/


### PR DESCRIPTION
lychee is failing to follow
https://github.com/confidential-containers/cloud-api-adaptor/commits/main/

```
 ## Errors per input

 ### Errors in src/cloud-api-adaptor/test/e2e/README.md

 * [429] [https://github.com/confidential-containers/cloud-api-adaptor/commits/main/](https://github.com/confidential-containers/cloud-api-adaptor/commits/main/) | Failed: Network error: Too Many Requests

 ##[error]Process completed with exit code 2
```

So let's add that link to the list of exclusion.