### PR TITLE
ci: fix azure nightly mkosi build

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   build-podvm-image:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: cloud-api-adaptor/src/cloud-api-adaptor/podvm-mkosi
@@ -49,7 +49,7 @@ jobs:
         path: cloud-api-adaptor
         ref: "${{ inputs.git-ref || 'main' }}"
 
-    - uses: cachix/install-nix-action@v27
+    - uses: cachix/install-nix-action@v30
       with:
         nix_path: nixpkgs=channel:nixos-unstable
 
@@ -66,11 +66,7 @@ jobs:
         ATTESTER="az-snp-vtpm-attester,az-tdx-vtpm-attester" make binaries
 
     - name: Build image
-      run: |
-        touch resources/buildBootableImage
-        sudo mkosi --environment=VARIANT_ID=production
-        ln -s "$(which nix)" /usr/local/bin/nix
-        sudo make image-debug
+      run: make image
 
     - uses: azure/login@v2
       name: 'Az CLI login'


### PR DESCRIPTION
Due to a rebase fail, the workflow attempted to use the ubuntu mkosi build. Reverted to building using nix to stay close to the documented procedure. If we opt to use the ubuntu-packaged mkosi, more testing is required and we should change it everywhere.

In the mid-term this would make sense, because currently mkosi is marked as broken in nixos-24.05 and nix-unstable. the version we have pinned in the nix flake (v17) is rather old now.

Drive-by fix: sudo is not required for mkosi images on Ubuntu 22.04