### PR TITLE
test: Update Trustee deployment to match the simplifed deployment overlays

### DIFF
--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -46,7 +46,7 @@ git:
     reference: v1.5.0
   kbs:
     url: https://github.com/confidential-containers/trustee
-    reference: v0.10.1
+    reference: f287fcd60b0b3ddbef5546d646669813b9e68f8d
 oci:
   pause:
     registry: docker://registry.k8s.io/pause


### PR DESCRIPTION
In https://github.com/confidential-containers/trustee/pull/521 I did some work to enable Trustee to work on s390x (without SE) and generally simplify deployments, such that overlays are only needed for ibm-se, not for x86/s390x in general.

This PR adapts us to use this approach.