### PR TITLE
ci: fix passing of image-id to e2e test

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -1,4 +1,4 @@
-name: Azure PodVM image build
+name: azure-podvm-image-build
 
 on:
   workflow_call:
@@ -28,10 +28,10 @@ permissions:
 env:
   AZURE_PODVM_IMAGE_DEF_NAME: "${{ vars.AZURE_PODVM_IMAGE_DEF_NAME }}"
   AZURE_PODVM_IMAGE_VERSION: "${{ inputs.image-version }}"
-  COMMUNITY_GALLERY_PREFIX: "/CommunityGalleries/${{ vars.AZURE_COMMUNITY_GALLERY_NAME }}"
   PODVM_IMAGE_NAME: "peerpod-image-${{ github.run_id }}-${{ github.run_attempt }}"
   UPLOSI_VERSION: "0.3.0"
   UPLOSI_SHA256: "687bcab7398ab0fda65a3809492e8cd4d6a25aad1573927be5ec75ac1c4cbc35"
+  IMAGE_ID: "/CommunityGalleries/${{ vars.AZURE_COMMUNITY_GALLERY_NAME }}/Images/${{ vars.AZURE_PODVM_IMAGE_DEF_NAME }}/Versions/${{ inputs.image-version }}"
 
 jobs:
   build-podvm-image:


### PR DESCRIPTION
sry, for the stream of gh actions-related PRs. sadly, nested workflow invocations are pretty hard to test, even on forks.

Some workflow input/output glue didn't work anymore after switching to mkosi images, so the image id wasn't passed to the e2e test.