### PR TITLE
workflows: Install gh cli on self-hosted runner

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -96,6 +96,10 @@ jobs:
           override: true
           profile: minimal
 
+      - name: Install gh cli
+        run: |
+          sudo apt install -y gh
+
       - name: Checkout kbs Repository and build kbs-client
         run: |
           sudo apt-get update -y
@@ -117,6 +121,8 @@ jobs:
           # For debugging
           ls ./target/release
           popd
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: run tests
         id: runTests


### PR DESCRIPTION
In #2077 I forgot about pull_request_target not testing workflows in PRs and that self-hosted runners wouldn't have the gh cli installed, so this attempts to fix the workflows and install gh cli first.

I also set `GH_TOKEN` env in the step that uses `gh` based on the `gh help environment` doc that states:
GH_TOKEN: an authentication token for github.com API requests. Setting this avoids being prompted to authenticate.

Hopefully this is enough to get us back passing.

Note: I did find a few actions to do this, but they were only used by single digit projects, so I figured it would be safer to do it ourselves for now

*Disclaimer*: This assumes that `secrets.GITHUB_TOKEN` is created for self-hosted runners, which some guides hint is true, but I can't find concrete GitHub doc of this .