### PR TITLE
workflows: Install kustomize on e2e workflows

### DIFF
--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -196,6 +196,12 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y sipcalc
 
+    - name: Install kustomize
+      run: |
+        command -v kustomize >/dev/null || \
+        curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | \
+          bash -s /usr/local/bin
+
     - name: Set Provisioner Environment Variables
       run: |
           echo "TEST_PROVISION_FILE=${{ format(env.TEST_PROVISION_PATH_TEMPLATE, matrix.parameters.id) }}" >> "$GITHUB_ENV"

--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -100,6 +100,12 @@ jobs:
         run: |
           sudo apt install -y gh
 
+      - name: Install kustomize
+        run: |
+          command -v kustomize >/dev/null || \
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | \
+            bash -s /usr/local/bin
+
       - name: Checkout kbs Repository and build kbs-client
         run: |
           sudo apt-get update -y


### PR DESCRIPTION
We also need kustomize installed, which I think it needed on the self-hosted and github hosted runner