### PR TITLE
test: Add checkout kbs helper script

### DIFF
--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -235,21 +235,9 @@ jobs:
     - name: Extract kbs reference
       run: echo "KBS_VERSION=$(yq -e '.git.kbs.reference' versions.yaml)" >> "$GITHUB_ENV"
 
-    - name: Checkout kbs Repository
+    - name: Checkout KBS Repository
       run: |
-        rm -rf test/trustee
-        git clone https://github.com/confidential-containers/trustee test/trustee
-        pushd test/trustee
-        git checkout "${KBS_VERSION}"
-        pushd kbs/config/kubernetes/base/
-        # Trustee only updates their staging image reliably with sha tags,
-        # so switch to use that and convert the version to the sha
-        KBS_SHA=$(gh api repos/confidential-containers/trustee/commits/${KBS_VERSION} -q .sha)
-        kustomize edit set image kbs-container-image=ghcr.io/confidential-containers/staged-images/kbs:${KBS_SHA}
-        # For debugging
-        echo "Trustee deployment: $(cat kustomization.yaml). Images: $(cat kustomization.yaml | grep -A 5 images:)"
-        popd
-        popd
+        test/utils/checkout_kbs.sh
 
     - name: Run e2e test
       env:

--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -106,27 +106,9 @@ jobs:
           curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | \
             bash -s /usr/local/bin
 
-      - name: Checkout kbs Repository and build kbs-client
+      - name: Checkout KBS Repository
         run: |
-          sudo apt-get update -y
-          sudo apt-get install -y build-essential pkg-config libssl-dev
-          git clone "${KBS_REPO}" test/trustee
-          pushd test/trustee
-          git checkout "${KBS_VERSION}"
-          pushd kbs
-          make CLI_FEATURES=sample_only cli
-          pushd config/kubernetes/base/
-          # Trustee only updates their staging image reliably with sha tags,
-          # so switch to use that and convert the version to the sha
-          KBS_SHA=$(gh api repos/confidential-containers/trustee/commits/${KBS_VERSION} -q .sha)
-          kustomize edit set image kbs-container-image=ghcr.io/confidential-containers/staged-images/kbs:${KBS_SHA}
-          # For debugging
-          echo "Trustee deployment: $(cat kustomization.yaml). Images: $(cat kustomization.yaml | grep -A 5 images:)"
-          popd
-          popd
-          # For debugging
-          ls ./target/release
-          popd
+          test/utils/checkout_kbs.sh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -103,8 +103,9 @@ jobs:
       - name: Install kustomize
         run: |
           command -v kustomize >/dev/null || \
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | \
+          sudo curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | \
             bash -s /usr/local/bin
+          sudo chmod a+x /usr/local/bin/kustomize
 
       - name: Checkout KBS Repository
         run: |

--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -57,25 +57,10 @@ $ RUN_TESTS=CreateSimplePod TEST_PROVISION=yes TEST_PODVM_IMAGE="path/to/podvm-b
 ## Attestation and KBS specific
 
 We need artifacts from the trustee repo when doing the attestation tests.
-To prepare trustee, execute the following steps:
+To prepare trustee, execute the following helper script:
 
 ```sh
-pushd ${cloud-api-adaptor-repo-dir}/src/cloud-api-adaptor/test
-git clone https://github.com/confidential-containers/trustee.git
-pushd trustee
-KBS_VERSION=$(../../hack/yq-shim.sh '.git.kbs.reference' ../../versions.yaml)
-git checkout ${KBS_VERSION}
-pushd kbs
-pushd config/kubernetes/base/
-# Trustee only updates their staging image reliably with sha tags,
-# so switch to use that and convert the version to the sha
-KBS_SHA=$(gh api repos/confidential-containers/trustee/commits/${KBS_VERSION} -q .sha)
-kustomize edit set image kbs-container-image=ghcr.io/confidential-containers/staged-images/kbs:${KBS_SHA}
-popd
-make CLI_FEATURES=sample_only cli
-popd
-popd
-popd
+${cloud-api-adaptor-repo-dir}/src/cloud-api-adaptor/test/utils/checkout_kbs.sh
 ```
 
 We need build and use the PodVM image:

--- a/src/cloud-api-adaptor/test/utils/checkout_kbs.sh
+++ b/src/cloud-api-adaptor/test/utils/checkout_kbs.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright (c) 2024 IBM Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+TEST_DIR=$(cd "$(dirname "$(realpath "$0")")/../"; pwd)
+
+VERSIONS_YAML_PATH=$(realpath "${TEST_DIR}/../versions.yaml")
+
+KBS_REPO=$(yq -e '.git.kbs.url' "${VERSIONS_YAML_PATH}")
+KBS_VERSION=$(yq -e '.git.kbs.reference' "${VERSIONS_YAML_PATH}")
+
+echo "${KBS_REPO}, ${KBS_VERSION}"
+
+rm -rf "${TEST_DIR}/trustee"
+git clone "${KBS_REPO}" "${TEST_DIR}/trustee"
+pushd "${TEST_DIR}/trustee"
+git checkout "${KBS_VERSION}"
+
+# kbs-client setup - to be removed when we use the cached version instead
+sudo apt-get update -y
+sudo apt-get install -y build-essential pkg-config libssl-dev
+pushd kbs
+make CLI_FEATURES=sample_only cli
+popd
+
+pushd kbs/config/kubernetes/base/
+# Trustee only updates their staging image reliably with sha tags,
+# so switch to use that and convert the version to the sha
+KBS_SHA=$(gh api repos/confidential-containers/trustee/commits/${KBS_VERSION} -q .sha)
+kustomize edit set image kbs-container-image=ghcr.io/confidential-containers/staged-images/kbs:${KBS_SHA}
+# For debugging
+echo "Trustee deployment: $(cat kustomization.yaml). Images: $(grep -A 5 images: kustomization.yaml)"


### PR DESCRIPTION
We have duplicate code in multiple e2e workflows
and manual doc instructions for checking out the KBS repo and switching to the correct branch. This both makes updating it prone to errors/omissions and means that if we make changes we can't test them in PRs due to the
`pull_request_target` limitation, so split these out into a single script we can call from elsewhere.