### PR TITLE
Fix kustomize install for non root

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -103,9 +103,8 @@ jobs:
       - name: Install kustomize
         run: |
           command -v kustomize >/dev/null || \
-          sudo curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | \
-            bash -s /usr/local/bin
-          sudo chmod a+x /usr/local/bin/kustomize
+          sudo curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          sudo install -o root -g root -m 0755 kustomize /usr/local/bin/kustomize
 
       - name: Checkout KBS Repository
         run: |


### PR DESCRIPTION
- Fix kustomize install for non-root user by installing in a local
    directory and then using sudo install to put it in /usr/local/bin/

This was tested in my fork with a non-root self-hosted runner in https://github.com/stevenhorsman/cloud-api-adaptor/actions/runs/11289806458/job/31400382940 so hopefully this is the last fix. Sorry for the missteps.