### PR TITLE
workflow: Fix kustomize permission issue

### DIFF
--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -200,7 +200,7 @@ jobs:
       run: |
         command -v kustomize >/dev/null || \
         curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | \
-          bash -s /usr/local/bin
+          sudo bash -s /usr/local/bin
 
     - name: Set Provisioner Environment Variables
       run: |

--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -103,8 +103,8 @@ jobs:
       - name: Install kustomize
         run: |
           command -v kustomize >/dev/null || \
-          sudo curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
-          sudo install -o root -g root -m 0755 kustomize /usr/local/bin/kustomize
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | \
+            sudo bash -s /usr/local/bin
 
       - name: Checkout KBS Repository
         run: |


### PR DESCRIPTION
- Use Wainer's suggested approach of `sudo bash -s` rather than the separate install
- Also update Azure's e2e workflow with the fix

libvirt tested with forked workflow: https://github.com/stevenhorsman/cloud-api-adaptor/actions/runs/11295615233/job/31418883368