### PR TITLE
ci: add eastus2 region in azure nightly build

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -95,7 +95,7 @@ jobs:
         provider = "azure"
 
         [variant.default.azure]
-        replicationRegions = ["eastus","westeurope","northeurope"]
+        replicationRegions = ["eastus","eastus2","westeurope","northeurope"]
         EOF
 
         uplosi upload build/system.raw


### PR DESCRIPTION
Extend regions list to be able to use podvm in eastus2 region