### PR TITLE
test/e2e: kbs: Use the cached kbs-client 

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -51,9 +51,6 @@ jobs:
       - name: Read properties from versions.yaml
         run: |
           sudo snap install yq
-          echo "KBS_REPO=$(yq -e '.git.kbs.url' versions.yaml)" >> "$GITHUB_ENV"
-          echo "KBS_VERSION=$(yq -e '.git.kbs.reference' versions.yaml)" >> "$GITHUB_ENV"
-          echo "RUST_VERSION=$(yq -e '.tools.rust' versions.yaml)" >> "$GITHUB_ENV"
           go_version="$(yq '.tools.golang' versions.yaml)"
           [ -n "$go_version" ]
           echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"
@@ -89,13 +86,6 @@ jobs:
           echo "CAA_IMAGE=\"${{ inputs.caa_image }}\"" >> libvirt.properties
           # For debugging
           cat libvirt.properties
-
-      - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-          override: true
-          profile: minimal
 
       - uses: oras-project/setup-oras@v1
         with:

--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -62,6 +62,10 @@ To prepare trustee, execute the following helper script:
 ```sh
 ${cloud-api-adaptor-repo-dir}/src/cloud-api-adaptor/test/utils/checkout_kbs.sh
 ```
+> [!NOTE]
+> This script requires [oras](https://oras.land/docs/installation/) to be installed to pull down and verify
+the cached kbs-client.
+
 
 We need build and use the PodVM image:
 

--- a/src/cloud-api-adaptor/test/provisioner/trustee_kbs.go
+++ b/src/cloud-api-adaptor/test/provisioner/trustee_kbs.go
@@ -466,12 +466,11 @@ func (p *KeyBrokerService) GetKbsEndpoint(ctx context.Context, cfg *envconf.Conf
 }
 
 func (p *KeyBrokerService) EnableKbsCustomizedResourcePolicy(customizedOpaFile string) error {
-	kbsClientDir := filepath.Join(trusteeRepoPath, "target/release")
 	privateKey := filepath.Join(getKbsKubernetesFilePath(), "base/kbs.key")
 	policyFile := filepath.Join(trusteeRepoPath, "kbs/sample_policies", customizedOpaFile)
 	log.Info("EnableKbsCustomizedPolicy: ", policyFile)
 	cmd := exec.Command("./kbs-client", "--url", p.endpoint, "config", "--auth-private-key", privateKey, "set-resource-policy", "--policy-file", policyFile)
-	cmd.Dir = kbsClientDir
+	cmd.Dir = trusteeRepoPath
 	cmd.Env = os.Environ()
 	stdoutStderr, err := cmd.CombinedOutput()
 	log.Tracef("%v, output: %s", cmd, stdoutStderr)
@@ -482,12 +481,11 @@ func (p *KeyBrokerService) EnableKbsCustomizedResourcePolicy(customizedOpaFile s
 }
 
 func (p *KeyBrokerService) EnableKbsCustomizedAttestationPolicy(customizedOpaFile string) error {
-	kbsClientDir := filepath.Join(trusteeRepoPath, "target/release")
 	privateKey := filepath.Join(getKbsKubernetesFilePath(), "base/kbs.key")
 	policyFile := filepath.Join(trusteeRepoPath, "kbs/sample_policies", customizedOpaFile)
 	log.Info("EnableKbsCustomizedPolicy: ", policyFile)
 	cmd := exec.Command("./kbs-client", "--url", p.endpoint, "config", "--auth-private-key", privateKey, "set-attestation-policy", "--policy-file", policyFile)
-	cmd.Dir = kbsClientDir
+	cmd.Dir = trusteeRepoPath
 	cmd.Env = os.Environ()
 	stdoutStderr, err := cmd.CombinedOutput()
 	log.Tracef("%v, output: %s", cmd, stdoutStderr)
@@ -498,7 +496,6 @@ func (p *KeyBrokerService) EnableKbsCustomizedAttestationPolicy(customizedOpaFil
 }
 
 func (p *KeyBrokerService) SetSampleSecretKey() error {
-	kbsClientDir := filepath.Join(trusteeRepoPath, "target/release")
 	privateKey := filepath.Join(getKbsKubernetesFilePath(), "base/kbs.key")
 	overlaysPath, err := getOverlaysPath()
 	if err != nil {
@@ -507,7 +504,7 @@ func (p *KeyBrokerService) SetSampleSecretKey() error {
 	keyFilePath := filepath.Join(getKbsKubernetesFilePath(), overlaysPath, "key.bin")
 	log.Info("set key resource: ", keyFilePath)
 	cmd := exec.Command("./kbs-client", "--url", p.endpoint, "config", "--auth-private-key", privateKey, "set-resource", "--path", "reponame/workload_key/key.bin", "--resource-file", keyFilePath)
-	cmd.Dir = kbsClientDir
+	cmd.Dir = trusteeRepoPath
 	cmd.Env = os.Environ()
 	stdoutStderr, err := cmd.CombinedOutput()
 	log.Tracef("%v, output: %s", cmd, stdoutStderr)

--- a/src/cloud-api-adaptor/test/utils/checkout_kbs.sh
+++ b/src/cloud-api-adaptor/test/utils/checkout_kbs.sh
@@ -13,7 +13,13 @@ VERSIONS_YAML_PATH=$(realpath "${TEST_DIR}/../versions.yaml")
 KBS_REPO=$(yq -e '.git.kbs.url' "${VERSIONS_YAML_PATH}")
 KBS_VERSION=$(yq -e '.git.kbs.reference' "${VERSIONS_YAML_PATH}")
 
-echo "${KBS_REPO}, ${KBS_VERSION}"
+install_kbs_client() {
+    kbs_sha=$1
+    arch=$(uname -m)
+
+    oras pull "ghcr.io/confidential-containers/staged-images/kbs-client:sample_only-${arch}-linux-gnu-${kbs_sha}"
+    chmod +x ./kbs-client
+}
 
 rm -rf "${TEST_DIR}/trustee"
 git clone "${KBS_REPO}" "${TEST_DIR}/trustee"
@@ -21,16 +27,11 @@ pushd "${TEST_DIR}/trustee"
 git checkout "${KBS_VERSION}"
 KBS_SHA="$(git rev-parse HEAD)"
 
-# kbs-client setup - to be removed when we use the cached version instead
-sudo apt-get update -y
-sudo apt-get install -y build-essential pkg-config libssl-dev
-pushd kbs
-make CLI_FEATURES=sample_only cli
-popd
+install_kbs_client "${KBS_SHA}"
 
 pushd kbs/config/kubernetes/base/
 # Trustee only updates their staging image reliably with sha tags,
 # so switch to use that and convert the version to the sha
-kustomize edit set image kbs-container-image=ghcr.io/confidential-containers/staged-images/kbs:${KBS_SHA}
+kustomize edit set image kbs-container-image=ghcr.io/confidential-containers/staged-images/kbs:"${KBS_SHA}"
 # For debugging
 echo "Trustee deployment: $(cat kustomization.yaml). Images: $(grep -A 5 images: kustomization.yaml)"


### PR DESCRIPTION
To save us storage space, time and the requirement
on the rust toolchain, we can pull down the cached
kbs-client rather than building it ourselves.

Update checkout_kbs.sh to use oras to pull the kbs-client
binary from the cache rather than building it.