### PR TITLE
SecureComms: Add testing facility for e2e tests

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -23,7 +23,11 @@ on:
         description: Git ref to checkout the cloud-api-adaptor repository. Defaults to main.
         required: false
         type: string
-
+      secure_comms:
+        default: 'none'
+        description: SecureComms configuration. Defaults to none.
+        required: false
+        type: string
 env:
   CLOUD_PROVIDER: libvirt
   DEBIAN_FRONTEND: noninteractive
@@ -86,6 +90,7 @@ jobs:
 
       - name: Config Libvirt
         run: |
+          export TEST_E2E_SECURE_COMMS="${{ inputs.secure_comms }}"
           ./libvirt/config_libvirt.sh
           echo "CAA_IMAGE=\"${{ inputs.caa_image }}\"" >> libvirt.properties
           # For debugging
@@ -124,6 +129,7 @@ jobs:
           export TEST_PROVISION_FILE="$PWD/libvirt.properties"
           export TEST_PODVM_IMAGE="${{ env.PODVM_QCOW2 }}"
           export TEST_E2E_TIMEOUT="75m"
+          export TEST_E2E_SECURE_COMMS="${{ inputs.secure_comms }}"
 
           make test-e2e
 

--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -99,6 +99,8 @@ jobs:
   prep_install:
     needs: [image]
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
     env:
       PROVIDERS: "libvirt"
     steps:
@@ -148,6 +150,11 @@ jobs:
           path: src/cloud-api-adaptor/install/
           retention-days: 7
 
+      - name: Define Test Matrix
+        id: matrix
+        run: |
+          echo "matrix=$(jq -c . < ./libvirt/e2e_matrix_libvirt.json)" >> "$GITHUB_OUTPUT"
+
   # Run libvirt e2e tests if pull request labeled 'test_e2e_libvirt'
   libvirt:
     name: libvirt
@@ -158,17 +165,12 @@ jobs:
     needs: [podvm, image, prep_install]
     strategy:
       fail-fast: false
-      matrix:
-        os:
-          - ubuntu
-        provider:
-          - generic
-        arch:
-          - amd64
+      matrix: ${{ fromJSON(needs.prep_install.outputs.matrix) }}
     uses: ./.github/workflows/e2e_libvirt.yaml
     with:
       caa_image: ${{ inputs.registry }}/cloud-api-adaptor:${{ inputs.caa_image_tag }}-dev
       podvm_image: ${{ inputs.registry }}/podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ matrix.arch }}:${{ inputs.podvm_image_tag }}
       install_directory_artifact: install_directory
       git_ref: ${{ inputs.git_ref }}
+      secure_comms: ${{ matrix.secure_comms }}
     secrets: inherit

--- a/src/cloud-api-adaptor/docs/SecureComms.md
+++ b/src/cloud-api-adaptor/docs/SecureComms.md
@@ -165,6 +165,10 @@ Successful connection result in exit code of 0
 
 Alternatively, the client and server can be separately executed in independent terminals using `./test/securecomms/double/wnssh.go` and `./test/securecomms/ppssh/main.go` respectively.
 
+# E2E Testing
+
+To facilitate end-to-end testing, the libvirt github workflow `e2e_libvirt.yaml` adds an environment variable named `TEST_E2E_SECURE_COMMS` which indicates the secure comm configuration set to be used. The `config_libvirt.sh` uses this environment variable to set proper values in the `libvirt.properties` file.
+
 ## Future Plans
 
 - Add DeleteResource() support in KBS, KBC, api-server-rest, than cleanup resources added by Secure Comms to KBS whenever a Peer Pod fail to be created or when a Peer Pod is terminated.

--- a/src/cloud-api-adaptor/libvirt/config_libvirt.sh
+++ b/src/cloud-api-adaptor/libvirt/config_libvirt.sh
@@ -92,6 +92,9 @@ installK8sclis() {
     fi
 }
 
+TEST_E2E_SECURE_COMMS=${TEST_E2E_SECURE_COMMS:-none}.
+echo "SECURE_COMMS is ${TEST_E2E_SECURE_COMMS}"
+
 echo "Installing Go..."
 installGolang
 echo "Installing Libvirt..."
@@ -118,3 +121,12 @@ rm -f libvirt.properties
 echo "libvirt_uri=\"qemu+ssh://${USER}@${IP}/system?no_verify=1\"" >> libvirt.properties
 echo "libvirt_ssh_key_file=\"id_rsa\"" >> libvirt.properties
 echo "CLUSTER_NAME=\"peer-pods\"" >> libvirt.properties
+
+# switch to the appropriate e2e test and add configs to libvirt.properties as needed
+case $TEST_E2E_SECURE_COMMS in
+
+  *)
+    echo "processing none"
+    echo "SECURE_COMMS=\"false\"" >> libvirt.properties
+    ;;
+esac

--- a/src/cloud-api-adaptor/libvirt/e2e_matrix_libvirt.json
+++ b/src/cloud-api-adaptor/libvirt/e2e_matrix_libvirt.json
@@ -1,0 +1,6 @@
+{
+    "secure_comms": ["none"],
+    "os": ["ubuntu"],
+    "provider": ["generic"],
+    "arch": ["amd64"]
+}


### PR DESCRIPTION
Modify the .github/workflow files to enable adding e2e tests for secure comms.
The added code is generalized to enable controlling the libvirt e2e testing matrix using a json file
