### PR TITLE
workflow: e2e_libvirt fix rust version error

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -53,6 +53,7 @@ jobs:
           sudo snap install yq
           echo "KBS_REPO=$(yq -e '.git.kbs.url' versions.yaml)" >> "$GITHUB_ENV"
           echo "KBS_VERSION=$(yq -e '.git.kbs.reference' versions.yaml)" >> "$GITHUB_ENV"
+          echo "RUST_VERSION=$(yq -e '.tools.rust' versions.yaml)" >> "$GITHUB_ENV"
           go_version="$(yq '.tools.golang' versions.yaml)"
           [ -n "$go_version" ]
           echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"


### PR DESCRIPTION
In github.com/confidential-containers/cloud-api-adaptor/pull/2074 we removed the RUST_VERSION env, but we still use it in The `Install rust toolchain` step which it needed to build the kbs client. I plan to remove this need very sooner by using the cached kbs client, but can't test those changes due to this error.