### PR TITLE
ci: set golang cache key as **/go.sum glob

### DIFF
--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -41,15 +41,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Extract go version number
-      run: echo "GO_VERSION=$(yq -e '.tools.golang' versions.yaml)" >> "$GITHUB_ENV"
-
-    - name: Set up Go environment
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ env.GO_VERSION }}
-        cache-dependency-path: go.sum
-
     - uses: azure/login@v2
       name: 'Az CLI login'
       with:
@@ -59,11 +50,6 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-
-    - name: Install build dependencies
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y libvirt-dev
 
     - name: Build container image
       id: build-container
@@ -104,7 +90,8 @@ jobs:
     - name: Set up Go environment
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version: "${{ env.GO_VERSION }}"
+        cache-dependency-path: "**/go.sum"
 
     - name: Set Provisioner Environment Variables
       run: |
@@ -190,6 +177,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
+        cache-dependency-path: "**/go.sum"
 
     - name: Install cidr calculator
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/go.sum"
       - name: Install build dependencies
         if: matrix.type == 'dev'
         run: |
@@ -91,6 +92,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/go.sum"
 
       - name: Install build dependencies
         if: matrix.controller == 'peerpod-ctrl'
@@ -135,6 +137,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/go.sum"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -181,6 +184,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/go.sum"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/caa_build_and_push.yaml
+++ b/.github/workflows/caa_build_and_push.yaml
@@ -73,6 +73,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/go.sum"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Install build dependencies

--- a/.github/workflows/caa_build_and_push_per_arch.yaml
+++ b/.github/workflows/caa_build_and_push_per_arch.yaml
@@ -92,6 +92,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/go.sum"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/csi_wrapper_images.yaml
+++ b/.github/workflows/csi_wrapper_images.yaml
@@ -50,6 +50,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/go.sum"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to quay Container Registry

--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -60,6 +60,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/go.sum"
 
       - name: Setup docker
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/go.sum"
       - name: Install dependencies
         run: |
           sudo apt-get update -y
@@ -56,6 +57,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/go.sum"
       - name: Install dependencies
         run: |
           sudo apt-get update -y
@@ -97,6 +99,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/go.sum"
       - name: Go tidy check
         run: make tidy-check
 
@@ -115,6 +118,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/go.sum"
       - name: Install dependencies
         run: |
           sudo apt-get update -y

--- a/.github/workflows/webhook_image.yaml
+++ b/.github/workflows/webhook_image.yaml
@@ -45,6 +45,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/go.sum"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to quay Container Registry


### PR DESCRIPTION
This should speed up all go builds somewhat, since after reorganizing the repo, the cache that is set up by setup-go has not been working anymore:

```
Restore cache failed: Dependencies file is not found in
/home/runner/work/cloud-api-adaptor/cloud-api-adaptor.
```

drive-by fix: remove unnecessary steps from az oci image build