### PR TITLE
workflows: Cancel previous jobs if PR/branch is updated

### DIFF
--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -29,6 +29,10 @@ on:
         type: string
         description: prebuilt caa image
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-caa-container-image:
     if: github.event.inputs.caa-image == ''

--- a/.github/workflows/azure-nightly-build.yml
+++ b/.github/workflows/azure-nightly-build.yml
@@ -6,6 +6,10 @@ on:
   # will base on default branch `main`
   - cron: '0 3 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   generate-podvm-image-version:
     if: github.event.inputs.podvm-image-id == ''

--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -33,6 +33,10 @@ env:
   UPLOSI_SHA256: "687bcab7398ab0fda65a3809492e8cd4d6a25aad1573927be5ec75ac1c4cbc35"
   IMAGE_ID: "/CommunityGalleries/${{ vars.AZURE_COMMUNITY_GALLERY_NAME }}/Images/${{ vars.AZURE_PODVM_IMAGE_DEF_NAME }}/Versions/${{ inputs.image-version }}"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-podvm-image:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build-golang-fedora.yaml
+++ b/.github/workflows/build-golang-fedora.yaml
@@ -25,6 +25,10 @@ on:
         description: "The tag part of the container image name"
         default: ""
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   caa:
     name: cloud-api-adaptor

--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -9,6 +9,10 @@ env:
 
     https://github.com/confidential-containers/confidential-containers/blob/main/CONTRIBUTING.md#patch-format
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   commit-message-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily-e2e-tests-ibmcloud.yaml
+++ b/.github/workflows/daily-e2e-tests-ibmcloud.yaml
@@ -12,6 +12,10 @@ on:
     - cron: '0 5 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   daily-e2e-tests:
     name: e2e tests

--- a/.github/workflows/daily-e2e-tests-libvirt.yaml
+++ b/.github/workflows/daily-e2e-tests-libvirt.yaml
@@ -12,6 +12,10 @@ on:
     - cron: '15 4 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     uses: ./.github/workflows/e2e_run_all.yaml

--- a/.github/workflows/e2e_on_pull.yaml
+++ b/.github/workflows/e2e_on_pull.yaml
@@ -26,6 +26,10 @@ on:
     branches:
       - 'main'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   authorize:
     runs-on: ubuntu-latest

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checklinks:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,6 +12,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   vet-and-fmt:
     name: vet and fmt

--- a/.github/workflows/publish_images_on_push.yaml
+++ b/.github/workflows/publish_images_on_push.yaml
@@ -9,8 +9,11 @@ on:
   push:
     branches:
       - 'main'
-
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   caa:
@@ -31,7 +34,7 @@ jobs:
     with:
       image_tags: latest,${{ github.sha }}
       git_ref: ${{ github.sha }}
-    secrets: inherit  
+    secrets: inherit
 
   webhook:
     uses: ./.github/workflows/webhook_image.yaml


### PR DESCRIPTION
During some testing on my fork and sometimes when running PR testing I've found that I want to re-push whilst the existing CI runs are still going and I need to go in and cancel the old jobs first. This PR looks to address this.

Update our (non-callable) jobs to cancel if another push is done to the PR, or branch, or the unlikely event that another cron job is triggered in order to save time and costs running out of date jobs.

Approach based on stack overflow suggestion:
This is based on the following stack overflow suggestion: https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre which is the same approach that kata-containers uses.

Some of these feel a bit redundant as the jobs are quite short e.g. the commit-message-check, but I
figured that for consistency's sake there wasn't any harm in updating these anyway.