### PR TITLE
GitHub hosted runner support

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -70,8 +70,10 @@ jobs:
       - name: Extract qcow2 from ${{ inputs.podvm_image }}
         run: |
            qcow2=$(echo ${{ inputs.podvm_image }} | sed -e "s#.*/\(.*\):.*#\1.qcow2#")
-           ./hack/download-image.sh ${{ inputs.podvm_image }} . -o ${qcow2}
+           ./hack/download-image.sh ${{ inputs.podvm_image }} . -o ${qcow2} --clean-up
            echo "PODVM_QCOW2=$(pwd)/${qcow2}" >> "$GITHUB_ENV"
+           # Clean up docker images to make space
+           docker system prune -a -f
         working-directory: src/cloud-api-adaptor/podvm
 
       - name: Get the install directory

--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -63,6 +63,7 @@ jobs:
           cache-dependency-path: "**/go.sum"
 
       - name: Setup docker
+        if: ${{ runner.environment == 'self-hosted' }}
         run: |
           sudo apt-get install -y docker.io
           sudo usermod -aG docker "$USER"

--- a/src/cloud-api-adaptor/podvm/hack/download-image.sh
+++ b/src/cloud-api-adaptor/podvm/hack/download-image.sh
@@ -3,7 +3,7 @@
 # takes an image reference and a directory and
 # extracts the qcow image into that directory
 function usage() {
-    echo "Usage: $0 <image> <directory> [-o <name>]"
+    echo "Usage: $0 <image> <directory> [-o <name>] [--clean-up]"
 }
 
 function error() {
@@ -13,12 +13,14 @@ function error() {
 image=$1
 directory=$2
 output=
+clean_up_image=
 
 shift 2
 while (( "$#" )); do
     case "$1" in
         -o) output=$2 ;;
         --output) output=$2 ;;
+        --clean-up) clean_up_image="yes"; shift 1 ;;
         --help) usage; exit 0 ;;
         *)      usage 1>&2; exit 1;;
     esac
@@ -51,6 +53,9 @@ $container_binary create --pull=always --platform="$platform" --name "$container
 # Destory container after use
 rm-container(){
     $container_binary rm -f "$container_name" >/dev/null 2>&1;
+    if [ -n "${clean_up_image:-}" ]; then
+        $container_binary rmi ${image}
+    fi
 }
 trap rm-container 0
 


### PR DESCRIPTION
Workflow updates to support using the github-hosted runner. Specifically:
- docker image clean up due to reduced disk space on the runner. If we switch to oras for the podvm "publish" in future we might be able to reduce this, but after looking at it it's non-trivial, so doesn't seem worth adding support for this to the packer based podvm build, which we want to remove soon.
- Making the docker install optional to avoid clashes with the gh-provided version

If people feel we are ready to get switch over in this PR I'm happy to try it, but I thought that getting the changes in and stable first might de-risk the switch.