### PR TITLE
ci: disable concurrency for child workflows

### DIFF
--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -29,10 +29,6 @@ on:
         type: string
         description: prebuilt caa image
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build-caa-container-image:
     if: github.event.inputs.caa-image == ''

--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -33,10 +33,6 @@ env:
   UPLOSI_SHA256: "687bcab7398ab0fda65a3809492e8cd4d6a25aad1573927be5ec75ac1c4cbc35"
   IMAGE_ID: "/CommunityGalleries/${{ vars.AZURE_COMMUNITY_GALLERY_NAME }}/Images/${{ vars.AZURE_PODVM_IMAGE_DEF_NAME }}/Versions/${{ inputs.image-version }}"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build-podvm-image:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Those should not be set for callable workflows, since it's not supported to have concurrency groups set on both parent and children workflows.

https://github.com/github/vscode-github-actions/issues/135