### PR TITLE
workflow: Switch libvirt e2e test to gh-runnner

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -34,7 +34,7 @@ defaults:
 
 jobs:
   test:
-    runs-on: az-ubuntu-2204
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -176,3 +176,7 @@ jobs:
           echo "::endgroup::"
         # Avoid running with `set -e` as command fails should be allowed
         shell: bash {0}
+
+      - name: Clean-up cluster
+        if: ${{ runner.environment == 'self-hosted' }}
+        run: ./libvirt/kcli_cluster.sh delete

--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -132,8 +132,14 @@ jobs:
         run: |
           export KUBECONFIG="${HOME}/.kcli/clusters/peer-pods/auth/kubeconfig"
 
+          echo "::group::KBS installation"
+          kubectl get pods -n coco-tenant
+          kubectl describe pods -n coco-tenant
+          echo "::endgroup::"
+
           echo "::group::CoCo and Peer Pods installation"
           kubectl get pods -n confidential-containers-system
+          kubectl describe pods -n confidential-containers-system
           echo "::endgroup::"
 
           echo "::group::cloud-api-adaptor logs"


### PR DESCRIPTION
Now the pre-work changes have gone in in #2130,
we should be able to switch over to use the gh-hosted runner for libvirt e2e tests, so save Azure credits and make it easier to do testing on local forks.

Drive by fixes to add KBS debug info & add cluster clean-up support for "bare-metal" runners.

Tested in https://github.com/stevenhorsman/cloud-api-adaptor/actions/runs/11558678218/job/32171610739