### PR TITLE
versions: Bump fedora base image to f40

### DIFF
--- a/hack/Dockerfile.golang
+++ b/hack/Dockerfile.golang
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.5-labs
 
-ARG BASE_IMAGE=registry.fedoraproject.org/fedora:39
+ARG BASE_IMAGE=registry.fedoraproject.org/fedora:40
 FROM --platform=$TARGETPLATFORM ${BASE_IMAGE} AS base
 
 # DO NOT UPDATE THIS BY HAND !!

--- a/src/cloud-api-adaptor/Dockerfile
+++ b/src/cloud-api-adaptor/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_TYPE=dev
 ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.22.7-39
-ARG BASE=registry.fedoraproject.org/fedora:39
+ARG BASE=registry.fedoraproject.org/fedora:40
 
 # This dockerfile uses Go cross-compilation to build the binary,
 # we build on the host platform ($BUILDPLATFORM) and then copy the

--- a/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.podvm
+++ b/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.podvm
@@ -1,6 +1,6 @@
 # Adapted from https://github.com/kubernetes-sigs/kind/blob/main/images/base/Dockerfile
 
-ARG BASE_IMAGE=registry.fedoraproject.org/fedora:39
+ARG BASE_IMAGE=registry.fedoraproject.org/fedora:40
 FROM $BASE_IMAGE AS base
 
 RUN echo "Installing Packages ..." \

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.fedora
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.fedora
@@ -5,7 +5,7 @@
 #
 # Build binaries for mkosi podvm image
 #
-FROM registry.fedoraproject.org/fedora:39
+FROM registry.fedoraproject.org/fedora:40
 
 ARG ARCH="amd64"
 ARG YQ_ARCH="amd64"
@@ -25,8 +25,8 @@ RUN dnf groupinstall -y 'Development Tools' && \
     dnf clean all
 
 RUN dnf install 'dnf-command(config-manager)' && \
-	dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
-	dnf install -y gh --repo gh-cli
+    dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
+    dnf install -y gh --repo gh-cli
 
 ADD https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz go${GO_VERSION}.linux-${ARCH}.tar.gz
 RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go${GO_VERSION}.linux-${ARCH}.tar.gz && rm -f go${GO_VERSION}.linux-${ARCH}.tar.gz

--- a/src/peerpod-ctrl/Dockerfile
+++ b/src/peerpod-ctrl/Dockerfile
@@ -30,7 +30,7 @@ COPY peerpod-ctrl/controllers/ controllers/
 RUN CC=gcc CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build ${GOFLAGS} -a -o manager main.go
 
 # Target Image
-FROM --platform=$TARGETPLATFORM registry.fedoraproject.org/fedora:39
+FROM --platform=$TARGETPLATFORM registry.fedoraproject.org/fedora:40
 ARG CGO_ENABLED=1
 
 RUN if [ "$CGO_ENABLED" = 1 ] ; then dnf install -y libvirt-libs openssh-clients && dnf clean all; fi


### PR DESCRIPTION
Fedora 39 is EoL in a couple of weeks and I've started seeing a few repo connection errors, so lets bump to F40 as the latest supported version.

> [!NOTE]
> Once `golang-fedora:1.22.7-39` is built, this will be followed up with
a bump of the builder_base as well.