### PR TITLE
podvm_builder: Add s390x gh install support

### DIFF
--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.fedora
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.fedora
@@ -24,18 +24,22 @@ RUN dnf groupinstall -y 'Development Tools' && \
     clang which xz jq && \
     dnf clean all
 
-RUN dnf install 'dnf-command(config-manager)' && \
-    dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
-    dnf install -y gh --repo gh-cli
-
 ADD https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz go${GO_VERSION}.linux-${ARCH}.tar.gz
 RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go${GO_VERSION}.linux-${ARCH}.tar.gz && rm -f go${GO_VERSION}.linux-${ARCH}.tar.gz
+
+ENV PATH="/usr/local/go/bin:$PATH"
+
+RUN if [ "$(uname -m)" != "s390x" ]; then dnf install 'dnf-command(config-manager)' && \
+    dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
+    dnf install -y gh --repo gh-cli; else git clone https://github.com/cli/cli.git gh-cli && \
+    cd gh-cli && mkdir -p /usr/local/gh && make install prefix=/usr/local/gh && cd .. && \
+    rm -rf gh-cli; fi
+
+ENV PATH="/usr/local/gh/bin:$PATH"
 
 ADD https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${YQ_ARCH} /usr/local/bin/yq
 RUN echo "${YQ_CHECKSUM#sha256:} /usr/local/bin/yq" | sha256sum -c
 RUN chmod a+x /usr/local/bin/yq
-
-ENV PATH="/usr/local/go/bin:$PATH"
 
 ADD https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip
 RUN unzip protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip -d /usr/local && rm -f protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip


### PR DESCRIPTION
#2074 introduced the installation of the gh cli into the fedora podvm_builder Dockerfile using dnf. This isn't available for s390x and there isn't a released s390x version of the gh cli, so build it from source on that architecture.