### PR TITLE
versions: Fix csi-wrapper's base image

### DIFF
--- a/src/csi-wrapper/Dockerfile.csi_wrappers
+++ b/src/csi-wrapper/Dockerfile.csi_wrappers
@@ -7,13 +7,13 @@
 ARG SOURCE_FROM=remote
 
 ##### Builder Dev Image #####
-FROM --platform=${BUILDPLATFORM} quay.io/confidential-containers/golang-fedora:1.21.12-40 AS builder-local
+FROM --platform=${BUILDPLATFORM} quay.io/confidential-containers/golang-fedora:1.22.7-40 AS builder-local
 WORKDIR /src
 COPY csi-wrapper ./cloud-api-adaptor/src/csi-wrapper/
 COPY cloud-api-adaptor ./cloud-api-adaptor/src/cloud-api-adaptor
 
 ##### Builder Release Image #####
-FROM --platform=${BUILDPLATFORM} quay.io/confidential-containers/golang-fedora:1.21.12-40 AS builder-remote
+FROM --platform=${BUILDPLATFORM} quay.io/confidential-containers/golang-fedora:1.22.7-40 AS builder-remote
 ARG BINARY
 ARG CAA_SRC="https://github.com/confidential-containers/cloud-api-adaptor"
 ARG CAA_SRC_REF="main"


### PR DESCRIPTION
In #2136 I completed missed that we'd forgotten to bump the base image for golang updates, so just updated the fedora version and broken things.