### PR TITLE
Misc security related fixes for AWS and Azure

### DIFF
--- a/src/cloud-providers/go.mod
+++ b/src/cloud-providers/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/kdomanski/iso9660 v0.4.0
 	github.com/stretchr/testify v1.9.0
 	github.com/vmware/govmomi v0.33.1
+	golang.org/x/crypto v0.24.0
 	golang.org/x/oauth2 v0.17.0
 	google.golang.org/api v0.149.0
 	google.golang.org/protobuf v1.33.0
@@ -110,7 +111,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.25.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.25.0 // indirect
 	go.opentelemetry.io/otel/trace v1.25.0 // indirect
-	golang.org/x/crypto v0.24.0 // indirect
 	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect
 	golang.org/x/term v0.21.0 // indirect


### PR DESCRIPTION
aws: Avoid integer overflow when processing RootVolumeSize
azure: Verify the SSH key to ensure the file is using a supported  public key format