### PR TITLE
podvm: re-arrange service order for sealed secrets

### DIFF
--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system-preset/30-coco.preset
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system-preset/30-coco.preset
@@ -2,7 +2,7 @@ enable attestation-protocol-forwarder.service
 enable attestation-agent.service
 enable api-server-rest.path
 enable confidential-data-hub.path
-enable kata-agent.service
+enable kata-agent.path
 enable netns@.service
 enable process-user-data.service
 enable setup-nat-for-imds.service

--- a/src/cloud-api-adaptor/podvm/files/etc/ocicrypt_config.json
+++ b/src/cloud-api-adaptor/podvm/files/etc/ocicrypt_config.json
@@ -1,7 +1,0 @@
-{
-	"key-providers": {
-		"attestation-agent": {
-			"ttrpc": "unix:///run/confidential-containers/cdh.sock"
-		}
-	}
-}

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/agent-protocol-forwarder.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/agent-protocol-forwarder.service
@@ -1,9 +1,7 @@
 [Unit]
 Description=Agent Protocol Forwarder
 After=kata-agent.service
-Wants=kata-agent.service
 DefaultDependencies=no
-
 
 [Service]
 Type=notify

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/kata-agent.path
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/kata-agent.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Monitor for the Confidential Data Hub socket
+
+[Path]
+PathExists=/run/confidential-containers/cdh.sock
+Unit=kata-agent.service
+
+[Install]
+WantedBy=multi-user.target

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/kata-agent.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/kata-agent.service
@@ -1,11 +1,9 @@
 [Unit]
 Description=Kata Agent
 BindsTo=netns@podns.service
-Wants=process-user-data.service attestation-agent.service
-After=netns@podns.service process-user-data.service attestation-agent.service
+After=netns@podns.service process-user-data.service
 
 [Service]
-Environment=OCICRYPT_KEYPROVIDER_CONFIG=/etc/ocicrypt_config.json
 ExecStartPre=mkdir -p /run/kata-containers
 ExecStart=/usr/local/bin/kata-agent --config /run/peerpod/agent-config.toml
 ExecStartPre=-umount /sys/fs/cgroup/misc

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/kata-agent.path
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/kata-agent.path
@@ -1,0 +1,1 @@
+../kata-agent.path

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/kata-agent.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/kata-agent.service
@@ -1,1 +1,0 @@
-../kata-agent.service

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -49,7 +49,7 @@ oci:
     tag: 3.9
   kata-containers:
     registry: ghcr.io/kata-containers/cached-artefacts
-    reference: 9a33a3413b222868232402a7412562f4f6fb5736
+    reference: a2b9527be36ce5adb76491a27c7e02780feade6b
   guest-components:
     registry: ghcr.io/confidential-containers/guest-components
     reference: d8da69072424e496486dfb5421a26f16ff2a7abf


### PR DESCRIPTION
For sealed secrets to work kata-agent needs to connect to CDH, since it will repace env-variables in the container procoss with an unsealed confidential secret. A systemd path monitor watches for the CDH socket to appear to launch kata-agent.

Also, kata is writing the ocicrypt_config to /run in the agent process so we should not have bundle another in the podvm disk.

~Draft until https://github.com/kata-containers/kata-containers/pull/10481 is merged, need to bump kata to the new revision.~