### PR TITLE
workflows: Switch to pin ubuntu runners

### DIFF
--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   build-caa-container-image:
     if: github.event.inputs.caa-image == ''
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: src/cloud-api-adaptor
@@ -64,7 +64,7 @@ jobs:
         echo "caa-image=${ACR_URL}/cloud-api-adaptor:dev-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
 
   install-aks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: src/cloud-api-adaptor
@@ -152,7 +152,7 @@ jobs:
         ./caa-provisioner-cli -action=createcluster
 
   run-e2e-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: src/cloud-api-adaptor
@@ -238,7 +238,7 @@ jobs:
         make test-e2e RUN_TESTS="^Test\(CreateSimplePodAzure\|RemoteAttestation\)$"
 
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
     - run-e2e-test
     if: always()

--- a/.github/workflows/azure-nightly-build.yml
+++ b/.github/workflows/azure-nightly-build.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   generate-podvm-image-version:
     if: github.event.inputs.podvm-image-id == ''
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       image-version: "${{ steps.generate-image-version.outputs.image-version }}"
     steps:

--- a/.github/workflows/build-golang-fedora.yaml
+++ b/.github/workflows/build-golang-fedora.yaml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
           - dev
           - release
         runner:
-          - ubuntu-latest
+          - ubuntu-24.04
     defaults:
       run:
         working-directory: src/cloud-api-adaptor
@@ -73,7 +73,7 @@ jobs:
 
   controllers:
     name: controllers
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -118,7 +118,7 @@ jobs:
 
   volumes:
     name: volume controllers
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -170,7 +170,7 @@ jobs:
           echo "::endgroup::"
 
   webhook:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: src/webhook

--- a/.github/workflows/caa_build_and_push.yaml
+++ b/.github/workflows/caa_build_and_push.yaml
@@ -41,7 +41,7 @@ defaults:
 jobs:
   build_push_job:
     name: build and push
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/caa_build_and_push_per_arch.yaml
+++ b/.github/workflows/caa_build_and_push_per_arch.yaml
@@ -30,7 +30,7 @@ defaults:
 
 jobs:
   upload_tags:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
   build_push_job:
     name: build and push
     needs: [upload_tags]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -155,7 +155,7 @@ jobs:
 
   manifest_job:
     name: generate images manifest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [build_push_job]
     steps:
       - name: Checkout the code

--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   commit-message-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Commit Message Check
     steps:
       - name: Get PR Commits

--- a/.github/workflows/csi_wrapper_images.yaml
+++ b/.github/workflows/csi_wrapper_images.yaml
@@ -26,7 +26,7 @@ on:
 jobs:
   build_push_job:
     name: build and push
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/daily-e2e-tests-ibmcloud.yaml
+++ b/.github/workflows/daily-e2e-tests-ibmcloud.yaml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   daily-e2e-tests:
     name: e2e tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e_on_pull.yaml
+++ b/.github/workflows/e2e_on_pull.yaml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   authorize:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: contains(github.event.pull_request.labels.*.name, 'test_e2e_libvirt')
     steps:
       - run: "true"

--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -98,7 +98,7 @@ jobs:
   # "aws libvirt").
   prep_install:
     needs: [image]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     env:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   checklinks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/peerpod-ctrl_image.yaml
+++ b/.github/workflows/peerpod-ctrl_image.yaml
@@ -26,7 +26,7 @@ on:
 jobs:
   peerpod_push:
     name: build and push peerpod-ctrl
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: src/peerpod-ctrl

--- a/.github/workflows/podvm.yaml
+++ b/.github/workflows/podvm.yaml
@@ -22,7 +22,7 @@ defaults:
 jobs:
   build:
     name: Create pod vm image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/podvm_binaries.yaml
+++ b/.github/workflows/podvm_binaries.yaml
@@ -22,7 +22,7 @@ defaults:
 jobs:
   build:
     name: Create pod vm binaries image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/podvm_builder.yaml
+++ b/.github/workflows/podvm_builder.yaml
@@ -30,7 +30,7 @@ jobs:
           # Please keep this list in alphabetical order.
           - ubuntu
         runner:
-          - ubuntu-latest
+          - ubuntu-24.04
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4

--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -15,7 +15,7 @@ jobs:
   build-binaries:
     name: Build binaries
     if : ${{ github.event.inputs.binaries-image == '' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
@@ -67,7 +67,7 @@ jobs:
               github.event.inputs.binaries-image != ''
           )
       )
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -15,7 +15,7 @@ defaults:
 
 jobs:
   list-dockerfiles:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ env.MATRIX }}
     steps:
@@ -25,7 +25,7 @@ jobs:
   build:
     name: Create Test Images
     needs: list-dockerfiles
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/webhook_image.yaml
+++ b/.github/workflows/webhook_image.yaml
@@ -25,7 +25,7 @@ on:
 jobs:
   build_push_webhook:
     name: build and push webhook
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: src/webhook


### PR DESCRIPTION
Switch all our workflows to use the pinned ubuntu-24.04 runner rather than ubuntu-latest