### PR TITLE
SecComms: Fix flaky tests

### DIFF
--- a/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud_test.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud_test.go
@@ -155,7 +155,10 @@ func TestCloudServiceWithSecureComms(t *testing.T) {
 	kubemgr.InitKubeMgrMock()
 	test.CreatePKCS8Secret(t)
 	test.KBSServer("9009")
-	test.HttpServer(forwarder.DefaultListenPort)
+	s9009 := test.HttpServer(forwarder.DefaultListenPort)
+	if s9009 == nil {
+		t.Error("Failed - could not create server")
+	}
 
 	// create a podvm
 	gkc := test.NewGetKeyClient("9019")

--- a/src/cloud-api-adaptor/pkg/podnetwork/podnetwork_test.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/podnetwork_test.go
@@ -50,7 +50,7 @@ func TestWorkerNode(t *testing.T) {
 	mockTunnelType := "mock"
 	tunneler.Register(mockTunnelType, newMockWorkerNodeTunneler, newMockPodNodeTunneler)
 
-	workerNodeNS := tuntest.NewNamedNS(t, "test-workernode")
+	workerNodeNS, _ := tuntest.NewNamedNS(t, "test-workernode")
 	defer tuntest.DeleteNamedNS(t, workerNodeNS)
 
 	tuntest.BridgeAdd(t, workerNodeNS, "ens0")
@@ -59,7 +59,7 @@ func TestWorkerNode(t *testing.T) {
 	tuntest.AddrAdd(t, workerNodeNS, "ens1", "192.168.1.2/24")
 	tuntest.RouteAdd(t, workerNodeNS, "", "192.168.0.1", "ens0")
 
-	workerPodNS := tuntest.NewNamedNS(t, "test-workerpod")
+	workerPodNS, _ := tuntest.NewNamedNS(t, "test-workerpod")
 	defer tuntest.DeleteNamedNS(t, workerPodNS)
 
 	tuntest.BridgeAdd(t, workerPodNS, "eth0")
@@ -122,7 +122,7 @@ func TestPodNode(t *testing.T) {
 	mockTunnelType := "mock"
 	tunneler.Register(mockTunnelType, newMockWorkerNodeTunneler, newMockPodNodeTunneler)
 
-	podNodeNS := tuntest.NewNamedNS(t, "test-podnode")
+	podNodeNS, _ := tuntest.NewNamedNS(t, "test-podnode")
 	defer tuntest.DeleteNamedNS(t, podNodeNS)
 
 	tuntest.BridgeAdd(t, podNodeNS, "ens0")
@@ -149,7 +149,7 @@ func TestPodNode(t *testing.T) {
 		},
 	} {
 
-		podNS := tuntest.NewNamedNS(t, "test-pod")
+		podNS, _ := tuntest.NewNamedNS(t, "test-pod")
 		func() {
 			defer tuntest.DeleteNamedNS(t, podNS)
 
@@ -197,7 +197,7 @@ func TestPodNode(t *testing.T) {
 func TestPluginDetectHostInterface(t *testing.T) {
 	testutils.SkipTestIfNotRoot(t)
 
-	hostNS := tuntest.NewNamedNS(t, "test-host")
+	hostNS, _ := tuntest.NewNamedNS(t, "test-host")
 	defer tuntest.DeleteNamedNS(t, hostNS)
 
 	tuntest.BridgeAdd(t, hostNS, "eth0")

--- a/src/cloud-api-adaptor/pkg/podnetwork/tunneler/routing/iptables_test.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/tunneler/routing/iptables_test.go
@@ -14,7 +14,7 @@ import (
 func TestIPTables(t *testing.T) {
 	testutils.SkipTestIfNotRoot(t)
 
-	workerNS := tuntest.NewNamedNS(t, "test-host")
+	workerNS, _ := tuntest.NewNamedNS(t, "test-host")
 	defer tuntest.DeleteNamedNS(t, workerNS)
 
 	ipt, err := iptables.New(iptables.IPFamily(iptables.ProtocolIPv4))

--- a/src/cloud-api-adaptor/pkg/podnetwork/tuntest/tuntest.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/tuntest/tuntest.go
@@ -56,10 +56,10 @@ func RunTunnelTest(t *testing.T, tunnelType string, newWorkerNodeTunneler, newPo
 		{podAddr: "10.128.0.3/24", podHwAddr: "0a:58:0a:84:03:cf", podNodePrimaryAddr: "10.10.1.3/16", podNodeSecondaryAddr: "192.168.0.3/24"},
 	}
 
-	bridgeNS := NewNamedNS(t, "test-bridge")
+	bridgeNS, _ := NewNamedNS(t, "test-bridge")
 	defer DeleteNamedNS(t, bridgeNS)
 
-	workerNS := NewNamedNS(t, "test-worker")
+	workerNS, _ := NewNamedNS(t, "test-worker")
 	defer DeleteNamedNS(t, workerNS)
 
 	if err := workerNS.Run(func() error {
@@ -98,7 +98,7 @@ func RunTunnelTest(t *testing.T, tunnelType string, newWorkerNodeTunneler, newPo
 		pod.workerNodeTunneler = newWorkerNodeTunneler()
 		pod.podNodeTunneler = newPodNodeTunneler()
 
-		pod.workerPodNS = NewNamedNS(t, fmt.Sprintf("test-workerpod%d", i))
+		pod.workerPodNS, _ = NewNamedNS(t, fmt.Sprintf("test-workerpod%d", i))
 		defer DeleteNamedNS(t, pod.workerPodNS)
 
 		veth := fmt.Sprintf("veth%d", i)
@@ -109,7 +109,7 @@ func RunTunnelTest(t *testing.T, tunnelType string, newWorkerNodeTunneler, newPo
 		HwAddrAdd(t, pod.workerPodNS, "eth0", pod.podHwAddr)
 		RouteAdd(t, pod.workerPodNS, "", gatewayIP, "eth0")
 
-		pod.podNodeNS = NewNamedNS(t, fmt.Sprintf("test-podvm%d", i))
+		pod.podNodeNS, _ = NewNamedNS(t, fmt.Sprintf("test-podvm%d", i))
 		defer DeleteNamedNS(t, pod.podNodeNS)
 
 		vmEth0 := fmt.Sprintf("podvm%d-eth0", i)
@@ -122,7 +122,7 @@ func RunTunnelTest(t *testing.T, tunnelType string, newWorkerNodeTunneler, newPo
 		LinkSetMaster(t, bridgeNS, vmEth0, "br0")
 		LinkSetMaster(t, bridgeNS, vmEth1, "br1")
 
-		pod.podNS = NewNamedNS(t, fmt.Sprintf("test-pod%d", i))
+		pod.podNS, _ = NewNamedNS(t, fmt.Sprintf("test-pod%d", i))
 		defer DeleteNamedNS(t, pod.podNS)
 	}
 

--- a/src/cloud-api-adaptor/pkg/podnetwork/tuntest/util.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/tuntest/util.go
@@ -21,7 +21,7 @@ import (
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/netops"
 )
 
-func NewNamedNS(t *testing.T, prefix string) netops.Namespace {
+func NewNamedNS(t *testing.T, prefix string) (netops.Namespace, string) {
 	t.Helper()
 
 	var nsPath string
@@ -54,7 +54,7 @@ func NewNamedNS(t *testing.T, prefix string) netops.Namespace {
 		t.Fatalf("failed to set the link up: lo")
 	}
 
-	return ns
+	return ns, name
 }
 
 func DeleteNamedNS(t *testing.T, ns netops.Namespace) {

--- a/src/cloud-api-adaptor/pkg/securecomms/apic/apic_test.go
+++ b/src/cloud-api-adaptor/pkg/securecomms/apic/apic_test.go
@@ -2,48 +2,20 @@ package apic
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io/fs"
 	"testing"
 
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/podnetwork/tuntest"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/test/securecomms/test"
-	"github.com/google/uuid"
-	"github.com/vishvananda/netlink"
-	"github.com/vishvananda/netns"
 )
 
 func TestApiC(t *testing.T) {
-	namespace := uuid.NewString()
-	nsPath := "/run/netns/" + namespace
-	// Create a new network namespace
-	newns, err := netns.NewNamed(namespace)
-	if err != nil && !errors.Is(err, fs.ErrExist) {
-		if errors.Is(err, fs.ErrPermission) {
-			t.Skip("Skip due to missing permissions - run privileged!")
-		}
-		t.Errorf("netns.NewNamed(%s) returned err %s", namespace, err.Error())
-	}
-	defer func() {
-		newns.Close()
-		if err := netns.DeleteNamed(namespace); err != nil {
-			t.Errorf("failed to delete a named network namespace %s: %v", namespace, err)
-		}
-	}()
+	testNs, _ := tuntest.NewNamedNS(t, "test-TestApiC")
+	defer tuntest.DeleteNamedNS(t, testNs)
 
-	link, err := netlink.LinkByName("lo")
-	if err != nil {
-		t.Fatal(err)
-	}
+	apic := NewApiClient(7700, testNs.Path())
 
-	// bring the interface up
-	if err := netlink.LinkSetUp(link); err != nil {
-		t.Fatal(err)
-	}
-
-	apic := NewApiClient(7700, nsPath)
-
-	s := test.NamespacedHttpServer(7700, nsPath)
+	s := test.NamespacedHttpServer(7700, testNs.Path())
 	data, err := apic.GetKey("default/sshclient/publicKey")
 	if err != nil {
 		t.Error(err)

--- a/src/cloud-api-adaptor/pkg/securecomms/ppssh/ppssh_test.go
+++ b/src/cloud-api-adaptor/pkg/securecomms/ppssh/ppssh_test.go
@@ -208,6 +208,9 @@ func TestPpssh(t *testing.T) {
 	}
 
 	s := test.HttpServer("7105")
+	if s == nil {
+		t.Error("Failed - could not create server")
+	}
 
 	clientSshPeer.Ready()
 	clientSshPeer.Wait()

--- a/src/cloud-api-adaptor/pkg/securecomms/wnssh/wnssh_test.go
+++ b/src/cloud-api-adaptor/pkg/securecomms/wnssh/wnssh_test.go
@@ -16,11 +16,13 @@ func TestSshProxyReverseKBS(t *testing.T) {
 	sshport := "6003"
 	kubemgr.InitKubeMgrMock()
 
-	test.KBSServer("9001")
-	test.HttpServer("8053")
-	test.HttpServer("26443")
-	test.HttpServer("7121")
-
+	s9001 := test.KBSServer("9001")
+	s8053 := test.HttpServer("8053")
+	s26443 := test.HttpServer("26443")
+	s7121 := test.HttpServer("7121")
+	if s9001 == nil || s8053 == nil || s26443 == nil || s7121 == nil {
+		t.Error("Failed - could not create server")
+	}
 	test.CreatePKCS8Secret(t)
 
 	// CAA Initialization

--- a/src/cloud-api-adaptor/test/securecomms/test/httpServer.go
+++ b/src/cloud-api-adaptor/test/securecomms/test/httpServer.go
@@ -3,6 +3,7 @@ package test
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 )
 
@@ -24,10 +25,16 @@ func HttpServer(port string) *http.Server {
 		Addr:    "127.0.0.1:" + port,
 		Handler: mux,
 	}
+	ln, err := net.Listen("tcp", s.Addr)
+	if err != nil {
+		fmt.Printf("Listen Error %v\n", err)
+		return nil
+	}
+
 	go func() {
-		err := s.ListenAndServe()
+		err = s.Serve(ln)
 		if err != http.ErrServerClosed { // graceful shutdown
-			fmt.Printf("ListenAndServe Error %v\n", err)
+			fmt.Printf("Serve Error %v\n", err)
 		}
 	}()
 	return s

--- a/src/cloud-api-adaptor/test/securecomms/test/kbs.go
+++ b/src/cloud-api-adaptor/test/securecomms/test/kbs.go
@@ -39,7 +39,7 @@ func (p kbsport) getRoot(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "Not Found", http.StatusNotFound)
 }
 
-func KBSServer(port string) {
+func KBSServer(port string) *http.Server {
 	keys = map[string][]byte{}
 
 	p := kbsport(port)
@@ -50,10 +50,20 @@ func KBSServer(port string) {
 		Handler: mux,
 	}
 
+	ln, err := net.Listen("tcp", s.Addr)
+	if err != nil {
+		fmt.Printf("Listen Error %v\n", err)
+		return nil
+	}
+
 	go func() {
-		err := s.ListenAndServe()
-		fmt.Printf("ListenAndServe Error %v\n", err)
+		err = s.Serve(ln)
+		if err != http.ErrServerClosed { // graceful shutdown
+			fmt.Printf("Serve Error %v\n", err)
+		}
 	}()
+
+	return s
 }
 
 type GetKeyClient struct {

--- a/src/cloud-api-adaptor/test/securecomms/test/namespacedHttpServer.go
+++ b/src/cloud-api-adaptor/test/securecomms/test/namespacedHttpServer.go
@@ -53,10 +53,11 @@ func NamespacedHttpServer(port uint16, nsPath string) *http.Server {
 		Addr:    fmt.Sprintf("127.0.0.1:%s", retPort),
 		Handler: mux,
 	}
+
 	go func() {
 		err := http.Serve(tcpListener, mux)
 		if err != http.ErrServerClosed { // graceful shutdown
-			fmt.Printf("ListenAndServe Error %v\n", err)
+			fmt.Printf("Serve Error %v\n", err)
 		}
 	}()
 	return s


### PR DESCRIPTION
Fixes: #2153

Seperate ListenAndServe() of test servers to perform Listen() in the same thread as used by the client that rely on the server port to be open.

Move to reuse tuntest network namespace test code rather that maintaining seperate network namespace test code for SecureComms.