### PR TITLE
podvm-mkosi: bump to fedora 40

### DIFF
--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/initrd/mkosi.conf.d/fedora.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/initrd/mkosi.conf.d/fedora.conf
@@ -3,7 +3,7 @@ Distribution=fedora
 
 [Distribution]
 Distribution=fedora
-Release=39
+Release=40
 
 [Content]
 CleanPackageMetadata=true

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora.conf
@@ -3,7 +3,7 @@ Distribution=fedora
 
 [Distribution]
 Distribution=fedora
-Release=39
+Release=40
 
 [Content]
 CleanPackageMetadata=true


### PR DESCRIPTION
We forgot to bump the mkosi version to fedora 40 in the mkosi config.

I triggered an azure e2e-test w/ an [fedora40 podvm image](https://github.com/confidential-containers/cloud-api-adaptor/actions/runs/11894045370/job/33140667630#step:6:44) and it passed