### PR TITLE
Retiring "DISABLE_CLOUD_CONFIG" variable

### DIFF
--- a/src/cloud-api-adaptor/aws/image/rhel/aws-rhel.pkr.hcl
+++ b/src/cloud-api-adaptor/aws/image/rhel/aws-rhel.pkr.hcl
@@ -91,7 +91,6 @@ build {
     environment_vars = [
       "CLOUD_PROVIDER=${var.cloud_provider}",
       "PODVM_DISTRO=${var.podvm_distro}",
-      "DISABLE_CLOUD_CONFIG=${var.disable_cloud_config}",
       "FORWARDER_PORT=${var.forwarder_port}"
     ]
     inline = [

--- a/src/cloud-api-adaptor/aws/image/rhel/variables.pkr.hcl
+++ b/src/cloud-api-adaptor/aws/image/rhel/variables.pkr.hcl
@@ -43,11 +43,6 @@ variable "volume_size" {
   default = 30
 }
 
-variable "disable_cloud_config" {
-  type    = string
-  default = env("DISABLE_CLOUD_CONFIG")
-}
-
 variable "config_script_src" {
   type    = string
   default = ""

--- a/src/cloud-api-adaptor/aws/image/ubuntu/aws-ubuntu.pkr.hcl
+++ b/src/cloud-api-adaptor/aws/image/ubuntu/aws-ubuntu.pkr.hcl
@@ -77,7 +77,6 @@ build {
     environment_vars = [
       "CLOUD_PROVIDER=${var.cloud_provider}",
       "PODVM_DISTRO=${var.podvm_distro}",
-      "DISABLE_CLOUD_CONFIG=${var.disable_cloud_config}",
       "FORWARDER_PORT=${var.forwarder_port}"
     ]
     inline = [

--- a/src/cloud-api-adaptor/aws/image/ubuntu/variables.pkr.hcl
+++ b/src/cloud-api-adaptor/aws/image/ubuntu/variables.pkr.hcl
@@ -43,11 +43,6 @@ variable "volume_size" {
   default = 30
 }
 
-variable "disable_cloud_config" {
-  type    = string
-  default = env("DISABLE_CLOUD_CONFIG")
-}
-
 variable "config_script_src" {
   type    = string
   default = ""

--- a/src/cloud-api-adaptor/azure/build-image.md
+++ b/src/cloud-api-adaptor/azure/build-image.md
@@ -115,9 +115,6 @@ export CLOUD_PROVIDER=azure
 PODVM_DISTRO=ubuntu make image
 ```
 
-> [!NOTE]
-> If you want to disable cloud-init then `export DISABLE_CLOUD_CONFIG=true` before building the image.
-
 Use the `ManagedImageSharedImageGalleryId` field from output of the above command to populate the following environment variable. It's used while deploying cloud-api-adaptor:
 
 ```bash

--- a/src/cloud-api-adaptor/azure/image/rhel/azure-rhel.pkr.hcl
+++ b/src/cloud-api-adaptor/azure/image/rhel/azure-rhel.pkr.hcl
@@ -103,7 +103,6 @@ build {
     environment_vars = [
       "CLOUD_PROVIDER=${var.cloud_provider}",
       "PODVM_DISTRO=${var.podvm_distro}",
-      "DISABLE_CLOUD_CONFIG=${var.disable_cloud_config}",
       "FORWARDER_PORT=${var.forwarder_port}"
     ]
     inline = [

--- a/src/cloud-api-adaptor/azure/image/rhel/variables.pkr.hcl
+++ b/src/cloud-api-adaptor/azure/image/rhel/variables.pkr.hcl
@@ -96,11 +96,6 @@ variable "plan_publisher" {
   default = ""
 }
 
-variable "disable_cloud_config" {
-  type    = string
-  default = env("DISABLE_CLOUD_CONFIG")
-}
-
 # shared gallery name
 variable "az_gallery_name" {
   type    = string

--- a/src/cloud-api-adaptor/azure/image/ubuntu/azure-ubuntu.pkr.hcl
+++ b/src/cloud-api-adaptor/azure/image/ubuntu/azure-ubuntu.pkr.hcl
@@ -84,7 +84,6 @@ build {
     environment_vars = [
       "CLOUD_PROVIDER=${var.cloud_provider}",
       "PODVM_DISTRO=${var.podvm_distro}",
-      "DISABLE_CLOUD_CONFIG=${var.disable_cloud_config}",
       "FORWARDER_PORT=${var.forwarder_port}"
     ]
     inline = [

--- a/src/cloud-api-adaptor/azure/image/ubuntu/variables.pkr.hcl
+++ b/src/cloud-api-adaptor/azure/image/ubuntu/variables.pkr.hcl
@@ -114,11 +114,6 @@ variable "plan_publisher" {
   default = ""
 }
 
-variable "disable_cloud_config" {
-  type    = string
-  default = env("DISABLE_CLOUD_CONFIG")
-}
-
 variable "config_script_src" {
   type    = string
   default = ""

--- a/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.podvm
+++ b/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.podvm
@@ -30,7 +30,7 @@ COPY ./resources/binaries-tree/pause_bundle/ /pause_bundle/
 
 RUN curl -LO https://raw.githubusercontent.com/confidential-containers/cloud-api-adaptor/main/src/cloud-api-adaptor/podvm/qcow2/misc-settings.sh
 
-RUN PODVM_DISTRO=ubuntu CLOUD_PROVIDER=generic DISABLE_CLOUD_CONFIG=true bash ./misc-settings.sh
+RUN PODVM_DISTRO=ubuntu CLOUD_PROVIDER=generic bash ./misc-settings.sh
 
 COPY --chmod=0755 entrypoint.sh  /usr/local/bin/
 

--- a/src/cloud-api-adaptor/podvm/qcow2/misc-settings.sh
+++ b/src/cloud-api-adaptor/podvm/qcow2/misc-settings.sh
@@ -77,22 +77,6 @@ TLS_OPTIONS=-cert-file /etc/certificates/tls.crt -cert-key /etc/certificates/tls
 END
 fi
 
-# If DISABLE_CLOUD_CONFIG is not set or not set to true, then add cloud-init.target as a dependency for process-user-data.service
-# so that required files via cloud-config are available before kata-agent starts
-if [ -z "$DISABLE_CLOUD_CONFIG" ] || [ "$DISABLE_CLOUD_CONFIG" != "true" ]
-then
-# Add cloud-init.target as a dependency for process-user-data.service so that
-# required files via cloud-config are available before kata-agent starts
-    mkdir -p /etc/systemd/system/process-user-data.service.d
-    cat <<END >> /etc/systemd/system/process-user-data.service.d/10-override.conf
-[Unit]
-After=cloud-config.service
-
-[Service]
-ExecStartPre=
-END
-fi
-
 if [ -n "${FORWARDER_PORT}" ]; then
     cat <<END >> /etc/default/agent-protocol-forwarder 
 OPTIONS=-listen 0.0.0.0:${FORWARDER_PORT}

--- a/src/cloud-api-adaptor/podvm/qcow2/rhel/qemu-rhel.pkr.hcl
+++ b/src/cloud-api-adaptor/podvm/qcow2/rhel/qemu-rhel.pkr.hcl
@@ -106,8 +106,7 @@ build {
     remote_folder = "~"
     environment_vars = [
       "CLOUD_PROVIDER=${var.cloud_provider}",
-      "PODVM_DISTRO=${var.podvm_distro}",
-      "DISABLE_CLOUD_CONFIG=${var.disable_cloud_config}"
+      "PODVM_DISTRO=${var.podvm_distro}"
     ]
     inline = [
       "sudo -E bash ~/misc-settings.sh"

--- a/src/cloud-api-adaptor/podvm/qcow2/rhel/variables.pkr.hcl
+++ b/src/cloud-api-adaptor/podvm/qcow2/rhel/variables.pkr.hcl
@@ -98,11 +98,6 @@ variable "boot_wait" {
   default = "10s"
 }
 
-variable "disable_cloud_config" {
-  type    = string
-  default = env("DISABLE_CLOUD_CONFIG")
-}
-
 variable "se_boot" {
   type    = string
   default = env("SE_BOOT")

--- a/src/cloud-api-adaptor/podvm/qcow2/ubuntu/qemu-ubuntu.pkr.hcl
+++ b/src/cloud-api-adaptor/podvm/qcow2/ubuntu/qemu-ubuntu.pkr.hcl
@@ -92,8 +92,7 @@ build {
     remote_folder = "~"
     environment_vars = [
       "CLOUD_PROVIDER=${var.cloud_provider}",
-      "PODVM_DISTRO=${var.podvm_distro}",
-      "DISABLE_CLOUD_CONFIG=${var.disable_cloud_config}"
+      "PODVM_DISTRO=${var.podvm_distro}"
     ]
     inline = [
       "sudo -E bash ~/misc-settings.sh"

--- a/src/cloud-api-adaptor/podvm/qcow2/ubuntu/variables.pkr.hcl
+++ b/src/cloud-api-adaptor/podvm/qcow2/ubuntu/variables.pkr.hcl
@@ -107,8 +107,3 @@ variable "uefi_firmware" {
   type    = string
   default = "/usr/share/OVMF/OVMF_CODE.fd"
 }
-
-variable "disable_cloud_config" {
-  type    = string
-  default = env("DISABLE_CLOUD_CONFIG")
-}


### PR DESCRIPTION
As mentioned in
https://github.com/confidential-containers/cloud-api-adaptor/issues/1951
the variable "DISABLE_CLOUD_CONFIG" was removed in this PR
