### PR TITLE
e2e: add encrypted image test

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -180,7 +180,7 @@ AZURE_IMAGE_ID="unused"
 EOF
 ```
 
-Run the test suite with the respective flags:
+Run the test suite with the respective flags. Enable `TEST_KBS` and provide a `KBS_ENDPOINT` to run KBS-related test.
 
 ```bash
 make test-e2e \
@@ -189,6 +189,9 @@ TEST_TEARDOWN=no \
 TEST_PROVISION=no \
 TEST_INSTALL_CAA=no \
 TEST_PROVISION_FILE="${PWD}/skip-provisioning.properties" \
+TEST_KBS=yes \
+KBS_ENDPOINT=http://10.224.0.5:30362 \
+RUN_TESTS=TestAzureImageDecryption
 ```
 
 ### IBM Cloud

--- a/src/cloud-api-adaptor/test/e2e/azure_test.go
+++ b/src/cloud-api-adaptor/test/e2e/azure_test.go
@@ -155,3 +155,12 @@ func TestTrusteeOperatorKeyReleaseForSpecificKey(t *testing.T) {
 	kbsEndpoint, _ := keyBrokerService.GetCachedKbsEndpoint()
 	DoTestTrusteeOperatorKeyReleaseForSpecificKey(t, testEnv, assert, kbsEndpoint)
 }
+
+func TestAzureImageDecryption(t *testing.T) {
+	if !isTestWithKbs() {
+		t.Skip("Skipping kbs related test as kbs is not deployed")
+	}
+	t.Parallel()
+
+	DoTestImageDecryption(t, testEnv, assert, keyBrokerService)
+}

--- a/src/cloud-api-adaptor/test/e2e/libvirt_test.go
+++ b/src/cloud-api-adaptor/test/e2e/libvirt_test.go
@@ -124,6 +124,15 @@ func TestLibvirtPodsMTLSCommunication(t *testing.T) {
 	DoTestPodsMTLSCommunication(t, testEnv, assert)
 }
 
+func TestLibvirtImageDecryption(t *testing.T) {
+	if !isTestWithKbs() {
+		t.Skip("Skipping kbs related test as kbs is not deployed")
+	}
+
+	assert := LibvirtAssert{}
+	DoTestImageDecryption(t, testEnv, assert, keyBrokerService)
+}
+
 func TestLibvirtSealedSecret(t *testing.T) {
 	if !isTestWithKbs() {
 		t.Skip("Skipping kbs related test as kbs is not deployed")


### PR DESCRIPTION
this adds a test for image layer decryption to the libvirt & azure suite. The test currently uses a predefined image with hardcoded key + keyid. In the future we might want to do something more comprehensive, but it's crucial that we have CI coverage for this feature. 

note: we _do_ need the `io.containerd.cri.runtime-handler` annotation set for encrypted images, at least that was the case in my local tests.