### PR TITLE
ci: fix verify-provenance for agent

### DIFF
--- a/src/cloud-api-adaptor/podvm/Makefile.inc
+++ b/src/cloud-api-adaptor/podvm/Makefile.inc
@@ -57,7 +57,7 @@ ifeq ($(shell echo $(KATA_REF) | grep -E "[0-9a-f]{40}"),)
 	KATA_COMMIT := $(shell curl \
 		--silent \
 		--retry 3 \
-		https://api.github.com/repos/$(KATA_REPO)/commits/v$(KATA_REF) \
+		https://api.github.com/repos/$(KATA_REPO)/commits/$(KATA_REF) \
 		| jq -e -r .sha)
 else
 	KATA_COMMIT := $(KATA_REF)


### PR DESCRIPTION
The agent attestation can also be created by a workflow_trigger on main, so we have to allow that in the verification. There was also a bug in the routine that resolved a release tag to commit. kata doesn't tag their releases with a preceding 'v'.