### PR TITLE
version: Pin operator version

### DIFF
--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -30,7 +30,7 @@ tools:
 git:
   coco-operator:
     url: https://github.com/confidential-containers/operator
-    reference: main
+    reference: v0.11.0
   umoci:
     url: https://github.com/opencontainers/umoci
     reference: v0.4.7


### PR DESCRIPTION
Pin the operator version to v0.11.0 to ensure that people deploying this release get a fixed and compatible version of the kata runtime deployed.