### PR TITLE
workflows: Add workflow to close stale PRs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,17 @@
+name: 'Automatically close stale PRs'
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-pr-message: 'This PR has been opened without with no activity for 90 days. Comment on the issue otherwise it will be closed in 7 days'
+          days-before-pr-stale: 90
+          days-before-pr-close: 7
+          days-before-issue-stale: -1
+          days-before-issue-close: -1


### PR DESCRIPTION
We have a small number of old PRs that look to be stale, so we can implement an auto-comment-then-close action on these.

The initial settings for this are to
- Mark all the PRs that have no activity for more than 90 days as stale.
- If there's no activity on the PR for 7 days, the PR will be automatically closed.