### PR TITLE
doc: Update confidentialcontainers.org links

### DIFF
--- a/src/cloud-api-adaptor/azure/README.md
+++ b/src/cloud-api-adaptor/azure/README.md
@@ -1,3 +1,3 @@
 # Cloud API Adaptor (CAA) on Azure
 
-This documentation has been moved to the official location [here](https://confidentialcontainers.org/docs/cloud-api-adaptor/azure/).
+This documentation has been moved to the official location [here](https://confidentialcontainers.org/docs/examples/azure-simple/).

--- a/src/cloud-api-adaptor/docs/troubleshooting/README.md
+++ b/src/cloud-api-adaptor/docs/troubleshooting/README.md
@@ -1,3 +1,3 @@
 # Troubleshooting
 
-This documentation has been moved to the official location [here](https://confidentialcontainers.org/docs/cloud-api-adaptor/troubleshooting/).
+The official documentation for Confidential Containers is currently under re-work. An archived version of the Peer pods troubleshooting guide can be found [here](https://github.com/confidential-containers/confidentialcontainers.org/blob/7a861f4d26c48100004d2c6e72298f2592cc04c0/content/en/docs/cloud-api-adaptor/troubleshooting.md).


### PR DESCRIPTION
The CAA documentation has been moved/deleted
from the CoCo website, so update the links and point to the old github source where no new version exists.