### PR TITLE
Update go directive to 1.22.7 to address CVE

### DIFF
--- a/src/cloud-api-adaptor/go.mod
+++ b/src/cloud-api-adaptor/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor
 
-go 1.22.0
+go 1.22.7
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1

--- a/src/cloud-api-adaptor/podvm/go.mod
+++ b/src/cloud-api-adaptor/podvm/go.mod
@@ -4,4 +4,4 @@
 
 module github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/podvm
 
-go 1.22.0
+go 1.22.7

--- a/src/cloud-providers/go.mod
+++ b/src/cloud-providers/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers
 
-go 1.22.0
+go 1.22.7
 
 require (
 	cloud.google.com/go/compute v1.23.3

--- a/src/csi-wrapper/go.mod
+++ b/src/csi-wrapper/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/csi-wrapper
 
-go 1.22.0
+go 1.22.7
 
 require (
 	github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor v0.10.0

--- a/src/peerpod-ctrl/go.mod
+++ b/src/peerpod-ctrl/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/peerpod-ctrl
 
-go 1.22.0
+go 1.22.7
 
 require (
 	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers v0.10.0

--- a/src/webhook/go.mod
+++ b/src/webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/webhook
 
-go 1.22.0
+go 1.22.7
 
 require (
 	k8s.io/api v0.29.6


### PR DESCRIPTION
The encoding/gob package in the Go standard library is affected by CVE-2024-34156. This vulnerability is resolved in Go versions >=1.22.7 or >=1.23.1.

Our current go.mod directive (go 1.22.0) could allow the 1.22.0 toolchain to compile the code, leaving it vulnerable. Updating the directive to 1.22.7 ensures the code is built with a secure version of Go.