### PR TITLE
ci: kustomize CAA_IMAGE in e2e libvirt test

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -92,7 +92,6 @@ jobs:
         run: |
           export TEST_E2E_SECURE_COMMS="${{ inputs.secure_comms }}"
           ./libvirt/config_libvirt.sh
-          echo "CAA_IMAGE=\"${{ inputs.caa_image }}\"" >> libvirt.properties
           # For debugging
           cat libvirt.properties
 
@@ -115,6 +114,15 @@ jobs:
           test/utils/checkout_kbs.sh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Kustomize CAA image
+        working-directory: src/cloud-api-adaptor/install/overlays/libvirt
+        run: |
+          kustomize edit set image cloud-api-adaptor="${{ inputs.caa_image }}"
+          # Print for debugging
+          echo "::group::libvirt kustomization"
+          cat kustomization.yaml
+          echo "::endgroup::"
 
       - name: run tests
         id: runTests


### PR DESCRIPTION
There is no logic to kustomize the image in the provisioner code, so it will always deploy the default :latest from quay.io

Introduced steps to overwrite the image in the kustomization.yaml using kustomize.