### PR TITLE
ibmcloud: make image import.sh work on Mac

### DIFF
--- a/src/cloud-api-adaptor/ibmcloud/image/import.sh
+++ b/src/cloud-api-adaptor/ibmcloud/image/import.sh
@@ -22,6 +22,7 @@ bucket_region=$region
 instance=
 endpoint=
 api=${IBMCLOUD_API_ENDPOINT-https://cloud.ibm.com}
+platform=
 operating_system=
 
 shift 2
@@ -33,6 +34,7 @@ while (( "$#" )); do
         --region) bucket_region=$2 ;;
         --os) operating_system=$2 ;;
         --api) api=$2 ;;
+        --platform) platform=$2 ;;
         --help) usage; exit 0 ;;
         *)      usage 1>&2; exit 1;;
     esac
@@ -77,7 +79,7 @@ if [ -f ${image_file} ]; then
 else
     # Download image
     echo "Downloading file from image ${image_file}"
-    file=$($script_dir/../../podvm/hack/download-image.sh ${image_file} $script_dir) || error "Unable to download ${image_file}"
+    file=$($script_dir/../../podvm/hack/download-image.sh ${image_file} . --platform "${platform}") || error "Unable to download ${image_file}"
 fi
 
 echo "Uploading file ${file}"
@@ -101,7 +103,7 @@ if [ -z "$operating_system" ]; then
     image_arch="${image_name##*-}"
     operating_system="ubuntu-20-04-${image_arch/x86_64/amd64}"
 fi
-image_name="$(echo ${image_name,,} | sed 's/\./-/g' | sed 's/_/-/g')"
+image_name="$(echo ${image_name} | tr '[:upper:]' '[:lower:]' | sed 's/\./-/g' | sed 's/_/-/g')"
 image_json=$(ibmcloud is image-create "$image_name" --os-name "$operating_system" --file "$image_ref" --output JSON) || error "Unable to create vpc image $image_name"
 image_id=$(echo "$image_json" | jq -r '.id')
 

--- a/src/cloud-api-adaptor/ibmcloud/image/login.sh
+++ b/src/cloud-api-adaptor/ibmcloud/image/login.sh
@@ -26,7 +26,8 @@ if ! ibmcloud iam oauth-tokens &> /dev/null; then
 fi
 
 required_plugins=(vpc-infrastructure cloud-object-storage)
-mapfile -t installed_plugins < <(ibmcloud plugin list --output json | jq -r '.[].Name')
+# shellcheck disable=SC2207 # input is a list of names, 1 per line without spaces
+installed_plugins=($(ibmcloud plugin list --output json | jq -r '.[].Name'))
 
 for plugin in "${required_plugins[@]}"; do
     if ! [[ -n "${installed_plugins-}" && " ${installed_plugins[*]} " == *" $plugin "* ]]; then

--- a/src/cloud-api-adaptor/ibmcloud/image/multipart_upload.sh
+++ b/src/cloud-api-adaptor/ibmcloud/image/multipart_upload.sh
@@ -37,7 +37,7 @@ if [[ -z "${original_file-}" || -z "${bucket-}"  ]]; then
 fi
 
 # Divide the original file up into smaller sections
-split "$original_file" -b $split_size "$original_file."
+split -b $split_size "$original_file" "$original_file."
 # Create a multipart-upload, need the upload-id for part uploads
 upload_id=$(ibmcloud cos multipart-upload-create --bucket "$bucket" --key "$original_file" --output JSON | jq -r '.UploadId')
 if [[ -z "$upload_id" ]]; then


### PR DESCRIPTION
Running import.sh on Mac required the following changes:

1. login.sh
    - do not use mapfile
2. multipart_upload.sh
    - reorder args for split command
3. import.sh
   - added platform arg to download for different arch
   - use tr instead of ,, variable expansion