### PR TITLE
csi: Fix AWS example for CSI wrapper

### DIFF
--- a/src/csi-wrapper/examples/aws/README.md
+++ b/src/csi-wrapper/examples/aws/README.md
@@ -25,7 +25,7 @@ kubectl create secret generic aws-secret \
 ```
 3. Deploy the driver:
 ```
-kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.21"
+kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.37"
 ```
 4. Verify the pods are running:
 ```

--- a/src/csi-wrapper/examples/aws/dynamic-provisioning/pod.yaml
+++ b/src/csi-wrapper/examples/aws/dynamic-provisioning/pod.yaml
@@ -15,6 +15,10 @@ spec:
       type: Directory
   - emptyDir: {}
     name: plugin-dir
+  - hostPath:
+      path: /dev
+      type: Directory
+    name: device-dir
 
   containers:
   - name: app
@@ -24,6 +28,7 @@ spec:
     volumeMounts:
     - name: persistent-storage
       mountPath: /data
+      mountPropagation: HostToContainer
 
   - name: csi-podvm-node-driver
     env:
@@ -39,7 +44,7 @@ spec:
      # - name: AWS_REGION
      #   value: "us-east-1"
 
-    image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.21.0
+    image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.37.0
     imagePullPolicy: Always
     securityContext:
       privileged: true
@@ -55,6 +60,8 @@ spec:
         mountPropagation: Bidirectional
       - mountPath: /tmp
         name: plugin-dir
+      - mountPath: /dev
+        name: device-dir
 
   - name: csi-podvm-wrapper
     env:

--- a/src/csi-wrapper/examples/aws/dynamic-provisioning/storageclass.yaml
+++ b/src/csi-wrapper/examples/aws/dynamic-provisioning/storageclass.yaml
@@ -4,3 +4,5 @@ metadata:
   name: ebs-sc
 provisioner: ebs.csi.aws.com
 volumeBindingMode: WaitForFirstConsumer
+parameters:
+  peerpod: 'true'

--- a/src/csi-wrapper/examples/aws/rbac-ebs-csi-wrapper-podvm.yaml
+++ b/src/csi-wrapper/examples/aws/rbac-ebs-csi-wrapper-podvm.yaml
@@ -18,6 +18,9 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Updating the csi driver to latest 1.37 release and RBAC.
Additionally the `peerpod` key is mandaotry in the storageclass definition, without which peerpodVolume CRD will not be created.

Fixes: #2144