### PR TITLE
azure: Install qemu-utils

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -68,6 +68,11 @@ jobs:
         make fedora-binaries-builder
         make binaries
 
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y qemu-utils
+
     - name: Build image
       run: make image
 


### PR DESCRIPTION
Now the qcow2 build is part of the mkosi make image target, we need to install `qemu-utils`, so that the `qemu-img` tool is available