### PR TITLE
e2e-test: Add curl-jq test image

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/fixtures/Dockerfile.curl-jq
+++ b/src/cloud-api-adaptor/test/e2e/fixtures/Dockerfile.curl-jq
@@ -1,0 +1,5 @@
+FROM alpine:latest
+
+RUN apk add --no-cache curl jq
+
+ENTRYPOINT ["sh"]


### PR DESCRIPTION
This image is required to perform remote attestation tests which use api-server-rest. It will be built and pushed by the existing CI.