### PR TITLE
 workflow: Actually temporarily skip the s390x e2e tests

### DIFF
--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -266,12 +266,7 @@ jobs:
   libvirt_s390x:
     name: E2E tests on libvirt for the s390x architecture
     # Skip s390x e2e tests until Choi is available to set-up the s390x runner's pre-action properly. Then revert this.
-    if: |
-      false ||
-      github.event_name == 'schedule' ||
-      github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'test_e2e_libvirt') ||
-      contains(github.event.pull_request.labels.*.name, 'test_e2e_libvirt_s390x')
+    if: false
     needs: [podvm_mkosi_s390x, libvirt_e2e_arch_prep, caa_image_s390x]
     strategy:
       fail-fast: false


### PR DESCRIPTION
I realised too late that adding a `false` to a list of or's does nothing. I wanted to preserve the code, but we can just revert, so it was pointless. Sorry!