### PR TITLE
Kustomize: parameterize tunnel type

### DIFF
--- a/src/cloud-api-adaptor/docs/addnewprovider.md
+++ b/src/cloud-api-adaptor/docs/addnewprovider.md
@@ -281,6 +281,7 @@ optionals+=""
 # following is the incorrect method: optionals+="-option val"
 
 [[ "${PAUSE_IMAGE}" ]] && optionals+="-pause-image ${PAUSE_IMAGE} "
+[[ "${TUNNEL_TYPE}" ]] && optionals+="-tunnel-type ${TUNNEL_TYPE} "
 [[ "${VXLAN_PORT}" ]] && optionals+="-vxlan-port ${VXLAN_PORT} "
 [[ "${CACERT_FILE}" ]] && optionals+="-ca-cert-file ${CACERT_FILE} "
 [[ "${CERT_FILE}" ]] && [[ "${CERT_KEY}" ]] && optionals+="-cert-file ${CERT_FILE} -cert-key ${CERT_KEY} "

--- a/src/cloud-api-adaptor/entrypoint.sh
+++ b/src/cloud-api-adaptor/entrypoint.sh
@@ -13,6 +13,7 @@ optionals+=""
 # following is the incorrect method: optionals+="-option val"
 
 [[ "${PAUSE_IMAGE}" ]] && optionals+="-pause-image ${PAUSE_IMAGE} "
+[[ "${TUNNEL_TYPE}" ]] && optionals+="-tunnel-type ${TUNNEL_TYPE} "
 [[ "${VXLAN_PORT}" ]] && optionals+="-vxlan-port ${VXLAN_PORT} "
 [[ "${CACERT_FILE}" ]] && optionals+="-ca-cert-file ${CACERT_FILE} "
 [[ "${CERT_FILE}" ]] && [[ "${CERT_KEY}" ]] && optionals+="-cert-file ${CERT_FILE} -cert-key ${CERT_KEY} "

--- a/src/cloud-api-adaptor/install/overlays/aws/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/aws/kustomization.yaml
@@ -21,6 +21,7 @@ configMapGenerator:
   - CLOUD_CONFIG_VERIFY="false" # It's better set as true to enable could config verify in production env
   #- DISABLECVM="true" # Uncomment it if you want a generic VM
   #- PAUSE_IMAGE="" # Uncomment and set if you want to use a specific pause image
+  #- TUNNEL_TYPE="" # Uncomment and set if you want to use a specific tunnel type. Defaults to vxlan
   #- VXLAN_PORT="" # Uncomment and set if you want to use a specific vxlan port. Defaults to 4789
   #- PODVM_LAUNCHTEMPLATE_NAME="" # Uncomment and set if you want to use launch template
   # Comment out all the following variables if using launch template

--- a/src/cloud-api-adaptor/install/overlays/azure/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/azure/kustomization.yaml
@@ -36,6 +36,7 @@ configMapGenerator:
   - INITDATA="" # set default initdata for podvm
   #- DISABLECVM="" # Uncomment it if you want a generic VM
   #- PAUSE_IMAGE="" # Uncomment and set if you want to use a specific pause image
+  #- TUNNEL_TYPE="" # Uncomment and set if you want to use a specific tunnel type. Defaults to vxlan
   #- VXLAN_PORT="" # Uncomment and set if you want to use a specific vxlan port. Defaults to 4789
   #- AZURE_INSTANCE_SIZES="" # comma separated
   #- TAGS="" # Uncomment and add key1=value1,key2=value2 etc if you want to use specific tags for podvm

--- a/src/cloud-api-adaptor/install/overlays/docker/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/docker/kustomization.yaml
@@ -25,6 +25,7 @@ configMapGenerator:
     #- DOCKER_PODVM_IMAGE="quay.io/confidential-containers/podvm-docker-image" # Uncomment and set if you want to use a specific podvm image
     #- DOCKER_NETWORK_NAME="bridge" # Uncomment and set if you want to use a specific docker network
     #- PAUSE_IMAGE="" # Uncomment and set if you want to use a specific pause image
+    #- TUNNEL_TYPE="" # Uncomment and set if you want to use a specific tunnel type. Defaults to vxlan
     #- VXLAN_PORT="" # Uncomment and set if you want to use a specific vxlan port. Defaults to 4789
     #- PEERPODS_LIMIT_PER_NODE="10" # Max number of peer pods that can be created per node. Default is 10
 ##TLS_SETTINGS

--- a/src/cloud-api-adaptor/install/overlays/gcp/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/gcp/kustomization.yaml
@@ -18,6 +18,7 @@ configMapGenerator:
   literals:
   - CLOUD_PROVIDER="gcp"
   #- PAUSE_IMAGE="" # Uncomment and set if you want to use a specific pause image
+  #- TUNNEL_TYPE="" # Uncomment and set if you want to use a specific tunnel type. Defaults to vxlan
   #- VXLAN_PORT="" # Uncomment and set if you want to use a specific vxlan port. Defaults to 4789
   - PODVM_IMAGE_NAME="" # set from step "Build Pod VM Image" in gcp/README.md
   - GCP_PROJECT_ID="" # set

--- a/src/cloud-api-adaptor/install/overlays/ibmcloud-powervs/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/ibmcloud-powervs/kustomization.yaml
@@ -30,6 +30,7 @@ configMapGenerator:
   #- POWERVS_PROCESSOR_TYPE="" # Uncomment and set if you want to use a specific processor type
   #- POWERVS_SYSTEM_TYPE="" # Uncomment and set if you want to use a specific system type
   #- PAUSE_IMAGE="" # Uncomment and set if you want to use a specific pause image
+  #- TUNNEL_TYPE="" # Uncomment and set if you want to use a specific tunnel type. Defaults to vxlan
   #- VXLAN_PORT="" # Uncomment and set if you want to use a specific vxlan port. Defaults to 4789
   #- PROXY_TIMEOUT="" # Uncomment and set if you want to pass a specific timeout. Defaults to 5m
   #- USE_PUBLIC_IP="true" # Uncomment if you want to use public ip for podvm

--- a/src/cloud-api-adaptor/install/overlays/ibmcloud/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/ibmcloud/kustomization.yaml
@@ -31,6 +31,7 @@ configMapGenerator:
   - IBMCLOUD_VPC_ID="" #set
   - CRI_RUNTIME_ENDPOINT="/run/cri-runtime/containerd.sock"
   #- PAUSE_IMAGE="" # Uncomment and set if you want to use a specific pause image
+  #- TUNNEL_TYPE="" # Uncomment and set if you want to use a specific tunnel type. Defaults to vxlan
   #- VXLAN_PORT="" # Uncomment and set if you want to use a specific vxlan port. Defaults to 4789
   #- PEERPODS_LIMIT_PER_NODE="10" # Max number of peer pods that can be created per node. Default is 10
 ##TLS_SETTINGS

--- a/src/cloud-api-adaptor/install/overlays/libvirt/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/libvirt/kustomization.yaml
@@ -29,6 +29,7 @@ configMapGenerator:
   #- LIBVIRT_LAUNCH_SECURITY="" #sev or s390-pv
   #- LIBVIRT_VOL_NAME="" # Uncomment and set if you want to use a specific volume name. Defaults to podvm-base.qcow2
   #- PAUSE_IMAGE="" # Uncomment and set if you want to use a specific pause image
+  #- TUNNEL_TYPE="" # Uncomment and set if you want to use a specific tunnel type. Defaults to vxlan
   #- VXLAN_PORT="" # Uncomment and set if you want to use a specific vxlan port. Defaults to 4789
   #- PEERPODS_LIMIT_PER_NODE="10" # Max number of peer pods that can be created per node. Default is 10
 ##TLS_SETTINGS

--- a/src/cloud-api-adaptor/install/overlays/vsphere/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/vsphere/kustomization.yaml
@@ -44,6 +44,8 @@ configMapGenerator:
                        # (GOVC_DATACENTER/vm/GOVC_FOLDER).
 
   #- PAUSE_IMAGE=""    # Uncomment and set if you want to use a specific pause image
+  #- TUNNEL_TYPE=""    # Uncomment and set if you want to use a specific tunnel type.
+                       # Defaults to vxlan
   #- VXLAN_PORT=""     # Uncomment and set to use "9000" or change if you want to use a specific vxlan port.
                        # Defaults to 4789.
   #- PEERPODS_LIMIT_PER_NODE="10" # Max number of peer pods that can be created per node. Default is 10

--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -129,6 +129,7 @@ Use the properties on the table below for AWS:
 |podvm_aws_ami_id|AWS AMI ID of the podvm||
 |ssh_kp_name|AWS SSH key-pair name ||
 |use_public_ip|Set `true` to instantiate VMs with public IP. If `cluster_type=onprem` then this property is implictly applied||
+|tunnel_type|Tunnel type||
 |vxlan_port|VXLAN port number||
 
 >Notes:
@@ -152,6 +153,7 @@ Use the properties on the table below for Libvirt:
 |libvirt_conn_uri|Libvirt host URI|"qemu:///system"|
 |libvirt_ssh_key_file|Path to SSH private key||
 |pause_image|k8s pause image||
+|tunnel_type|Tunnel type||
 |vxlan_port| VXLAN port number||
 |cluster_name|Cluster Name| "peer-pods"|
 

--- a/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
@@ -110,6 +110,7 @@ type AWSProvisioner struct {
 	Image      *AMIImage
 	Vpc        *Vpc
 	PublicIP   string
+	TunnelType string
 	VxlanPort  string
 	SshKpName  string
 }
@@ -166,6 +167,7 @@ func NewAWSProvisioner(properties map[string]string) (pv.CloudProvisioner, error
 		PauseImage: properties["pause_image"],
 		Vpc:        vpc,
 		PublicIP:   properties["use_public_ip"],
+		TunnelType: properties["tunnel_type"],
 		VxlanPort:  properties["vxlan_port"],
 		SshKpName:  properties["ssh_kp_name"],
 	}
@@ -270,6 +272,7 @@ func (a *AWSProvisioner) GetProperties(ctx context.Context, cfg *envconf.Config)
 		"access_key_id":        credentials.AccessKeyID,
 		"secret_access_key":    credentials.SecretAccessKey,
 		"use_public_ip":        a.PublicIP,
+		"tunnel_type":          a.TunnelType,
 		"vxlan_port":           a.VxlanPort,
 	}
 }
@@ -1017,6 +1020,7 @@ func (a *AwsInstallOverlay) Edit(ctx context.Context, cfg *envconf.Config, prope
 		"subnet_id":            "AWS_SUBNET_ID",
 		"ssh_kp_name":          "SSH_KP_NAME",
 		"region":               "AWS_REGION",
+		"tunnel_type":          "TUNNEL_TYPE",
 		"vxlan_port":           "VXLAN_PORT",
 		"use_public_ip":        "USE_PUBLIC_IP",
 	}

--- a/src/cloud-api-adaptor/test/provisioner/azure/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/azure/provision_common.go
@@ -361,6 +361,7 @@ func getPropertiesImpl() map[string]string {
 		"AZURE_INSTANCE_SIZE":   AzureProps.InstanceSize,
 		"TAGS":                  AzureProps.Tags,
 		"CONTAINER_RUNTIME":     AzureProps.ContainerRuntime,
+		"VXLAN_PORT":            AzureProps.VxlanPort,
 	}
 
 	return props
@@ -379,7 +380,7 @@ func (p *AzureCloudProvisioner) UploadPodvm(imagePath string, ctx context.Contex
 
 func isAzureKustomizeConfigMapKey(key string) bool {
 	switch key {
-	case "CLOUD_PROVIDER", "AZURE_SUBSCRIPTION_ID", "AZURE_REGION", "AZURE_INSTANCE_SIZE", "AZURE_RESOURCE_GROUP", "AZURE_SUBNET_ID", "AZURE_IMAGE_ID", "SSH_USERNAME", "INITDATA", "TAGS":
+	case "CLOUD_PROVIDER", "AZURE_SUBSCRIPTION_ID", "AZURE_REGION", "AZURE_INSTANCE_SIZE", "AZURE_RESOURCE_GROUP", "AZURE_SUBNET_ID", "AZURE_IMAGE_ID", "SSH_USERNAME", "INITDATA", "TAGS", "VXLAN_PORT":
 		return true
 	default:
 		return false

--- a/src/cloud-api-adaptor/test/provisioner/azure/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/azure/provision_common.go
@@ -361,6 +361,7 @@ func getPropertiesImpl() map[string]string {
 		"AZURE_INSTANCE_SIZE":   AzureProps.InstanceSize,
 		"TAGS":                  AzureProps.Tags,
 		"CONTAINER_RUNTIME":     AzureProps.ContainerRuntime,
+		"TUNNEL_TYPE":           AzureProps.TunnelType,
 		"VXLAN_PORT":            AzureProps.VxlanPort,
 	}
 
@@ -380,7 +381,7 @@ func (p *AzureCloudProvisioner) UploadPodvm(imagePath string, ctx context.Contex
 
 func isAzureKustomizeConfigMapKey(key string) bool {
 	switch key {
-	case "CLOUD_PROVIDER", "AZURE_SUBSCRIPTION_ID", "AZURE_REGION", "AZURE_INSTANCE_SIZE", "AZURE_RESOURCE_GROUP", "AZURE_SUBNET_ID", "AZURE_IMAGE_ID", "SSH_USERNAME", "INITDATA", "TAGS", "VXLAN_PORT":
+	case "CLOUD_PROVIDER", "AZURE_SUBSCRIPTION_ID", "AZURE_REGION", "AZURE_INSTANCE_SIZE", "AZURE_RESOURCE_GROUP", "AZURE_SUBNET_ID", "AZURE_IMAGE_ID", "SSH_USERNAME", "INITDATA", "TAGS", "TUNNEL_TYPE", "VXLAN_PORT":
 		return true
 	default:
 		return false

--- a/src/cloud-api-adaptor/test/provisioner/azure/provision_initializer.go
+++ b/src/cloud-api-adaptor/test/provisioner/azure/provision_initializer.go
@@ -34,6 +34,7 @@ type AzureProperties struct {
 	CaaImage            string
 	IsSelfManaged       bool
 	Tags                string
+	TunnelType          string
 	VxlanPort           string
 
 	InstanceSize string
@@ -71,6 +72,7 @@ func initAzureProperties(properties map[string]string) error {
 		Tags:                    properties["TAGS"],
 		FederatedCredentialName: properties["FEDERATED_CREDENTIAL_NAME"],
 		ContainerRuntime:        properties["CONTAINER_RUNTIME"],
+		TunnelType:              properties["TUNNEL_TYPE"],
 		VxlanPort:               properties["VXLAN_PORT"],
 	}
 

--- a/src/cloud-api-adaptor/test/provisioner/azure/provision_initializer.go
+++ b/src/cloud-api-adaptor/test/provisioner/azure/provision_initializer.go
@@ -34,6 +34,7 @@ type AzureProperties struct {
 	CaaImage            string
 	IsSelfManaged       bool
 	Tags                string
+	VxlanPort           string
 
 	InstanceSize string
 	NodeName     string
@@ -70,6 +71,7 @@ func initAzureProperties(properties map[string]string) error {
 		Tags:                    properties["TAGS"],
 		FederatedCredentialName: properties["FEDERATED_CREDENTIAL_NAME"],
 		ContainerRuntime:        properties["CONTAINER_RUNTIME"],
+		VxlanPort:               properties["VXLAN_PORT"],
 	}
 
 	CIManagedStr := properties["IS_CI_MANAGED_CLUSTER"]

--- a/src/cloud-api-adaptor/test/provisioner/docker/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/docker/provision_common.go
@@ -39,6 +39,7 @@ type DockerProperties struct {
 	CaaImage         string
 	CaaImageTag      string
 	ContainerRuntime string
+	VxlanPort        string
 }
 
 var DockerProps = &DockerProperties{}
@@ -54,6 +55,7 @@ func initDockerProperties(properties map[string]string) error {
 		CaaImage:         properties["CAA_IMAGE"],
 		CaaImageTag:      properties["CAA_IMAGE_TAG"],
 		ContainerRuntime: properties["CONTAINER_RUNTIME"],
+		VxlanPort:        properties["VXLAN_PORT"],
 	}
 	return nil
 }
@@ -135,6 +137,7 @@ func (l *DockerProvisioner) GetProperties(ctx context.Context, cfg *envconf.Conf
 		"CAA_IMAGE":           DockerProps.CaaImage,
 		"CAA_IMAGE_TAG":       DockerProps.CaaImageTag,
 		"CONTAINER_RUNTIME":   DockerProps.ContainerRuntime,
+		"VXLAN_PORT":          DockerProps.VxlanPort,
 	}
 }
 
@@ -200,7 +203,7 @@ func NewDockerInstallOverlay(installDir, provider string) (pv.InstallOverlay, er
 
 func isDockerKustomizeConfigMapKey(key string) bool {
 	switch key {
-	case "CLOUD_PROVIDER", "DOCKER_HOST", "DOCKER_API_VERSION", "DOCKER_PODVM_IMAGE", "DOCKER_NETWORK_NAME", "INITDATA":
+	case "CLOUD_PROVIDER", "DOCKER_HOST", "DOCKER_API_VERSION", "DOCKER_PODVM_IMAGE", "DOCKER_NETWORK_NAME", "VXLAN_PORT", "INITDATA":
 		return true
 	default:
 		return false

--- a/src/cloud-api-adaptor/test/provisioner/docker/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/docker/provision_common.go
@@ -39,6 +39,7 @@ type DockerProperties struct {
 	CaaImage         string
 	CaaImageTag      string
 	ContainerRuntime string
+	TunnelType       string
 	VxlanPort        string
 }
 
@@ -55,6 +56,7 @@ func initDockerProperties(properties map[string]string) error {
 		CaaImage:         properties["CAA_IMAGE"],
 		CaaImageTag:      properties["CAA_IMAGE_TAG"],
 		ContainerRuntime: properties["CONTAINER_RUNTIME"],
+		TunnelType:       properties["TUNNEL_TYPE"],
 		VxlanPort:        properties["VXLAN_PORT"],
 	}
 	return nil
@@ -137,6 +139,7 @@ func (l *DockerProvisioner) GetProperties(ctx context.Context, cfg *envconf.Conf
 		"CAA_IMAGE":           DockerProps.CaaImage,
 		"CAA_IMAGE_TAG":       DockerProps.CaaImageTag,
 		"CONTAINER_RUNTIME":   DockerProps.ContainerRuntime,
+		"TUNNEL_TYPE":         DockerProps.TunnelType,
 		"VXLAN_PORT":          DockerProps.VxlanPort,
 	}
 }
@@ -203,7 +206,7 @@ func NewDockerInstallOverlay(installDir, provider string) (pv.InstallOverlay, er
 
 func isDockerKustomizeConfigMapKey(key string) bool {
 	switch key {
-	case "CLOUD_PROVIDER", "DOCKER_HOST", "DOCKER_API_VERSION", "DOCKER_PODVM_IMAGE", "DOCKER_NETWORK_NAME", "VXLAN_PORT", "INITDATA":
+	case "CLOUD_PROVIDER", "DOCKER_HOST", "DOCKER_API_VERSION", "DOCKER_PODVM_IMAGE", "DOCKER_NETWORK_NAME", "TUNNEL_TYPE", "VXLAN_PORT", "INITDATA":
 		return true
 	default:
 		return false

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_common.go
@@ -973,6 +973,7 @@ func (p *IBMCloudProvisioner) GetProperties(ctx context.Context, cfg *envconf.Co
 		"IBMCLOUD_IAM_PROFILE_ID":              IBMCloudProps.IamProfileID,
 		"IBMCLOUD_IAM_ENDPOINT":                IBMCloudProps.IamServiceURL,
 		"IBMCLOUD_PODVM_INSTANCE_PROFILE_LIST": getProfileList(),
+		"VXLAN_PORT":                           IBMCloudProps.VxlanPort,
 	}
 }
 

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_common.go
@@ -973,6 +973,7 @@ func (p *IBMCloudProvisioner) GetProperties(ctx context.Context, cfg *envconf.Co
 		"IBMCLOUD_IAM_PROFILE_ID":              IBMCloudProps.IamProfileID,
 		"IBMCLOUD_IAM_ENDPOINT":                IBMCloudProps.IamServiceURL,
 		"IBMCLOUD_PODVM_INSTANCE_PROFILE_LIST": getProfileList(),
+		"TUNNEL_TYPE":                          IBMCloudProps.TunnelType,
 		"VXLAN_PORT":                           IBMCloudProps.VxlanPort,
 	}
 }

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_ibmcloud.properties
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_ibmcloud.properties
@@ -54,3 +54,5 @@ IAM_SERVICE_URL=""
 VPC_SERVICE_URL=""
 # optional, URL for the Kubernetes service endpoint. Defaults to the global Kubernetes service endpoint for the public IBM Cloud if not provided
 IKS_SERVICE_URL=""
+# optional, VXLAN port number if using non-default non-default VXLAN port number
+VXLAN_PORT=""

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_ibmcloud.properties
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_ibmcloud.properties
@@ -54,5 +54,7 @@ IAM_SERVICE_URL=""
 VPC_SERVICE_URL=""
 # optional, URL for the Kubernetes service endpoint. Defaults to the global Kubernetes service endpoint for the public IBM Cloud if not provided
 IKS_SERVICE_URL=""
+# optional, tunnel type name if using non-default tunnel type
+TUNNEL_TYPE=""
 # optional, VXLAN port number if using non-default non-default VXLAN port number
 VXLAN_PORT=""

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_initializer.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_initializer.go
@@ -50,6 +50,7 @@ type IBMCloudProperties struct {
 	WorkerFlavor      string
 	WorkerOS          string
 	Zone              string
+	VxlanPort         string
 
 	WorkerCount   int
 	IsSelfManaged bool
@@ -92,6 +93,7 @@ func InitIBMCloudProperties(properties map[string]string) error {
 		SubnetID:          properties["VPC_SUBNET_ID"],
 		SecurityGroupID:   properties["VPC_SECURITY_GROUP_ID"],
 		VpcID:             properties["VPC_ID"],
+		VxlanPort:         properties["VXLAN_PORT"],
 	}
 
 	if len(IBMCloudProps.IBMCloudProvider) <= 0 {

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_initializer.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_initializer.go
@@ -50,6 +50,7 @@ type IBMCloudProperties struct {
 	WorkerFlavor      string
 	WorkerOS          string
 	Zone              string
+	TunnelType        string
 	VxlanPort         string
 
 	WorkerCount   int
@@ -93,6 +94,7 @@ func InitIBMCloudProperties(properties map[string]string) error {
 		SubnetID:          properties["VPC_SUBNET_ID"],
 		SecurityGroupID:   properties["VPC_SECURITY_GROUP_ID"],
 		VpcID:             properties["VPC_ID"],
+		TunnelType:        properties["TUNNEL_TYPE"],
 		VxlanPort:         properties["VXLAN_PORT"],
 	}
 

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_kustomize.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_kustomize.go
@@ -55,6 +55,8 @@ func isKustomizeConfigMapKey(key string) bool {
 		return true
 	case "CRI_RUNTIME_ENDPOINT":
 		return true
+	case "VXLAN_PORT":
+		return true
 	default:
 		return false
 	}

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_kustomize.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_kustomize.go
@@ -55,6 +55,8 @@ func isKustomizeConfigMapKey(key string) bool {
 		return true
 	case "CRI_RUNTIME_ENDPOINT":
 		return true
+	case "TUNNEL_TYPE":
+		return true
 	case "VXLAN_PORT":
 		return true
 	default:

--- a/src/cloud-api-adaptor/test/provisioner/libvirt/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/libvirt/provision_common.go
@@ -32,6 +32,7 @@ type LibvirtProvisioner struct {
 	wd               string           // libvirt's directory path on this repository
 	volumeName       string           // Podvm volume name
 	clusterName      string           // Cluster name
+	vxlanPort        string           // VXLAN port number
 }
 
 // LibvirtInstallOverlay implements the InstallOverlay interface
@@ -83,6 +84,11 @@ func NewLibvirtProvisioner(properties map[string]string) (pv.CloudProvisioner, e
 		clusterName = properties["cluster_name"]
 	}
 
+	vxlanPort := ""
+	if properties["vxlan_port"] != "" {
+		vxlanPort = properties["vxlan_port"]
+	}
+
 	// TODO: Check network and storage are not nil?
 	return &LibvirtProvisioner{
 		conn:             conn,
@@ -94,6 +100,7 @@ func NewLibvirtProvisioner(properties map[string]string) (pv.CloudProvisioner, e
 		wd:               wd,
 		volumeName:       vol_name,
 		clusterName:      clusterName,
+		vxlanPort:        vxlanPort,
 	}, nil
 }
 
@@ -204,6 +211,7 @@ func (l *LibvirtProvisioner) GetProperties(ctx context.Context, cfg *envconf.Con
 		"ssh_key_file":      l.ssh_key_file,
 		"storage":           l.storage,
 		"uri":               l.uri,
+		"vxlan_port":        l.vxlanPort,
 	}
 }
 

--- a/src/cloud-api-adaptor/test/provisioner/libvirt/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/libvirt/provision_common.go
@@ -32,6 +32,7 @@ type LibvirtProvisioner struct {
 	wd               string           // libvirt's directory path on this repository
 	volumeName       string           // Podvm volume name
 	clusterName      string           // Cluster name
+	tunnelType       string           // Tunnel Type
 	vxlanPort        string           // VXLAN port number
 }
 
@@ -84,6 +85,11 @@ func NewLibvirtProvisioner(properties map[string]string) (pv.CloudProvisioner, e
 		clusterName = properties["cluster_name"]
 	}
 
+	tunnelType := ""
+	if properties["tunnel_type"] != "" {
+		tunnelType = properties["tunnel_type"]
+	}
+
 	vxlanPort := ""
 	if properties["vxlan_port"] != "" {
 		vxlanPort = properties["vxlan_port"]
@@ -100,6 +106,7 @@ func NewLibvirtProvisioner(properties map[string]string) (pv.CloudProvisioner, e
 		wd:               wd,
 		volumeName:       vol_name,
 		clusterName:      clusterName,
+		tunnelType:       tunnelType,
 		vxlanPort:        vxlanPort,
 	}, nil
 }
@@ -211,6 +218,7 @@ func (l *LibvirtProvisioner) GetProperties(ctx context.Context, cfg *envconf.Con
 		"ssh_key_file":      l.ssh_key_file,
 		"storage":           l.storage,
 		"uri":               l.uri,
+		"tunnel_type":       l.tunnelType,
 		"vxlan_port":        l.vxlanPort,
 	}
 }
@@ -323,6 +331,7 @@ func (lio *LibvirtInstallOverlay) Edit(ctx context.Context, cfg *envconf.Config,
 		"pause_image":  {"", "PAUSE_IMAGE"},
 		"podvm_volume": {"", "LIBVIRT_VOL_NAME"},
 		"uri":          {"qemu+ssh://root@192.168.122.1/system?no_verify=1", "LIBVIRT_URI"},
+		"tunnel_type":  {"", "TUNNEL_TYPE"},
 		"vxlan_port":   {"", "VXLAN_PORT"},
 		"INITDATA":     {"", "INITDATA"},
 	}


### PR DESCRIPTION
This is a prerequisite of https://github.com/confidential-containers/cloud-api-adaptor/issues/688

This PR introduces a parameter to specify the tunnel type for pod networking. If this parameter is not set, the default VXLAN is used.

Some e2e test provisioners do not have a parameter for VXLAN port. This PR also introduces a parameter for it in such providers.
