### PR TITLE
providers/libvirt: add support for aarch64 host

### DIFF
--- a/src/cloud-providers/libvirt/libvirt.go
+++ b/src/cloud-providers/libvirt/libvirt.go
@@ -21,6 +21,8 @@ import (
 const (
 	// architecture value for the s390x architecture
 	archS390x = "s390x"
+	// architecutre value for aarch64/arm64
+	archAArch64 = "aarch64"
 	// hvm indicates that the OS is one designed to run on bare metal, so requires full virtualization.
 	typeHardwareVirtualMachine = "hvm"
 	// The amount of retries to get the domain IP addresses
@@ -490,11 +492,122 @@ func enableSEV(client *libvirtClient, cfg *domainConfig, vm *vmConfig, domain *l
 	return domain, nil
 }
 
+func createDomainXMLaarch64(client *libvirtClient, cfg *domainConfig, vm *vmConfig) (*libvirtxml.Domain, error) {
+
+	guest, err := getGuestForArchType(client.caps, archAArch64, typeHardwareVirtualMachine)
+	if err != nil {
+		return nil, err
+	}
+	canonicalmachine, err := getCanonicalMachineName(client.caps, archAArch64, typeHardwareVirtualMachine, "virt")
+	if err != nil {
+		return nil, err
+	}
+
+	bootDisk := libvirtxml.DomainDisk{
+		Device: "disk",
+		Target: &libvirtxml.DomainDiskTarget{
+			Dev: "vda",
+			Bus: "virtio",
+		},
+		Driver: &libvirtxml.DomainDiskDriver{
+			Name: "qemu",
+			Type: "qcow2",
+			// only for virtio device
+			IOMMU: "on",
+		},
+		Source: &libvirtxml.DomainDiskSource{
+			File: &libvirtxml.DomainDiskSourceFile{
+				File: cfg.bootDisk,
+			},
+		},
+		Boot: &libvirtxml.DomainDeviceBoot{
+			Order: 1,
+		},
+	}
+	cloudInitDisk := libvirtxml.DomainDisk{
+		Device: "cdrom",
+		Target: &libvirtxml.DomainDiskTarget{
+			// logical dev name, just a hint
+			Dev: "sda",
+			Bus: "scsi",
+		},
+		Driver: &libvirtxml.DomainDiskDriver{
+			Name: "qemu",
+			Type: "raw",
+		},
+		Source: &libvirtxml.DomainDiskSource{
+			File: &libvirtxml.DomainDiskSourceFile{
+				File: cfg.cidataDisk,
+			},
+		},
+		ReadOnly: &libvirtxml.DomainDiskReadOnly{},
+	}
+
+	domain := &libvirtxml.Domain{
+		Type:        "kvm",
+		Name:        cfg.name,
+		Description: "This Virtual Machine is the peer-pod VM",
+		OS: &libvirtxml.DomainOS{
+			Type: &libvirtxml.DomainOSType{
+				Type:    typeHardwareVirtualMachine,
+				Arch:    archAArch64,
+				Machine: canonicalmachine,
+			},
+			// firmware autoselection since libvirt v5.2.0
+			// https://libvirt.org/formatdomain.html#bios-bootloader
+			Firmware: "efi",
+		},
+		Memory: &libvirtxml.DomainMemory{Value: cfg.mem, Unit: "GiB"},
+		VCPU:   &libvirtxml.DomainVCPU{Value: cfg.cpu},
+		CPU:    &libvirtxml.DomainCPU{Mode: "host-passthrough"},
+		Devices: &libvirtxml.DomainDeviceList{
+			Disks: []libvirtxml.DomainDisk{
+				bootDisk,
+				cloudInitDisk,
+			},
+			// scsi target device for readonly ROM device
+			// virtio-scsi controller for better compatibility
+			Controllers: []libvirtxml.DomainController{
+				{
+					Type:  "scsi",
+					Model: "virtio-scsi",
+				},
+			},
+			Emulator:   guest.Arch.Emulator,
+			MemBalloon: &libvirtxml.DomainMemBalloon{Model: "virtio", Driver: &libvirtxml.DomainMemBalloonDriver{IOMMU: "on"}},
+			Interfaces: []libvirtxml.DomainInterface{
+				{
+					Model: &libvirtxml.DomainInterfaceModel{
+						Type: "virtio",
+					},
+					Source: &libvirtxml.DomainInterfaceSource{
+						Network: &libvirtxml.DomainInterfaceSourceNetwork{
+							Network: cfg.networkName,
+						},
+					},
+					Driver: &libvirtxml.DomainInterfaceDriver{
+						IOMMU: "on",
+					},
+				},
+			},
+			Consoles: []libvirtxml.DomainConsole{
+				{
+					Target: &libvirtxml.DomainConsoleTarget{Type: "serial"},
+				},
+			},
+		},
+	}
+
+	return domain, nil
+}
+
 // createDomainXML detects the machine type of the libvirt host and will return a libvirt XML for that machine type
 func createDomainXML(client *libvirtClient, cfg *domainConfig, vm *vmConfig) (*libvirtxml.Domain, error) {
 	switch client.nodeInfo.Model {
 	case archS390x:
 		return createDomainXMLs390x(client, cfg, vm)
+	case archAArch64:
+		return createDomainXMLaarch64(client, cfg, vm)
 	default:
 		return createDomainXMLx86_64(client, cfg, vm)
 	}


### PR DESCRIPTION
Create domainXML for aarch64/arm64 arch in cloud-provider/libvirt, and check iommu=on for virtio device only in test.

This patch is similar to 63a002cc25b29627653f41e3f1d5a4dc4b71c534, and ARM CCA CVM will be added later like 4422f14fc6f3a4ffba5571cb049c3207cfe83630, when it's ready. This will initially support non-CCA workloads and eventually allow the creation of a Realm on a local/remote host.

go test on aarch64/arm64 host: 
```
$ LIBVIRT_URI="qemu+ssh://taoxu01@192.168.122.1/system?no_verify=1" go test -v
=== RUN   TestCloudInit
temp file: /tmp/CloudInit-12504980.iso--- PASS: TestCloudInit (0.01s)
=== RUN   TestInMemoryCopier
--- PASS: TestInMemoryCopier (0.00s)
=== RUN   TestLibvirtConnection
2024/12/06 11:27:46 [adaptor/cloud/libvirt] Created libvirt connection
--- PASS: TestLibvirtConnection (0.64s)
=== RUN   TestGetArchitecture
2024/12/06 11:27:47 [adaptor/cloud/libvirt] Created libvirt connection
--- PASS: TestGetArchitecture (0.63s)
=== RUN   TestCreateDomainXMLs390x
2024/12/06 11:27:47 [adaptor/cloud/libvirt] Created libvirt connection
    libvirt_test.go:110: Skipping because architecture is [aarch64] and not [s390x].
--- SKIP: TestCreateDomainXMLs390x (0.61s)
=== RUN   TestCreateDomainXMLaarch64
2024/12/06 11:27:48 [adaptor/cloud/libvirt] Created libvirt connection
--- PASS: TestCreateDomainXMLaarch64 (0.60s)
PASS
ok  	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers/libvirt	2.590s
```
go test on x86_64/amd64 host:
```
$ LIBVIRT_URI="qemu+ssh://taoxu01@192.168.122.1/system?no_verify=1" go test -v
=== RUN   TestCloudInit
temp file: /tmp/CloudInit-2407912272.iso--- PASS: TestCloudInit (0.00s)
=== RUN   TestInMemoryCopier
--- PASS: TestInMemoryCopier (0.00s)
=== RUN   TestLibvirtConnection
2024/12/06 11:34:11 [adaptor/cloud/libvirt] Created libvirt connection
--- PASS: TestLibvirtConnection (0.60s)
=== RUN   TestGetArchitecture
2024/12/06 11:34:12 [adaptor/cloud/libvirt] Created libvirt connection
--- PASS: TestGetArchitecture (0.36s)
=== RUN   TestCreateDomainXMLs390x
2024/12/06 11:34:12 [adaptor/cloud/libvirt] Created libvirt connection
    libvirt_test.go:110: Skipping because architecture is [x86_64] and not [s390x].
--- SKIP: TestCreateDomainXMLs390x (0.28s)
=== RUN   TestCreateDomainXMLaarch64
2024/12/06 11:34:12 [adaptor/cloud/libvirt] Created libvirt connection
    libvirt_test.go:147: Skipping because architecture is [x86_64] and not [aarch64].
--- SKIP: TestCreateDomainXMLaarch64 (0.29s)
PASS
ok  	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers/libvirt	1.541s
```
libvirt E2E test needs additional changes in build scripts (operator and cloud-api-adaptor to build the new code) plus podvm to run on aarch64/arm64 machine. Those will be separated as they're more related to build.

E2E tests were done on aarch64/arm64 baremetal server to run demo peer-pods: 
(based on v0.9.0 and v0.10.0 podvm, latest v0.11.0 podvm introduced cached artifacts in #2074).
```
$ kubectl get pods -o wide
NAME             READY   STATUS    RESTARTS   AGE     IP           NODE                 NOMINATED NODE   READINESS GATES
busybox-remote   1/1     Running   0          6m16s   10.244.1.8   peer-pods-worker-0   <none>           <none>

$ kubectl exec pods/busybox-remote -- uname -srim
Linux 5.4.0-136-generic aarch64 unknown

$ kcli list vm
+-------------------------------+--------+-----------------+------------+-----------+---------+
|              Name             | Status |        Ip       |   Source   |    Plan   | Profile |
+-------------------------------+--------+-----------------+------------+-----------+---------+
|      peer-pods-ctlplane-0     |   up   |  192.168.122.20 | ubuntu2204 | peer-pods |  kvirt  |
|       peer-pods-worker-0      |   up   | 192.168.122.199 | ubuntu2204 | peer-pods |  kvirt  |
| podvm-busybox-remote-62291ece |   up   | 192.168.122.237 |            |           |         |
+-------------------------------+--------+-----------------+------------+-----------+---------+

$ virsh list
 Id   Name                            State
-----------------------------------------------
 70   peer-pods-ctlplane-0            running
 71   peer-pods-worker-0              running
 72   podvm-busybox-remote-62291ece   running 
```