### PR TITLE
Makefile: support aarch64/arm64 build

### DIFF
--- a/src/cloud-api-adaptor/Makefile
+++ b/src/cloud-api-adaptor/Makefile
@@ -7,12 +7,22 @@ include Makefile.defaults
 
 SHELL = bash -o pipefail
 
-ARCH        ?= $(subst x86_64,amd64,$(shell uname -m))
+ARCH ?= $(shell uname -m)
+TARGET_ARCH ?= amd64
+PROTOC_ARCH ?= x86_64
+ifeq ($(ARCH),aarch64)
+	TARGET_ARCH := arm64
+	PROTOC_ARCH := aarch_64
+else ifeq ($(ARCH),s390x)
+	TARGET_ARCH := s390x
+	PROTOC_ARCH := s390_64
+endif
+
 # Default is dev build. To create release build set RELEASE_BUILD=true
 RELEASE_BUILD ?= false
 # CLOUD_PROVIDER is used for runtime -- which provider should be run against the binary/code.
 CLOUD_PROVIDER ?=
-GOOPTIONS   ?= GOOS=linux GOARCH=$(ARCH) CGO_ENABLED=0
+GOOPTIONS   ?= GOOS=linux GOARCH=$(TARGET_ARCH) CGO_ENABLED=0
 GOFLAGS     ?=
 BINARIES    := cloud-api-adaptor agent-protocol-forwarder process-user-data
 SOURCEDIRS  := ./cmd ./pkg
@@ -24,7 +34,7 @@ TEST_E2E_TIMEOUT ?= 60m
 RUN_TESTS ?= ''
 
 RESOURCE_CTRL ?= true
-YQ_CHECKSUM_${ARCH} ?= $(YQ_CHECKSUM)
+YQ_CHECKSUM_$(TARGET_ARCH) ?= $(YQ_CHECKSUM)
 # BUILTIN_CLOUD_PROVIDERS is used for binary build -- what providers are built in the binaries.
 ifeq ($(RELEASE_BUILD),true)
 	BUILTIN_CLOUD_PROVIDERS ?= aws azure gcp ibmcloud vsphere
@@ -112,11 +122,11 @@ clean: ## Remove binaries.
 
 .PHONY: image
 image: .git-commit ## Build and push docker image to $registry
-	COMMIT=$(COMMIT) VERSION=$(VERSION) YQ_VERSION=$(YQ_VERSION) YQ_CHECKSUM=$(YQ_CHECKSUM) hack/build.sh -i
+	COMMIT=$(COMMIT) VERSION=$(VERSION) YQ_VERSION=$(YQ_VERSION) hack/build.sh -i
 
 .PHONY: image-with-arch
 image-with-arch: .git-commit ## Build the per arch image
-	COMMIT=$(COMMIT) VERSION=$(VERSION) YQ_VERSION=$(YQ_VERSION) YQ_CHECKSUM=$(YQ_CHECKSUM) hack/build.sh -a
+	COMMIT=$(COMMIT) VERSION=$(VERSION) YQ_VERSION=$(YQ_VERSION) hack/build.sh -a
 
 ##@ Deployment
 
@@ -162,8 +172,8 @@ PODVM_DISTRO ?= ubuntu
 PODVM_TAG ?= $(VERSIONS_HASH)
 
 PODVM_BUILDER_IMAGE ?= $(REGISTRY)/podvm-builder-$(PODVM_DISTRO):$(PODVM_TAG)
-PODVM_BINARIES_IMAGE ?= $(REGISTRY)/podvm-binaries-$(PODVM_DISTRO)-$(ARCH):$(PODVM_TAG)
-PODVM_IMAGE ?= $(REGISTRY)/podvm-$(or $(CLOUD_PROVIDER),generic)-$(PODVM_DISTRO)-$(ARCH):$(PODVM_TAG)
+PODVM_BINARIES_IMAGE ?= $(REGISTRY)/podvm-binaries-$(PODVM_DISTRO)-$(TARGET_ARCH):$(PODVM_TAG)
+PODVM_IMAGE ?= $(REGISTRY)/podvm-$(or $(CLOUD_PROVIDER),generic)-$(PODVM_DISTRO)-$(TARGET_ARCH):$(PODVM_TAG)
 
 PUSH ?= false
 # If not pushing `--load` into the local docker cache
@@ -179,12 +189,12 @@ podvm-builder:
 	--build-arg GO_VERSION=$(GO_VERSION) \
 	--build-arg ORG_ID=$(ORG_ID) \
 	--build-arg ACTIVATION_KEY=$(ACTIVATION_KEY) \
-	--build-arg ARCH=$(ARCH) \
+	--build-arg ARCH=$(TARGET_ARCH) \
 	--build-arg PROTOC_VERSION=$(PROTOC_VERSION) \
 	--build-arg YQ_VERSION=$(YQ_VERSION) \
-	--build-arg YQ_CHECKSUM=${YQ_CHECKSUM_$(ARCH)} \
-	--build-arg YQ_ARCH=$(ARCH) \
-	--build-arg PROTOC_ARCH=$(if $(filter amd64,$(ARCH)),x86_64,s390_64) \
+	--build-arg YQ_CHECKSUM=${YQ_CHECKSUM_$(TARGET_ARCH)} \
+	--build-arg YQ_ARCH=$(TARGET_ARCH) \
+	--build-arg PROTOC_ARCH=$(PROTOC_ARCH) \
 	--build-arg ORAS_VERSION=$(ORAS_VERSION) \
 	--build-arg PACKER_VERSION=$(PACKER_VERSION) \
 	$(DOCKER_OPTS) .
@@ -194,7 +204,7 @@ podvm-binaries:
 	cd ../ && docker buildx build -t $(PODVM_BINARIES_IMAGE) -f cloud-api-adaptor/podvm/$(BINARIES_DOCKERFILE) \
 	--build-arg BUILDER_IMG=$(PODVM_BUILDER_IMAGE) \
 	--build-arg PODVM_DISTRO=$(PODVM_DISTRO) \
-	--build-arg ARCH=$(ARCH) \
+	--build-arg ARCH=$(TARGET_ARCH) \
 	--build-arg TEE_PLATFORM=$(TEE_PLATFORM) \
 	--build-arg PAUSE_REPO=$(PAUSE_REPO) \
 	--build-arg PAUSE_VERSION=$(PAUSE_VERSION) \
@@ -217,7 +227,7 @@ endif
 	--build-arg BUILDER_IMG=$(PODVM_BUILDER_IMAGE) \
 	--build-arg BINARIES_IMG=$(PODVM_BINARIES_IMAGE) \
 	--build-arg PODVM_DISTRO=$(PODVM_DISTRO) \
-	--build-arg ARCH=$(ARCH) \
+	--build-arg ARCH=$(TARGET_ARCH) \
 	--build-arg CLOUD_PROVIDER=$(or $(CLOUD_PROVIDER),generic) \
 	--build-arg IMAGE_URL=$(IMAGE_URL) \
 	--build-arg IMAGE_CHECKSUM=$(IMAGE_CHECKSUM) \

--- a/src/cloud-api-adaptor/Makefile.defaults
+++ b/src/cloud-api-adaptor/Makefile.defaults
@@ -8,6 +8,7 @@ PAUSE_BIN ?= pause
 YQ_VERSION := v4.35.1
 YQ_CHECKSUM := "sha256:bd695a6513f1196aeda17b174a15e9c351843fb1cef5f9be0af170f2dd744f08"
 YQ_CHECKSUM_s390x := "sha256:4e6324d08630e7df733894a11830412a43703682d65a76f1fc925aac08268a45"
+YQ_CHECKSUM_arm64 := "sha256:1d830254fe5cc2fb046479e6c781032976f5cf88f9d01a6385898c29182f9bed"
 # none,az-cvm-vtpm,tdx,se,cca
 TEE_PLATFORM ?= none
 
@@ -25,6 +26,8 @@ ubuntu_amd64_IMAGE_URL := $(call query,cloudimg.ubuntu.$(ubuntu_RELEASE).amd64.u
 ubuntu_amd64_IMAGE_CHECKSUM := $(call query,cloudimg.ubuntu.$(ubuntu_RELEASE).amd64.checksum)
 ubuntu_s390x_IMAGE_URL := $(call query,cloudimg.ubuntu.$(ubuntu_RELEASE).s390x.url)
 ubuntu_s390x_IMAGE_CHECKSUM := $(call query,cloudimg.ubuntu.$(ubuntu_RELEASE).s390x.checksum)
+ubuntu_arm64_IMAGE_URL := $(call query,cloudimg.ubuntu.$(ubuntu_RELEASE).arm64.url)
+ubuntu_arm64_IMAGE_CHECKSUM := $(call query,cloudimg.ubuntu.$(ubuntu_RELEASE).arm64.checksum)
 rhel_amd64_IMAGE_URL := $(call query,cloudimg.rhel.$(rhel_RELEASE).amd64.url)
 rhel_amd64_IMAGE_CHECKSUM := $(call query,cloudimg.rhel.$(rhel_RELEASE).amd64.checksum)
 rhel_s390x_IMAGE_URL := $(call query,cloudimg.rhel.$(rhel_RELEASE).s390x.url)

--- a/src/cloud-api-adaptor/hack/build.sh
+++ b/src/cloud-api-adaptor/hack/build.sh
@@ -57,7 +57,6 @@ function build_caa_payload_image() {
 		--build-arg VERSION="${version}" \
 		--build-arg COMMIT="${commit}" \
 		--build-arg YQ_VERSION="${YQ_VERSION}" \
-		--build-arg YQ_CHECKSUM="${YQ_CHECKSUM}" \
 		-f cloud-api-adaptor/Dockerfile \
 		${tag_string} \
 		--push \
@@ -100,7 +99,6 @@ function build_caa_payload_arch_specific() {
 		--build-arg VERSION="${version}" \
 		--build-arg COMMIT="${commit}" \
 		--build-arg YQ_VERSION="${YQ_VERSION}" \
-		--build-arg YQ_CHECKSUM="${YQ_CHECKSUM}" \
 		-f cloud-api-adaptor/Dockerfile \
 		${tag_string} \
 		--push \

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -9,6 +9,9 @@ cloudimg:
       s390x:
         url: https://cloud-images.ubuntu.com/releases/focal/release-20230107/ubuntu-20.04-server-cloudimg-s390x.img
         checksum: "sha256:24673aa86785573d3a92e15166ff81beff88cbb0abc01938f156eb1332e87cd3"
+      arm64:
+        url: https://cloud-images.ubuntu.com/releases/focal/release-20230107/ubuntu-20.04-server-cloudimg-arm64.img
+        checksum: "sha256:5bb6152947fa566d6ab40dc2e5b849aea3e07ab7e1c113d00372a7f99b950cae"
   rhel:
     9: # dummy links, get trial image from: https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux/server/trial
       amd64:


### PR DESCRIPTION
Support build cloud-api-adaptor (except podvm) on aarch64/arm64 platform, and it's tested on both x86_64 and aarch64 servers.

Podvm build support is excluded as it's recently changed from local build to ORAS cached artifacts to get guest-component in #2074. Will rebase with latest v0.11.0 changes later.

E2E test is able to run on aarch64/arm64 server with changes in #2193, plus operator's arm64 build and local built podvm (v0.9.0 and v0.10.0, and by packer and mkosi):
```
$ kubectl get pods -o wide
NAME             READY   STATUS    RESTARTS   AGE     IP           NODE                 NOMINATED NODE   READINESS GATES
busybox-remote   1/1     Running   0          6m16s   10.244.1.8   peer-pods-worker-0   <none>           <none>

$ kubectl exec pods/busybox-remote -- uname -srim
Linux 5.4.0-136-generic aarch64 unknown

$ kcli list vm
+-------------------------------+--------+-----------------+------------+-----------+---------+
|              Name             | Status |        Ip       |   Source   |    Plan   | Profile |
+-------------------------------+--------+-----------------+------------+-----------+---------+
|      peer-pods-ctlplane-0     |   up   |  192.168.122.20 | ubuntu2204 | peer-pods |  kvirt  |
|       peer-pods-worker-0      |   up   | 192.168.122.199 | ubuntu2204 | peer-pods |  kvirt  |
| podvm-busybox-remote-62291ece |   up   | 192.168.122.237 |            |           |         |
+-------------------------------+--------+-----------------+------------+-----------+---------+

$ virsh list
 Id   Name                            State
-----------------------------------------------
 70   peer-pods-ctlplane-0            running
 71   peer-pods-worker-0              running
 72   podvm-busybox-remote-62291ece   running 
```