### PR TITLE
test/e2e: Fix cri-o auth tests

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/common_suite.go
+++ b/src/cloud-api-adaptor/test/e2e/common_suite.go
@@ -257,6 +257,9 @@ func DoTestCreatePeerPodWithAuthenticatedImageWithoutCredentials(t *testing.T, e
 	imageName := os.Getenv("AUTHENTICATED_REGISTRY_IMAGE")
 	pod := NewPod(E2eNamespace, podName, podName, imageName, WithRestartPolicy(v1.RestartPolicyNever))
 	expectedErrorString := "401 UNAUTHORIZED"
+	if isTestOnCrio() {
+		expectedErrorString = "access to the requested resource is not authorized"
+	}
 	NewTestCase(t, e, "InvalidAuthImagePeerPod", assert, "Peer pod with Authenticated Image without Credentials has been created").WithPod(pod).WithNoAuthJson().WithExpectedPodEventError(expectedErrorString).WithCustomPodState(v1.PodPending).Run()
 }
 


### PR DESCRIPTION
For the cri-o tests, the error we get back for
unauthorized access to a private image is
different to containerd, so add logic to handle
this.