### PR TITLE
workflows: mksoi: Remove mid-build caching

### DIFF
--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -114,15 +114,7 @@ jobs:
 
       - name: Read properties from versions.yaml
         run: |
-          go_version="$(yq '.tools.golang' versions.yaml)"
-          echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"
           echo "ORAS_VERSION=$(yq -e '.tools.oras' versions.yaml)" >> "$GITHUB_ENV"
-
-      - name: Setup Golang version ${{ env.GO_VERSION }}
-        if: ${{ inputs.arch == 's390x' }}
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
 
       - uses: oras-project/setup-oras@v1
         with:
@@ -131,50 +123,16 @@ jobs:
       - name: Build builder
         id: build_builder
         working-directory: src/cloud-api-adaptor/podvm-mkosi
-        run: |
-          # If the builder image matching our git sha exists, then skip this build
-          builder_image=${{ inputs.registry }}/podvm-builder-fedora-${{ inputs.arch }}
-          tag=$(git rev-parse --short HEAD)
-
-          if ! docker manifest inspect "${builder_image}:${tag}"; then
-            PODVM_BUILDER_IMAGE="${builder_image}:${tag}" make fedora-binaries-builder
-          fi
-          echo "image=${builder_image}:${tag}" | tee -a "$GITHUB_OUTPUT"
-
-          # If the input has a different image-tag then also push it with that tag
-          if [ -n "${{ inputs.image_tag }}" ] && [ "${{ inputs.image_tag }}" != "${tag}" ];then
-            docker pull "${builder_image}:${tag}"
-            docker tag "${builder_image}:${tag}" ${builder_image}:${{ inputs.image_tag }}
-            docker push "${builder_image}:${{ inputs.image_tag }}"
-          fi
+        run: make fedora-binaries-builder
         env:
-          PUSH: true
           ARCH: ${{ inputs.arch }}
 
       - name: Build binaries
         id: build_binaries
         working-directory: src/cloud-api-adaptor/podvm-mkosi
-        run: |
-          # If the binaries which matching git sha exists, then skip this build
-          binaries_image=${{ inputs.registry }}/podvm-binaries-fedora-${{ inputs.arch }}
-          tag="$(git rev-parse --short HEAD)"
-          echo "image_tag=${image_tag}" | tee -a "$GITHUB_OUTPUT"
-
-          if ! docker manifest inspect "${binaries_image}:${tag}"; then
-            PODVM_BINARIES_IMAGE="${binaries_image}:${tag}" make binaries
-          fi
-          echo "image=${binaries_image}:${tag}" | tee -a "$GITHUB_OUTPUT"
-
-          # If the input has a different image-tag then also push it with that tag
-          if [ -n "${{ inputs.image_tag }}" ] && [ "${{ inputs.image_tag }}" != "${tag}" ];then
-            docker pull "${binaries_image}:${tag}"
-            docker tag "${binaries_image}:${tag}" ${binaries_image}:${{ inputs.image_tag }}
-            docker push "${binaries_image}:${{ inputs.image_tag }}"
-          fi
+        run: make binaries
         env:
-          PUSH: true
           ARCH: ${{ inputs.arch }}
-          PODVM_BUILDER_IMAGE: ${{ steps.build_builder.outputs.image }}
 
       - name: Install mkosi
         if: ${{ inputs.arch == 's390x' }}
@@ -191,39 +149,6 @@ jobs:
       - name: Build nix shell to cache dependencies
         if: ${{ inputs.arch == 'amd64' }}
         run: nix build .#devShells.x86_64-linux.podvm-mkosi
-
-      - name: Install crane with nix
-        if: ${{ inputs.arch == 'amd64' }}
-        run: nix profile install nixpkgs#crane
-
-      - name: Install crane with go
-        if: ${{ inputs.arch == 's390x' }}
-        run: |
-          go install github.com/google/go-containerregistry/cmd/crane@latest
-          echo "PATH=${PATH}:$(go env GOPATH)/bin" >> "$GITHUB_ENV"
-
-      - name: Second checkout
-        if: ${{ inputs.arch == 'amd64' }}
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: "${{ inputs.git_ref }}"
-
-
-      - name: Rebase the code
-        if: github.event_name == 'pull_request_target'
-        working-directory: ./
-        run: |
-          ./hack/ci-helper.sh rebase-atop-of-the-latest-target-branch
-
-      - name: Download binaries and unpack into binaries-tree
-        run: |
-          crane export \
-            ${{ steps.build_binaries.outputs.image }} \
-            podvm-binaries.tar
-          mkdir -p podvm-mkosi/resources/binaries-tree
-          tar xf podvm-binaries.tar -C podvm-mkosi/resources/binaries-tree
-          rm podvm-binaries.tar
 
       - name: Build mkosi debug image
         if: ${{ inputs.debug == 'true' }}
@@ -278,15 +203,15 @@ jobs:
           sudo rm -rf ./build
           sudo rm -rf ./mkosi.cache
 
-      - name: Build image for docker provider
+      - name: Build and push image for docker provider
         id: build_docker_oci
         working-directory: src/cloud-api-adaptor/podvm-mkosi
         run: |
           tag=$(git rev-parse --short HEAD)
           PODVM_TAG=${tag} make image-container
+          PODVM_TAG=${tag} make push-image-container
           arch=$(uname -m)
           arch=${arch/x86_64/amd64}
           echo "image=ghcr.io/${{ github.repository }}/podvm-docker-image-${arch}:${tag}" >> "$GITHUB_OUTPUT"
         env:
-          PUSH: true
           REGISTRY: ghcr.io/${{ github.repository }}

--- a/src/cloud-api-adaptor/podvm-mkosi/Makefile
+++ b/src/cloud-api-adaptor/podvm-mkosi/Makefile
@@ -15,10 +15,6 @@ PODVM_IMAGE ?= $(REGISTRY)/podvm-generic-$(PODVM_DISTRO)$(if $(filter $(SE_BOOT)
 PODVM_CONTAINER_NAME ?= $(REGISTRY)/podvm-docker-image-$(ARCH)
 VERIFY_PROVENANCE ?= no
 
-PUSH ?= false
-# If not pushing `--load` into the local docker cache
-DOCKER_OPTS := $(if $(filter $(PUSH),true),--push,--load) $(EXTRA_DOCKER_OPTS)
-
 .DEFAULT_GOAL := all
 .PHONY: all
 all: fedora-binaries-builder binaries image
@@ -46,7 +42,7 @@ fedora-binaries-builder:
 		--build-arg YQ_ARCH=$(ARCH) \
 		--build-arg PROTOC_ARCH=$(if $(filter amd64,$(ARCH)),x86_64,s390x) \
 		--build-arg ORAS_VERSION=$(ORAS_VERSION) \
-		$(DOCKER_OPTS) \
+		--load \
 		-f ../podvm/Dockerfile.podvm_builder.fedora ../.
 
 PHONY: binaries
@@ -68,8 +64,7 @@ endif
 		--build-arg VERIFY_PROVENANCE=$(VERIFY_PROVENANCE) \
 		$(if $(AUTHFILE),--build-arg AUTHFILE=$(AUTHFILE),) \
 		$(if $(DEFAULT_AGENT_POLICY_FILE),--build-arg DEFAULT_AGENT_POLICY_FILE=$(DEFAULT_AGENT_POLICY_FILE),) \
-		$(if $(filter $(PUSH),true),,-o type=local,dest="./resources/binaries-tree") \
-		$(DOCKER_OPTS) \
+		-o type=local,dest="./resources/binaries-tree" \
 		-f ../podvm/Dockerfile.podvm_binaries.fedora ../../
 
 PHONY: image
@@ -120,7 +115,6 @@ image-container:
 	docker buildx build \
 		-t $(PODVM_CONTAINER_NAME):$(PODVM_TAG) \
 		-t $(PODVM_CONTAINER_NAME):latest \
-		$(DOCKER_OPTS) \
 		-f Dockerfile.podvm_docker_provider .
 
 PHONY: push-image


### PR DESCRIPTION
Remove the push of the builder and binaries during the mkosi build, but just output them to the local directory always to simplify the flow and remove the need to use crane to pull them down.