### PR TITLE
Libvirt: Change the libvirt Volumename for s390x architecture

### DIFF
--- a/src/cloud-providers/libvirt/cloudinit.go
+++ b/src/cloud-providers/libvirt/cloudinit.go
@@ -10,14 +10,16 @@ import (
 )
 
 const (
-	userDataFilename   = "user-data"
-	metaDataFilename   = "meta-data"
-	vendorDataFilename = "vendor-data"
-	ciDataVolumeName   = "cidata"
+	userDataFilename      = "user-data"
+	metaDataFilename      = "meta-data"
+	vendorDataFilename    = "vendor-data"
+	ciDataVolumeName      = "cidata"
+	ciDatas390xVolumeName = "cc_cidata"
+	ARCHS390x             = "s390x"
 )
 
 // createCloudInit produces a cloud init ISO file as a data blob with a userdata and a metadata section
-func createCloudInit(userData, metaData []byte) ([]byte, error) {
+func createCloudInit(userData, metaData []byte, arch string) ([]byte, error) {
 	writer, err := iso9660.NewWriter()
 	if err != nil {
 		return nil, err
@@ -40,8 +42,12 @@ func createCloudInit(userData, metaData []byte) ([]byte, error) {
 	}
 
 	var buf bytes.Buffer
-
-	err = writer.WriteTo(&buf, ciDataVolumeName)
+	// Assign different volumeName for s390x architecture
+	if arch == ARCHS390x {
+		err = writer.WriteTo(&buf, ciDatas390xVolumeName)
+	} else {
+		err = writer.WriteTo(&buf, ciDataVolumeName)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/src/cloud-providers/libvirt/cloudinit_test.go
+++ b/src/cloud-providers/libvirt/cloudinit_test.go
@@ -28,8 +28,9 @@ func TestCloudInit(t *testing.T) {
 
 	userDataContent := []byte("userdata")
 	metaDataContent := []byte("metadata")
+	arch := "s390x"
 
-	isoData, err := createCloudInit(userDataContent, metaDataContent)
+	isoData, err := createCloudInit(userDataContent, metaDataContent, arch)
 	require.NoError(t, err)
 
 	err = os.WriteFile(file.Name(), isoData, os.ModePerm)

--- a/src/cloud-providers/libvirt/libvirt.go
+++ b/src/cloud-providers/libvirt/libvirt.go
@@ -65,13 +65,13 @@ func (s *sevGuestPolicy) getGuestPolicy() uint {
 }
 
 // createCloudInitISO creates an ISO file with a userdata and a metadata file. The ISO image will be created in-memory since it is small
-func createCloudInitISO(v *vmConfig) ([]byte, error) {
+func createCloudInitISO(v *vmConfig, arch string) ([]byte, error) {
 	logger.Println("Create cloudInit iso")
 
 	userData := v.userData
 	metaData := fmt.Sprintf("local-hostname: %s", v.name)
 
-	return createCloudInit([]byte(userData), []byte(metaData))
+	return createCloudInit([]byte(userData), []byte(metaData), arch)
 }
 
 func checkDomainExistsByName(name string, libvirtClient *libvirtClient) (exist bool, err error) {
@@ -680,8 +680,8 @@ func CreateDomain(ctx context.Context, libvirtClient *libvirtClient, v *vmConfig
 	if err != nil {
 		return nil, fmt.Errorf("Error in creating volume: %s", err)
 	}
-
-	cloudInitIso, err := createCloudInitISO(v)
+	// Pass the architecture to createCloudInitISO(), Use this value to take action for specific architecture.
+	cloudInitIso, err := createCloudInitISO(v, libvirtClient.nodeInfo.Model)
 	if err != nil {
 		return nil, fmt.Errorf("error in creating cloud init ISO file, cause: %w", err)
 	}


### PR DESCRIPTION
For s390x Architecture,  there is need for differentiate the Volume Name.
In s390x environment, to differentiate hyper protect peer pod image and  other image, we planned to use the volumeName as the differentiator. Hence we planned to change the volume Name from "cidata" to "cc_cidata".
Existing s390x code base uses the VolumeName as differentiator.  Hence we need to use same approach.
