### PR TITLE
S390x runner testing

### DIFF
--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -265,9 +265,7 @@ jobs:
   # Run libvirt s390x e2e tests, based on the mkosi image, if pull request labeled 'test_e2e_libvirt'
   libvirt_s390x:
     name: E2E tests on libvirt for the s390x architecture
-    # Skip s390x e2e tests until Choi is available to set-up the s390x runner's pre-action properly. Then revert this.
     if: |
-      false ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'test_e2e_libvirt') ||

--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -266,7 +266,12 @@ jobs:
   libvirt_s390x:
     name: E2E tests on libvirt for the s390x architecture
     # Skip s390x e2e tests until Choi is available to set-up the s390x runner's pre-action properly. Then revert this.
-    if: false
+    if: |
+      false ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'test_e2e_libvirt') ||
+      contains(github.event.pull_request.labels.*.name, 'test_e2e_libvirt_s390x')
     needs: [podvm_mkosi_s390x, libvirt_e2e_arch_prep, caa_image_s390x]
     strategy:
       fail-fast: false


### PR DESCRIPTION
Revert the changes that skipped s390x testing so we can debug the runners now that @BbolroC is back to help us.
Unfortunately we can't test it on fork runners as in a fresh environment it all passed, so we specifically need to ensure that the runners shared with other CoCo projects are cleaned up to run our workfloads