### PR TITLE
webhook: Skip flakey e2e test

### DIFF
--- a/src/webhook/tests/e2e/webhook_tests.bats
+++ b/src/webhook/tests/e2e/webhook_tests.bats
@@ -121,6 +121,8 @@ teardown() {
 }
 
 @test "$test_tags test default parameters can be changed" {
+	skip "This test is unstable. See issue #2179."
+
 	local runtimeclass="kata-wh-test"
 
 	# Create a dummy runtimeClass to use on this test.


### PR DESCRIPTION
The third webhook test is frequently failing (see #2179), so skip this until there is time to investigate and fix it.