### PR TITLE
ci: re-order sysctl step for podvm_mkosi wf

### DIFF
--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -75,16 +75,16 @@ jobs:
       qcow2_oras_image: ${{ steps.publish_oras_qcow2.outputs.image }}:${{ steps.publish_oras_qcow2.outputs.tag }}
       docker_oci_image: ${{ steps.build_docker_oci.outputs.image }}
     steps:
-      # Required by rootless mkosi
-      - name: Un-restrict user namespaces
-        if: inputs.arch == 'amd64'
-        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: "${{ inputs.git_ref }}"
+
+      # Required by rootless mkosi
+      - name: Un-restrict user namespaces
+        if: inputs.arch == 'amd64'
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: Rebase the code
         if: github.event_name == 'pull_request_target'


### PR DESCRIPTION
A default directory is set workflow-wide that will only work after checkout, hence the sysctl call fails.