### PR TITLE
DO NOT MERGE: s390x debug

### DIFF
--- a/src/cloud-api-adaptor/hack/build-s390x-image.sh
+++ b/src/cloud-api-adaptor/hack/build-s390x-image.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 set -euo pipefail
+DEBUG="true"
+[ -n "${DEBUG:-}" ] && set -o xtrace
 
 pushd ../podvm-mkosi/build
 

--- a/src/cloud-api-adaptor/hack/build-s390x-image.sh
+++ b/src/cloud-api-adaptor/hack/build-s390x-image.sh
@@ -6,11 +6,13 @@ DEBUG="true"
 
 pushd ../podvm-mkosi/build
 
-workdir=.
+workdir=$PWD
 tmp_img_path="${workdir}/tmp.qcow2"
 tmp_nbd=/dev/nbd1
 dst_mnt=./dst_mnt
 disksize=100G
+
+echo "tmp_img_path: ${tmp_img_path}"
 
 qemu-img create -f qcow2 "${tmp_img_path}" "${disksize}"
 


### PR DESCRIPTION
In the s390x mkosi podvm build we are occasionally hitting:
> qemu-img: Could not open './tmp.qcow2': Failed to get shared "write" lock
> Is another process using the image [./tmp.qcow2]?
> make: *** [Makefile:78: image] Error 1

Add some debug to try and understand what's going on here.