### PR TITLE
podvm_mkosi: Remove remaining references to builder

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -65,7 +65,6 @@ jobs:
         TEE_PLATFORM: az-cvm-vtpm
         VERIFY_PROVENANCE: yes
       run: |
-        make fedora-binaries-builder
         make binaries
 
     - name: Install build dependencies

--- a/src/cloud-api-adaptor/podvm-mkosi/Makefile
+++ b/src/cloud-api-adaptor/podvm-mkosi/Makefile
@@ -17,13 +17,13 @@ VERIFY_PROVENANCE ?= no
 
 .DEFAULT_GOAL := all
 .PHONY: all
-all: fedora-binaries-builder binaries image
+all: binaries image
 
 .PHONY: debug
-debug: fedora-binaries-builder binaries image-debug
+debug:binaries image-debug
 
 .PHONY: container
-container: fedora-binaries-builder binaries image-container
+container: binaries image-container
 
 ifeq ($(ARCH),s390x)
 YQ_CHECKSUM = $(YQ_CHECKSUM_s390x)

--- a/src/cloud-api-adaptor/podvm-mkosi/README.md
+++ b/src/cloud-api-adaptor/podvm-mkosi/README.md
@@ -92,7 +92,6 @@ Another issue is s390x does not support UEFI. Instead, we can first use **mkosi*
 
 It requires a **s390x host** to build s390x image with make commands:
 ```
-make fedora-binaries-builder
 TEE_PLATFORM=se-attester make binaries
 make image
 # SE_BOOT=true make image


### PR DESCRIPTION
Sorry, I didn't do the full job when merging the builder and binaries phase, so left some references to
fedora-binaries-builder in the code and docs (I was going to run both in parallel, but decided it
made more sense to switch and only did a partial job). This should fix the azure nightly build (and we still need to work
on integrating that with the other workflows I guess).
