### PR TITLE
docker: Fix userdata bind mount path inside the container

### DIFF
--- a/src/cloud-api-adaptor/pkg/paths/paths.go
+++ b/src/cloud-api-adaptor/pkg/paths/paths.go
@@ -7,5 +7,5 @@ const (
 	InitDataPath     = "/run/peerpod/initdata"
 	AgentCfgPath     = "/run/peerpod/agent-config.toml"
 	ForwarderCfgPath = "/run/peerpod/daemon.json"
-	UserDataPath     = "/run/media/cidata/user-data"
+	UserDataPath     = "/media/cidata/user-data"
 )

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system/process-user-data.service.d/10-override.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system/process-user-data.service.d/10-override.conf
@@ -1,6 +1,5 @@
 [Service]
 # mount config disk if available
-ExecStartPre=-/bin/mkdir -p /run/media/cidata
-ExecStartPre=-/bin/mount -t iso9660 -o ro /dev/disk/by-label/cidata /run/media/cidata
+ExecStartPre=-/bin/mount -t iso9660 -o ro /dev/disk/by-label/cidata /media/cidata
 # The digest is a string in hex representation, we truncate it to a 32 bytes hex string
 ExecStartPost=-/bin/bash -c 'tpm2_pcrextend 8:sha256=$(head -c64 /run/peerpod/initdata.digest)'

--- a/src/cloud-api-adaptor/podvm/files/media/cidata/.gitignore
+++ b/src/cloud-api-adaptor/podvm/files/media/cidata/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/cloud-providers/docker/provider.go
+++ b/src/cloud-providers/docker/provider.go
@@ -72,12 +72,12 @@ func (p *dockerProvider) CreateInstance(ctx context.Context, podName, sandboxID 
 
 	// Create volume binding for the container
 
-	// mount userdata to /run/media/cidata/user-data
+	// mount userdata to /media/cidata/user-data
 	// This file will be read by process-user-data and daemon.json will be written to
 	// /run/peerpods/daemon.json at runtime
 	volumeBinding := []string{
 		// note: we are not importing that path from the CAA package to avoid circular dependencies
-		fmt.Sprintf("%s:%s", instanceUserdataFile, "/run/media/cidata/user-data"),
+		fmt.Sprintf("%s:%s", instanceUserdataFile, "/media/cidata/user-data"),
 	}
 
 	// Add host bind mount for /run/kata-containers and /run/image to avoid


### PR DESCRIPTION
For docker provider we use systemd container which mounts /run as a tmpfs volume.
This mounting of /run happens after docker has bind mounted the userdata file inside the container and consequently the userdata file is no longer accessible.

This commit changes the path of the userdata file to not use `/run` for the docker provider.