### PR TITLE
tests/e2e: Skip tests after analysis

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/libvirt_test.go
+++ b/src/cloud-api-adaptor/test/e2e/libvirt_test.go
@@ -66,16 +66,25 @@ func TestLibvirtCreatePeerPodAndCheckUserLogs(t *testing.T) {
 }
 
 func TestLibvirtCreatePeerPodAndCheckWorkDirLogs(t *testing.T) {
+	// This test is causing issues on CI with instability, so skip until we can resolve this.
+	// See https://github.com/confidential-containers/cloud-api-adaptor/issues/1831
+	SkipTestOnCI(t)
 	assert := LibvirtAssert{}
 	DoTestCreatePeerPodAndCheckWorkDirLogs(t, testEnv, assert)
 }
 
 func TestLibvirtCreatePeerPodAndCheckEnvVariableLogsWithImageOnly(t *testing.T) {
+	// This test is causing issues on CI with instability, so skip until we can resolve this.
+	// See https://github.com/confidential-containers/cloud-api-adaptor/issues/1831
+	SkipTestOnCI(t)
 	assert := LibvirtAssert{}
 	DoTestCreatePeerPodAndCheckEnvVariableLogsWithImageOnly(t, testEnv, assert)
 }
 
 func TestLibvirtCreatePeerPodAndCheckEnvVariableLogsWithDeploymentOnly(t *testing.T) {
+	// This test is causing issues on CI with instability, so skip until we can resolve this.
+	// See https://github.com/confidential-containers/cloud-api-adaptor/issues/1831
+	SkipTestOnCI(t)
 	assert := LibvirtAssert{}
 	DoTestCreatePeerPodAndCheckEnvVariableLogsWithDeploymentOnly(t, testEnv, assert)
 }


### PR DESCRIPTION
Based in the test analysis done for 18 days of nighty tests in https://github.com/confidential-containers/cloud-api-adaptor/issues/1831#issuecomment-2541712756 the only containerd test failures we saw were:
- `TestLibvirtCreatePeerPodAndCheckEnvVariableLogsWithImageOnly` - three times
- `TestLibvirtCreatePeerPodAndCheckWorkDirLogs` - four times
- `TestLibvirtCreatePeerPodAndCheckEnvVariableLogsWithDeploymentOnly` - twice

Although the chances of failure for each of these tests is < 25%, we want to reduce the re-runs required, so if we skip these we should have more stable CI tests. It should also be noted that most of the failures were seen on the packer built images. This is probably just chance, but might indicate that the peer pod boot speed is related and we should re-evaluate again once we can remove the packer podvm images.