### PR TITLE
podvm-mkosi: fixes nix error during make image

### DIFF
--- a/src/cloud-api-adaptor/podvm-mkosi/Makefile
+++ b/src/cloud-api-adaptor/podvm-mkosi/Makefile
@@ -74,7 +74,7 @@ else ifeq ($(ARCH),s390x)
 	sudo -E ../hack/build-s390x-image.sh
 else
 	touch resources/buildBootableImage
-	nix develop ..#podvm-mkosi --command mkosi --environment=VARIANT_ID=production
+	nix --extra-experimental-features 'nix-command flakes' develop ..#podvm-mkosi --command mkosi --environment=VARIANT_ID=production
 	qemu-img convert -f raw -O qcow2 build/system.raw build/podvm-$(PODVM_DISTRO)-$(ARCH).qcow2
 endif
 
@@ -95,7 +95,7 @@ else ifeq ($(ARCH),s390x)
 	sudo -E ../hack/build-s390x-image.sh
 else
 	touch resources/buildBootableImage
-	nix develop ..#podvm-mkosi --command mkosi --environment=VARIANT_ID=debug
+	nix --extra-experimental-features 'nix-command flakes' develop ..#podvm-mkosi --command mkosi --environment=VARIANT_ID=debug
 	qemu-img convert -f raw -O qcow2 build/system.raw build/podvm-$(PODVM_DISTRO)-$(ARCH).qcow2
 endif
 


### PR DESCRIPTION
Currently, the `make image` target fails with the following error:

"experimental Nix feature 'nix-command' is disabled; add '--extra-experimental-features nix-command' to enable it."

This change explicitly enables the 'nix-command' and 'flakes' experimental features in the Makefile target to resolve this issue.

Otherwise, users would need to modify their local nix.conf configuration.