### PR TITLE
CAA: add support to look up imagePullSecrets for pods

### DIFF
--- a/src/cloud-api-adaptor/docs/registries-authentication.md
+++ b/src/cloud-api-adaptor/docs/registries-authentication.md
@@ -7,8 +7,4 @@ To authenticate with private container image registry you are required to provid
 
 Even though in the current CoCo configuration the images are being pulled on the pod, the pod spec still needs to have the pull secret defined. This is because metadata of an OCI image is still being accessed on the worker node, even if kata-agent pulls an image in the podvm. Please refer to the kubernetes docs to learn more about [pull secrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod).
 
-## Deploy auth.json along with cloud-api-adaptor deployment
-
-- CAA receives a registry auth file from the `auth-json-secret` secret that is mounted in the CAA pod using `install/overlays/$(CLOUD_PROVIDER)/kustomization.yaml`.
-- Make sure you do set a valid [auth.json](https://github.com/containers/image/blob/main/docs/containers-auth.json.5.md) as an entry for `auth-json-secret` when you configure `install/overlays/$(CLOUD_PROVIDER)/kustomization.yaml` prior to `make deploy`
-- If CAA encounters an auth.json file, it will configure kata-agent to use it.
+CAA configures kata-agent with auth.json by reading the pod and service account image pull secrets.

--- a/src/cloud-api-adaptor/install/overlays/aws/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/aws/kustomization.yaml
@@ -47,10 +47,6 @@ configMapGenerator:
 ##TLS_SETTINGS
 
 secretGenerator:
-- name: auth-json-secret
-  namespace: confidential-containers-system
-  files:
-  #- auth.json # set - path to auth.json pull credentials file
 - name: peer-pods-secret
   namespace: confidential-containers-system
   # This file should look like this (w/o quotes!):

--- a/src/cloud-api-adaptor/install/overlays/azure/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/azure/kustomization.yaml
@@ -53,10 +53,6 @@ configMapGenerator:
 ##TLS_SETTINGS
 
 secretGenerator:
-- name: auth-json-secret
-  namespace: confidential-containers-system
-  files:
-  #- auth.json # set - path to auth.json pull credentials file
 - name: peer-pods-secret
   namespace: confidential-containers-system
   # This file should look like this (w/o quotes!):

--- a/src/cloud-api-adaptor/install/overlays/docker/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/docker/kustomization.yaml
@@ -38,10 +38,6 @@ configMapGenerator:
 ##TLS_SETTINGS
 
 secretGenerator:
-  - name: auth-json-secret
-    namespace: confidential-containers-system
-  #  files:
-  #- auth.json # set - path to auth.json pull credentials file
   - name: peer-pods-secret
     namespace: confidential-containers-system
     literals:

--- a/src/cloud-api-adaptor/install/overlays/gcp/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/gcp/kustomization.yaml
@@ -36,10 +36,6 @@ configMapGenerator:
 ##TLS_SETTINGS
 
 secretGenerator:
-- name: auth-json-secret
-  namespace: confidential-containers-system
-  files:
-  #- auth.json # set - path to auth.json pull credentials file
 - name: peer-pods-secret
   namespace: confidential-containers-system
   files:

--- a/src/cloud-api-adaptor/install/overlays/ibmcloud-powervs/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/ibmcloud-powervs/kustomization.yaml
@@ -46,10 +46,6 @@ configMapGenerator:
 ##TLS_SETTINGS
 
 secretGenerator:
-- name: auth-json-secret
-  namespace: confidential-containers-system
-  files:
-  #- auth.json # set - path to auth.json pull credentials file
 - name: peer-pods-secret
   namespace: confidential-containers-system
   # the below file should be in this format

--- a/src/cloud-api-adaptor/install/overlays/ibmcloud/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/ibmcloud/kustomization.yaml
@@ -45,10 +45,6 @@ configMapGenerator:
 ##TLS_SETTINGS
 
 secretGenerator:
-- name: auth-json-secret
-  namespace: confidential-containers-system
-  files:
-  #- auth.json # set - path to auth.json pull credentials file
 - name: peer-pods-secret
   namespace: confidential-containers-system
   literals:

--- a/src/cloud-api-adaptor/install/overlays/libvirt/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/libvirt/kustomization.yaml
@@ -42,10 +42,6 @@ configMapGenerator:
 ##TLS_SETTINGS
 
 secretGenerator:
-- name: auth-json-secret
-  namespace: confidential-containers-system
-  files:
-  #- auth.json # set - path to auth.json pull credentials file
 - name: ssh-key-secret
   namespace: confidential-containers-system
   files: # key generation example: ssh-keygen -f ./id_rsa -N "" && sudo cat id_rsa.pub >> /root/.ssh/authorized_keys

--- a/src/cloud-api-adaptor/install/overlays/vsphere/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/vsphere/kustomization.yaml
@@ -59,10 +59,6 @@ configMapGenerator:
 ##TLS_SETTINGS
 
 secretGenerator:
-- name: auth-json-secret
-  namespace: confidential-containers-system
-  files:
-  #- auth.json # set - path to auth.json pull credentials file
 - name: peer-pods-secret
   namespace: confidential-containers-system
   literals:

--- a/src/cloud-api-adaptor/install/rbac/peer-pod.yaml
+++ b/src/cloud-api-adaptor/install/rbac/peer-pod.yaml
@@ -14,6 +14,12 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/src/cloud-api-adaptor/install/yamls/caa-pod.yaml
+++ b/src/cloud-api-adaptor/install/yamls/caa-pod.yaml
@@ -48,9 +48,6 @@ spec:
           periodSeconds: 20
           initialDelaySeconds: 20
         volumeMounts:
-        - name: auth-json
-          mountPath: "/root/containers/" # hardcoded
-          readOnly: true
         - mountPath: /root/.ssh/
           name: ssh
           readOnly: true
@@ -73,10 +70,6 @@ spec:
       nodeSelector:
         node.kubernetes.io/worker: ""
       volumes:
-      - name: auth-json
-        secret:
-          secretName: auth-json-secret
-          optional: true # failing?
       - name: ssh
         secret:
           defaultMode: 384

--- a/src/cloud-api-adaptor/libvirt/README.md
+++ b/src/cloud-api-adaptor/libvirt/README.md
@@ -252,7 +252,6 @@ clusterrolebinding.rbac.authorization.k8s.io "node-viewer" deleted
 clusterrolebinding.rbac.authorization.k8s.io "peerpod-editor" deleted
 clusterrolebinding.rbac.authorization.k8s.io "pod-viewer" deleted
 configmap "peer-pods-cm" deleted
-secret "auth-json-secret" deleted
 secret "peer-pods-secret" deleted
 secret "ssh-key-secret" deleted
 daemonset.apps "cloud-api-adaptor-daemonset" deleted

--- a/src/cloud-api-adaptor/pkg/adaptor/k8sops/node.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/k8sops/node.go
@@ -81,6 +81,98 @@ func RemoveExtendedResources() error {
 	return nil
 }
 
+// Auths contains Registries with credentials
+type Auths struct {
+	Registries Registries `json:"auths"`
+}
+
+// Registries contains credentials for hosts
+type Registries map[string]Auth
+
+// Auth contains credentials for a given host
+type Auth struct {
+	Auth string `json:"auth"`
+}
+
+// GetImagePullSecrets gets image pull secrets for the specified pod
+func GetImagePullSecrets(podName string, namespace string) ([]byte, error) {
+
+	config, err := getKubeConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get k8s config: %v", err)
+	}
+
+	cli, err := getClient(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get k8s client: %v", err)
+	}
+
+	pod, err := cli.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	accountName := pod.Spec.ServiceAccountName
+	if accountName == "" {
+		accountName = "default"
+	}
+	serviceaAccount, err := cli.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), accountName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	auths := Auths{}
+	auths.Registries = make(map[string]Auth)
+	for _, secret := range serviceaAccount.ImagePullSecrets {
+		err := addAuths(cli, namespace, secret.Name, &auths)
+		if err != nil {
+			return nil, err
+		}
+	}
+	for _, secret := range pod.Spec.ImagePullSecrets {
+		err := addAuths(cli, namespace, secret.Name, &auths)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if len(auths.Registries) > 0 {
+		authJSON, err := json.Marshal(auths)
+		if err != nil {
+			return nil, err
+		}
+		return authJSON, nil
+	}
+	return nil, nil
+}
+
+// getAuths get auth credentials from specified docker secret
+func addAuths(cli *k8sclient.Clientset, namespace string, secretName string, auths *Auths) error {
+	secret, err := cli.CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+	if err != nil {
+		// Ignore errors getting secrets to match K8S behavior
+		return nil
+	}
+	registries := Registries{}
+	if secretData, ok := secret.Data[".dockerconfigjson"]; ok {
+		auths := Auths{}
+		err := json.Unmarshal(secretData, &auths)
+		if err != nil {
+			return err
+		}
+		registries = auths.Registries
+	} else if secretData, ok := secret.Data[".dockercfg"]; ok {
+		err = json.Unmarshal(secretData, &registries)
+		if err != nil {
+			return err
+		}
+	}
+	for registry, creds := range registries {
+		auths.Registries[registry] = creds
+	}
+	return nil
+}
+
 // patchNodeStatus patches the status of a node
 func patchNodeStatus(c *k8sclient.Clientset, nodeName string, patches []jsonPatch) error {
 	if len(patches) > 0 {

--- a/src/cloud-api-adaptor/test/e2e/assessment_helpers.go
+++ b/src/cloud-api-adaptor/test/e2e/assessment_helpers.go
@@ -708,12 +708,33 @@ func DeleteAndWaitForNamespace(ctx context.Context, client klient.Client, namesp
 	return nil
 }
 
-func AddImagePullSecretToDefaultServiceAccount(ctx context.Context, client klient.Client, secretName string) error {
+func getDefaultServiceAccount(ctx context.Context, client klient.Client) (*v1.ServiceAccount, error) {
+	clientSet, err := kubernetes.NewForConfig(client.RESTConfig())
+	if err != nil {
+		return nil, err
+	}
+	serviceAccount, err := clientSet.CoreV1().ServiceAccounts(E2eNamespace).Get(context.TODO(), "default", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return serviceAccount, nil
+}
+
+func setImagePullSecretsOnServiceAccount(ctx context.Context, client klient.Client, serviceAccount *v1.ServiceAccount, imagePullSecrets []v1.LocalObjectReference) error {
 	clientSet, err := kubernetes.NewForConfig(client.RESTConfig())
 	if err != nil {
 		return err
 	}
-	serviceAccount, err := clientSet.CoreV1().ServiceAccounts(E2eNamespace).Get(context.TODO(), "default", metav1.GetOptions{})
+	serviceAccount.ImagePullSecrets = imagePullSecrets
+	_, err = clientSet.CoreV1().ServiceAccounts(E2eNamespace).Update(context.TODO(), serviceAccount, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func AddImagePullSecretToDefaultServiceAccount(ctx context.Context, client klient.Client, secretName string) error {
+	serviceAccount, err := getDefaultServiceAccount(ctx, client)
 	if err != nil {
 		return err
 	}
@@ -725,13 +746,29 @@ func AddImagePullSecretToDefaultServiceAccount(ctx context.Context, client klien
 		}
 	}
 	if !secretExists {
-		// Update the ServiceAccount to add the imagePullSecret
-		serviceAccount.ImagePullSecrets = append(serviceAccount.ImagePullSecrets, v1.LocalObjectReference{Name: secretName})
-		_, err := clientSet.CoreV1().ServiceAccounts(E2eNamespace).Update(context.TODO(), serviceAccount, metav1.UpdateOptions{})
+		imagePullSecrets := append(serviceAccount.ImagePullSecrets, v1.LocalObjectReference{Name: secretName})
+		err := setImagePullSecretsOnServiceAccount(ctx, client, serviceAccount, imagePullSecrets)
 		if err != nil {
 			return err
 		}
-		log.Infof("ServiceAccount %s updated successfully.", "default")
+	}
+	return nil
+}
+
+func RemoveImagePullSecretFromDefaultServiceAccount(ctx context.Context, client klient.Client, secretName string) error {
+	serviceAccount, err := getDefaultServiceAccount(ctx, client)
+	if err != nil {
+		return err
+	}
+	newSecrets := []v1.LocalObjectReference{}
+	for _, secret := range serviceAccount.ImagePullSecrets {
+		if secret.Name != secretName {
+			newSecrets = append(newSecrets, secret)
+		}
+	}
+	err = setImagePullSecretsOnServiceAccount(ctx, client, serviceAccount, newSecrets)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/src/cloud-api-adaptor/test/e2e/common.go
+++ b/src/cloud-api-adaptor/test/e2e/common.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -402,6 +403,22 @@ func NewConfigMap(namespace, name string, configMapData map[string]string) *core
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 		Data:       configMapData,
 	}
+}
+
+// NewImagePullSecret returns a new imagePull secret object.
+func NewImagePullSecret(namespace, name string, image string, credentials string) *corev1.Secret {
+	registryName := strings.Split(image, "/")[0]
+	template := `{
+	"auths": {
+		"%s": {
+			"auth": "%s"
+		}
+	}
+}`
+	authJSON := fmt.Sprintf(template, registryName, credentials)
+	secretData := map[string][]byte{v1.DockerConfigJsonKey: []byte(authJSON)}
+
+	return NewSecret(namespace, name, secretData, v1.SecretTypeDockerConfigJson)
 }
 
 // NewSecret returns a new secret object.

--- a/src/cloud-api-adaptor/test/e2e/docker_test.go
+++ b/src/cloud-api-adaptor/test/e2e/docker_test.go
@@ -136,10 +136,19 @@ func TestDockerCreatePeerPodWithAuthenticatedImageWithoutCredentials(t *testing.
 	}
 }
 
-func TestDockerCreatePeerPodWithAuthenticatedImageWithValidCredentials(t *testing.T) {
+func TestDockerCreatePeerPodWithAuthenticatedImageWithImagePullSecretInServiceAccount(t *testing.T) {
 	assert := DockerAssert{}
 	if os.Getenv("REGISTRY_CREDENTIAL_ENCODED") != "" && os.Getenv("AUTHENTICATED_REGISTRY_IMAGE") != "" {
-		DoTestCreatePeerPodWithAuthenticatedImageWithValidCredentials(t, testEnv, assert)
+		DoTestCreatePeerPodWithAuthenticatedImageWithImagePullSecretInServiceAccount(t, testEnv, assert)
+	} else {
+		t.Skip("Registry Credentials, or authenticated image name not exported")
+	}
+}
+
+func TestDockerCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t *testing.T) {
+	assert := DockerAssert{}
+	if os.Getenv("REGISTRY_CREDENTIAL_ENCODED") != "" && os.Getenv("AUTHENTICATED_REGISTRY_IMAGE") != "" {
+		DoTestCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t, testEnv, assert)
 	} else {
 		t.Skip("Registry Credentials, or authenticated image name not exported")
 	}

--- a/src/cloud-api-adaptor/test/e2e/ibmcloud_test.go
+++ b/src/cloud-api-adaptor/test/e2e/ibmcloud_test.go
@@ -146,12 +146,23 @@ func TestCreatePeerPodWithPVC(t *testing.T) {
 	}
 }
 
-func TestCreatePeerPodWithAuthenticatedImageWithValidCredentials(t *testing.T) {
+func TestIBMCloudCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	if os.Getenv("REGISTRY_CREDENTIAL_ENCODED") != "" && os.Getenv("AUTHENTICATED_REGISTRY_IMAGE") != "" {
-		DoTestCreatePeerPodWithAuthenticatedImageWithValidCredentials(t, testEnv, assert)
+		DoTestCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t, testEnv, assert)
+	} else {
+		t.Skip("Registry Credentials not exported")
+	}
+}
+
+func TestIBMCloudCreatePeerPodWithAuthenticatedImageWithImagePullSecretInServiceAccount(t *testing.T) {
+	assert := IBMCloudAssert{
+		VPC: pv.IBMCloudProps.VPC,
+	}
+	if os.Getenv("REGISTRY_CREDENTIAL_ENCODED") != "" && os.Getenv("AUTHENTICATED_REGISTRY_IMAGE") != "" {
+		DoTestCreatePeerPodWithAuthenticatedImageWithImagePullSecretInServiceAccount(t, testEnv, assert)
 	} else {
 		t.Skip("Registry Credentials not exported")
 	}

--- a/src/cloud-api-adaptor/test/e2e/libvirt_test.go
+++ b/src/cloud-api-adaptor/test/e2e/libvirt_test.go
@@ -232,10 +232,19 @@ func TestLibvirtCreatePeerPodWithAuthenticatedImageWithoutCredentials(t *testing
 	}
 }
 
-func TestLibvirtCreatePeerPodWithAuthenticatedImageWithValidCredentials(t *testing.T) {
+func TestLibvirtCreatePeerPodWithAuthenticatedImageWithImagePullSecretInServiceAccount(t *testing.T) {
 	assert := LibvirtAssert{}
 	if os.Getenv("REGISTRY_CREDENTIAL_ENCODED") != "" && os.Getenv("AUTHENTICATED_REGISTRY_IMAGE") != "" {
-		DoTestCreatePeerPodWithAuthenticatedImageWithValidCredentials(t, testEnv, assert)
+		DoTestCreatePeerPodWithAuthenticatedImageWithImagePullSecretInServiceAccount(t, testEnv, assert)
+	} else {
+		t.Skip("Registry Credentials, or authenticated image name not exported")
+	}
+}
+
+func TestLibvirtCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t *testing.T) {
+	assert := LibvirtAssert{}
+	if os.Getenv("REGISTRY_CREDENTIAL_ENCODED") != "" && os.Getenv("AUTHENTICATED_REGISTRY_IMAGE") != "" {
+		DoTestCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t, testEnv, assert)
 	} else {
 		t.Skip("Registry Credentials, or authenticated image name not exported")
 	}

--- a/src/cloud-api-adaptor/test/provisioner/docker/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/docker/provision_common.go
@@ -257,10 +257,6 @@ func (lio *DockerInstallOverlay) Edit(ctx context.Context, cfg *envconf.Config, 
 		}
 	}
 
-	if err := lio.Overlay.SetAuthJsonSecretIfApplicable(); err != nil {
-		return err
-	}
-
 	if err := lio.Overlay.YamlReload(); err != nil {
 		return err
 	}

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_kustomize.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_kustomize.go
@@ -170,10 +170,6 @@ func (lio *IBMCloudInstallOverlay) Edit(ctx context.Context, cfg *envconf.Config
 		}
 	}
 
-	if err = lio.Overlay.SetAuthJsonSecretIfApplicable(); err != nil {
-		return err
-	}
-
 	if err = lio.Overlay.YamlReload(); err != nil {
 		return err
 	}

--- a/src/cloud-api-adaptor/test/provisioner/kustomize.go
+++ b/src/cloud-api-adaptor/test/provisioner/kustomize.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"golang.org/x/exp/slices"
@@ -428,26 +427,5 @@ func setSecretGeneratorLiteral(k *ktypes.Kustomization, secretName string, key s
 	newLiterals := setLiteral(secretg.GeneratorArgs.DataSources.LiteralSources, key, value)
 	secretg.GeneratorArgs.DataSources.LiteralSources = newLiterals
 
-	return nil
-}
-
-func (kh *KustomizeOverlay) SetAuthJsonSecretIfApplicable() error {
-	if cred := os.Getenv("REGISTRY_CREDENTIAL_ENCODED"); cred != "" {
-		registryName := strings.Split(os.Getenv("AUTHENTICATED_REGISTRY_IMAGE"), "/")[0]
-		template := `{
-			"auths": {
-				"%s": {
-					"auth": "%s"
-				}
-			}
-		}`
-		authJSON := fmt.Sprintf(template, registryName, cred)
-		if err := os.WriteFile(filepath.Join(kh.ConfigDir, "auth.json"), []byte(authJSON), 0644); err != nil {
-			return err
-		}
-		if err := kh.SetKustomizeSecretGeneratorFile("auth-json-secret", "auth.json"); err != nil {
-			return err
-		}
-	}
 	return nil
 }

--- a/src/cloud-api-adaptor/test/provisioner/libvirt/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/libvirt/provision_common.go
@@ -387,10 +387,6 @@ func (lio *LibvirtInstallOverlay) Edit(ctx context.Context, cfg *envconf.Config,
 		}
 	}
 
-	if err = lio.Overlay.SetAuthJsonSecretIfApplicable(); err != nil {
-		return err
-	}
-
 	if err = lio.Overlay.YamlReload(); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR initializes auth.json with the imagePullSecrets listed on the pod and service account.

Fixes: #2231