### PR TITLE
CI: don't install uefi deps on s390x podvm builds

### DIFF
--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -118,11 +118,16 @@ jobs:
             alien \
             bubblewrap \
             dnf \
-            mtools \
             qemu-utils \
-            systemd-ukify \
             uidmap
           sudo snap install yq
+
+      - name: Install UEFI build dependencies
+        if: inputs.arch == 'amd64'
+        run: |
+          sudo apt-get update -y
+            mtools \
+            systemd-ukify
 
       - name: Read properties from versions.yaml
         run: |


### PR DESCRIPTION
There are no UKI tools for s390x packaged in ubuntu at the moment, thus we have to split this out. s390x will not attempt to build UEFI images, so we don't need those tools for an mkosi build on that platform.