### PR TITLE
caa: Re-add ppc64le support to build

### DIFF
--- a/src/cloud-api-adaptor/Makefile
+++ b/src/cloud-api-adaptor/Makefile
@@ -16,6 +16,9 @@ ifeq ($(ARCH),aarch64)
 else ifeq ($(ARCH),s390x)
 	TARGET_ARCH := s390x
 	PROTOC_ARCH := s390_64
+else ifeq ($(ARCH),ppc64le)
+	TARGET_ARCH := ppc64le
+	PROTOC_ARCH := ppc64le_64
 endif
 
 # Default is dev build. To create release build set RELEASE_BUILD=true


### PR DESCRIPTION
When the arm support was added in #2194 it seems
to have broken ppc64le builds: e.g.
https://github.com/confidential-containers/cloud-api-adaptor/actions/runs/12747057891 so try and fix this