### PR TITLE
ci: bump azure podvm build workflow to 24.04

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   build-podvm-image:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: cloud-api-adaptor/src/cloud-api-adaptor/podvm-mkosi


### PR DESCRIPTION
It was on 22.04, which lacks the ukify package.