### PR TITLE
Kata 3.13.0 dependency bump

### DIFF
--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -17,9 +17,9 @@ version is picked) and [trustee releases](https://github.com/confidential-contai
     `externals.coco-guest-components.version`, `externals.coco-trustee` and the `image-rs` crate in the agent's
     [`Cargo.toml`](https://github.com/kata-containers/kata-containers/blob/main/src/agent/Cargo.toml).
     - At this point it makes sense for us to stay in sync, by updating the guest-components and kbs that we use in peer pods,
-    by changing the `oci.guest-components.reference`, `oci.kbs.tag` and `oci.kbs-client.reference` values in [versions.yaml](../src/cloud-api-adaptor/versions.yaml).
-    We should also bump the kata agent to the latest commit
-    hash in our [version.yaml](../src/cloud-api-adaptor/versions.yaml) for testing.
+    by changing the `oci.guest-components.reference` and `git.kbs.tag`values in [versions.yaml](../src/cloud-api-adaptor/versions.yaml).
+    We should also bump the kata agent to the latest commit hash by updating `oci.kata-containers.reference` in
+    [version.yaml](../src/cloud-api-adaptor/versions.yaml) for testing.
 1. Kata Containers [releases](https://github.com/kata-containers/kata-containers/releases)
     - We should already be in sync with the guest-components and trustee, from the previous step, but now we should update:
       - The kata-containers source branch that we use in [versions.yaml](../src/cloud-api-adaptor/versions.yaml) to
@@ -198,7 +198,7 @@ To github.com:confidential-containers/cloud-api-adaptor.git
 Total 0 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
 To github.com:confidential-containers/cloud-api-adaptor.git
  * [new tag]         src/peerpod-ctrl/v0.8.0 -> src/peerpod-ctrl/v0.8.0
-Total 0 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0) 
+Total 0 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
 To github.com:confidential-containers/cloud-api-adaptor.git
  * [new tag]         src/webhook/v0.8.0 -> src/webhook/v0.8.0
 ```

--- a/src/cloud-api-adaptor/go.mod
+++ b/src/cloud-api-adaptor/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/coreos/go-iptables v0.6.0
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0
-	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20241120084537-30bad4ee438b
+	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250116150548-2777b13db748
 	github.com/opencontainers/runtime-spec v1.1.1-0.20230922153023-c0e90434df2a
 	github.com/stretchr/testify v1.9.0
 	github.com/vishvananda/netlink v1.2.1-beta.2

--- a/src/cloud-api-adaptor/go.sum
+++ b/src/cloud-api-adaptor/go.sum
@@ -375,8 +375,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20241120084537-30bad4ee438b h1:6g8Z2/tswaR856bWwzgcImk3wp9m6RtSIN/yae++QEs=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20241120084537-30bad4ee438b/go.mod h1:E4YBwwlTgi4TmfBfGDbMRhVaD6iHRaMLM7v8g1reHT8=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250116150548-2777b13db748 h1:XUH7vVrQ0u1AKlysWhmiAxgb5S9GQImYKTW8S5LUTs8=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250116150548-2777b13db748/go.mod h1:E4YBwwlTgi4TmfBfGDbMRhVaD6iHRaMLM7v8g1reHT8=
 github.com/kdomanski/iso9660 v0.4.0 h1:BPKKdcINz3m0MdjIMwS0wx1nofsOjxOq8TOr45WGHFg=
 github.com/kdomanski/iso9660 v0.4.0/go.mod h1:OxUSupHsO9ceI8lBLPJKWBTphLemjrCQY8LPXM7qSzU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/src/cloud-api-adaptor/test/e2e/common.go
+++ b/src/cloud-api-adaptor/test/e2e/common.go
@@ -511,7 +511,7 @@ func CreateSealedSecretValue(resourceURI string) string {
 	if err != nil {
 		panic(err)
 	}
-	payload := b64.URLEncoding.EncodeToString([]byte(metadataStr))
+	payload := b64.RawURLEncoding.EncodeToString([]byte(metadataStr))
 	header := "fakejwsheader"
 	signature := "fakesignature"
 	return fmt.Sprintf("sealed.%s.%s.%s", header, payload, signature)

--- a/src/cloud-api-adaptor/test/e2e/common_suite.go
+++ b/src/cloud-api-adaptor/test/e2e/common_suite.go
@@ -547,10 +547,6 @@ func DoTestImageDecryption(t *testing.T, e env.Environment, assert CloudAssert, 
 		if err != nil {
 			t.Fatalf("Failed to enable KBS customized resource policy: %v", err)
 		}
-		err = kbs.EnableKbsCustomizedAttestationPolicy("allow_all.rego")
-		if err != nil {
-			t.Fatalf("Failed to enable KBS customized attestation policy: %v", err)
-		}
 		kbsEndpoint, err = kbs.GetCachedKbsEndpoint()
 		if err != nil {
 			t.Fatalf("Failed to get KBS endpoint: %v", err)

--- a/src/cloud-api-adaptor/test/e2e/libvirt_test.go
+++ b/src/cloud-api-adaptor/test/e2e/libvirt_test.go
@@ -159,10 +159,6 @@ func TestLibvirtSealedSecret(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EnableKbsCustomizedResourcePolicy failed with: %v", err)
 	}
-	err = keyBrokerService.EnableKbsCustomizedAttestationPolicy("allow_all.rego")
-	if err != nil {
-		t.Fatalf("EnableKbsCustomizedAttestationPolicy failed with: %v", err)
-	}
 	kbsEndpoint, err := keyBrokerService.GetCachedKbsEndpoint()
 	if err != nil {
 		t.Fatalf("GetCachedKbsEndpoint failed with: %v", err)
@@ -182,13 +178,9 @@ func TestLibvirtKbsKeyRelease(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SetSecret failed with: %v", err)
 	}
-	err = keyBrokerService.EnableKbsCustomizedResourcePolicy("allow_all.rego")
+	err = keyBrokerService.EnableKbsCustomizedResourcePolicy("deny_all.rego")
 	if err != nil {
 		t.Fatalf("EnableKbsCustomizedResourcePolicy failed with: %v", err)
-	}
-	err = keyBrokerService.EnableKbsCustomizedAttestationPolicy("deny_all.rego")
-	if err != nil {
-		t.Fatalf("EnableKbsCustomizedAttestationPolicy failed with: %v", err)
 	}
 	kbsEndpoint, err := keyBrokerService.GetCachedKbsEndpoint()
 	if err != nil {
@@ -213,9 +205,9 @@ func TestLibvirtKbsKeyRelease(t *testing.T) {
 		DoTestKbsKeyRelease(t, testEnv, assert, kbsEndpoint, resourcePath, testSecret)
 	} else {
 		t.Log("KBS normal cases")
-		err = keyBrokerService.EnableKbsCustomizedAttestationPolicy("allow_all.rego")
+		err = keyBrokerService.EnableKbsCustomizedResourcePolicy("allow_all.rego")
 		if err != nil {
-			t.Fatalf("EnableKbsCustomizedAttestationPolicy failed with: %v", err)
+			t.Fatalf("EnableKbsCustomizedResourcePolicy failed with: %v", err)
 		}
 		DoTestKbsKeyRelease(t, testEnv, assert, kbsEndpoint, resourcePath, testSecret)
 	}

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -43,7 +43,7 @@ git:
     reference: v1.5.0
   kbs:
     url: https://github.com/confidential-containers/trustee
-    reference: f287fcd60b0b3ddbef5546d646669813b9e68f8d
+    reference: 68e2a8d25dbfa012b422ff464f31d18f3afa6677
 # If a tag is given it will attempt to pull the oci image by tag. if a
 # reference is specified the corresponding tag will be constructed using
 # the reference and suffixes like architecture or tee.
@@ -53,7 +53,7 @@ oci:
     tag: 3.9
   kata-containers:
     registry: ghcr.io/kata-containers/cached-artefacts
-    reference: 3.11.0
+    reference: 3.13.0
   guest-components:
     registry: ghcr.io/confidential-containers/guest-components
-    reference: d8da69072424e496486dfb5421a26f16ff2a7abf
+    reference: 3df6c412059f29127715c3fdbac9fa41f56cfce4

--- a/src/csi-wrapper/go.mod
+++ b/src/csi-wrapper/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang/glog v1.1.2
 	github.com/golang/protobuf v1.5.4
-	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20241120084537-30bad4ee438b
+	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250116150548-2777b13db748
 	golang.org/x/net v0.33.0
 	google.golang.org/grpc v1.61.2
 	k8s.io/apimachinery v0.26.2

--- a/src/csi-wrapper/go.sum
+++ b/src/csi-wrapper/go.sum
@@ -80,8 +80,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20241120084537-30bad4ee438b h1:6g8Z2/tswaR856bWwzgcImk3wp9m6RtSIN/yae++QEs=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20241120084537-30bad4ee438b/go.mod h1:E4YBwwlTgi4TmfBfGDbMRhVaD6iHRaMLM7v8g1reHT8=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250116150548-2777b13db748 h1:XUH7vVrQ0u1AKlysWhmiAxgb5S9GQImYKTW8S5LUTs8=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250116150548-2777b13db748/go.mod h1:E4YBwwlTgi4TmfBfGDbMRhVaD6iHRaMLM7v8g1reHT8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=


### PR DESCRIPTION
Bump kata-containers, guest-components and trustee versions in response to them being bumped in the kata-containers 3.13.0 release.