### PR TITLE
CI: revert mkosi-amd64 back to v17

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   build-podvm-image:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: cloud-api-adaptor/src/cloud-api-adaptor/podvm-mkosi
@@ -49,29 +49,9 @@ jobs:
         path: cloud-api-adaptor
         ref: "${{ inputs.git-ref || 'main' }}"
 
-    - name: Install build dependencies
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y \
-          alien \
-          bubblewrap \
-          dnf \
-          mtools \
-          qemu-utils \
-          systemd-ukify \
-          uidmap
-        sudo snap install yq
-
-    - name: Read properties from versions.yaml
-      run: |
-        echo "MKOSI_VERSION=$(yq -e '.tools.mkosi' versions.yaml)" >> "$GITHUB_ENV"
-
-    - name: Setup mkosi
-      run: |
-        git clone -b "$MKOSI_VERSION" https://github.com/systemd/mkosi
-        PATH="$PWD/mkosi/bin:$PATH"
-        mkosi --version
-        echo "PATH=$PWD/mkosi/bin:$PATH" >> "$GITHUB_ENV"
+    - uses: cachix/install-nix-action@v30
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
 
     - name: Install uplosi
       run: |
@@ -86,6 +66,11 @@ jobs:
         VERIFY_PROVENANCE: yes
       run: |
         make binaries
+
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y qemu-utils
 
     - name: Build image
       run: make image

--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -114,35 +114,17 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y \
-            alien \
-            bubblewrap \
-            dnf \
-            qemu-utils \
-            uidmap
+          sudo apt-get install -y bubblewrap alien dnf qemu-utils uidmap
           sudo snap install yq
-
-      - name: Install UEFI build dependencies
-        if: inputs.arch == 'amd64'
-        run: |
-          sudo apt-get update -y
-            mtools \
-            systemd-ukify
 
       - name: Read properties from versions.yaml
         run: |
-          echo "MKOSI_VERSION=$(yq -e '.tools.mkosi' versions.yaml)" >> "$GITHUB_ENV"
           echo "ORAS_VERSION=$(yq -e '.tools.oras' versions.yaml)" >> "$GITHUB_ENV"
+
       - uses: oras-project/setup-oras@v1
         with:
           version: ${{ env.ORAS_VERSION }}
 
-      - name: Setup mkosi
-        run: |
-          git clone -b "$MKOSI_VERSION" https://github.com/systemd/mkosi
-          PATH="$PWD/mkosi/bin:$PATH"
-          mkosi --version
-          echo "PATH=$PWD/mkosi/bin:$PATH" >> "$GITHUB_ENV"
 
       - name: Build binaries
         id: build_binaries
@@ -150,6 +132,22 @@ jobs:
         run: make binaries
         env:
           ARCH: ${{ inputs.arch }}
+
+      - name: Install mkosi
+        if: ${{ inputs.arch == 's390x' }}
+        run: |
+          git clone -b v22 https://github.com/systemd/mkosi
+          sudo rm -f /usr/local/bin/mkosi
+          sudo ln -s "$PWD/mkosi/bin/mkosi" /usr/local/bin/mkosi
+          mkosi --version
+
+      - name: Install Nix
+        if: ${{ inputs.arch == 'amd64' }}
+        uses: cachix/install-nix-action@v30
+
+      - name: Build nix shell to cache dependencies
+        if: ${{ inputs.arch == 'amd64' }}
+        run: nix build .#devShells.x86_64-linux.podvm-mkosi
 
       - name: Build mkosi debug image
         if: ${{ inputs.debug == 'true' }}
@@ -194,11 +192,13 @@ jobs:
           subject-digest: ${{ steps.publish_oras_qcow2.outputs.digest }}
           push-to-registry: true
 
+
       - name: Clean up some space for the docker provider build
         working-directory: src/cloud-api-adaptor/podvm-mkosi
         run: |
           sudo du --max-depth=2 /home/runner || true
           sudo du --max-depth=2 /var/lib || true
+          sudo rm -rf /nix
           sudo rm -rf ./build
           sudo rm -rf ./mkosi.cache
 

--- a/src/cloud-api-adaptor/flake.lock
+++ b/src/cloud-api-adaptor/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgsUnstable": {
+      "locked": {
+        "lastModified": 1696019113,
+        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgsUnstable": "nixpkgsUnstable"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/src/cloud-api-adaptor/flake.nix
+++ b/src/cloud-api-adaptor/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "Cloud API Adaptor for Confidential Containers";
+
+  inputs = {
+    nixpkgsUnstable = {
+      url = "github:nixos/nixpkgs/nixos-unstable";
+    };
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+    };
+  };
+
+  outputs =
+    { self
+    , nixpkgsUnstable
+    , flake-utils
+    }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+      let
+        pkgsUnstable = import nixpkgsUnstable { inherit system; };
+      in
+      {
+        devShells = {
+          # Shell for building podvm images with mkosi.
+          podvm-mkosi = pkgsUnstable.mkShell {
+            nativeBuildInputs = with pkgsUnstable; [
+              btrfs-progs
+              cryptsetup
+              dnf5
+              dosfstools
+              mkosi-full
+              mtools
+              rpm
+              squashfsTools
+              util-linux
+              zstd
+              e2fsprogs # remove when switching to squashFS
+            ];
+          };
+        };
+
+        formatter = nixpkgsUnstable.legacyPackages.${system}.nixpkgs-fmt;
+      });
+}

--- a/src/cloud-api-adaptor/podvm-mkosi/Makefile
+++ b/src/cloud-api-adaptor/podvm-mkosi/Makefile
@@ -65,13 +65,16 @@ image:
 	rm -rf ./build
 	@echo "Building image..."
 ifeq ($(SE_BOOT),true)
+	touch resources/buildS390xImage
 	sudo mkosi --profile production.conf --image system
 	sudo -E ../hack/build-s390x-se-image.sh
 else ifeq ($(ARCH),s390x)
+	touch resources/buildS390xImage
 	sudo mkosi --profile production.conf --image system
 	sudo -E ../hack/build-s390x-image.sh
 else
-	mkosi --profile production.conf
+	touch resources/buildBootableImage
+	nix develop ..#podvm-mkosi --command mkosi --environment=VARIANT_ID=production
 	qemu-img convert -f raw -O qcow2 build/system.raw build/podvm-$(PODVM_DISTRO)-$(ARCH).qcow2
 endif
 
@@ -79,16 +82,20 @@ PHONY: image-debug
 image-debug:
 	@echo "Enabling debug preset..."
 	rm -rf resources/build*Image
+	touch resources/buildDebugImage
 	rm -rf ./build
 	@echo "Building debug image..."
 ifeq ($(SE_BOOT),true)
+	touch resources/buildS390xImage
 	sudo mkosi --profile debug.conf
 	sudo -E ../hack/build-s390x-se-image.sh
 else ifeq ($(ARCH),s390x)
+	touch resources/buildS390xImage
 	sudo mkosi --profile debug.conf
 	sudo -E ../hack/build-s390x-image.sh
 else
-	mkosi --profile debug.conf
+	touch resources/buildBootableImage
+	nix develop ..#podvm-mkosi --command mkosi --environment=VARIANT_ID=debug
 	qemu-img convert -f raw -O qcow2 build/system.raw build/podvm-$(PODVM_DISTRO)-$(ARCH).qcow2
 endif
 

--- a/src/cloud-api-adaptor/podvm-mkosi/README.md
+++ b/src/cloud-api-adaptor/podvm-mkosi/README.md
@@ -4,9 +4,7 @@
 
 ## Prerequisites
 
-There are various ways to install mkosi documented on the [project page](https://github.com/systemd/mkosi). Different distributions also package mkosi in their repositories, alongside the dependencies.
-
-Refer to the [CI workflow](../../../.github/workflows/podvm_mkosi.yaml) to see which additional tools are required to build an image.
+Currently, mksoi and other related tools are provided through a [Nix](https://nixos.org/) flake. Nix ensures all tools used in the build of the image are itself reproducible and pinned. mkosi requires a very recent systemd version, so using tools installed on the host is usually not possible. Nix needs to be configured to enable `flakes` and `nix command`. It is recommended to install Nix with the `DeterminateSystems nix-installer`, which comes with a configuration that is ready to use.
 
 ### Building the image
 
@@ -79,7 +77,7 @@ reduce complexity of configuration and CI and shall not be seen as open to-dos.
   from IMDS via the project's `process-user-data` tool.
 
 ## Build s390x image
-We can use the mkosi **ToolsTree** feature defined in `mkosi.conf` to download latest tools automatically:
+Since the [nix OS](https://nixos.org/download/#download-nix) does not support s390x, we can use the mkosi **ToolsTree** feature defined in `mkosi.conf` to download latest tools automatically:
 ```
 [Host]
 ToolsTree=default

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/initrd/mkosi.conf.d/fedora-s390x.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/initrd/mkosi.conf.d/fedora-s390x.conf
@@ -1,6 +1,11 @@
 [Match]
 Distribution=fedora
-Architecture=s390x
+
+# mkosi version in nix is 17.1,
+# which doesn't support Architecture in [Match]
+# As a workaround, use a flag file instead.
+#Architecture=s390x
+PathExists=../../resources/buildS390xImage
 
 [Content]
 Packages=kernel-core

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-bootable.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-bootable.conf
@@ -1,6 +1,11 @@
 [Match]
 Distribution=fedora
-Architecture=!s390x
+
+# mkosi version in nix is 17.1,
+# which doesn't support Architecture in [Match]
+# As a workaround, use a flag file instead.
+#Architecture=!s390x
+PathExists=../../resources/buildBootableImage
 
 [Content]
 Packages=systemd-boot

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-debug-aux.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-debug-aux.conf
@@ -1,9 +1,12 @@
 [Match]
 Distribution=fedora
-Profile=debug
+
+PathExists=../../resources/buildDebugImage
+
 # Overwrite default ssh config, but conflict with 
 # cloud-init which is installed for s390x.
-Architecture=!s390x
+#Architecture=!s390x
+PathExists=../../resources/buildBootableImage
 
 [Content]
 ExtraTrees=../../mkosi.skeleton-debug

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-debug-keys.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-debug-keys.conf
@@ -1,6 +1,7 @@
 [Match]
 Distribution=fedora
-Profile=debug
+# Only for debug images and if authorized_keys exists
+PathExists=../../resources/buildDebugImage
 PathExists=../../resources/authorized_keys
 
 [Content]

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-debug.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-debug.conf
@@ -1,6 +1,8 @@
 [Match]
 Distribution=fedora
-Profile=debug
+# This is a little hack to define different image types in a mkosi config.
+# There is also imageId, but it renames the output, which is not what we want.
+PathExists=../../resources/buildDebugImage
 
 [Content]
 Autologin=true

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-s390x.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-s390x.conf
@@ -1,6 +1,11 @@
 [Match]
 Distribution=fedora
-Architecture=s390x
+
+# mkosi version in nix is 17.1,
+# which doesn't support Architecture in [Match]
+# As a workaround, use a flag file instead.
+#Architecture=s390x
+PathExists=../../resources/buildS390xImage
 
 [Content]
 Bootable=no

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -23,12 +23,11 @@ cloudimg:
 
 tools:
   bats: 1.10.0
-  iptables-wrapper: v0.0.0-20240819165702-06cad2ec6cb5
   golang: 1.22.7
-  kcli: 99.0.202408152044
-  mkosi: v22
   protoc: 3.15.0
   packer: v1.9.4
+  kcli: 99.0.202408152044
+  iptables-wrapper: v0.0.0-20240819165702-06cad2ec6cb5
   oras: 1.2.0
 # Referenced Git repositories
 git:


### PR DESCRIPTION
The images that are built on the runners directly with updated mkosi do not boot on libvirt VMs, so we need to revert and revisit this at a later point.

Revert "CI: don't install uefi deps on s390x podvm builds"

This reverts commit c1b26f1803c179bf8589b557318f4f77dd315854.

Revert "ci: bump azure podvm build workflow to 24.04"

This reverts commit 3ebb741a6766bf9a797e39accf839ba7e7b7dc76.

Revert "ci: use profile instead of marker files"

This reverts commit 6e25be399498f9353e14cb826dba72cd877bdb89.

Revert "ci: install mkosi from repository for x86_64"

This reverts commit e7bd8bada2846de92d4298fa1e5298f1ab9f8967.