### PR TITLE
CI: build mkosi in docker + downgrade podvm to f39

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -49,10 +49,15 @@ jobs:
         path: cloud-api-adaptor
         ref: "${{ inputs.git-ref || 'main' }}"
 
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y qemu-utils
+        sudo snap install yq
+
     - name: Read properties from versions.yaml
       run: |
-        sudo snap install yq
-        echo "MKOSI_VERSION=$(yq -e '.tools.mkosi' versions.yaml)" >> "$GITHUB_ENV"
+        echo "MKOSI_VERSION=$(yq -e '.tools.mkosi' ../versions.yaml)" >> "$GITHUB_ENV"
 
     - name: Install uplosi
       run: |

--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -49,29 +49,10 @@ jobs:
         path: cloud-api-adaptor
         ref: "${{ inputs.git-ref || 'main' }}"
 
-    - name: Install build dependencies
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y \
-          alien \
-          bubblewrap \
-          dnf \
-          mtools \
-          qemu-utils \
-          systemd-ukify \
-          uidmap
-        sudo snap install yq
-
     - name: Read properties from versions.yaml
       run: |
+        sudo snap install yq
         echo "MKOSI_VERSION=$(yq -e '.tools.mkosi' versions.yaml)" >> "$GITHUB_ENV"
-
-    - name: Setup mkosi
-      run: |
-        git clone -b "$MKOSI_VERSION" https://github.com/systemd/mkosi
-        PATH="$PWD/mkosi/bin:$PATH"
-        mkosi --version
-        echo "PATH=$PWD/mkosi/bin:$PATH" >> "$GITHUB_ENV"
 
     - name: Install uplosi
       run: |

--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          sudo apt-get update -y
+          sudo apt-get update
           sudo apt-get install -y \
             alien \
             bubblewrap \
@@ -122,27 +122,28 @@ jobs:
             uidmap
           sudo snap install yq
 
-      - name: Install UEFI build dependencies
-        if: inputs.arch == 'amd64'
-        run: |
-          sudo apt-get update -y
-            mtools \
-            systemd-ukify
-
       - name: Read properties from versions.yaml
         run: |
           echo "MKOSI_VERSION=$(yq -e '.tools.mkosi' versions.yaml)" >> "$GITHUB_ENV"
           echo "ORAS_VERSION=$(yq -e '.tools.oras' versions.yaml)" >> "$GITHUB_ENV"
+
+      - name: Install mkosi dependencies
+        if: ${{ inputs.arch == 's390x' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap alien dnf qemu-utils uidmap
+
+      - name: Install mkosi
+        if: ${{ inputs.arch == 's390x' }}
+        run: |
+          git clone -b "${MKOSI_VERSION}" https://github.com/systemd/mkosi
+          sudo rm -f /usr/local/bin/mkosi
+          sudo ln -s "$PWD/mkosi/bin/mkosi" /usr/local/bin/mkosi
+          mkosi --version
+
       - uses: oras-project/setup-oras@v1
         with:
           version: ${{ env.ORAS_VERSION }}
-
-      - name: Setup mkosi
-        run: |
-          git clone -b "$MKOSI_VERSION" https://github.com/systemd/mkosi
-          PATH="$PWD/mkosi/bin:$PATH"
-          mkosi --version
-          echo "PATH=$PWD/mkosi/bin:$PATH" >> "$GITHUB_ENV"
 
       - name: Build binaries
         id: build_binaries

--- a/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.mkosi
+++ b/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.mkosi
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1.5.0-labs
+FROM fedora:40 AS builder
+
+ARG MKOSI_VERSION="v22"
+ARG PROFILE="debug"
+
+RUN dnf install -y \
+	bubblewrap \
+	git
+
+RUN mkdir -p /build
+WORKDIR /build
+RUN git clone -b "$MKOSI_VERSION" https://github.com/systemd/mkosi
+ENV PATH="/build/mkosi/bin:$PATH"
+RUN mkosi --version
+
+RUN mkdir /image
+WORKDIR /image
+COPY mkosi.postinst /image/mkosi.postinst
+COPY mkosi.presets /image/mkosi.presets
+COPY mkosi.profiles /image/mkosi.profiles
+COPY mkosi.skeleton /image/mkosi.skeleton
+COPY mkosi.skeleton-debug /image/mkosi.skeleton-debug
+COPY mkosi.workspace /image/mkosi.workspace
+COPY resources /image/resources
+COPY mkosi.conf /image/mkosi.conf
+RUN --security=insecure mkosi --tools-tree=default --profile=$PROFILE
+
+FROM scratch
+COPY --from=builder /image/build/system.raw /

--- a/src/cloud-api-adaptor/podvm-mkosi/Makefile
+++ b/src/cloud-api-adaptor/podvm-mkosi/Makefile
@@ -14,6 +14,7 @@ PODVM_BINARIES_IMAGE ?= $(REGISTRY)/podvm-binaries-$(PODVM_DISTRO)-$(ARCH):$(POD
 PODVM_IMAGE ?= $(REGISTRY)/podvm-generic-$(PODVM_DISTRO)$(if $(filter $(SE_BOOT),true),-se,)-$(ARCH):$(PODVM_TAG)
 PODVM_CONTAINER_NAME ?= $(REGISTRY)/podvm-docker-image-$(ARCH)
 VERIFY_PROVENANCE ?= no
+MKOSI_VERSION ?= v22
 
 .DEFAULT_GOAL := all
 .PHONY: all
@@ -58,10 +59,15 @@ endif
 		$(DOCKER_OPTS) \
 		-f ../podvm/Dockerfile.podvm_binaries.fedora ../../
 
+PHONY: insecure-builder
+insecure-builder:
+	docker buildx ls | grep "^insecure-builder" || docker buildx create \
+		--driver-opt image=moby/buildkit:master \
+		--name insecure-builder \
+		--buildkitd-flags '--allow-insecure-entitlement security.insecure'
+
 PHONY: image
-image:
-	@echo "Enabling production preset..."
-	rm -rf resources/build*Image
+image: insecure-builder
 	rm -rf ./build
 	@echo "Building image..."
 ifeq ($(SE_BOOT),true)
@@ -71,14 +77,21 @@ else ifeq ($(ARCH),s390x)
 	sudo mkosi --profile production.conf --image system
 	sudo -E ../hack/build-s390x-image.sh
 else
-	mkosi --profile production.conf
+	mkdir -p build
+	docker buildx build \
+		-f Dockerfile.mkosi \
+		-t $(PODVM_IMAGE) \
+		--build-arg PROFILE=production --build-arg MKOSI_VERSION \
+		--progress=plain \
+		-o type=local,dest=./build \
+		--builder insecure-builder \
+		--allow security.insecure \
+		.
 	qemu-img convert -f raw -O qcow2 build/system.raw build/podvm-$(PODVM_DISTRO)-$(ARCH).qcow2
 endif
 
 PHONY: image-debug
-image-debug:
-	@echo "Enabling debug preset..."
-	rm -rf resources/build*Image
+image-debug: insecure-builder
 	rm -rf ./build
 	@echo "Building debug image..."
 ifeq ($(SE_BOOT),true)
@@ -88,7 +101,16 @@ else ifeq ($(ARCH),s390x)
 	sudo mkosi --profile debug.conf
 	sudo -E ../hack/build-s390x-image.sh
 else
-	mkosi --profile debug.conf
+	mkdir -p build
+	docker buildx build \
+		-f Dockerfile.mkosi \
+		-t $(PODVM_IMAGE) \
+		--build-arg PROFILE=debug --build-arg MKOSI_VERSION \
+		--progress=plain \
+		-o type=local,dest=./build \
+		--builder insecure-builder \
+		--allow security.insecure \
+		.
 	qemu-img convert -f raw -O qcow2 build/system.raw build/podvm-$(PODVM_DISTRO)-$(ARCH).qcow2
 endif
 
@@ -119,6 +141,5 @@ push-image-container:
 
 PHONY: clean
 clean:
-	rm -rf resources/buildDebugImage
 	rm -rf ./build
 	rm -rf ./resources/binaries-tree

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/initrd/mkosi.conf.d/fedora.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/initrd/mkosi.conf.d/fedora.conf
@@ -3,7 +3,7 @@ Distribution=fedora
 
 [Distribution]
 Distribution=fedora
-Release=40
+Release=39
 
 [Content]
 CleanPackageMetadata=true

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora.conf
@@ -3,7 +3,7 @@ Distribution=fedora
 
 [Distribution]
 Distribution=fedora
-Release=40
+Release=39
 
 [Content]
 CleanPackageMetadata=true


### PR DESCRIPTION
There is a problem when running mkosi on a github ubuntu runner, the images will build successfully, but the EFI partition will not be setup in a way that libvirt can boot from it.

The packages on a generic github runner aren't really predictable, to make an mkosi build more reproducible, we can launch mkosi in a fedora container with `--tools-tree=default`.

Since this implies running a user ns within a container, we need to configure a docker buildx builder that allows this and run mkosi with a special flag in the Dockerfile.

Another problem has been introduced in f40 in recent days. With a bump from 6.12.8-100.fc40 => 6.12.9-100.fc40 in fedora40, there is a regression for peerpod, tests will not pass. We need further investigation about that, but to unblock the CI we can downgrade to fedora39, which is stuck on kernel 6.11.9-100.fc39.

Finally, there are some minor fixes to the Azure podvm build.

[Here](https://github.com/mkulke/cloud-api-adaptor/actions/runs/12809685381/job/35715029998) is a successful run w/ mkosi22 + fedora39
