### PR TITLE
gcp: add note on discard_unpacked_layers for GKE

### DIFF
--- a/src/cloud-api-adaptor/docs/troubleshooting/nydus-snapshotter.md
+++ b/src/cloud-api-adaptor/docs/troubleshooting/nydus-snapshotter.md
@@ -25,7 +25,26 @@ Sometimes when creating a pod you might encounter the following error:
 Warning  Failed     8m51s (x7 over 10m)  kubelet            Error: failed to create containerd container: error unpacking image: failed to extract layer sha256:d51af96cf93e225825efd484ea457f867cb2b967f7415b9a3b7e65a2f803838a: failed to get reader from content store: content digest sha256:ec562eabd705d25bfea8c8d79e4610775e375524af00552fe871d3338261563c: not found
 ```
 
-To resolve this, login to the worker node and explicitly fetch the image using the following command:
+If you encounter this error, first check if the `discard_unpacked_layers`
+setting is enabled in the containerd configuration. This setting removes
+compressed image layers after unpacking, which can cause issues because
+PeerPods workloads rely on those layers. To disable it, update
+`/etc/containerd/config.toml` with:
+
+```toml
+[plugins."io.containerd.grpc.v1.cri".containerd]
+  discard_unpacked_layers = false
+```
+
+Restart containerd after making the change:
+
+```bash
+sudo systemctl restart containerd
+```
+
+Alternatively, you can pre-fetch the images on the worker nodes:
+
+To do this, login to the worker node and explicitly fetch the image using the following command:
 
 ```sh
 export image=<_set_>

--- a/src/cloud-api-adaptor/gcp/README.md
+++ b/src/cloud-api-adaptor/gcp/README.md
@@ -101,6 +101,14 @@ gcloud container clusters create my-cluster \
   --num-nodes 3
 ```
 
+> [!NOTE]
+> Starting with GKE version 1.27, GCP configures containerd with the
+> `discard_unpacked_layers=true` flag to optimize disk usage by removing
+> compressed image layers after they are unpacked. However, this can cause
+> issues with PeerPods, as the workload may fail to locate required layers. To
+> avoid this, disable the `discard_unpacked_layers` setting in the containerd
+> configuration.
+
 Regardless of the method used, at the end you should have a KUBECONFIG pointing
 to the auth file and a cluster up and running:
 


### PR DESCRIPTION
GKE uses `discard_unpacked_layers=true` for optimizations, starting with version 1.27. This can cause `failed to extract layer sha256:xxx: not found` errors with PeerPods. The note explains disabling this flag in containerd to avoid issues.