### PR TITLE
podvm: Fix debug image build issue on s390x

### DIFF
--- a/src/cloud-api-adaptor/podvm-mkosi/Makefile
+++ b/src/cloud-api-adaptor/podvm-mkosi/Makefile
@@ -71,10 +71,10 @@ image: insecure-builder
 	rm -rf ./build
 	@echo "Building image..."
 ifeq ($(SE_BOOT),true)
-	sudo mkosi --profile production.conf --image system
+	sudo mkosi --profile production --image system
 	sudo -E ../hack/build-s390x-se-image.sh
 else ifeq ($(ARCH),s390x)
-	sudo mkosi --profile production.conf --image system
+	sudo mkosi --profile production --image system
 	sudo -E ../hack/build-s390x-image.sh
 else
 	mkdir -p build
@@ -95,10 +95,10 @@ image-debug: insecure-builder
 	rm -rf ./build
 	@echo "Building debug image..."
 ifeq ($(SE_BOOT),true)
-	sudo mkosi --profile debug.conf
+	sudo mkosi --profile debug
 	sudo -E ../hack/build-s390x-se-image.sh
 else ifeq ($(ARCH),s390x)
-	sudo mkosi --profile debug.conf
+	sudo mkosi --profile debug
 	sudo -E ../hack/build-s390x-image.sh
 else
 	mkdir -p build


### PR DESCRIPTION
This patch fixes the debug image build issue on s390x. 

Currently, I cannot build a debug podvm image on s390x. The following command just build a production podvm image.

```
sudo make image-debug
```

I guess this issue was revealed by this recent change.

https://github.com/confidential-containers/cloud-api-adaptor/commit/6e25be399498f9353e14cb826dba72cd877bdb89#diff-0578158244ea494f1ad5e1970ee5560d1cf6bfc62fd70243bd3a46280a237a14
