### PR TITLE
version: Pin operator version

### DIFF
--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -48,7 +48,7 @@ payload to the Kata Containers' release version, during it's release.
 Therefore in order to have the correct version of the kata-containers payload in our peer pods releases, we need to
 wait for this CoCo operator release before we can start the peer pods release process. After this operator payload
 pinning is done, we should pick the matching operator release/commit containing this and update the
-`git.coco-operator.reference` value in [versions.yaml](../src/cloud-api-adaptor/versions.yaml)
+`git.coco-operator.reference` and `git.coco-operator.config` values in [versions.yaml](../src/cloud-api-adaptor/versions.yaml)
 and create a commit for this. In order to save review cycles, this change can go in with the go module updates in
 the next section in the same PR.
 

--- a/src/cloud-api-adaptor/Makefile
+++ b/src/cloud-api-adaptor/Makefile
@@ -136,7 +136,7 @@ image-with-arch: .git-commit ## Build the per arch image
 .PHONY: deploy
 deploy: ## Deploy cloud-api-adaptor using the operator, according to install/overlays/$(CLOUD_PROVIDER)/kustomization.yaml file.
 ifneq ($(CLOUD_PROVIDER),)
-	kubectl apply -k "$(COCO_OPERATOR_REPO)/config/default?ref=$(COCO_OPERATOR_REF)"
+	kubectl apply -k "$(COCO_OPERATOR_REPO)/config/$(COCO_OPERATOR_CONFIG)?ref=$(COCO_OPERATOR_REF)"
 	kubectl apply -k "$(COCO_OPERATOR_REPO)/config/samples/ccruntime/peer-pods?ref=$(COCO_OPERATOR_REF)"
 	kubectl apply -k install/overlays/$(CLOUD_PROVIDER)
 else

--- a/src/cloud-api-adaptor/Makefile.defaults
+++ b/src/cloud-api-adaptor/Makefile.defaults
@@ -34,6 +34,7 @@ rhel_s390x_IMAGE_URL := $(call query,cloudimg.rhel.$(rhel_RELEASE).s390x.url)
 rhel_s390x_IMAGE_CHECKSUM := $(call query,cloudimg.rhel.$(rhel_RELEASE).s390x.checksum)
 
 COCO_OPERATOR_REF := $(or $(COCO_OPERATOR_REF),$(call query,git.coco-operator.reference))
+COCO_OPERATOR_CONFIG := $(or $(COCO_OPERATOR_CONFIG),$(call query,git.coco-operator.config))
 COCO_OPERATOR_REPO := $(or $(COCO_OPERATOR_REPO),$(call query,git.coco-operator.url))
 KATA_REGISTRY := $(or $(KATA_REGISTRY), $(call query,oci.kata-containers.registry))
 KATA_REF := $(or $(KATA_REF), $(call query,oci.kata-containers.reference))

--- a/src/cloud-api-adaptor/test/provisioner/provision.go
+++ b/src/cloud-api-adaptor/test/provisioner/provision.go
@@ -49,6 +49,7 @@ type CloudAPIAdaptor struct {
 	caaDaemonSet         *appsv1.DaemonSet    // Represents the cloud-api-adaptor daemonset
 	ccDaemonSet          *appsv1.DaemonSet    // Represents the CoCo installer daemonset
 	ccOpGitRepo          string               // CoCo operator's repository URL
+	ccOpConfig           string               // CoCo operator's config to use: default or release
 	ccOpGitRef           string               // CoCo operator's repository reference
 	cloudProvider        string               // Cloud provider
 	controllerDeployment *appsv1.Deployment   // Represents the controller manager deployment
@@ -98,6 +99,7 @@ func NewCloudAPIAdaptor(provider string, installDir string) (*CloudAPIAdaptor, e
 		caaDaemonSet:         &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "cloud-api-adaptor-daemonset", Namespace: namespace}},
 		ccDaemonSet:          &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "cc-operator-daemon-install", Namespace: namespace}},
 		ccOpGitRepo:          ccOperator.Url,
+		ccOpConfig:           ccOperator.Config,
 		ccOpGitRef:           ccOperator.Ref,
 		cloudProvider:        provider,
 		controllerDeployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "cc-operator-controller-manager", Namespace: namespace}},
@@ -186,7 +188,7 @@ func (p *CloudAPIAdaptor) Delete(ctx context.Context, cfg *envconf.Config) error
 	deployments := &appsv1.DeploymentList{Items: []appsv1.Deployment{*p.controllerDeployment}}
 
 	log.Info("Uninstall the controller manager")
-	cmd = exec.Command("kubectl", "delete", "-k", p.ccOpGitRepo+"/operator/config/default?ref="+p.ccOpGitRef)
+	cmd = exec.Command("kubectl", "delete", "-k", p.ccOpGitRepo+"/operator/config/"+p.ccOpConfig+"?ref="+p.ccOpGitRef)
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+cfg.KubeconfigFile())
 	stdoutStderr, err = cmd.CombinedOutput()
 	log.Tracef("%v, output: %s", cmd, stdoutStderr)
@@ -234,7 +236,7 @@ func (p *CloudAPIAdaptor) Deploy(ctx context.Context, cfg *envconf.Config, props
 
 	log.Info("Install the controller manager")
 	// TODO - find go idiomatic way to apply/delete remote kustomize and apply to this file
-	cmd := exec.Command("kubectl", "apply", "-k", p.ccOpGitRepo+"/config/default?ref="+p.ccOpGitRef)
+	cmd := exec.Command("kubectl", "apply", "-k", p.ccOpGitRepo+"/config/"+p.ccOpConfig+"?ref="+p.ccOpGitRef)
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+cfg.KubeconfigFile())
 	stdoutStderr, err := cmd.CombinedOutput()
 	log.Tracef("%v, output: %s", cmd, stdoutStderr)

--- a/src/cloud-api-adaptor/test/utils/versions.go
+++ b/src/cloud-api-adaptor/test/utils/versions.go
@@ -15,8 +15,9 @@ const VersionsFile = "../../versions.yaml"
 // Versions represents the project's versions.yaml
 type Versions struct {
 	Git map[string]struct {
-		Url string `yaml:"url"`
-		Ref string `yaml:"reference"`
+		Url    string `yaml:"url"`
+		Ref    string `yaml:"reference"`
+		Config string `yaml:"config"`
 	}
 }
 

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -34,6 +34,7 @@ tools:
 git:
   coco-operator:
     url: https://github.com/confidential-containers/operator
+    config: default
     reference: main
   umoci:
     url: https://github.com/opencontainers/umoci

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -34,8 +34,8 @@ tools:
 git:
   coco-operator:
     url: https://github.com/confidential-containers/operator
-    config: default
-    reference: main
+    config: release
+    reference: v0.12.0
   umoci:
     url: https://github.com/opencontainers/umoci
     reference: v0.4.7


### PR DESCRIPTION
Pin the operator version to v0.12.0 to ensure that people deploying this release get a fixed and compatible version of the kata runtime deployed.