### PR TITLE
workflow: Downgrade github runner

### DIFF
--- a/.github/workflows/caa_build_and_push_per_arch.yaml
+++ b/.github/workflows/caa_build_and_push_per_arch.yaml
@@ -30,7 +30,7 @@ defaults:
 
 jobs:
   upload_tags:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
   build_push_job:
     name: build and push
     needs: [upload_tags]
-    runs-on: ${{ matrix.type == 'dev-s390x' && 's390x' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.type == 'dev-s390x' && 's390x' || 'ubuntu-22.04' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/peerpod-ctrl_image.yaml
+++ b/.github/workflows/peerpod-ctrl_image.yaml
@@ -26,7 +26,7 @@ on:
 jobs:
   peerpod_push:
     name: build and push peerpod-ctrl
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: src/peerpod-ctrl


### PR DESCRIPTION
Due to an
[issue](https://github.com/actions/runner-images/issues/11471) with Ubuntu 24.04 20250120.5.0 runner image
we have been seeing failures in our multi-arch images for the last few days which is blocking the release. I assume that the issue is something related to qemu, so downgrade to 22.04 until this issue is resolved.