### PR TITLE
podvm: Add --pull option to import.sh and download-image.sh

### DIFF
--- a/src/cloud-api-adaptor/ibmcloud/image/import.sh
+++ b/src/cloud-api-adaptor/ibmcloud/image/import.sh
@@ -12,7 +12,7 @@ error(){
 script_dir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 
 function usage() {
-    echo "Usage: $0 <docker-image/qcow2-file> <vpc-region> [--bucket <name> --region <cos-region> --instance <cos-instance> --endpoint <cos-endpoint> --api <cloud-endpoint> --os <operating-system>]"
+    echo "Usage: $0 <docker-image/qcow2-file> <vpc-region> [--bucket <name> --region <cos-region> --instance <cos-instance> --endpoint <cos-endpoint> --api <cloud-endpoint> --os <operating-system> --pull always(default)|missing|never]"
 }
 
 image_file=$1
@@ -24,6 +24,7 @@ endpoint=
 api=${IBMCLOUD_API_ENDPOINT-https://cloud.ibm.com}
 platform=
 operating_system=
+pull=always
 
 shift 2
 while (( "$#" )); do
@@ -35,6 +36,7 @@ while (( "$#" )); do
         --os) operating_system=$2 ;;
         --api) api=$2 ;;
         --platform) platform=$2 ;;
+        --pull) pull=$2 ;;
         --help) usage; exit 0 ;;
         *)      usage 1>&2; exit 1;;
     esac
@@ -79,7 +81,7 @@ if [ -f ${image_file} ]; then
 else
     # Download image
     echo "Downloading file from image ${image_file}"
-    file=$($script_dir/../../podvm/hack/download-image.sh ${image_file} . --platform "${platform}") || error "Unable to download ${image_file}"
+    file=$($script_dir/../../podvm/hack/download-image.sh ${image_file} . --platform "${platform}" --pull "${pull}") || error "Unable to download ${image_file}"
 fi
 
 echo "Uploading file ${file}"

--- a/src/cloud-api-adaptor/podvm/hack/download-image.sh
+++ b/src/cloud-api-adaptor/podvm/hack/download-image.sh
@@ -3,7 +3,7 @@
 # takes an image reference and a directory and
 # extracts the qcow image into that directory
 function usage() {
-    echo "Usage: $0 <image> <directory> [-o <name>] [-p <platform>] [--clean-up]"
+    echo "Usage: $0 <image> <directory> [-o <name>] [-p <platform>] [--pull always(default)|missing|never] [--clean-up]"
 }
 
 function error() {
@@ -15,6 +15,7 @@ directory=$2
 output=
 platform=
 clean_up_image=
+pull=always
 
 shift 2
 while (( "$#" )); do
@@ -23,6 +24,7 @@ while (( "$#" )); do
         --output) output=$2 ;;
         -p) platform=$2 ;;
         --platform) platform=$2 ;;
+        --pull) pull=$2 ;;
         --clean-up) clean_up_image="yes"; shift 1 ;;
         --help) usage; exit 0 ;;
         *)      usage 1>&2; exit 1;;
@@ -54,7 +56,7 @@ elif [[ "${image}" == *"podvm-generic-ubuntu-s390x"* ]]; then
 fi
 
 # Create a non-running container to extract image
-$container_binary create --pull=always ${platform_flag} --name "$container_name" "$image" /bin/sh >/dev/null 2>&1;
+$container_binary create --pull=${pull} ${platform_flag} --name "$container_name" "$image" /bin/sh >/dev/null 2>&1;
 # Destory container after use
 rm-container(){
     $container_binary rm -f "$container_name" >/dev/null 2>&1;


### PR DESCRIPTION
Currently, download-image.sh uses pull=always when it creates the container for the specified docker image, which fails if the image version is not available in the remote registry. Adding a pull option will allow users to import a docker image that is only available locally by specifying --pull=never.