### PR TITLE
ci: add delay on podvm smoke-test

### DIFF
--- a/.github/workflows/podvm_smoketest.yaml
+++ b/.github/workflows/podvm_smoketest.yaml
@@ -146,15 +146,21 @@ jobs:
             fi
             echo "sleeping for ${n} seconds"
             sleep "$n"
-            VM_IP="$(sudo virsh -q domifaddr smoketest | awk '{print $4}' | cut -d/ -f1)"
-            if [ -n "$VM_IP" ]; then
+            vm_ip="$(sudo virsh -q domifaddr smoketest | awk '{print $4}' | cut -d/ -f1)"
+            if [ -n "$vm_ip" ]; then
               break
             fi
           done
-          echo "VM_IP=$VM_IP" >> "$GITHUB_ENV"
+          echo "VM_IP=$vm_ip" >> "$GITHUB_ENV"
 
       - name: Run smoke test
         run: |
-          socat UNIX-LISTEN:./apf.sock,fork "TCP:${VM_IP}:15150" &
-          sleep 1
-          kata-agent-ctl connect --server-address unix://./apf.sock --cmd CreateSandbox
+          host_port="${VM_IP}:15150"
+          sock="./agent.sock"
+          echo "bridge ${host_port} to ${sock}"
+          socat "UNIX-LISTEN:${sock},fork" "TCP:${host_port}" &
+          echo "sleeping for 5 seconds"
+          sleep 5
+          kata-agent-ctl connect \
+            --server-address "unix://${sock}" \
+            --cmd CreateSandbox


### PR DESCRIPTION
1s delay between claiming an IP address and launching kata-agent is not enough in some cases, resulting in a flaky test.

Changing the delay before attempting to connect to the agent to 5s seems to resolve the issue. Running the test in a loop with 25+ launches didn't produce a failure, while doing the same with the original 1s delay, will result in "connection refused" failure after a couple of runs.