### PR TITLE
docker: Use iptables-wrapper in pod VM container image

### DIFF
--- a/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.podvm_docker_provider
+++ b/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.podvm_docker_provider
@@ -1,12 +1,21 @@
 # Adapted from https://github.com/kubernetes-sigs/kind/blob/main/images/base/Dockerfile
 
 ARG BASE_IMAGE=registry.fedoraproject.org/fedora:40
+
+FROM $BASE_IMAGE AS iptables
+
+RUN echo "Building iptables-wrapper... " \
+    && dnf install -y git golang \
+    && git clone https://github.com/kubernetes-sigs/iptables-wrappers.git /iptables \
+    && cd /iptables \
+    && make BIN_DIR=. build
+
 FROM $BASE_IMAGE AS base
 
 RUN echo "Installing Packages ..." \
     && dnf install -y \
       systemd \
-      conntrack iptables nftables iproute ethtool util-linux kmod \
+      conntrack iptables iptables-legacy iptables-nft nftables iproute ethtool util-linux kmod \
       libseccomp pigz fuse-overlayfs \
       nfs-utils which systemd-pam \
       bash ca-certificates curl jq procps \
@@ -22,6 +31,8 @@ RUN echo "Enabling / Disabling services ... " \
     && systemctl mask systemd-binfmt.service \
     && systemctl enable systemd-logind dbus.socket
 
+RUN --mount=type=cache,target=/iptables,from=iptables,source=/iptables,readonly \
+    cd /iptables && ./iptables-wrapper-installer.sh --no-sanity-check --no-cleanup
 
 # Add podvm resources
 COPY ./resources/binaries-tree/etc/ /etc/

--- a/src/cloud-providers/docker/provider.go
+++ b/src/cloud-providers/docker/provider.go
@@ -86,6 +86,10 @@ func (p *dockerProvider) CreateInstance(ctx context.Context, podName, sandboxID 
 	volumeBinding = append(volumeBinding, fmt.Sprintf("%s:%s",
 		filepath.Join(p.DataDir, "kata-containers"), "/run/kata-containers"))
 
+	// Add host bind mounts required by iptables
+	volumeBinding = append(volumeBinding, fmt.Sprintf("%s:%s", "/lib/modules", "/lib/modules"))
+	volumeBinding = append(volumeBinding, fmt.Sprintf("%s:%s", "/run/xtables.lock", "/run/xtables.lock"))
+
 	if spec.Image != "" {
 		logger.Printf("Choosing %s from annotation as the docker image for the PodVM image", spec.Image)
 		p.PodVMDockerImage = spec.Image


### PR DESCRIPTION
Pod VM containers launched by Docker provider fail to start with the following error at least on my environment.
```
Feb 04 06:21:30 908cee3eddf7 agent-protocol-forwarder[208]: /usr/local/bin/agent-protocol-forwarder: error running a service *forwarder.daemon: failed to set up pod network: failed to set up tunnel "vxlan": failed to check the existence of iptables chain "peerpod-OUTPUT": running [/usr/sbin/iptables -t raw -S peerpod-OUTPUT 1 --wait]: exit status 3: modprobe: FATAL: Module ip_tables not found in directory /lib/modules/5.14.0-503.22.1.el9_5.x86_64
Feb 04 06:21:30 908cee3eddf7 agent-protocol-forwarder[208]: iptables v1.8.10 (legacy): can't initialize iptables table `raw': Table does not exist (do you need to insmod?)
```

This PR fixes this problem by using [iptables wrapper](https://github.com/kubernetes-sigs/iptables-wrappers)

iptables wrapper is already used in Cloud API Adaptor daemon set (https://github.com/confidential-containers/cloud-api-adaptor/pull/2016)
