### PR TITLE
workflow: Add test_e2e_docker trigger

### DIFF
--- a/.github/workflows/e2e_on_pull.yaml
+++ b/.github/workflows/e2e_on_pull.yaml
@@ -16,8 +16,8 @@ on:
   # triggering this workflow).
   pull_request_target:
     types:
-      # This workflow will be run if the pull request is labeled test_e2e_libvirt, so
-      # adding 'labeled' to the list of activity types.
+      # This workflow will be run if the pull request is labeled test_e2e_libvirt, or
+      # test_e2e_docker, so adding 'labeled' to the list of activity types.
       #
       - opened
       - synchronize
@@ -33,7 +33,9 @@ concurrency:
 jobs:
   authorize:
     runs-on: ubuntu-24.04
-    if: contains(github.event.pull_request.labels.*.name, 'test_e2e_libvirt')
+    if: |
+     contains(github.event.pull_request.labels.*.name, 'test_e2e_libvirt') ||
+     contains(github.event.pull_request.labels.*.name, 'test_e2e_docker')
     steps:
       - run: "true"
   e2e:


### PR DESCRIPTION
Currently the e2e tests only are authorised if they contain `test_e2e_libvirt`, but now we have the docker provider tests we might want to trigger them in isolation too.