### PR TITLE
gcp: allow users to set podvm disk-type and align CLI options

### DIFF
--- a/src/cloud-api-adaptor/entrypoint.sh
+++ b/src/cloud-api-adaptor/entrypoint.sh
@@ -98,7 +98,7 @@ gcp() {
     [[ "${GCP_PROJECT_ID}" ]] && optionals+="-gcp-project-id ${GCP_PROJECT_ID} "
     [[ "${GCP_ZONE}" ]] && optionals+="-gcp-zone ${GCP_ZONE} "                         # if not set retrieved from IMDS
     [[ "${GCP_MACHINE_TYPE}" ]] && optionals+="-machine-type ${GCP_MACHINE_TYPE} "     # default e2-medium
-    [[ "${GCP_NETWORK}" ]] && optionals+="-gcp-network ${GCP_NETWORK} "                # defaults to 'default'
+    [[ "${GCP_NETWORK}" ]] && optionals+="-network ${GCP_NETWORK} "                # defaults to 'default'
 
     set -x
     exec cloud-api-adaptor gcp \

--- a/src/cloud-api-adaptor/entrypoint.sh
+++ b/src/cloud-api-adaptor/entrypoint.sh
@@ -96,7 +96,7 @@ gcp() {
 
     [[ "${PODVM_IMAGE_NAME}" ]] && optionals+="-image-name ${PODVM_IMAGE_NAME} "
     [[ "${GCP_PROJECT_ID}" ]] && optionals+="-gcp-project-id ${GCP_PROJECT_ID} "
-    [[ "${GCP_ZONE}" ]] && optionals+="-gcp-zone ${GCP_ZONE} "                         # if not set retrieved from IMDS
+    [[ "${GCP_ZONE}" ]] && optionals+="-zone ${GCP_ZONE} "                         # if not set retrieved from IMDS
     [[ "${GCP_MACHINE_TYPE}" ]] && optionals+="-machine-type ${GCP_MACHINE_TYPE} "     # default e2-medium
     [[ "${GCP_NETWORK}" ]] && optionals+="-network ${GCP_NETWORK} "                # defaults to 'default'
 

--- a/src/cloud-api-adaptor/entrypoint.sh
+++ b/src/cloud-api-adaptor/entrypoint.sh
@@ -99,6 +99,7 @@ gcp() {
     [[ "${GCP_ZONE}" ]] && optionals+="-zone ${GCP_ZONE} "                         # if not set retrieved from IMDS
     [[ "${GCP_MACHINE_TYPE}" ]] && optionals+="-machine-type ${GCP_MACHINE_TYPE} "     # default e2-medium
     [[ "${GCP_NETWORK}" ]] && optionals+="-network ${GCP_NETWORK} "                # defaults to 'default'
+    [[ "${GCP_DISK_TYPE}" ]] && optionals+="-disk-type ${GCP_DISK_TYPE} "              # defaults to 'pd-standard'
 
     set -x
     exec cloud-api-adaptor gcp \

--- a/src/cloud-api-adaptor/entrypoint.sh
+++ b/src/cloud-api-adaptor/entrypoint.sh
@@ -94,7 +94,7 @@ azure() {
 gcp() {
     test_vars GCP_CREDENTIALS GCP_PROJECT_ID GCP_ZONE PODVM_IMAGE_NAME
 
-    [[ "${PODVM_IMAGE_NAME}" ]] && optionals+="-gcp-image-name ${PODVM_IMAGE_NAME} "
+    [[ "${PODVM_IMAGE_NAME}" ]] && optionals+="-image-name ${PODVM_IMAGE_NAME} "
     [[ "${GCP_PROJECT_ID}" ]] && optionals+="-gcp-project-id ${GCP_PROJECT_ID} "
     [[ "${GCP_ZONE}" ]] && optionals+="-gcp-zone ${GCP_ZONE} "                         # if not set retrieved from IMDS
     [[ "${GCP_MACHINE_TYPE}" ]] && optionals+="-gcp-machine-type ${GCP_MACHINE_TYPE} " # default e2-medium

--- a/src/cloud-api-adaptor/entrypoint.sh
+++ b/src/cloud-api-adaptor/entrypoint.sh
@@ -97,7 +97,7 @@ gcp() {
     [[ "${PODVM_IMAGE_NAME}" ]] && optionals+="-image-name ${PODVM_IMAGE_NAME} "
     [[ "${GCP_PROJECT_ID}" ]] && optionals+="-gcp-project-id ${GCP_PROJECT_ID} "
     [[ "${GCP_ZONE}" ]] && optionals+="-gcp-zone ${GCP_ZONE} "                         # if not set retrieved from IMDS
-    [[ "${GCP_MACHINE_TYPE}" ]] && optionals+="-gcp-machine-type ${GCP_MACHINE_TYPE} " # default e2-medium
+    [[ "${GCP_MACHINE_TYPE}" ]] && optionals+="-machine-type ${GCP_MACHINE_TYPE} "     # default e2-medium
     [[ "${GCP_NETWORK}" ]] && optionals+="-gcp-network ${GCP_NETWORK} "                # defaults to 'default'
 
     set -x

--- a/src/cloud-providers/gcp/manager.go
+++ b/src/cloud-providers/gcp/manager.go
@@ -22,7 +22,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	flags.StringVar(&gcpcfg.GcpCredentials, "gcp-credentials", "", "Google Application Credentials, defaults to `GCP_CREDENTIALS`")
 	flags.StringVar(&gcpcfg.ProjectId, "gcp-project-id", "", "GCP Project ID")
 	flags.StringVar(&gcpcfg.Zone, "gcp-zone", "", "Zone")
-	flags.StringVar(&gcpcfg.ImageName, "gcp-image-name", "", "Pod VM image name")
+	flags.StringVar(&gcpcfg.ImageName, "image-name", "", "Pod VM image name")
 	flags.StringVar(&gcpcfg.MachineType, "gcp-machine-type", "e2-medium", "Pod VM instance type")
 	flags.StringVar(&gcpcfg.Network, "gcp-network", "", "Network ID to be used for the Pod VMs")
 }

--- a/src/cloud-providers/gcp/manager.go
+++ b/src/cloud-providers/gcp/manager.go
@@ -24,7 +24,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	flags.StringVar(&gcpcfg.Zone, "gcp-zone", "", "Zone")
 	flags.StringVar(&gcpcfg.ImageName, "image-name", "", "Pod VM image name")
 	flags.StringVar(&gcpcfg.MachineType, "machine-type", "e2-medium", "Pod VM instance type")
-	flags.StringVar(&gcpcfg.Network, "gcp-network", "", "Network ID to be used for the Pod VMs")
+	flags.StringVar(&gcpcfg.Network, "network", "", "Network ID to be used for the Pod VMs")
 }
 
 func (_ *Manager) LoadEnv() {

--- a/src/cloud-providers/gcp/manager.go
+++ b/src/cloud-providers/gcp/manager.go
@@ -21,7 +21,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 
 	flags.StringVar(&gcpcfg.GcpCredentials, "gcp-credentials", "", "Google Application Credentials, defaults to `GCP_CREDENTIALS`")
 	flags.StringVar(&gcpcfg.ProjectId, "gcp-project-id", "", "GCP Project ID")
-	flags.StringVar(&gcpcfg.Zone, "gcp-zone", "", "Zone")
+	flags.StringVar(&gcpcfg.Zone, "zone", "", "Zone")
 	flags.StringVar(&gcpcfg.ImageName, "image-name", "", "Pod VM image name")
 	flags.StringVar(&gcpcfg.MachineType, "machine-type", "e2-medium", "Pod VM instance type")
 	flags.StringVar(&gcpcfg.Network, "network", "", "Network ID to be used for the Pod VMs")

--- a/src/cloud-providers/gcp/manager.go
+++ b/src/cloud-providers/gcp/manager.go
@@ -25,6 +25,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	flags.StringVar(&gcpcfg.ImageName, "image-name", "", "Pod VM image name")
 	flags.StringVar(&gcpcfg.MachineType, "machine-type", "e2-medium", "Pod VM instance type")
 	flags.StringVar(&gcpcfg.Network, "network", "", "Network ID to be used for the Pod VMs")
+	flags.StringVar(&gcpcfg.DiskType, "disk-type", "pd-standard", "Any GCP disk type (pd-standard, pd-ssd, pd-balanced or pd-extreme)")
 }
 
 func (_ *Manager) LoadEnv() {

--- a/src/cloud-providers/gcp/manager.go
+++ b/src/cloud-providers/gcp/manager.go
@@ -23,7 +23,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	flags.StringVar(&gcpcfg.ProjectId, "gcp-project-id", "", "GCP Project ID")
 	flags.StringVar(&gcpcfg.Zone, "gcp-zone", "", "Zone")
 	flags.StringVar(&gcpcfg.ImageName, "image-name", "", "Pod VM image name")
-	flags.StringVar(&gcpcfg.MachineType, "gcp-machine-type", "e2-medium", "Pod VM instance type")
+	flags.StringVar(&gcpcfg.MachineType, "machine-type", "e2-medium", "Pod VM instance type")
 	flags.StringVar(&gcpcfg.Network, "gcp-network", "", "Network ID to be used for the Pod VMs")
 }
 

--- a/src/cloud-providers/gcp/provider.go
+++ b/src/cloud-providers/gcp/provider.go
@@ -107,7 +107,7 @@ func (p *gcpProvider) CreateInstance(ctx context.Context, podName, sandboxID str
 					InitializeParams: &computepb.AttachedDiskInitializeParams{
 						DiskSizeGb:  proto.Int64(20),
 						SourceImage: srcImage,
-						DiskType:    proto.String(fmt.Sprintf("zones/%s/diskTypes/pd-standard", p.serviceConfig.Zone)),
+						DiskType:    proto.String(fmt.Sprintf("zones/%s/diskTypes/%s", p.serviceConfig.Zone, p.serviceConfig.DiskType)),
 					},
 					AutoDelete: proto.Bool(true),
 					Boot:       proto.Bool(true),

--- a/src/cloud-providers/gcp/types.go
+++ b/src/cloud-providers/gcp/types.go
@@ -14,6 +14,7 @@ type Config struct {
 	ImageName      string
 	MachineType    string
 	Network        string
+	DiskType       string
 }
 
 func (c Config) Redact() Config {


### PR DESCRIPTION
This PR allows users to set the PodVM disk type for GCP instead of using the hardcoded pd-standard.

Also cleaned up some CLI options to be more consistent across providers, by dropping extra gcp- prefix.