### PR TITLE
versions: Bump golang-fedora image version

### DIFF
--- a/src/cloud-api-adaptor/Dockerfile
+++ b/src/cloud-api-adaptor/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILD_TYPE=dev
-ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.22.11-40
+ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.22.12-40
 ARG BASE=registry.fedoraproject.org/fedora:40
 
 # This dockerfile uses Go cross-compilation to build the binary,

--- a/src/cloud-api-adaptor/docs/addnewprovider.md
+++ b/src/cloud-api-adaptor/docs/addnewprovider.md
@@ -24,7 +24,7 @@ Create an `init` function to add your manager to the cloud provider table.
 
 ```go
 func init() {
-	cloud.AddCloud("aws", &Manager{})
+ cloud.AddCloud("aws", &Manager{})
 }
 ```
 
@@ -34,9 +34,9 @@ func init() {
 
 The Provider interface defines a set of methods that need to be implemented by the cloud provider for managing virtual instances. Add the required methods:
 
- - CreateInstance
- - DeleteInstance
- - Teardown
+- CreateInstance
+- DeleteInstance
+- Teardown
 
 :information_source:[Example code](../../cloud-providers/aws/provider.go)
 
@@ -51,6 +51,7 @@ To include your provider you need reference it from the main package. Go build t
 ```go
 //go:build aws
 ```
+
 Note the comment at the top of the file, when building ensure `-tags=` is set to include your new provider. See the [Makefile](../../cloud-api-adaptor/Makefile#L26) for more context and usage.
 
 ### Step 2.4 Add code to receive user-data on the Pod VM image
@@ -65,8 +66,8 @@ For using the provider, a pod VM image needs to be created in order to create th
 
 For more information, please refer to the section on [adding support for a new cloud provider](../test/e2e/README.md#adding-support-for-a-new-cloud-provider) in the E2E testing documentation.
 
-
 # :memo: Adding support for a new external provider
+
 External plugins are loaded dynamically and you don't need to recompile `cloud-api-adaptor` and `peerpod-ctrl` for adding external plugins.
 
 The following section describes building and using an external `libvirt` plugin.
@@ -86,41 +87,43 @@ cat > manager.go <<EOF
 package main
 
 import (
-	"flag"
+ "flag"
 
-	providers "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers"
-	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers/libvirt"
+ providers "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers"
+ "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers/libvirt"
 )
 
 type Manager struct {
-	libvirtManager *libvirt.Manager
+ libvirtManager *libvirt.Manager
 }
 
 func init() {
-	libvirtManager := &libvirt.Manager{}
-	manager := &Manager{
-		libvirtManager: libvirtManager,
-	}
-	providers.AddCloudProvider("libvirt", manager)
+ libvirtManager := &libvirt.Manager{}
+ manager := &Manager{
+  libvirtManager: libvirtManager,
+ }
+ providers.AddCloudProvider("libvirt", manager)
 }
 
 func (m *Manager) ParseCmd(flags *flag.FlagSet) {
-	m.libvirtManager.ParseCmd(flags)
+ m.libvirtManager.ParseCmd(flags)
 }
 
 func (m *Manager) LoadEnv() {
 
-	m.libvirtManager.LoadEnv()
+ m.libvirtManager.LoadEnv()
 }
 
 func (m *Manager) NewProvider() (providers.Provider, error) {
-	return NewProvider(m.libvirtManager.GetConfig())
+ return NewProvider(m.libvirtManager.GetConfig())
 }
 EOF
 ```
+
 > **Note:** The the package name must be "main" for external plugin, all other required methods are same as built-in plugin.
 
 ### Step 2: Add provider specific code
+
 ```bash
 cat > provider.go <<EOF
 //go:build cgo
@@ -128,72 +131,73 @@ cat > provider.go <<EOF
 package main
 
 import (
-	"context"
-	"fmt"
-	"log"
+ "context"
+ "fmt"
+ "log"
 
-	providers "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers"
-	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers/libvirt"
-	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers/util/cloudinit"
+ providers "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers"
+ "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers/libvirt"
+ "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers/util/cloudinit"
 )
 
 var logger = log.New(log.Writer(), "[adaptor/cloud/libvirt] ", log.LstdFlags|log.Lmsgprefix)
 
 type libvirtext struct {
-	libvirtProvider providers.Provider
-	serviceConfig   *libvirt.Config
+ libvirtProvider providers.Provider
+ serviceConfig   *libvirt.Config
 }
 
 func NewProvider(config *libvirt.Config) (providers.Provider, error) {
 
-	libvirtProvider, err := libvirt.NewProvider(config)
+ libvirtProvider, err := libvirt.NewProvider(config)
 
-	if err != nil {
-		return nil, err
-	}
+ if err != nil {
+  return nil, err
+ }
 
-	provider := &libvirtext{
-		libvirtProvider: libvirtProvider,
-		serviceConfig:   config,
-	}
+ provider := &libvirtext{
+  libvirtProvider: libvirtProvider,
+  serviceConfig:   config,
+ }
 
-	return provider, nil
+ return provider, nil
 }
 
 func (p *libvirtext) CreateInstance(ctx context.Context, podName, sandboxID string, cloudConfig cloudinit.CloudConfigGenerator, spec providers.InstanceTypeSpec) (*providers.Instance, error) {
-	cloudInitCloudConfigData, ok := cloudConfig.(*cloudinit.CloudConfig)
-	// Debug print cloudInitCloudConfigData
-	if !ok {
-		return nil, fmt.Errorf("User Data generator did not use the cloud-init Cloud Config data format")
-	}
-	userData, err := cloudInitCloudConfigData.Generate()
-	if err != nil {
-		return nil, err
-	}
-	logger.Printf("===CreateInstance: userData from libvirt: %s", userData)
+ cloudInitCloudConfigData, ok := cloudConfig.(*cloudinit.CloudConfig)
+ // Debug print cloudInitCloudConfigData
+ if !ok {
+  return nil, fmt.Errorf("User Data generator did not use the cloud-init Cloud Config data format")
+ }
+ userData, err := cloudInitCloudConfigData.Generate()
+ if err != nil {
+  return nil, err
+ }
+ logger.Printf("===CreateInstance: userData from libvirt: %s", userData)
 
-	return p.libvirtProvider.CreateInstance(ctx, podName, sandboxID, cloudConfig, spec)
+ return p.libvirtProvider.CreateInstance(ctx, podName, sandboxID, cloudConfig, spec)
 }
 
 func (p *libvirtext) DeleteInstance(ctx context.Context, instanceID string) error {
-	return p.libvirtProvider.DeleteInstance(ctx, instanceID)
+ return p.libvirtProvider.DeleteInstance(ctx, instanceID)
 }
 
 func (p *libvirtext) Teardown() error {
-	return nil
+ return nil
 }
 
 func (p *libvirtext) ConfigVerifier() error {
-	VolName := p.serviceConfig.VolName
-	if len(VolName) == 0 {
-		return fmt.Errorf("VolName is empty")
-	}
-	return nil
+ VolName := p.serviceConfig.VolName
+ if len(VolName) == 0 {
+  return fmt.Errorf("VolName is empty")
+ }
+ return nil
 }
 EOF
 ```
 
 ### Step 3: Prepare the go.mod and go.sum
+
 ```bash
 cat > go.mod <<EOF
 module github.com/confidential-containers/cloud-api-adaptor/src/libvirt
@@ -210,9 +214,10 @@ go mod tidy
 ```
 
 ### Step 4: build the external cloud provider plugin file via docker
+
 ```bash
 cat > Dockerfile <<EOF
-ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.22.11-40
+ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.22.12-40
 FROM --platform="\$TARGETPLATFORM" \$BUILDER_BASE AS builder
 RUN dnf install -y libvirt-devel && dnf clean all
 WORKDIR /work
@@ -227,12 +232,13 @@ COPY --from=builder /work/libvirt/libvirt.so /libvirt.so
 EOF
 
 cd ../ && docker buildx build --platform "linux/amd64" \
-	-t quay.io/confidential-containers/libvirt \
-	-f libvirt/Dockerfile \
-	-o type=local,dest="./libvirt/build" \
-	.
+ -t quay.io/confidential-containers/libvirt \
+ -f libvirt/Dockerfile \
+ -o type=local,dest="./libvirt/build" \
+ .
 cd ../
 ```
+
 > **Note:** the external cloud provider plugin need to be built using the same golang and package versions that was used to build cloud-api-adaptor.
 
 The built out external plugin file is "src/libvirt/build/libvirt.so"
@@ -240,12 +246,16 @@ The built out external plugin file is "src/libvirt/build/libvirt.so"
 ### Step 5: Prepare the test libvirt peerpod env by following this [document](../libvirt/README.md)
 
 ### Step 6: Update the "peer-pods-cm" configmap to enable cloud provider external `libvirt` plugin
+
 - Calculate the SHA256 checksum of the built external plugin
+
 ```bash
 sha256sum src/libvirt/build/libvirt.so
 60e5cdbcb910c6331c796ce66dfa32e50bf083689ffdf18ee136d91a9da5ddab src/libvirt/build/libvirt.so
 ```
+
 - Update "peer-pods-cm" configmap
+
 ```bash
 kubectl edit cm peer-pods-cm -n confidential-containers-system
 ...
@@ -255,15 +265,20 @@ kubectl edit cm peer-pods-cm -n confidential-containers-system
   CLOUD_PROVIDER_EXTERNAL_PLUGIN_PATH: /cloud-providers/libvirt.so
 ...
 ```
+
 > **Note:** CLOUD_PROVIDER_EXTERNAL_PLUGIN_HASH is sha256sum of the built out external cloud provider plugin
 
 ### Step 7: Actions on the worker node
+
 - Copy the external plugin file to worker node `/opt/cloud-api-adaptor/plugins` folder
+
 ```bash
 ssh root@worker-ip 'mkdir -p /opt/cloud-api-adaptor/plugins && chmod +x /opt/cloud-api-adaptor/plugins'
 scp src/libvirt/build/libvirt.so root@worker-ip:/opt/cloud-api-adaptor/plugins
 ```
+
 - Prepare `entrypoint.sh` for the external `libvirt` plugin
+
 ```bash
 cat <<'EOF' > src/libvirt/build/entrypoint.sh
 #!/bin/bash
@@ -323,9 +338,9 @@ libvirt() {
 help_msg() {
     cat <<'HELP_EOF'
 Usage:
-	CLOUD_PROVIDER=libvirt $0
+ CLOUD_PROVIDER=libvirt $0
 or
-	$0 libvirt
+ $0 libvirt
 in addition all cloud provider specific env variables must be set and valid
 (CLOUD_PROVIDER is currently set to "$CLOUD_PROVIDER")
 HELP_EOF
@@ -339,23 +354,32 @@ fi
 EOF
 chmod +x src/libvirt/build/entrypoint.sh
 ```
--  Copy the external plugin file to worker node `/opt/cloud-api-adaptor/plugins` folder
+
+- Copy the external plugin file to worker node `/opt/cloud-api-adaptor/plugins` folder
+
 ```bash
 scp src/libvirt/build/entrypoint.sh root@worker-ip:/opt/cloud-api-adaptor/plugins
 ```
+
 ### Step 8: Update cloud-api-adaptor damonset to use the external `libvirt` plugin
+
 - Run the `kubectl edit` command to update cloud-api-adaptor damonset
+
 ```bash
 kubectl edit ds cloud-api-adaptor-daemonset -n confidential-containers-system
 ```
+
 - Overwrite the command
+
 ```yaml
     spec:
       containers:
       - command:
         - /cloud-providers/entrypoint.sh
 ```
+
 - Mount `/opt/cloud-api-adaptor/plugins/` from worker node to the `cloud-api-adaptor-con` container
+
 ```yaml
 ...
         volumeMounts:
@@ -369,12 +393,17 @@ kubectl edit ds cloud-api-adaptor-daemonset -n confidential-containers-system
         name: provider-dir
 ...
 ```
+
 ### Step 9: Update peerpod-ctrl deployment to use the external `libvirt` plugin
+
 - Run the edit command to update peerpod-ctrl deployment
+
 ```bash
 kubectl edit deployment peerpod-ctrl-controller-manager -n confidential-containers-system
 ```
+
 - Mount `/opt/cloud-api-adaptor/plugins` from worker node to the `manager` container
+
 ```yaml
 ...
         volumeMounts:
@@ -388,7 +417,9 @@ kubectl edit deployment peerpod-ctrl-controller-manager -n confidential-containe
         name: provider-dir
 ...
 ```
+
 ### Step 10: Verify cloud-api-adaptor/peerpod-ctrl pod is running without error
+
 ```bash
 kubectl logs -n confidential-containers-system ds/cloud-api-adaptor-daemonset
 
@@ -413,26 +444,30 @@ cloud-api-adaptor: starting Cloud API Adaptor daemon for "libvirt"
 
 kubectl logs -n confidential-containers-system $(kubectl get po -A | grep peerpod-ctrl-controller-manager | awk '{print $2}')
 
-2024-04-17T04:35:20Z	INFO	controller-runtime.metrics	Metrics server is starting to listen	{"addr": "127.0.0.1:8080"}
+2024-04-17T04:35:20Z INFO controller-runtime.metrics Metrics server is starting to listen {"addr": "127.0.0.1:8080"}
 2024/04/17 04:35:20 [adaptor/cloud] Loading external plugin libvirt from /cloud-providers/libvirt.so
 2024/04/17 04:35:20 [adaptor/cloud] Successfully opened the external plugin /cloud-providers/libvirt.so
 2024/04/17 04:35:20 [adaptor/cloud/libvirt] libvirt config: &libvirt.Config{URI:"qemu+ssh://root@192.168.122.1/system?no_verify=1", PoolName:"default", NetworkName:"default", DataDir:"", DisableCVM:false, VolName:"podvm-base.qcow2", LaunchSecurity:"", Firmware:"/usr/share/edk2/ovmf/OVMF_CODE.fd"}
 2024/04/17 04:35:20 [adaptor/cloud/libvirt] Created libvirt connection
-2024-04-17T04:35:20Z	INFO	setup	starting manager
-2024-04-17T04:35:20Z	INFO	Starting server	{"path": "/metrics", "kind": "metrics", "addr": "127.0.0.1:8080"}
+2024-04-17T04:35:20Z INFO setup starting manager
+2024-04-17T04:35:20Z INFO Starting server {"path": "/metrics", "kind": "metrics", "addr": "127.0.0.1:8080"}
 I0417 04:35:20.876671       1 leaderelection.go:248] attempting to acquire leader lease confidential-containers-system/33f6c5d6.confidentialcontainers.org...
-2024-04-17T04:35:20Z	INFO	Starting server	{"kind": "health probe", "addr": "[::]:8081"}
+2024-04-17T04:35:20Z INFO Starting server {"kind": "health probe", "addr": "[::]:8081"}
 I0417 04:35:37.265021       1 leaderelection.go:258] successfully acquired lease confidential-containers-system/33f6c5d6.confidentialcontainers.org
-2024-04-17T04:35:37Z	DEBUG	events	peerpod-ctrl-controller-manager-865cb874d-mknth_da8a80e2-4984-4720-828e-3d3b3ff53b2a became leader	{"type": "Normal", "object": {"kind":"Lease","namespace":"confidential-containers-system","name":"33f6c5d6.confidentialcontainers.org","uid":"3e18f493-803b-490d-b9e0-b23104bac54e","apiVersion":"coordination.k8s.io/v1","resourceVersion":"17873"}, "reason": "LeaderElection"}
-2024-04-17T04:35:37Z	INFO	Starting EventSource	{"controller": "peerpod", "controllerGroup": "confidentialcontainers.org", "controllerKind": "PeerPod", "source": "kind source: *v1alpha1.PeerPod"}
-2024-04-17T04:35:37Z	INFO	Starting Controller	{"controller": "peerpod", "controllerGroup": "confidentialcontainers.org", "controllerKind": "PeerPod"}
-2024-04-17T04:35:37Z	INFO	Starting workers	{"controller": "peerpod", "controllerGroup": "confidentialcontainers.org", "controllerKind": "PeerPod", "worker count": 1}
+2024-04-17T04:35:37Z DEBUG events peerpod-ctrl-controller-manager-865cb874d-mknth_da8a80e2-4984-4720-828e-3d3b3ff53b2a became leader {"type": "Normal", "object": {"kind":"Lease","namespace":"confidential-containers-system","name":"33f6c5d6.confidentialcontainers.org","uid":"3e18f493-803b-490d-b9e0-b23104bac54e","apiVersion":"coordination.k8s.io/v1","resourceVersion":"17873"}, "reason": "LeaderElection"}
+2024-04-17T04:35:37Z INFO Starting EventSource {"controller": "peerpod", "controllerGroup": "confidentialcontainers.org", "controllerKind": "PeerPod", "source": "kind source: *v1alpha1.PeerPod"}
+2024-04-17T04:35:37Z INFO Starting Controller {"controller": "peerpod", "controllerGroup": "confidentialcontainers.org", "controllerKind": "PeerPod"}
+2024-04-17T04:35:37Z INFO Starting workers {"controller": "peerpod", "controllerGroup": "confidentialcontainers.org", "controllerKind": "PeerPod", "worker count": 1}
 ...
 ```
 
 #### Troubleshooting
+
 - "failed to map segment from shared object" from CAA/Peerpod-ctrl log
+>
 > - Please make sure `CLOUD_PROVIDER_EXTERNAL_PLUGIN_PATH` on worker node have execute permissions, `chmod +x $CLOUD_PROVIDER_EXTERNAL_PLUGIN_PATH`
+>
 - "plugin was built with a different version of package XXX" from CAA/Peerpod-ctrl log
+>
 > - Please check the go.mod of CAA and plugins project, the CAA and plugins should be built with same version of issue package XXX
 > - Please make sure use same golang env to build CAA, Peerpod-ctrl and cloud-provider plugins

--- a/src/csi-wrapper/Dockerfile.csi_wrappers
+++ b/src/csi-wrapper/Dockerfile.csi_wrappers
@@ -7,13 +7,13 @@
 ARG SOURCE_FROM=remote
 
 ##### Builder Dev Image #####
-FROM --platform=${BUILDPLATFORM} quay.io/confidential-containers/golang-fedora:1.22.11-40 AS builder-local
+FROM --platform=${BUILDPLATFORM} quay.io/confidential-containers/golang-fedora:1.22.12-40 AS builder-local
 WORKDIR /src
 COPY csi-wrapper ./cloud-api-adaptor/src/csi-wrapper/
 COPY cloud-api-adaptor ./cloud-api-adaptor/src/cloud-api-adaptor
 
 ##### Builder Release Image #####
-FROM --platform=${BUILDPLATFORM} quay.io/confidential-containers/golang-fedora:1.22.11-40 AS builder-remote
+FROM --platform=${BUILDPLATFORM} quay.io/confidential-containers/golang-fedora:1.22.12-40 AS builder-remote
 ARG BINARY
 ARG CAA_SRC="https://github.com/confidential-containers/cloud-api-adaptor"
 ARG CAA_SRC_REF="main"

--- a/src/peerpod-ctrl/Dockerfile
+++ b/src/peerpod-ctrl/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$TARGETPLATFORM quay.io/confidential-containers/golang-fedora:1.22.11-40 AS builder
+FROM --platform=$TARGETPLATFORM quay.io/confidential-containers/golang-fedora:1.22.12-40 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG CGO_ENABLED=1


### PR DESCRIPTION
Now that `golang-fedora:1.22.12-40` has been built to quay,
we can update our builds to use this remove the CVE associated
with the older version

Signed-off-by: stevenhorsman <steven@uk.ibm.com>