### PR TITLE
ibmcloud: add option to enable/disable confidential VM

### DIFF
--- a/src/cloud-api-adaptor/entrypoint.sh
+++ b/src/cloud-api-adaptor/entrypoint.sh
@@ -110,6 +110,8 @@ gcp() {
 ibmcloud() {
     one_of IBMCLOUD_API_KEY IBMCLOUD_IAM_PROFILE_ID
 
+    [[ "${DISABLECVM}" = "true" ]] && optionals+="-disable-cvm "
+
     set -x
     exec cloud-api-adaptor ibmcloud \
         -iam-service-url "${IBMCLOUD_IAM_ENDPOINT}" \

--- a/src/cloud-api-adaptor/install/overlays/ibmcloud/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/ibmcloud/kustomization.yaml
@@ -30,6 +30,7 @@ configMapGenerator:
   - IBMCLOUD_VPC_SG_ID="" #set
   - IBMCLOUD_VPC_ID="" #set
   - CRI_RUNTIME_ENDPOINT="/run/cri-runtime/containerd.sock"
+  - DISABLECVM="true" # Set to false to enable confidential VM
   #- PAUSE_IMAGE="" # Uncomment and set if you want to use a specific pause image
   #- TUNNEL_TYPE="" # Uncomment and set if you want to use a specific tunnel type. Defaults to vxlan
   #- VXLAN_PORT="" # Uncomment and set if you want to use a specific vxlan port. Defaults to 4789

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_common.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -975,6 +976,7 @@ func (p *IBMCloudProvisioner) GetProperties(ctx context.Context, cfg *envconf.Co
 		"IBMCLOUD_PODVM_INSTANCE_PROFILE_LIST": getProfileList(),
 		"TUNNEL_TYPE":                          IBMCloudProps.TunnelType,
 		"VXLAN_PORT":                           IBMCloudProps.VxlanPort,
+		"DISABLECVM":                           strconv.FormatBool(IBMCloudProps.DisableCVM),
 	}
 }
 

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_initializer.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_initializer.go
@@ -55,6 +55,7 @@ type IBMCloudProperties struct {
 
 	WorkerCount   int
 	IsSelfManaged bool
+	DisableCVM    bool
 
 	VPC        *vpcv1.VpcV1
 	ClusterAPI containerv2.Clusters
@@ -134,6 +135,10 @@ func InitIBMCloudProperties(properties map[string]string) error {
 	selfManagedStr := properties["IS_SELF_MANAGED_CLUSTER"]
 	if strings.EqualFold(selfManagedStr, "yes") || strings.EqualFold(selfManagedStr, "true") {
 		IBMCloudProps.IsSelfManaged = true
+	}
+	confidentialComputingStr := properties["DISABLECVM"]
+	if strings.EqualFold(confidentialComputingStr, "yes") || strings.EqualFold(confidentialComputingStr, "true") {
+		IBMCloudProps.DisableCVM = true
 	}
 
 	if len(IBMCloudProps.ResourceGroupID) <= 0 {

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_kustomize.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_kustomize.go
@@ -59,6 +59,8 @@ func isKustomizeConfigMapKey(key string) bool {
 		return true
 	case "VXLAN_PORT":
 		return true
+	case "DISABLECVM":
+		return true
 	default:
 		return false
 	}

--- a/src/cloud-providers/ibmcloud/manager.go
+++ b/src/cloud-providers/ibmcloud/manager.go
@@ -35,6 +35,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	flags.StringVar(&ibmcloudVPCConfig.SecondarySecurityGroupID, "secondary-security-group-id", "", "Secondary security group ID")
 	flags.StringVar(&ibmcloudVPCConfig.KeyID, "key-id", "", "SSH Key ID")
 	flags.StringVar(&ibmcloudVPCConfig.VpcID, "vpc-id", "", "VPC ID")
+	flags.BoolVar(&ibmcloudVPCConfig.DisableCVM, "disable-cvm", false, "Use non-CVMs for peer pods")
 
 }
 

--- a/src/cloud-providers/ibmcloud/provider.go
+++ b/src/cloud-providers/ibmcloud/provider.go
@@ -177,6 +177,13 @@ func (p *ibmcloudVPCProvider) getInstancePrototype(instanceName, userData, insta
 			Enabled:  core.BoolPtr(true),
 			Protocol: core.StringPtr(vpcv1.InstanceMetadataServicePatchProtocolHTTPConst),
 		},
+		ConfidentialComputeMode: core.StringPtr("tdx"), // TODO when available: vpcv1.InstanceConfidentialComputeModeTdxConst
+		EnableSecureBoot:        core.BoolPtr(true),
+	}
+
+	if p.serviceConfig.DisableCVM {
+		prototype.ConfidentialComputeMode = core.StringPtr(vpcv1.InstanceConfidentialComputeModeDisabledConst)
+		prototype.EnableSecureBoot = core.BoolPtr(false)
 	}
 
 	if p.serviceConfig.KeyID != "" {

--- a/src/cloud-providers/ibmcloud/provider_test.go
+++ b/src/cloud-providers/ibmcloud/provider_test.go
@@ -144,6 +144,7 @@ func TestCreateInstance(t *testing.T) {
 		serviceConfig: &Config{
 			ProfileName: "bx2-2x8",
 			Images:      images,
+			DisableCVM:  true,
 		},
 	}
 
@@ -161,6 +162,8 @@ func TestCreateInstance(t *testing.T) {
 	p, ok := vpc.prototype.(*vpcv1.InstancePrototype)
 	assert.True(t, ok)
 	assert.Equal(t, "cloud config", *p.UserData)
+	assert.Equal(t, false, *p.EnableSecureBoot)
+	assert.Equal(t, "disabled", *p.ConfidentialComputeMode)
 }
 
 func TestDeleteInstance(t *testing.T) {

--- a/src/cloud-providers/ibmcloud/types.go
+++ b/src/cloud-providers/ibmcloud/types.go
@@ -77,6 +77,7 @@ type Config struct {
 	VpcID                    string
 	InstanceProfiles         instanceProfiles
 	InstanceProfileSpecList  []provider.InstanceTypeSpec
+	DisableCVM               bool
 }
 
 func (c Config) Redact() Config {


### PR DESCRIPTION
Added the DISABLECVM property to the ibmcloud adaptor config and to the caa-provisioner-cli properties for ibmcloud.