### PR TITLE
libvirt: Remove SEV code

### DIFF
--- a/src/cloud-api-adaptor/install/overlays/libvirt/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/libvirt/kustomization.yaml
@@ -26,7 +26,7 @@ configMapGenerator:
   - SECURE_COMMS="false" # set as true to enable Secure Comms
   - INITDATA="" # set default initdata for podvm
   - LIBVIRT_EFI_FIRMWARE="/usr/share/OVMF/OVMF_CODE_4M.fd" # Edit to change the EFI firmware path, or comment to unset, if not using EFI.
-  #- LIBVIRT_LAUNCH_SECURITY="" #sev or s390-pv
+  #- LIBVIRT_LAUNCH_SECURITY="" #s390-pv
   #- LIBVIRT_VOL_NAME="" # Uncomment and set if you want to use a specific volume name. Defaults to podvm-base.qcow2
   #- PAUSE_IMAGE="" # Uncomment and set if you want to use a specific pause image
   #- TUNNEL_TYPE="" # Uncomment and set if you want to use a specific tunnel type. Defaults to vxlan

--- a/src/cloud-providers/libvirt/manager.go
+++ b/src/cloud-providers/libvirt/manager.go
@@ -36,7 +36,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	flags.StringVar(&libvirtcfg.NetworkName, "network-name", defaultNetworkName, "libvirt network pool")
 	flags.StringVar(&libvirtcfg.DataDir, "data-dir", defaultDataDir, "libvirt storage dir")
 	flags.BoolVar(&libvirtcfg.DisableCVM, "disable-cvm", false, "Use non-CVMs for peer pods")
-	flags.StringVar(&libvirtcfg.LaunchSecurity, "launch-security", defaultLaunchSecurity, "Libvirt's LaunchSecurity element for Confidential VMs. SEV or s390-pv. If omitted, will automatically determine.")
+	flags.StringVar(&libvirtcfg.LaunchSecurity, "launch-security", defaultLaunchSecurity, "Libvirt's LaunchSecurity element for Confidential VMs: s390-pv. If omitted, will automatically determine.")
 	flags.StringVar(&libvirtcfg.Firmware, "firmware", defaultFirmware, "Path to OVMF")
 
 }

--- a/src/cloud-providers/libvirt/provider.go
+++ b/src/cloud-providers/libvirt/provider.go
@@ -63,8 +63,6 @@ func (p *libvirtProvider) CreateInstance(ctx context.Context, podName, sandboxID
 		vm.launchSecurityType = NoLaunchSecurity
 	} else if p.serviceConfig.LaunchSecurity != "" {
 		switch p.serviceConfig.LaunchSecurity {
-		case "sev":
-			vm.launchSecurityType = SEV
 		case "s390-pv":
 			vm.launchSecurityType = S390PV
 		default:

--- a/src/cloud-providers/libvirt/types.go
+++ b/src/cloud-providers/libvirt/types.go
@@ -65,7 +65,6 @@ type LaunchSecurityType int
 
 const (
 	NoLaunchSecurity LaunchSecurityType = iota
-	SEV
 	S390PV
 )
 
@@ -73,8 +72,6 @@ func (l LaunchSecurityType) String() string {
 	switch l {
 	case NoLaunchSecurity:
 		return "None"
-	case SEV:
-		return "SEV"
 	case S390PV:
 		return "S390PV"
 	default:


### PR DESCRIPTION
SEV has been deprecated in kata by the AMD team and wasn't supported for on-prem in CAA, so we can remove it.