### PR TITLE
caa: Enable running without Kubernetes

### DIFF
--- a/src/cloud-api-adaptor/pkg/adaptor/k8sops/node.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/k8sops/node.go
@@ -215,3 +215,9 @@ func getClient(kubeConfig *restclient.Config) (*k8sclient.Clientset, error) {
 	}
 	return clientSet, nil
 }
+
+// isKubernetesEnvironment checks if the environment is Kubernetes
+func IsKubernetesEnvironment() bool {
+	nodeName := os.Getenv("NODE_NAME")
+	return nodeName != ""
+}

--- a/src/cloud-api-adaptor/pkg/adaptor/server.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/server.go
@@ -78,9 +78,11 @@ func (s *server) Start(ctx context.Context) (err error) {
 		}
 	}
 	// Advertise node resources
-	err = k8sops.AdvertiseExtendedResources(s.PeerPodsLimitPerNode)
-	if err != nil {
-		return err
+	if k8sops.IsKubernetesEnvironment() {
+		err = k8sops.AdvertiseExtendedResources(s.PeerPodsLimitPerNode)
+		if err != nil {
+			return err
+		}
 	}
 
 	ttRpc, err := ttrpc.NewServer()


### PR DESCRIPTION
Log the error instead of exiting when Kubernetes configuration is missing.

Similar to what already happens in `cloud.go`:
https://github.com/confidential-containers/cloud-api-adaptor/blob/main/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go#L137