### PR TITLE
mkosi: fix Fedora GPG key issue in mkosi build

### DIFF
--- a/src/cloud-api-adaptor/go.mod
+++ b/src/cloud-api-adaptor/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/coreos/go-iptables v0.6.0
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0
-	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250116150548-2777b13db748
+	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250220145350-19a7f2773679
 	github.com/opencontainers/runtime-spec v1.1.1-0.20230922153023-c0e90434df2a
 	github.com/stretchr/testify v1.9.0
 	github.com/vishvananda/netlink v1.2.1-beta.2

--- a/src/cloud-api-adaptor/go.sum
+++ b/src/cloud-api-adaptor/go.sum
@@ -380,8 +380,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250116150548-2777b13db748 h1:XUH7vVrQ0u1AKlysWhmiAxgb5S9GQImYKTW8S5LUTs8=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250116150548-2777b13db748/go.mod h1:E4YBwwlTgi4TmfBfGDbMRhVaD6iHRaMLM7v8g1reHT8=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250220145350-19a7f2773679 h1:KDg0q3zgnnk5HQoDwHGGItzLYVQuIY/ERWDkul162cA=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250220145350-19a7f2773679/go.mod h1:b6luAOpsTPgkmwYII4H/PC/Ctc+yF1g6I/b0f/wIenw=
 github.com/kdomanski/iso9660 v0.4.0 h1:BPKKdcINz3m0MdjIMwS0wx1nofsOjxOq8TOr45WGHFg=
 github.com/kdomanski/iso9660 v0.4.0/go.mod h1:OxUSupHsO9ceI8lBLPJKWBTphLemjrCQY8LPXM7qSzU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.mkosi
+++ b/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.mkosi
@@ -6,7 +6,16 @@ ARG PROFILE="debug"
 
 RUN dnf install -y \
 	bubblewrap \
-	git
+	git \
+	cpio \
+	systemd-repart \
+	kmod \
+	systemd-boot \
+	cryptsetup-libs \
+	squashfs-tools \
+	systemd-ukify \
+	dosfstools \
+	mtools
 
 RUN mkdir -p /build
 WORKDIR /build
@@ -24,7 +33,7 @@ COPY mkosi.skeleton-debug /image/mkosi.skeleton-debug
 COPY mkosi.workspace /image/mkosi.workspace
 COPY resources /image/resources
 COPY mkosi.conf /image/mkosi.conf
-RUN --security=insecure mkosi --tools-tree=default --profile=$PROFILE
+RUN --security=insecure mkosi --profile=$PROFILE
 
 FROM scratch
 COPY --from=builder /image/build/system.raw /

--- a/src/cloud-api-adaptor/podvm-mkosi/Makefile
+++ b/src/cloud-api-adaptor/podvm-mkosi/Makefile
@@ -74,7 +74,7 @@ ifeq ($(SE_BOOT),true)
 	sudo mkosi --profile production --image system
 	sudo -E ../hack/build-s390x-se-image.sh
 else ifeq ($(ARCH),s390x)
-	sudo mkosi --profile production --image system
+	sudo mkosi --tools-tree=default --tools-tree-release=40 --profile production --image system
 	sudo -E ../hack/build-s390x-image.sh
 else
 	mkdir -p build
@@ -95,10 +95,10 @@ image-debug: insecure-builder
 	rm -rf ./build
 	@echo "Building debug image..."
 ifeq ($(SE_BOOT),true)
-	sudo mkosi --profile debug
+	sudo mkosi --tools-tree=default --tools-tree-release=40 --profile debug
 	sudo -E ../hack/build-s390x-se-image.sh
 else ifeq ($(ARCH),s390x)
-	sudo mkosi --profile debug
+	sudo mkosi --tools-tree=default --tools-tree-release=40 --profile debug
 	sudo -E ../hack/build-s390x-image.sh
 else
 	mkdir -p build

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/initrd/mkosi.conf.d/fedora.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/initrd/mkosi.conf.d/fedora.conf
@@ -3,7 +3,7 @@ Distribution=fedora
 
 [Distribution]
 Distribution=fedora
-Release=39
+Release=40
 
 [Content]
 CleanPackageMetadata=true

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-s390x.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-s390x.conf
@@ -2,6 +2,10 @@
 Distribution=fedora
 Architecture=s390x
 
+[Distribution]
+Distribution=fedora
+Release=40
+
 [Content]
 Bootable=no
 Packages=s390utils

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora.conf
@@ -3,7 +3,7 @@ Distribution=fedora
 
 [Distribution]
 Distribution=fedora
-Release=39
+Release=40
 
 [Content]
 CleanPackageMetadata=true

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.repart/00-esp.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.repart/00-esp.conf
@@ -2,5 +2,5 @@
 Type=esp
 Format=vfat
 CopyFiles=/efi:/
-SizeMinBytes=256M
-SizeMaxBytes=512M
+SizeMinBytes=512M
+SizeMaxBytes=1024M

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -57,4 +57,4 @@ oci:
     reference: 3.14.0
   guest-components:
     registry: ghcr.io/confidential-containers/guest-components
-    reference: 3df6c412059f29127715c3fdbac9fa41f56cfce4
+    reference: 514c561d933cb11a0f1628621a0b930157af76cd

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -54,7 +54,7 @@ oci:
     tag: 3.9
   kata-containers:
     registry: ghcr.io/kata-containers/cached-artefacts
-    reference: 3.13.0
+    reference: 3.14.0
   guest-components:
     registry: ghcr.io/confidential-containers/guest-components
     reference: 3df6c412059f29127715c3fdbac9fa41f56cfce4

--- a/src/csi-wrapper/go.mod
+++ b/src/csi-wrapper/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang/glog v1.2.4
 	github.com/golang/protobuf v1.5.4
-	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250116150548-2777b13db748
+	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250220145350-19a7f2773679
 	golang.org/x/net v0.33.0
 	google.golang.org/grpc v1.61.2
 	k8s.io/apimachinery v0.26.2

--- a/src/csi-wrapper/go.sum
+++ b/src/csi-wrapper/go.sum
@@ -70,8 +70,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250116150548-2777b13db748 h1:XUH7vVrQ0u1AKlysWhmiAxgb5S9GQImYKTW8S5LUTs8=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250116150548-2777b13db748/go.mod h1:E4YBwwlTgi4TmfBfGDbMRhVaD6iHRaMLM7v8g1reHT8=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250220145350-19a7f2773679 h1:KDg0q3zgnnk5HQoDwHGGItzLYVQuIY/ERWDkul162cA=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250220145350-19a7f2773679/go.mod h1:b6luAOpsTPgkmwYII4H/PC/Ctc+yF1g6I/b0f/wIenw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=


### PR DESCRIPTION
Attempt to bump to F40. Since F39 is EOL since 2024-11-26. Which will conflict with 165e989 