### PR TITLE
Update CLOUD_PROVIDER for iptables installation

### DIFF
--- a/src/cloud-api-adaptor/podvm/qcow2/rhel/qemu-rhel.pkr.hcl
+++ b/src/cloud-api-adaptor/podvm/qcow2/rhel/qemu-rhel.pkr.hcl
@@ -106,7 +106,10 @@ build {
     remote_folder = "~"
     environment_vars = [
       "CLOUD_PROVIDER=${var.cloud_provider}",
-      "PODVM_DISTRO=${var.podvm_distro}"
+      "PODVM_DISTRO=${var.podvm_distro}",
+      "ACTIVATION_KEY=${var.activation_key}",
+      "ORG_ID=${var.org_id}",
+      "ARCH=${var.os_arch}"
     ]
     inline = [
       "sudo -E bash ~/misc-settings.sh"

--- a/src/cloud-api-adaptor/podvm/qcow2/rhel/variables.pkr.hcl
+++ b/src/cloud-api-adaptor/podvm/qcow2/rhel/variables.pkr.hcl
@@ -73,6 +73,16 @@ variable "cloud_provider" {
   default = env("CLOUD_PROVIDER")
 }
 
+variable "activation_key" {
+  type    = string
+  default = env("ACTIVATION_KEY")
+}
+
+variable "org_id" {
+  type    = string
+  default = env("ORG_ID")
+}
+
 variable "machine_type" {
   type    = string
   default = "pc"


### PR DESCRIPTION
Fixes https://github.com/confidential-containers/cloud-api-adaptor/issues/2304

Extending the CLOUD_PROVIDER check for installing iptables which fixes the APF failure seen with libvirt provider.
Also, wrapping `setup-nat-for-imds` service only for `azure, aws and generic` providers.