### PR TITLE
workflow:e2e_run_all: Switch s390x image build runner

### DIFF
--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -238,7 +238,7 @@ jobs:
       dev_tags: ${{ inputs.caa_image_tag }}-s390x-dev
       release_tags: ${{ inputs.caa_image_tag }}-s390x
       git_ref: ${{ inputs.git_ref }}
-      runner: 's390x'
+      runner: s390x-large
     secrets: inherit
 
   libvirt_e2e_arch_prep:


### PR DESCRIPTION
With a recent change in the s390x CoCo runners, we now can only build the mkosi image on larger s390x runner (that runs on a different physical system), so update the workflow to reflect this.