### PR TITLE
workflow: podvm_mkosi: Switch s390x image build runner

### DIFF
--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -65,7 +65,7 @@ defaults:
 jobs:
   build-image:
     name: Build mkosi image
-    runs-on: ${{ inputs.arch == 's390x' && 's390x' || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.arch == 's390x' && 's390x-large' || 'ubuntu-24.04' }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
This is the other half of  6bd4e3297f98fe033560759e07f580758a05fa02 that I missed earlier in #2312 :(

With a recent change in the s390x CoCo runners,
coco-runner-02 (not tagged with s390x-large) is now running ubuntu 24.04. As documented in #2310, there are currently issues with the s390x building on ubuntu 24.04, so in the short-term, we should stop the mkosi build running on those systems and therefore switch to the s390x-large runner, which is still on 22.04.