### PR TITLE
adaptor: log error causing agent proxy connection failure

### DIFF
--- a/src/cloud-api-adaptor/pkg/adaptor/proxy/proxy.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/proxy/proxy.go
@@ -111,7 +111,7 @@ func (p *agentProxy) dial(ctx context.Context, address string) (net.Conn, error)
 		func() error {
 			var err error
 			if conn, err = dialer.DialContext(ctx, "tcp", address); err != nil {
-				logger.Printf("Retrying agent proxy connection to %s...", address)
+				logger.Printf("Retrying failed agent proxy connection: %v", err)
 			}
 			return err
 		},


### PR DESCRIPTION
Print the error instead of the address in the log message when retrying a failed agent proxy connection attempt.