### PR TITLE
workflow: build mkosi image on s390x-large runner

### DIFF
--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -65,7 +65,7 @@ defaults:
 jobs:
   build-image:
     name: Build mkosi image
-    runs-on: ${{ inputs.arch == 's390x' && 's390x' || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.arch == 's390x' && 's390x-large' || 'ubuntu-24.04' }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Since #2312 forgot to switch to the s390x-large runner for building the mkosi image, this PR makes that change.
(See https://github.com/confidential-containers/cloud-api-adaptor/actions/runs/13646208194/job/38145497668)

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>