### PR TITLE
podvm_mkosi: Use container to run mkosi on s390x

### DIFF
--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -127,20 +127,6 @@ jobs:
           echo "MKOSI_VERSION=$(yq -e '.tools.mkosi' versions.yaml)" >> "$GITHUB_ENV"
           echo "ORAS_VERSION=$(yq -e '.tools.oras' versions.yaml)" >> "$GITHUB_ENV"
 
-      - name: Install mkosi dependencies
-        if: ${{ inputs.arch == 's390x' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y bubblewrap alien dnf qemu-utils uidmap
-
-      - name: Install mkosi
-        if: ${{ inputs.arch == 's390x' }}
-        run: |
-          git clone -b "${MKOSI_VERSION}" https://github.com/systemd/mkosi
-          sudo rm -f /usr/local/bin/mkosi
-          sudo ln -s "$PWD/mkosi/bin/mkosi" /usr/local/bin/mkosi
-          mkosi --version
-
       - uses: oras-project/setup-oras@v1
         with:
           version: ${{ env.ORAS_VERSION }}

--- a/src/cloud-api-adaptor/podvm-mkosi/Makefile
+++ b/src/cloud-api-adaptor/podvm-mkosi/Makefile
@@ -30,6 +30,14 @@ ifeq ($(ARCH),s390x)
 YQ_CHECKSUM = $(YQ_CHECKSUM_s390x)
 endif
 
+define run_mkosi_in_container
+	docker run --rm --privileged \
+		-v "$(shell pwd)":/workspace \
+		-w /workspace \
+		fedora:40 \
+		bash -c "dnf install -y mkosi && mkosi --tools-tree=default --tools-tree-release=40 $(1)"
+endef
+
 binaries:
 	@echo "Building binaries..."
 	rm -rf ./resources/binaries-tree
@@ -71,10 +79,10 @@ image: insecure-builder
 	rm -rf ./build
 	@echo "Building image..."
 ifeq ($(SE_BOOT),true)
-	sudo mkosi --profile production --image system
+	$(call run_mkosi_in_container,--profile production --image system)
 	sudo -E ../hack/build-s390x-se-image.sh
 else ifeq ($(ARCH),s390x)
-	sudo mkosi --tools-tree=default --tools-tree-release=40 --profile production --image system
+	$(call run_mkosi_in_container,--profile production --image system)
 	sudo -E ../hack/build-s390x-image.sh
 else
 	mkdir -p build
@@ -95,10 +103,10 @@ image-debug: insecure-builder
 	rm -rf ./build
 	@echo "Building debug image..."
 ifeq ($(SE_BOOT),true)
-	sudo mkosi --tools-tree=default --tools-tree-release=40 --profile debug
+	$(call run_mkosi_in_container,--profile debug)
 	sudo -E ../hack/build-s390x-se-image.sh
 else ifeq ($(ARCH),s390x)
-	sudo mkosi --tools-tree=default --tools-tree-release=40 --profile debug
+	$(call run_mkosi_in_container,--profile debug)
 	sudo -E ../hack/build-s390x-image.sh
 else
 	mkdir -p build


### PR DESCRIPTION
This PR runs mkosi inside a Fedora-based container for building images. This would provide a more consistent environment and prevent issues caused by upgrading Ubuntu on GHA self-hosted runners.

The change has been verified on a Ubuntu 24.04 runner: https://github.com/BbolroC/cloud-api-adaptor/actions/runs/13654124912/job/38169137973

I confirmed that the change works on both Ubuntu 22.04 and Ubuntu 24.04.

Fixes: #2310

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>