### PR TITLE
Fixes for RHEL/s390x PODVM builds

### DIFF
--- a/src/cloud-api-adaptor/Makefile
+++ b/src/cloud-api-adaptor/Makefile
@@ -230,6 +230,8 @@ endif
 	--build-arg BUILDER_IMG=$(PODVM_BUILDER_IMAGE) \
 	--build-arg BINARIES_IMG=$(PODVM_BINARIES_IMAGE) \
 	--build-arg PODVM_DISTRO=$(PODVM_DISTRO) \
+	--build-arg ORG_ID=$(ORG_ID) \
+	--build-arg ACTIVATION_KEY=$(ACTIVATION_KEY) \
 	--build-arg ARCH=$(TARGET_ARCH) \
 	--build-arg CLOUD_PROVIDER=$(or $(CLOUD_PROVIDER),generic) \
 	--build-arg IMAGE_URL=$(IMAGE_URL) \

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm.rhel
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm.rhel
@@ -13,6 +13,8 @@ FROM ${BUILDER_IMG} AS podvm_builder
 ARG CLOUD_PROVIDER
 ARG PODVM_DISTRO=rhel
 ARG UEFI=false
+ARG ORG_ID
+ARG ACTIVATION_KEY
 
 # If not provided, uses system architecture
 ARG ARCH
@@ -57,7 +59,7 @@ COPY . /src
 
 WORKDIR /src/cloud-api-adaptor/podvm
 
-RUN LIBC=gnu make image
+RUN LIBC=gnu ORG_ID=${ORG_ID} ACTIVATION_KEY=${ACTIVATION_KEY} make image
 
 # The below instructions can be used if you prefer to rebuild all the binaries
 #RUN make binaries

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.rhel
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.rhel
@@ -42,7 +42,7 @@ RUN subscription-manager repos --enable codeready-builder-for-rhel-9-${ARCH/amd6
     dnf groupinstall -y 'Development Tools'; \
     dnf install -y yum-utils gnupg git --allowerasing curl pkg-config clang perl libseccomp-devel gpgme-devel \
     device-mapper-devel qemu-kvm unzip wget libassuan-devel genisoimage cloud-utils-growpart cloud-init \
-    perl-FindBin openssl-devel tpm2-tss-devel
+    perl-FindBin openssl-devel tpm2-tss-devel jq
 
 RUN curl -L -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${YQ_ARCH} \
     && echo "${YQ_CHECKSUM#sha256:}  /usr/local/bin/yq" | sha256sum -c -

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.rhel
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.rhel
@@ -50,7 +50,7 @@ RUN chmod a+x /usr/local/bin/yq && \
     curl https://dl.google.com/go/go${GO_VERSION}.linux-${YQ_ARCH}.tar.gz -o go${GO_VERSION}.linux-${YQ_ARCH}.tar.gz && \
     rm -rf /usr/local/go && tar -C /usr/local -xzf go${GO_VERSION}.linux-${YQ_ARCH}.tar.gz && \
     rm -f go${GO_VERSION}.linux-${YQ_ARCH}.tar.gz
-ENV PATH="/usr/local/go/bin:${PATH}"
+ENV PATH="/usr/local/go/bin:/usr/local/bin:${PATH}"
 
 # Install packer. Packer doesn't have prebuilt s390x arch binaries beyond Packer version 0.1.5
 RUN if [ "${ARCH}" == "s390x" ]; then \

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -27,7 +27,7 @@ tools:
   golang: 1.23.6
   kcli: 99.0.202408152044
   mkosi: v22
-  protoc: 3.15.0
+  protoc: 3.16.0
   packer: v1.9.4
   oras: 1.2.0
 # Referenced Git repositories


### PR DESCRIPTION
- Bump protoc to 3.16.0 because 3.15.0 is not available on s390x
- Ensure jq is installed in the builder image
- Ensure yq is in PATH in the builder image
- Ensure subscription credentials are passed to packer when running in a container