### PR TITLE
versions: Bump kcli to 99.0.202504041449

### DIFF
--- a/src/cloud-api-adaptor/libvirt/kcli_cluster.sh
+++ b/src/cloud-api-adaptor/libvirt/kcli_cluster.sh
@@ -46,9 +46,6 @@ wait_for_process() {
 #
 create () {
 	local sdn="flannel"
-	# Networking services don't work fine with the flannel and crio combination
-	# See https://github.com/karmab/kcli/issues/744
-	[ "$CONTAINER_RUNTIME" = "crio" ] && sdn="cilium"
 
 	parameters="-P domain=kata.com \
 		-P pool=$LIBVIRT_POOL \

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -25,7 +25,7 @@ tools:
   bats: 1.10.0
   iptables-wrapper: v0.0.0-20240819165702-06cad2ec6cb5
   golang: 1.23.6
-  kcli: 99.0.202408152044
+  kcli: 99.0.202504041449
   mkosi: v22
   protoc: 3.16.0
   packer: v1.9.4


### PR DESCRIPTION
This PR updates kcli to the latest to fix a CI issue for Ubuntu 24.04 on s390x. See the following issues:

- https://github.com/karmab/kcli/issues/793
- https://github.com/karmab/kcli/issues/796

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>