### PR TITLE
GHA: Use 390x runners again for building libvirt test artifacts

### DIFF
--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -238,7 +238,7 @@ jobs:
       dev_tags: ${{ inputs.caa_image_tag }}-s390x-dev
       release_tags: ${{ inputs.caa_image_tag }}-s390x
       git_ref: ${{ inputs.git_ref }}
-      runner: s390x-large
+      runner: 's390x'
     secrets: inherit
 
   libvirt_e2e_arch_prep:

--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -65,7 +65,7 @@ defaults:
 jobs:
   build-image:
     name: Build mkosi image
-    runs-on: ${{ inputs.arch == 's390x' && 's390x-large' || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.arch == 's390x' && 's390x' || 'ubuntu-24.04' }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
As mentioned in #2310, this commit reverts #2312 and #2313 to use all `s390x` runners again for building libvirt test artifacts.

FYI: the libvirt e2e test should run on the `s390x-large` runner due to resource constraints. 

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>

CC: @stevenhorsman @ldoktor 