### PR TITLE
ibmcloud-powervs: fix processors config

### DIFF
--- a/src/cloud-providers/ibmcloud-powervs/manager.go
+++ b/src/cloud-providers/ibmcloud-powervs/manager.go
@@ -52,7 +52,7 @@ func (_ *Manager) LoadEnv() {
 		ibmcloudPowerVSConfig.Memory, _ = strconv.ParseFloat(memoryStr, 64)
 	}
 
-	provider.DefaultToEnv(&processorsStr, "POWERVS_MEMORY", "")
+	provider.DefaultToEnv(&processorsStr, "POWERVS_PROCESSORS", "")
 	if processorsStr != "" {
 		ibmcloudPowerVSConfig.Processors, _ = strconv.ParseFloat(processorsStr, 64)
 	}


### PR DESCRIPTION
This PR uses the correct env var to initialize PowerVS processors.

Fixes: #2323