### PR TITLE
ibmcloud: Move away from Ubuntu 20.04

### DIFF
--- a/src/cloud-api-adaptor/ibmcloud/IMPORT_PODVM_TO_VPC.md
+++ b/src/cloud-api-adaptor/ibmcloud/IMPORT_PODVM_TO_VPC.md
@@ -1,6 +1,6 @@
 # Importing Public PODVM images into IBM Cloud VPC
 
-As part of the release process pre-built images are published as container images to the confidential-containers quay repository. e.g. `quay.io/confidential-containers/podvm-ibmcloud-ubuntu-s390x` that contain a single qcow2 file that can be extracted. Alternatively images can be built and distributed directly as qcow2 files. These qcow2 that needs to be uploaded to ibmcloud to use as a vpc image. 
+As part of the release process pre-built images are published as container images to the confidential-containers quay repository. e.g. `quay.io/confidential-containers/podvm-ibmcloud-ubuntu-s390x` that contain a single qcow2 file that can be extracted. Alternatively images can be built and distributed directly as qcow2 files. These qcow2 that needs to be uploaded to ibmcloud to use as a vpc image.
 
 To simpify this process a script has been created to aid this. `ibmcloud/image/import.sh`.
 
@@ -10,7 +10,7 @@ To simpify this process a script has been created to aid this. `ibmcloud/image/i
 
 - jq `apt install jq`
 - ibmcloud `curl -fsSL https://clis.cloud.ibm.com/install/linux | sh` (https://cloud.ibm.com/docs/cli?topic=cli-getting-started)
-- docker/podman `apt install docker.io`    
+- docker/podman `apt install docker.io`
 It's failed to install `docker` on Ubuntu20.04 with above single command. `docker` can be installed with `snap` as below.
     ```
     sudo snap install docker
@@ -42,7 +42,7 @@ The later options:
 - `bucket`: name of the bucket to use. Will use an available bucket if not specified
 - `region`: name of the region the bucket is in. Only required if that region is different from the VPC region
 - `endpoint`: the COS endpoint to upload to. Optional, but required if using staging, where the endpoint can be found in the 'Configuration' tab in the COS bucket page of the IBM Cloud UI.
-- `os`: name of the operating-system for the image, will default to `ubuntu-20-04-<< image-suffix >>` e.g. `ubuntu-20-04-s390x`. The HyperProtect OS is `hyper-protect-1-0-s390x`.
+- `os`: name of the operating-system for the image, will default to `ubuntu-22-04-<< image-suffix >>` e.g. `ubuntu-22-04-s390x`. The HyperProtect OS is `hyper-protect-1-0-s390x`.
 
 The script will sanitise `.` and `_` into `-` and lowercase the image name. Only lowercase alphanumeric characters and hyphens only (without spaces) are allowed for image names. If your image file name contains other special characters please rename it before attempting to import.
 

--- a/src/cloud-api-adaptor/ibmcloud/cluster/README.md
+++ b/src/cloud-api-adaptor/ibmcloud/cluster/README.md
@@ -94,7 +94,7 @@ twice under different SSHs key names. This key needs to be password-less and on 
 > - `node_image` (optional) is a name of IBM Cloud infrastructure image. This name is used to create virtual server
  instances for the Kubernetes control plane and worker. For more information, about VPC custom images, see 
  [IBM Cloud Importing and managing custom images](https://cloud.ibm.com/docs/vpc?topic=vpc-managing-images).
-  If not set it defaults to `ibm-ubuntu-20-04-2-minimal-s390x-1` for **`s390x`** architecture.
+  If not set it defaults to `ibm-ubuntu-22-04-4-minimal-s390x-3` for **`s390x`** architecture.
 > - `node_profile` (optional) is a name of IBM Cloud virtual server instance profile. This name is used to create virtual server instances for the Kubernetes control plane and worker. For more information, about virtual server instance profile, see [instance profiles](https://cloud.ibm.com/docs/vpc?topic=vpc-profiles). If not set it defaults to `bz2-2x8`, which uses the `s390x` architecture, has 2 vCPUs and 8 GB memory.
 > - `nodes` (optional) is the number of VSIs created to be used as Kubernetes nodes. There will be a single control 
 plane node and the rest will be worker nodes. If not set it defaults to `2`.
@@ -108,7 +108,7 @@ and `image_name` parameters. E.g., to create an **x86** architecture based clust
 the `terraform.tfvars` file
 >
 >     node_profile = "bx2-2x8"
->     node_image = "ibm-ubuntu-20-04-3-minimal-amd64-1"
+>     node_image = "ibm-ubuntu-22-04-5-minimal-amd64-1"
 >
 
 After writing you `terraform.tfvars` file you can create your VPC by executing the following commands on your

--- a/src/cloud-api-adaptor/ibmcloud/cluster/variables.tf
+++ b/src/cloud-api-adaptor/ibmcloud/cluster/variables.tf
@@ -29,10 +29,10 @@ variable "subnet_name" {
   default     = ""
 }
 
-# amd64: ibm-ubuntu-20-04-3-minimal-amd64-1
-# s390x: ibm-ubuntu-20-04-2-minimal-s390x-1
+# amd64: ibm-ubuntu-22-04-5-minimal-amd64-1
+# s390x: ibm-ubuntu-22-04-4-minimal-s390x-3
 variable "node_image" {
-  default = "ibm-ubuntu-20-04-2-minimal-s390x-1"
+  default = "ibm-ubuntu-22-04-4-minimal-s390x-3"
 }
 
 # amd64: bx2-2x8

--- a/src/cloud-api-adaptor/ibmcloud/image/import.sh
+++ b/src/cloud-api-adaptor/ibmcloud/image/import.sh
@@ -107,7 +107,12 @@ image_ref="cos://$location/$bucket/$file"
 # If OS isn't specified infer from file name
 if [ -z "$operating_system" ]; then
     image_arch="${image_name##*-}"
-    operating_system="ubuntu-20-04-${image_arch/x86_64/amd64}"
+    operating_system="ubuntu-24-04"
+    # 24.04 image type isn't available for s390x yet, so label it 22-04 as a workaround
+    if [[ ${image_arch} == "s390x" ]]; then
+        operating_system="ubuntu-22-04"
+    fi
+    operating_system=${operating_system}"-${image_arch/x86_64/amd64}"
 fi
 image_name="$(echo ${image_name} | tr '[:upper:]' '[:lower:]' | sed 's/\./-/g' | sed 's/_/-/g')"
 image_json=$(ibmcloud is image-create "$image_name" --os-name "$operating_system" --file "$image_ref" --output JSON) || error "Unable to create vpc image $image_name"

--- a/src/cloud-api-adaptor/ibmcloud/image/push.sh
+++ b/src/cloud-api-adaptor/ibmcloud/image/push.sh
@@ -95,7 +95,13 @@ fi
 image_ref="cos://$location/$cos_bucket/$object_key"
 
 arch=$(uname -m)
-[ "${SE_BOOT:-false}" = "true" ] && os_name="hyper-protect-1-0-s390x" || os_name="ubuntu-20-04-${arch/x86_64/amd64}"
+if [[ "${SE_BOOT:-false}" = "true" ]]; then
+    os_name="hyper-protect-1-0-s390x"
+elif [[ ${arch} == "s390x" ]]; then
+    os_name="ubuntu-22-04-s390x"
+else
+    os_name="ubuntu-24-04-${arch/x86_64/amd64}"
+fi
 
 echo -e "\nCreating image \"$image_name\" with $image_ref\n"
 image_json=$(ibmcloud is image-create "$image_name" --os-name "$os_name" --file "$image_ref" --output json)

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_common.go
@@ -912,10 +912,10 @@ func (p *IBMCloudProvisioner) UploadPodvm(imagePath string, ctx context.Context,
 		if strings.Contains(IBMCloudProps.InstanceProfile, "e-") {
 			osNames = []string{"hyper-protect-1-0-s390x"}
 		} else {
-			osNames = []string{"ubuntu-20-04-s390x"}
+			osNames = []string{"ubuntu-22-04-s390x"}
 		}
 	} else {
-		osNames = []string{"ubuntu-20-04-amd64"}
+		osNames = []string{"ubuntu-24-04-amd64"}
 
 	}
 	operatingSystemIdentityModel := &vpcv1.OperatingSystemIdentityByName{

--- a/src/csi-wrapper/examples/ibm/README.md
+++ b/src/csi-wrapper/examples/ibm/README.md
@@ -27,7 +27,7 @@ ibmcloud is ins |grep ${your-worker-node-name}
 The expected result should look like:
 ```bash
 ...
-0797_162a604f-82da-4b8c-9144-1204d4c560db   liudali-csi-amd64-node-1                   running   10.242.64.19   141.125.156.56    bx2-2x8     ibm-ubuntu-20-04-3-minimal-amd64-1                se-image-e2e-test-eu-gb        eu-gb-2   Default
+0797_162a604f-82da-4b8c-9144-1204d4c560db   liudali-csi-amd64-node-1                   running   10.242.64.19   141.125.156.56    bx2-2x8     ibm-ubuntu-22-04-5-minimal-amd64-1                se-image-e2e-test-eu-gb        eu-gb-2   Default
 ```
 In the example `0797_162a604f-82da-4b8c-9144-1204d4c560db` is the instanceID, `liudali-csi-amd64-node-1` is the node-name, `eu-gb-2` is the zone, the region should be `eu-gb`.
 


### PR DESCRIPTION
Ubuntu 20.04 is EoL soon, so switch our defaults to 22.04 for self-managed cluster creation (as s390x doesn't have a 24.04 image yet). Also update the import.sh to reflect that packer builds a 24.04 image now (again s390x doesn't support 24.04 label, so we need to fudge it a bit here).