### PR TITLE
docker: bump fedora image to 41

### DIFF
--- a/hack/Dockerfile.golang
+++ b/hack/Dockerfile.golang
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.5-labs
 
-ARG BASE_IMAGE=registry.fedoraproject.org/fedora:40
+ARG BASE_IMAGE=registry.fedoraproject.org/fedora:41
 FROM --platform=$TARGETPLATFORM ${BASE_IMAGE} AS base
 
 # DO NOT UPDATE THIS BY HAND !!

--- a/src/cloud-api-adaptor/Dockerfile
+++ b/src/cloud-api-adaptor/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_TYPE=dev
 ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.23.8-40
-ARG BASE=registry.fedoraproject.org/fedora:40
+ARG BASE=registry.fedoraproject.org/fedora:41
 
 # This dockerfile uses Go cross-compilation to build the binary,
 # we build on the host platform ($BUILDPLATFORM) and then copy the

--- a/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.mkosi
+++ b/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.mkosi
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.5.0-labs
-FROM fedora:40 AS builder
+FROM fedora:41 AS builder
 
 ARG MKOSI_VERSION="v22"
 ARG PROFILE="debug"
@@ -16,7 +16,8 @@ RUN dnf install -y \
 	squashfs-tools \
 	systemd-ukify \
 	dosfstools \
-	mtools
+	mtools \
+	python3
 
 RUN mkdir -p /build
 WORKDIR /build

--- a/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.podvm_docker_provider
+++ b/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.podvm_docker_provider
@@ -1,6 +1,6 @@
 # Adapted from https://github.com/kubernetes-sigs/kind/blob/main/images/base/Dockerfile
 
-ARG BASE_IMAGE=registry.fedoraproject.org/fedora:40
+ARG BASE_IMAGE=registry.fedoraproject.org/fedora:41
 
 FROM $BASE_IMAGE AS iptables
 

--- a/src/cloud-api-adaptor/podvm-mkosi/Makefile
+++ b/src/cloud-api-adaptor/podvm-mkosi/Makefile
@@ -37,7 +37,7 @@ define run_mkosi_in_container
 		-v "$(shell pwd)":/workspace \
 		-w /workspace \
 		fedora:40 \
-		bash -c "dnf install -y mkosi && mkosi --tools-tree=default --tools-tree-release=40 $(1)"
+		bash -c "dnf install -y mkosi && mkosi --tools-tree=default --tools-tree-release=41 $(1)"
 endef
 
 binaries:

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_binaries.fedora
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_binaries.fedora
@@ -5,7 +5,7 @@
 #
 # Build binaries for mkosi podvm image
 #
-FROM registry.fedoraproject.org/fedora:40 AS builder
+FROM registry.fedoraproject.org/fedora:41 AS builder
 
 ARG ARCH="x86_64"
 ARG GO_ARCH="amd64"
@@ -18,7 +18,7 @@ ARG YQ_VERSION
 ARG YQ_CHECKSUM
 ARG ORAS_VERSION
 
-RUN dnf groupinstall -y 'Development Tools' && \
+RUN dnf -y group install development-tools && \
     dnf install -y yum-utils gnupg git perl-core pkg-config libseccomp-devel gpgme-devel \
     device-mapper-devel unzip libassuan-devel \
     perl-FindBin openssl-devel tpm2-tss-devel \
@@ -31,7 +31,7 @@ RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go${GO_VERSION}.linux-${GO_AR
 ENV PATH="/usr/local/go/bin:$PATH"
 
 RUN if [ "$(uname -m)" != "s390x" ]; then dnf install 'dnf-command(config-manager)' && \
-    dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
+    dnf config-manager addrepo --from-repofile="https://cli.github.com/packages/rpm/gh-cli.repo" && \
     dnf install -y gh --repo gh-cli; else git clone https://github.com/cli/cli.git gh-cli && \
     cd gh-cli && mkdir -p /usr/local/gh && make install prefix=/usr/local/gh && cd .. && \
     rm -rf gh-cli; fi

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.rhel
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.rhel
@@ -40,7 +40,7 @@ RUN if [[ -n "${ACTIVATION_KEY}" && -n "${ORG_ID}" ]]; then \
     fi
 
 RUN subscription-manager repos --enable codeready-builder-for-rhel-9-${ARCH/amd64/x86_64}-rpms; \
-    dnf groupinstall -y 'Development Tools'; \
+    dnf -y group install development-tools && \
     dnf install -y yum-utils gnupg git --allowerasing curl pkg-config clang perl libseccomp-devel gpgme-devel \
     device-mapper-devel qemu-kvm unzip wget libassuan-devel genisoimage cloud-utils-growpart cloud-init \
     perl-FindBin openssl-devel tpm2-tss-devel jq xz

--- a/src/peerpod-ctrl/Dockerfile
+++ b/src/peerpod-ctrl/Dockerfile
@@ -30,7 +30,7 @@ COPY peerpod-ctrl/controllers/ controllers/
 RUN CC=gcc CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build ${GOFLAGS} -a -o manager main.go
 
 # Target Image
-FROM --platform=$TARGETPLATFORM registry.fedoraproject.org/fedora:40
+FROM --platform=$TARGETPLATFORM registry.fedoraproject.org/fedora:41
 ARG CGO_ENABLED=1
 
 RUN if [ "$CGO_ENABLED" = 1 ] ; then dnf install -y libvirt-libs openssh-clients && dnf clean all; fi


### PR DESCRIPTION
- Bump image tag.
- Update dnf commands to the newer syntax.
- Add necessary dependencies that are not included in the new image.