### PR TITLE
e2e: fix initdata templating

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/azure_test.go
+++ b/src/cloud-api-adaptor/test/e2e/azure_test.go
@@ -10,13 +10,13 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	b64 "encoding/base64"
-	"fmt"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
 
 	_ "github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/test/provisioner/azure"
+	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
@@ -189,7 +189,10 @@ func TestAzureImageDecryption(t *testing.T) {
 // the az tpm attester requires the digest to be sha256 and is hence truncated
 func TestInitDataMeasurement(t *testing.T) {
 	kbsEndpoint := "http://some.endpoint"
-	initdata := fmt.Sprintf(testInitdata, kbsEndpoint, kbsEndpoint, kbsEndpoint)
+	initdata, err := buildInitdataBody(kbsEndpoint)
+	if err != nil {
+		log.Fatalf("failed to build initdata %s", err)
+	}
 
 	digest := sha512.Sum384([]byte(initdata))
 	truncatedDigest := digest[:32]

--- a/src/cloud-api-adaptor/test/e2e/common.go
+++ b/src/cloud-api-adaptor/test/e2e/common.go
@@ -30,7 +30,6 @@ import (
 const WAIT_DEPLOYMENT_AVAILABLE_TIMEOUT = time.Second * 180
 const DEFAULT_AUTH_SECRET = "auth-json-secret-default"
 
-var certContent string
 var testInitdata string = `algorithm = "sha384"
 version = "0.1.0"
 
@@ -86,6 +85,16 @@ default WaitProcessRequest := true
 default WriteStreamRequest := true
 '''
 `
+
+func buildInitdataBody(kbsEndpoint string) (string, error) {
+	content, err := os.ReadFile("../trustee/kbs/config/kubernetes/base/https-cert.pem")
+	if err != nil {
+		return "", err
+	}
+	certContent := string(content)
+	body := fmt.Sprintf(testInitdata, kbsEndpoint, kbsEndpoint, certContent, kbsEndpoint, certContent)
+	return body, nil
+}
 
 func isTestWithKbs() bool {
 	return os.Getenv("TEST_KBS") == "yes" || os.Getenv("TEST_KBS") == "true"
@@ -243,13 +252,11 @@ func WithInitdata(kbsEndpoint string) PodOption {
 		if p.ObjectMeta.Annotations == nil {
 			p.ObjectMeta.Annotations = make(map[string]string)
 		}
-		content, err := os.ReadFile("../trustee/kbs/config/kubernetes/base/https-cert.pem")
-		if err != nil {
-			fmt.Println("Error reading file:", err)
-		}
-		certContent = string(content)
 		key := "io.katacontainers.config.runtime.cc_init_data"
-		initdata := fmt.Sprintf(testInitdata, kbsEndpoint, kbsEndpoint, certContent, kbsEndpoint, certContent)
+		initdata, err := buildInitdataBody(kbsEndpoint)
+		if err != nil {
+			log.Fatalf("failed to build initdata %s", err)
+		}
 		value := b64.StdEncoding.EncodeToString([]byte(initdata))
 		p.ObjectMeta.Annotations[key] = value
 	}
@@ -372,7 +379,10 @@ func NewBusyboxPodWithName(namespace, podName string) PodOrError {
 }
 
 func NewBusyboxPodWithNameWithInitdata(namespace, podName string, kbsEndpoint string) PodOrError {
-	initdata := fmt.Sprintf(testInitdata, kbsEndpoint, kbsEndpoint, certContent, kbsEndpoint, certContent)
+	initdata, err := buildInitdataBody(kbsEndpoint)
+	if err != nil {
+		return fromError(err)
+	}
 	b64Data := b64.StdEncoding.EncodeToString([]byte(initdata))
 	annotationData := map[string]string{
 		"io.katacontainers.config.runtime.cc_init_data": b64Data,

--- a/src/cloud-api-adaptor/test/e2e/remote_attestation.go
+++ b/src/cloud-api-adaptor/test/e2e/remote_attestation.go
@@ -2,7 +2,7 @@ package e2e
 
 import (
 	b64 "encoding/base64"
-	"fmt"
+	"log"
 	"testing"
 
 	"sigs.k8s.io/e2e-framework/pkg/env"
@@ -14,7 +14,10 @@ func DoTestRemoteAttestation(t *testing.T, e env.Environment, assert CloudAssert
 	image := "quay.io/curl/curl:latest"
 	// fail on non 200 code, silent, but output on failure
 	cmd := []string{"curl", "-f", "-s", "-S", "-o", "/dev/null", "http://127.0.0.1:8006/aa/token?token_type=kbs"}
-	initdata := fmt.Sprintf(testInitdata, kbsEndpoint, kbsEndpoint, kbsEndpoint)
+	initdata, err := buildInitdataBody(kbsEndpoint)
+	if err != nil {
+		log.Fatalf("failed to build initdata %s", err)
+	}
 	b64Data := b64.StdEncoding.EncodeToString([]byte(initdata))
 	annotations := map[string]string{
 		"io.katacontainers.config.runtime.cc_init_data": b64Data,


### PR DESCRIPTION
The cert values weren't set in all places where initdata is used, which broke e2e tests on azure. The templating was put into its own fn to make this more obvious.