### PR TITLE
ibmcloud-powervs: Set PodVM name maximum length to 47

### DIFF
--- a/src/cloud-providers/ibmcloud-powervs/provider.go
+++ b/src/cloud-providers/ibmcloud-powervs/provider.go
@@ -19,7 +19,7 @@ import (
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers/util/cloudinit"
 )
 
-const maxInstanceNameLen = 63
+const maxInstanceNameLen = 47
 
 var logger = log.New(log.Writer(), "[adaptor/cloud/ibmcloud-powervs] ", log.LstdFlags|log.Lmsgprefix)
 


### PR DESCRIPTION
This PR sets the PodVM name maximum length to 47 instead of 63.

Fixes: #2333