### PR TITLE
tests/e2e : Add initdata related test cases, invalied initdata 

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/azure_test.go
+++ b/src/cloud-api-adaptor/test/e2e/azure_test.go
@@ -189,7 +189,7 @@ func TestAzureImageDecryption(t *testing.T) {
 // the az tpm attester requires the digest to be sha256 and is hence truncated
 func TestInitDataMeasurement(t *testing.T) {
 	kbsEndpoint := "http://some.endpoint"
-	initdata, err := buildInitdataBody(kbsEndpoint)
+	initdata, err := buildInitdataBody(kbsEndpoint, testInitdata)
 	if err != nil {
 		log.Fatalf("failed to build initdata %s", err)
 	}

--- a/src/cloud-api-adaptor/test/e2e/common.go
+++ b/src/cloud-api-adaptor/test/e2e/common.go
@@ -86,14 +86,15 @@ default WaitProcessRequest := true
 default WriteStreamRequest := true
 '''
 `
+var testEmptyInitdata string = " "
 
-func buildInitdataBody(kbsEndpoint string) (string, error) {
+func buildInitdataBody(kbsEndpoint string, testInitdataVal string) (string, error) {
 	content, err := os.ReadFile("../trustee/kbs/config/kubernetes/base/https-cert.pem")
 	if err != nil {
 		return "", err
 	}
 	certContent := string(content)
-	body := fmt.Sprintf(testInitdata, kbsEndpoint, kbsEndpoint, certContent, kbsEndpoint, certContent)
+	body := fmt.Sprintf(testInitdataVal, kbsEndpoint, kbsEndpoint, certContent, kbsEndpoint, certContent)
 	return body, nil
 }
 
@@ -254,7 +255,7 @@ func WithInitdata(kbsEndpoint string) PodOption {
 			p.ObjectMeta.Annotations = make(map[string]string)
 		}
 		key := "io.katacontainers.config.runtime.cc_init_data"
-		initdata, err := buildInitdataBody(kbsEndpoint)
+		initdata, err := buildInitdataBody(kbsEndpoint, testInitdata)
 		if err != nil {
 			log.Fatalf("failed to build initdata %s", err)
 		}
@@ -379,8 +380,8 @@ func NewBusyboxPodWithName(namespace, podName string) PodOrError {
 	return fromPod(NewPod(namespace, podName, "busybox", busyboxImage, WithCommand([]string{"/bin/sh", "-c", "sleep 3600"})))
 }
 
-func NewBusyboxPodWithNameWithInitdata(namespace, podName string, kbsEndpoint string) PodOrError {
-	initdata, err := buildInitdataBody(kbsEndpoint)
+func NewBusyboxPodWithNameWithInitdata(namespace, podName string, kbsEndpoint string, testInitdataVal string) PodOrError {
+	initdata, err := buildInitdataBody(kbsEndpoint, testInitdataVal)
 	if err != nil {
 		return fromError(err)
 	}

--- a/src/cloud-api-adaptor/test/e2e/common_suite.go
+++ b/src/cloud-api-adaptor/test/e2e/common_suite.go
@@ -595,7 +595,7 @@ func DoTestSealedSecret(t *testing.T, e env.Environment, assert CloudAssert, kbs
 // as test cases might be run in parallel
 func DoTestKbsKeyRelease(t *testing.T, e env.Environment, assert CloudAssert, kbsEndpoint, resourcePath, expectedSecret string) {
 	t.Log("Do test https kbs key release")
-	pod := NewBusyboxPodWithNameWithInitdata(E2eNamespace, "kbs-key-release", kbsEndpoint).GetPodOrFatal(t)
+	pod := NewBusyboxPodWithNameWithInitdata(E2eNamespace, "kbs-key-release", kbsEndpoint, testInitdata).GetPodOrFatal(t)
 	testCommands := []TestCommand{
 		{
 			Command:       []string{"wget", "-q", "-O-", "http://127.0.0.1:8006/cdh/resource/" + resourcePath},
@@ -619,7 +619,7 @@ func DoTestKbsKeyRelease(t *testing.T, e env.Environment, assert CloudAssert, kb
 // as test cases might be run in parallel
 func DoTestKbsKeyReleaseForFailure(t *testing.T, e env.Environment, assert CloudAssert, kbsEndpoint, resourcePath, expectedSecret string) {
 	t.Log("Do test kbs key release failure case")
-	pod := NewBusyboxPodWithNameWithInitdata(E2eNamespace, "kbs-failure", kbsEndpoint).GetPodOrFatal(t)
+	pod := NewBusyboxPodWithNameWithInitdata(E2eNamespace, "kbs-failure", kbsEndpoint, testInitdata).GetPodOrFatal(t)
 	testCommands := []TestCommand{
 		{
 			Command:       []string{"wget", "-q", "-O-", "http://127.0.0.1:8006/cdh/resource/" + resourcePath},
@@ -792,4 +792,11 @@ func DoTestPodWithCpuMemLimitsAndRequests(t *testing.T, e env.Environment, asser
 	// Custom resource added as req/limit - "kata.peerpods.io/vm
 
 	NewTestCase(t, e, "PodWithCpuMemLimitsAndRequests", assert, "Pod with cpu and memory limits and requests").WithPod(pod).Run()
+}
+
+// Test to check scenarios where initdata body is empty
+func DoTestPodWithoutInitdataAnnotations(t *testing.T, e env.Environment, assert CloudAssert, kbsEndpoint string) {
+	pod := NewBusyboxPodWithNameWithInitdata(E2eNamespace, "podwithout-initdata", kbsEndpoint, testEmptyInitdata).GetPodOrFatal(t)
+	expectedErrorString := "unmarshalling initdata: toml: invalid character at start of key"
+	NewTestCase(t, e, "PodwithoutInitdataAnnotations", assert, "PodVM without Initdata Annotation is created").WithPod(pod).WithExpectedPodEventError(expectedErrorString).WithCustomPodState(v1.PodPending).Run()
 }

--- a/src/cloud-api-adaptor/test/e2e/libvirt_test.go
+++ b/src/cloud-api-adaptor/test/e2e/libvirt_test.go
@@ -254,3 +254,12 @@ func TestLibvirtCreateWithCpuAndMemRequestLimit(t *testing.T) {
 	assert := LibvirtAssert{}
 	DoTestPodWithCpuMemLimitsAndRequests(t, testEnv, assert, "100m", "100Mi", "200m", "200Mi")
 }
+
+func TestLibvirtCreatePodWithoutInitdataAnnotations(t *testing.T) {
+	assert := LibvirtAssert{}
+	kbsEndpoint, err := keyBrokerService.GetCachedKbsEndpoint()
+	if err != nil {
+		t.Fatalf("GetCachedKbsEndpoint failed with: %v", err)
+	}
+	DoTestPodWithoutInitdataAnnotations(t, testEnv, assert, kbsEndpoint)
+}

--- a/src/cloud-api-adaptor/test/e2e/remote_attestation.go
+++ b/src/cloud-api-adaptor/test/e2e/remote_attestation.go
@@ -14,7 +14,7 @@ func DoTestRemoteAttestation(t *testing.T, e env.Environment, assert CloudAssert
 	image := "quay.io/curl/curl:latest"
 	// fail on non 200 code, silent, but output on failure
 	cmd := []string{"curl", "-f", "-s", "-S", "-o", "/dev/null", "http://127.0.0.1:8006/aa/token?token_type=kbs"}
-	initdata, err := buildInitdataBody(kbsEndpoint)
+	initdata, err := buildInitdataBody(kbsEndpoint, testInitdata)
 	if err != nil {
 		log.Fatalf("failed to build initdata %s", err)
 	}


### PR DESCRIPTION
Adding an end-to-end (E2E) test case to validate system behavior when invalied initdata body is provided.