### PR TITLE
ibmcloud-powervs: fix podvm image build

### DIFF
--- a/src/cloud-api-adaptor/ibmcloud-powervs/image/prereq.sh
+++ b/src/cloud-api-adaptor/ibmcloud-powervs/image/prereq.sh
@@ -9,8 +9,8 @@ yum install -y curl libseccomp-devel openssl openssl-devel skopeo clang clang-de
 wget https://rpmfind.net/linux/centos-stream/9-stream/CRB/ppc64le/os/Packages/protobuf-compiler-3.14.0-13.el9.ppc64le.rpm
 yum install -y protobuf-compiler-3.14.0-13.el9.ppc64le.rpm
 
-wget https://www.rpmfind.net/linux/centos-stream/9-stream/CRB/ppc64le/os/Packages/device-mapper-devel-1.02.197-2.el9.ppc64le.rpm
-yum install -y device-mapper-devel-1.02.197-2.el9.ppc64le.rpm
+wget https://www.rpmfind.net/linux/centos-stream/9-stream/CRB/ppc64le/os/Packages/device-mapper-devel-1.02.202-2.el9.ppc64le.rpm
+yum install -y device-mapper-devel-1.02.202-2.el9.ppc64le.rpm
 
 # Install Golang
 curl https://dl.google.com/go/go${GO_VERSION}.linux-ppc64le.tar.gz -o go${GO_VERSION}.linux-ppc64le.tar.gz && \


### PR DESCRIPTION
Update the device-mapper-devel package version to fix the image build.

Fixes: #2338