### PR TITLE
3.15.0 dependency bump

### DIFF
--- a/src/cloud-api-adaptor/go.mod
+++ b/src/cloud-api-adaptor/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/coreos/go-iptables v0.6.0
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0
-	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250220145350-19a7f2773679
+	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250320073820-c0632f847fe7
 	github.com/opencontainers/runtime-spec v1.1.1-0.20230922153023-c0e90434df2a
 	github.com/stretchr/testify v1.9.0
 	github.com/vishvananda/netlink v1.2.1-beta.2

--- a/src/cloud-api-adaptor/go.sum
+++ b/src/cloud-api-adaptor/go.sum
@@ -388,8 +388,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250220145350-19a7f2773679 h1:KDg0q3zgnnk5HQoDwHGGItzLYVQuIY/ERWDkul162cA=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250220145350-19a7f2773679/go.mod h1:b6luAOpsTPgkmwYII4H/PC/Ctc+yF1g6I/b0f/wIenw=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250320073820-c0632f847fe7 h1:iu7rYjGj1L7n6pIYEycqNYzcp4X36KI8lBbSlXVa4ns=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250320073820-c0632f847fe7/go.mod h1:Fhdl+GPnBrNJ3dizbZ9Slp5sTvSnCR0wz1ZW8kFmkZw=
 github.com/kdomanski/iso9660 v0.4.0 h1:BPKKdcINz3m0MdjIMwS0wx1nofsOjxOq8TOr45WGHFg=
 github.com/kdomanski/iso9660 v0.4.0/go.mod h1:OxUSupHsO9ceI8lBLPJKWBTphLemjrCQY8LPXM7qSzU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/src/cloud-api-adaptor/test/utils/checkout_kbs.sh
+++ b/src/cloud-api-adaptor/test/utils/checkout_kbs.sh
@@ -17,7 +17,7 @@ install_kbs_client() {
     kbs_sha=$1
     arch=$(uname -m)
 
-    oras pull "ghcr.io/confidential-containers/staged-images/kbs-client:sample_only-${arch}-linux-gnu-${kbs_sha}"
+    oras pull "ghcr.io/confidential-containers/staged-images/kbs-client:sample_only-${kbs_sha}-${arch}"
     chmod +x ./kbs-client
 }
 

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -34,8 +34,8 @@ tools:
 git:
   coco-operator:
     url: https://github.com/confidential-containers/operator
-    config: default
-    reference: main
+    config: release
+    reference: v0.13.0
   umoci:
     url: https://github.com/opencontainers/umoci
     reference: v0.4.7

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -44,7 +44,7 @@ git:
     reference: v1.5.0
   kbs:
     url: https://github.com/confidential-containers/trustee
-    reference: 68e2a8d25dbfa012b422ff464f31d18f3afa6677
+    reference: bc26ac5acd8314ba34fe837d6886beb1ce384106
 # If a tag is given it will attempt to pull the oci image by tag. if a
 # reference is specified the corresponding tag will be constructed using
 # the reference and suffixes like architecture or tee.
@@ -54,7 +54,7 @@ oci:
     tag: 3.9
   kata-containers:
     registry: ghcr.io/kata-containers/cached-artefacts
-    reference: 3.14.0
+    reference: 3.15.0
   guest-components:
     registry: ghcr.io/confidential-containers/guest-components
-    reference: 514c561d933cb11a0f1628621a0b930157af76cd
+    reference: 1191f8257eb65f42892ab0328cec02e58d40de84

--- a/src/csi-wrapper/go.mod
+++ b/src/csi-wrapper/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang/glog v1.2.4
 	github.com/golang/protobuf v1.5.4
-	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250220145350-19a7f2773679
+	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250320073820-c0632f847fe7
 	golang.org/x/net v0.33.0
 	google.golang.org/grpc v1.67.1
 	k8s.io/apimachinery v0.27.4

--- a/src/csi-wrapper/go.sum
+++ b/src/csi-wrapper/go.sum
@@ -76,8 +76,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250220145350-19a7f2773679 h1:KDg0q3zgnnk5HQoDwHGGItzLYVQuIY/ERWDkul162cA=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250220145350-19a7f2773679/go.mod h1:b6luAOpsTPgkmwYII4H/PC/Ctc+yF1g6I/b0f/wIenw=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250320073820-c0632f847fe7 h1:iu7rYjGj1L7n6pIYEycqNYzcp4X36KI8lBbSlXVa4ns=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250320073820-c0632f847fe7/go.mod h1:Fhdl+GPnBrNJ3dizbZ9Slp5sTvSnCR0wz1ZW8kFmkZw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -107,8 +107,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
-github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
+github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
+github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=


### PR DESCRIPTION
Bump kata and guest-components to match the 3.15.0 release that will form the basis of CoCo 0.13.0