### PR TITLE
podvm: remove --no-verify 

### DIFF
--- a/src/cloud-api-adaptor/podvm/qcow2/rhel/qemu-rhel.pkr.hcl
+++ b/src/cloud-api-adaptor/podvm/qcow2/rhel/qemu-rhel.pkr.hcl
@@ -126,7 +126,8 @@ build {
     environment_vars = [
       "SE_BOOT=${var.se_boot}",
       "PODVM_DISTRO=${var.podvm_distro}",
-      "ARCH=${var.os_arch}"
+      "ARCH=${var.os_arch}",
+      "SE_VERIFY=${var.se_verify}"
     ]
     inline = [
       "sudo -E bash ~/build-s390x-se-image.sh"

--- a/src/cloud-api-adaptor/podvm/qcow2/rhel/variables.pkr.hcl
+++ b/src/cloud-api-adaptor/podvm/qcow2/rhel/variables.pkr.hcl
@@ -113,6 +113,11 @@ variable "se_boot" {
   default = env("SE_BOOT")
 }
 
+variable "se_verify" {
+  type    = string
+  default = env("SE_VERIFY")
+}
+
 variable "output_directory" {
   type    = string
   default = "output"


### PR DESCRIPTION
Currently in s390x SE image building flow we use --no-verify. I've removed that tag and SE image is built with signing cert, CA certs and crls. These are downloaded in operator build flow if the image is created manually these files can be placed inside files directory along with HKD.