### PR TITLE
podvm: support aarch64/ARM64 build

### DIFF
--- a/src/cloud-api-adaptor/Dockerfile
+++ b/src/cloud-api-adaptor/Dockerfile
@@ -36,7 +36,7 @@ COPY cloud-api-adaptor/cmd   ./cmd
 COPY cloud-api-adaptor/pkg   ./pkg
 COPY cloud-api-adaptor/proto ./proto
 
-RUN CC=gcc make ARCH=$TARGETARCH COMMIT=$COMMIT VERSION=$VERSION RELEASE_BUILD=$RELEASE_BUILD cloud-api-adaptor
+RUN CC=gcc ARCH=$TARGETARCH make COMMIT=$COMMIT VERSION=$VERSION RELEASE_BUILD=$RELEASE_BUILD cloud-api-adaptor
 
 FROM builder-release AS iptables
 

--- a/src/cloud-api-adaptor/Makefile
+++ b/src/cloud-api-adaptor/Makefile
@@ -7,25 +7,11 @@ include Makefile.defaults
 
 SHELL = bash -o pipefail
 
-ARCH ?= $(shell uname -m)
-TARGET_ARCH ?= amd64
-PROTOC_ARCH ?= x86_64
-ifeq ($(ARCH),aarch64)
-	TARGET_ARCH := arm64
-	PROTOC_ARCH := aarch_64
-else ifeq ($(ARCH),s390x)
-	TARGET_ARCH := s390x
-	PROTOC_ARCH := s390_64
-else ifeq ($(ARCH),ppc64le)
-	TARGET_ARCH := ppc64le
-	PROTOC_ARCH := ppc64le_64
-endif
-
 # Default is dev build. To create release build set RELEASE_BUILD=true
 RELEASE_BUILD ?= false
 # CLOUD_PROVIDER is used for runtime -- which provider should be run against the binary/code.
 CLOUD_PROVIDER ?=
-GOOPTIONS   ?= GOOS=linux GOARCH=$(TARGET_ARCH) CGO_ENABLED=0
+GOOPTIONS   ?= GOOS=linux GOARCH=$(GO_ARCH) CGO_ENABLED=0
 GOFLAGS     ?=
 BINARIES    := cloud-api-adaptor agent-protocol-forwarder process-user-data
 SOURCEDIRS  := ./cmd ./pkg
@@ -37,7 +23,7 @@ TEST_E2E_TIMEOUT ?= 60m
 RUN_TESTS ?= ''
 
 RESOURCE_CTRL ?= true
-YQ_CHECKSUM_$(TARGET_ARCH) ?= $(YQ_CHECKSUM)
+YQ_CHECKSUM_$(GO_ARCH) ?= $(YQ_CHECKSUM)
 # BUILTIN_CLOUD_PROVIDERS is used for binary build -- what providers are built in the binaries.
 ifeq ($(RELEASE_BUILD),true)
 	BUILTIN_CLOUD_PROVIDERS ?= aws azure gcp ibmcloud vsphere
@@ -175,8 +161,8 @@ PODVM_DISTRO ?= ubuntu
 PODVM_TAG ?= $(VERSIONS_HASH)
 
 PODVM_BUILDER_IMAGE ?= $(REGISTRY)/podvm-builder-$(PODVM_DISTRO):$(PODVM_TAG)
-PODVM_BINARIES_IMAGE ?= $(REGISTRY)/podvm-binaries-$(PODVM_DISTRO)-$(TARGET_ARCH):$(PODVM_TAG)
-PODVM_IMAGE ?= $(REGISTRY)/podvm-$(or $(CLOUD_PROVIDER),generic)-$(PODVM_DISTRO)-$(TARGET_ARCH):$(PODVM_TAG)
+PODVM_BINARIES_IMAGE ?= $(REGISTRY)/podvm-binaries-$(PODVM_DISTRO)-$(DISTRO_ARCH):$(PODVM_TAG)
+PODVM_IMAGE ?= $(REGISTRY)/podvm-$(or $(CLOUD_PROVIDER),generic)-$(PODVM_DISTRO)-$(DISTRO_ARCH):$(PODVM_TAG)
 
 PUSH ?= false
 # If not pushing `--load` into the local docker cache
@@ -192,11 +178,13 @@ podvm-builder:
 	--build-arg GO_VERSION=$(GO_VERSION) \
 	--build-arg ORG_ID=$(ORG_ID) \
 	--build-arg ACTIVATION_KEY=$(ACTIVATION_KEY) \
-	--build-arg ARCH=$(TARGET_ARCH) \
+	--build-arg ARCH=$(ARCH) \
+	--build-arg GO_ARCH=$(GO_ARCH) \
+	--build-arg DISTRO_ARCH=$(DISTRO_ARCH) \
 	--build-arg PROTOC_VERSION=$(PROTOC_VERSION) \
 	--build-arg YQ_VERSION=$(YQ_VERSION) \
-	--build-arg YQ_CHECKSUM=${YQ_CHECKSUM_$(TARGET_ARCH)} \
-	--build-arg YQ_ARCH=$(TARGET_ARCH) \
+	--build-arg YQ_CHECKSUM=${YQ_CHECKSUM_$(GO_ARCH)} \
+	--build-arg YQ_ARCH=$(GO_ARCH) \
 	--build-arg PROTOC_ARCH=$(PROTOC_ARCH) \
 	--build-arg ORAS_VERSION=$(ORAS_VERSION) \
 	--build-arg PACKER_VERSION=$(PACKER_VERSION) \
@@ -207,7 +195,9 @@ podvm-binaries:
 	cd ../ && docker buildx build -t $(PODVM_BINARIES_IMAGE) -f cloud-api-adaptor/podvm/$(BINARIES_DOCKERFILE) \
 	--build-arg BUILDER_IMG=$(PODVM_BUILDER_IMAGE) \
 	--build-arg PODVM_DISTRO=$(PODVM_DISTRO) \
-	--build-arg ARCH=$(TARGET_ARCH) \
+	--build-arg ARCH=$(ARCH) \
+	--build-arg GO_ARCH=$(GO_ARCH) \
+	--build-arg DISTRO_ARCH=$(DISTRO_ARCH) \
 	--build-arg TEE_PLATFORM=$(TEE_PLATFORM) \
 	--build-arg PAUSE_REPO=$(PAUSE_REPO) \
 	--build-arg PAUSE_VERSION=$(PAUSE_VERSION) \
@@ -232,7 +222,7 @@ endif
 	--build-arg PODVM_DISTRO=$(PODVM_DISTRO) \
 	--build-arg ORG_ID=$(ORG_ID) \
 	--build-arg ACTIVATION_KEY=$(ACTIVATION_KEY) \
-	--build-arg ARCH=$(TARGET_ARCH) \
+	--build-arg ARCH=$(ARCH) \
 	--build-arg CLOUD_PROVIDER=$(or $(CLOUD_PROVIDER),generic) \
 	--build-arg IMAGE_URL=$(IMAGE_URL) \
 	--build-arg IMAGE_CHECKSUM=$(IMAGE_CHECKSUM) \

--- a/src/cloud-api-adaptor/Makefile.defaults
+++ b/src/cloud-api-adaptor/Makefile.defaults
@@ -12,6 +12,41 @@ YQ_CHECKSUM_arm64 := "sha256:1d830254fe5cc2fb046479e6c781032976f5cf88f9d01a63858
 # none,az-cvm-vtpm,tdx,se,cca
 TEE_PLATFORM ?= none
 
+# Normalise ARCH constraints and avoid pre-defined global variables in:
+# https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
+ARCH ?= $(shell uname -m)
+ifneq "$(filter $(ARCH),x86_64 amd64)" ""
+	ARCH := x86_64
+	GO_ARCH := amd64
+	PROTOC_ARCH := x86_64
+	DISTRO_ARCH := amd64
+else ifneq "$(filter $(ARCH),aarch64 arm64)" ""
+	ARCH := aarch64
+	GO_ARCH := arm64
+	PROTOC_ARCH := aarch_64
+	DISTRO_ARCH := arm64
+else ifneq "$(filter $(ARCH),s390x)" ""
+	ARCH := s390x
+	GO_ARCH := s390x
+	PROTOC_ARCH := s390_64
+	DISTRO_ARCH := s390x
+else ifneq "$(filter $(ARCH),ppc64le)" ""
+	ARCH := ppc64le
+	GO_ARCH := ppc64le
+	PROTOC_ARCH := ppc64le_64
+	DISTRO_ARCH := ppc64le
+endif
+
+ifndef GO_ARCH
+$(error GO_ARCH is not set)
+endif
+ifndef PROTOC_ARCH
+$(error PROTOC_ARCH is not set)
+endif
+ifndef DISTRO_ARCH
+$(error DISTRO_ARCH is not set)
+endif
+
 VERSIONS_HASH := $(firstword $(shell sha256sum $(VERSIONS_SRC)))
 
 define query

--- a/src/cloud-api-adaptor/ibmcloud/image/Makefile
+++ b/src/cloud-api-adaptor/ibmcloud/image/Makefile
@@ -9,7 +9,7 @@ include $(ROOT_DIR)podvm/Makefile.inc
 .PHONY: build push verify ubuntu clean
 
 UBUNTU_RELEASE     = noble
-UBUNTU_IMAGE_URL  := https://cloud-images.ubuntu.com/$(UBUNTU_RELEASE)/current/$(UBUNTU_RELEASE)-server-cloudimg-$(DEB_ARCH).img
+UBUNTU_IMAGE_URL  := https://cloud-images.ubuntu.com/$(UBUNTU_RELEASE)/current/$(UBUNTU_RELEASE)-server-cloudimg-$(DISTRO_ARCH).img
 UBUNTU_IMAGE_FILE := $(notdir $(UBUNTU_IMAGE_URL))
 
 UBUNTU_PACKAGES = jq

--- a/src/cloud-api-adaptor/podvm-mkosi/Makefile
+++ b/src/cloud-api-adaptor/podvm-mkosi/Makefile
@@ -1,14 +1,5 @@
 include ../Makefile.defaults
 
-ARCH      ?= $(subst x86_64,amd64,$(shell uname -m))
-PROTOC_ARCH ?= x86_64
-ifeq ($(ARCH),aarch64)
-	PROTOC_ARCH := aarch_64
-else ifeq ($(ARCH),s390x)
-	PROTOC_ARCH := s390_64
-else ifeq ($(ARCH),ppc64le)
-	PROTOC_ARCH := ppc64le_64
-endif
 SE_BOOT   ?= false
 IS_DEBIAN := $(shell if grep -q 'ID_LIKE=debian' /etc/os-release; then echo "true"; else echo "false"; fi)
 
@@ -17,10 +8,10 @@ PODVM_DISTRO ?= fedora
 ifeq ($(PODVM_TAG),)
 	PODVM_TAG := $(VERSIONS_HASH)
 endif
-PODVM_BUILDER_IMAGE ?= $(REGISTRY)/podvm-builder-$(PODVM_DISTRO)-$(ARCH):$(PODVM_TAG)
-PODVM_BINARIES_IMAGE ?= $(REGISTRY)/podvm-binaries-$(PODVM_DISTRO)-$(ARCH):$(PODVM_TAG)
-PODVM_IMAGE ?= $(REGISTRY)/podvm-generic-$(PODVM_DISTRO)$(if $(filter $(SE_BOOT),true),-se,)-$(ARCH):$(PODVM_TAG)
-PODVM_CONTAINER_NAME ?= $(REGISTRY)/podvm-docker-image-$(ARCH)
+PODVM_BUILDER_IMAGE ?= $(REGISTRY)/podvm-builder-$(PODVM_DISTRO)-$(DISTRO_ARCH):$(PODVM_TAG)
+PODVM_BINARIES_IMAGE ?= $(REGISTRY)/podvm-binaries-$(PODVM_DISTRO)-$(DISTRO_ARCH):$(PODVM_TAG)
+PODVM_IMAGE ?= $(REGISTRY)/podvm-generic-$(PODVM_DISTRO)$(if $(filter $(SE_BOOT),true),-se,)-$(DISTRO_ARCH):$(PODVM_TAG)
+PODVM_CONTAINER_NAME ?= $(REGISTRY)/podvm-docker-image-$(DISTRO_ARCH)
 VERIFY_PROVENANCE ?= no
 MKOSI_VERSION ?= v22
 
@@ -34,9 +25,7 @@ debug:binaries image-debug
 .PHONY: container
 container: binaries image-container
 
-ifeq ($(ARCH),s390x)
-YQ_CHECKSUM = $(YQ_CHECKSUM_s390x)
-endif
+YQ_CHECKSUM_$(GO_ARCH) ?= $(YQ_CHECKSUM)
 
 define run_mkosi_in_container
 	docker run --rm --privileged \
@@ -57,11 +46,13 @@ endif
 		--progress=plain \
 		--build-arg GO_VERSION=$(GO_VERSION) \
 		--build-arg ARCH=$(ARCH) \
+		--build-arg GO_ARCH=$(GO_ARCH) \
+		--build-arg DISTRO_ARCH=$(DISTRO_ARCH) \
 		--build-arg PROTOC_VERSION=$(PROTOC_VERSION) \
-		--build-arg YQ_VERSION=$(YQ_VERSION) \
-		--build-arg YQ_CHECKSUM=$(YQ_CHECKSUM) \
-		--build-arg YQ_ARCH=$(ARCH) \
 		--build-arg PROTOC_ARCH=$(PROTOC_ARCH) \
+		--build-arg YQ_VERSION=$(YQ_VERSION) \
+		--build-arg YQ_CHECKSUM=$(YQ_CHECKSUM_$(GO_ARCH)) \
+		--build-arg YQ_ARCH=$(GO_ARCH) \
 		--build-arg ORAS_VERSION=$(ORAS_VERSION) \
 		--build-arg TEE_PLATFORM=$(TEE_PLATFORM) \
 		--build-arg PAUSE_REPO=$(PAUSE_REPO) \
@@ -103,7 +94,7 @@ else
 		--builder insecure-builder \
 		--allow security.insecure \
 		.
-	qemu-img convert -f raw -O qcow2 build/system.raw build/podvm-$(PODVM_DISTRO)-$(ARCH).qcow2
+	qemu-img convert -f raw -O qcow2 build/system.raw build/podvm-$(PODVM_DISTRO)-$(DISTRO_ARCH).qcow2
 endif
 
 PHONY: image-debug
@@ -127,7 +118,7 @@ else
 		--builder insecure-builder \
 		--allow security.insecure \
 		.
-	qemu-img convert -f raw -O qcow2 build/system.raw build/podvm-$(PODVM_DISTRO)-$(ARCH).qcow2
+	qemu-img convert -f raw -O qcow2 build/system.raw build/podvm-$(PODVM_DISTRO)-$(DISTRO_ARCH).qcow2
 endif
 
 PHONY: image-container

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_binaries.fedora
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_binaries.fedora
@@ -7,7 +7,9 @@
 #
 FROM registry.fedoraproject.org/fedora:40 AS builder
 
-ARG ARCH="amd64"
+ARG ARCH="x86_64"
+ARG GO_ARCH="amd64"
+ARG DISTRO_ARCH="amd64"
 ARG YQ_ARCH="amd64"
 ARG PROTOC_ARCH="x86_64"
 ARG GO_VERSION
@@ -23,8 +25,8 @@ RUN dnf groupinstall -y 'Development Tools' && \
     clang which xz jq && \
     dnf clean all
 
-ADD https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz go${GO_VERSION}.linux-${ARCH}.tar.gz
-RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go${GO_VERSION}.linux-${ARCH}.tar.gz && rm -f go${GO_VERSION}.linux-${ARCH}.tar.gz
+ADD https://dl.google.com/go/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz go${GO_VERSION}.linux-${GO_ARCH}.tar.gz
+RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && rm -f go${GO_VERSION}.linux-${GO_ARCH}.tar.gz
 
 ENV PATH="/usr/local/go/bin:$PATH"
 
@@ -43,8 +45,8 @@ RUN chmod a+x /usr/local/bin/yq
 ADD https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip
 RUN unzip protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip -d /usr/local && rm -f protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip
 
-ADD https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${ARCH}.tar.gz oras_${ORAS_VERSION}_linux_${ARCH}.tar.gz
-RUN rm -rf /usr/local/bin/oras && tar -C /usr/local/bin -xzf oras_${ORAS_VERSION}_linux_${ARCH}.tar.gz && rm -f oras_${ORAS_VERSION}_linux_${ARCH}.tar.gz
+ADD https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${DISTRO_ARCH}.tar.gz oras_${ORAS_VERSION}_linux_${DISTRO_ARCH}.tar.gz
+RUN rm -rf /usr/local/bin/oras && tar -C /usr/local/bin -xzf oras_${ORAS_VERSION}_linux_${DISTRO_ARCH}.tar.gz && rm -f oras_${ORAS_VERSION}_linux_${DISTRO_ARCH}.tar.gz
 
 WORKDIR /src
 

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder
@@ -8,9 +8,10 @@
 #
 FROM ubuntu:24.04
 
-ARG ARCH="amd64"
+ARG ARCH="x86_64"
+ARG GO_ARCH="amd64"
+ARG DISTRO_ARCH="amd64"
 ARG YQ_ARCH="amd64"
-# PROTOC_ARCH="x86_64" | "s390_64"
 ARG PROTOC_ARCH="x86_64"
 ARG GO_VERSION
 ARG PROTOC_VERSION
@@ -29,18 +30,19 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y build-essential cloud-image-utils curl git gnupg \
-    libdevmapper-dev libgpgme-dev lsb-release pkg-config qemu-kvm \
+    libdevmapper-dev libgpgme-dev lsb-release pkg-config jq \
     musl-tools unzip wget git && \
+    apt-get install -y qemu-kvm && \
     wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
     echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-17 main" | tee -a /etc/apt/sources.list && \
     apt-get update && apt-get install -y clang-17 && \
     curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
-    echo "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee -a /etc/apt/sources.list && \
+    echo "deb [arch=${DISTRO_ARCH}] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee -a /etc/apt/sources.list && \
     apt-get update && apt-get install --no-install-recommends -y packer=1.9.4-1 && \
     apt-get clean
 
-ADD https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz go${GO_VERSION}.linux-amd64.tar.gz
-RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && rm -f go${GO_VERSION}.linux-amd64.tar.gz
+ADD https://dl.google.com/go/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz go${GO_VERSION}.linux-${GO_ARCH}.tar.gz
+RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && rm -f go${GO_VERSION}.linux-${GO_ARCH}.tar.gz
 
 ADD https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${YQ_ARCH} /usr/local/bin/yq
 RUN echo "${YQ_CHECKSUM#sha256:} /usr/local/bin/yq" | sha256sum -c
@@ -48,11 +50,11 @@ RUN chmod a+x /usr/local/bin/yq
 
 ENV PATH="/usr/local/go/bin:$PATH"
 
-ADD https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip protoc-${PROTOC_VERSION}-linux-x86_64.zip
-RUN unzip protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local && rm -f protoc-${PROTOC_VERSION}-linux-x86_64.zip
+ADD https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip
+RUN unzip protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip -d /usr/local && rm -f protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip
 
-ADD https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz oras_${ORAS_VERSION}_linux_amd64.tar.gz
-RUN rm -rf /usr/local/bin/oras && tar -C /usr/local/bin -xzf oras_${ORAS_VERSION}_linux_amd64.tar.gz && rm -f oras_${ORAS_VERSION}_linux_amd64.tar.gz
+ADD https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${DISTRO_ARCH}.tar.gz oras_${ORAS_VERSION}_linux_${DISTRO_ARCH}.tar.gz
+RUN rm -rf /usr/local/bin/oras && tar -C /usr/local/bin -xzf oras_${ORAS_VERSION}_linux_${DISTRO_ARCH}.tar.gz && rm -f oras_${ORAS_VERSION}_linux_${DISTRO_ARCH}.tar.gz
 
 WORKDIR /src
 

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.rhel
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.rhel
@@ -8,9 +8,10 @@
 #
 FROM registry.access.redhat.com/ubi9/ubi:9.4
 
-ARG ARCH="amd64"
+ARG ARCH="x86_64"
+ARG GO_ARCH="amd64"
+ARG DISTRO_ARCH="amd64"
 ARG YQ_ARCH="amd64"
-# PROTOC_ARCH="x86_64" | "s390_64"
 ARG PROTOC_ARCH="x86_64"
 ARG GO_VERSION
 ARG PROTOC_VERSION
@@ -77,8 +78,8 @@ ENV PATH="/usr/local/go/bin:$PATH"
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip && \
     unzip protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip -d /usr/local && rm -f protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip
 
-ADD https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${ARCH}.tar.gz oras_${ORAS_VERSION}_linux_${ARCH}.tar.gz
-RUN rm -rf /usr/local/bin/oras && tar -C /usr/local/bin -xzf oras_${ORAS_VERSION}_linux_${ARCH}.tar.gz && rm -f oras_${ORAS_VERSION}_linux_${ARCH}.tar.gz
+ADD https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${DISTRO_ARCH}.tar.gz oras_${ORAS_VERSION}_linux_${DISTRO_ARCH}.tar.gz
+RUN rm -rf /usr/local/bin/oras && tar -C /usr/local/bin -xzf oras_${ORAS_VERSION}_linux_${DISTRO_ARCH}.tar.gz && rm -f oras_${ORAS_VERSION}_linux_${DISTRO_ARCH}.tar.gz
 
 WORKDIR /src
 ENV GOPATH=/src

--- a/src/cloud-api-adaptor/podvm/Makefile
+++ b/src/cloud-api-adaptor/podvm/Makefile
@@ -10,8 +10,8 @@ include $(SELF_DIR)Makefile.inc
 
 IMAGE_SUFFIX := .qcow2
 PODVM_DISTRO ?= ubuntu
-IMAGE_URL := $(or $(IMAGE_URL),$($(PODVM_DISTRO)_$(DEB_ARCH)_IMAGE_URL))
-IMAGE_CHECKSUM := $(or $(IMAGE_CHECKSUM),$($(PODVM_DISTRO)_$(DEB_ARCH)_IMAGE_CHECKSUM))
+IMAGE_URL := $(or $(IMAGE_URL),$($(PODVM_DISTRO)_$(DISTRO_ARCH)_IMAGE_URL))
+IMAGE_CHECKSUM := $(or $(IMAGE_CHECKSUM),$($(PODVM_DISTRO)_$(DISTRO_ARCH)_IMAGE_CHECKSUM))
 
 ifndef IMAGE_URL
 $(error "IMAGE_URL is not defined")
@@ -23,6 +23,7 @@ endif
 AGENT_PROTOCOL_FORWARDER_SRC := ../
 
 QEMU_MACHINE_TYPE_s390x := s390-ccw-virtio
+QEMU_MACHINE_TYPE_aarch64 := virt
 
 UEFI ?= false
 UEFI_FIRMWARE_LOCATION ?=
@@ -40,12 +41,16 @@ setopts:
 ifeq ($(PODVM_DISTRO),ubuntu)
 	@echo defined
 	$(eval OPTS := -var se_boot=${SE_BOOT})
-ifneq ($(HOST_ARCH),$(ARCH))
+ifneq ($(ARCH),x86_64)
 	$(eval OPTS += -var machine_type=${QEMU_MACHINE_TYPE_${ARCH}})
 ifndef QEMU_BINARY
 	$(eval OPTS += -var qemu_binary=qemu-system-${ARCH})
 endif
-
+# UEFI for aarch64 on ubuntu
+ifeq ($(ARCH),aarch64)
+	$(eval OPTS += -var is_uefi=true -var os_arch="aarch64")
+	$(eval OPTS += -var uefi_firmware="/usr/share/qemu-efi-aarch64/QEMU_EFI.fd")
+endif
 endif
 else ifeq ($(PODVM_DISTRO),rhel)
 	@echo defined
@@ -67,7 +72,7 @@ ifdef QEMU_BINARY
 	$(eval OPTS += -var qemu_binary=${QEMU_BINARY} )
 endif
 
-# UEFI is enabled for x86_64 only
+# UEFI for x86_64
 ifeq ($(UEFI),true)
 	$(eval OPTS += -var is_uefi=true -var os_arch="x86_64" )
 ifdef UEFI_FIRMWARE_LOCATION
@@ -91,7 +96,7 @@ $(IMAGE_FILE): $(BINARIES) $(FILES) setopts
 		fi \
 	fi
 	packer init ./qcow2/${PODVM_DISTRO}
-	if [ "${ARCH}" = "x86_64" ]; then \
+	if [ "${ARCH}" = "x86_64" ] || [ "${ARCH}" = "aarch64" ]; then \
 		packer plugins install github.com/hashicorp/qemu v1.1.0; \
 	fi
 	packer build ${PACKER_DEFAULT_OPTS} ${OPTS} qcow2/${PODVM_DISTRO}

--- a/src/cloud-api-adaptor/podvm/Makefile.inc
+++ b/src/cloud-api-adaptor/podvm/Makefile.inc
@@ -18,13 +18,6 @@ include $(ROOT_DIR)Makefile.defaults
 
 IMAGE_PREFIX := podvm
 
-HOST_ARCH   := $(shell uname -m)
-ARCH        := $(or $(ARCH),$(HOST_ARCH))
-# Normalise x86_64 / amd64 for input ARCH
-ARCH        := $(subst amd64,x86_64,$(ARCH))
-DEB_ARCH    := $(subst x86_64,amd64,$(ARCH))
-LIBC        ?= $(if $(filter $(ARCH),s390x ppc64le),gnu,musl)
-
 # Auth json file for registry access. Used with skopeo
 AUTHFILE ?=
 
@@ -76,7 +69,7 @@ COMMIT := $(shell	commit=$$(git describe --match '' --dirty --always) && \
 ifndef COMMIT
 $(error Failed to derive an image name. Explicitly define IMAGE_NAME)
 endif
-IMAGE_NAME := $(IMAGE_PREFIX)-$(COMMIT)-$(DEB_ARCH)
+IMAGE_NAME := $(IMAGE_PREFIX)-$(COMMIT)-$(DISTRO_ARCH)
 endif
 
 IMAGE_SUFFIX ?=
@@ -170,11 +163,11 @@ endef
 binaries: $(BINARIES)
 
 $(AGENT_PROTOCOL_FORWARDER): always
-	cd "$(ROOT_DIR)" && ARCH=$(DEB_ARCH) $(MAKE) agent-protocol-forwarder
+	cd "$(ROOT_DIR)" && ARCH=$(ARCH) $(MAKE) agent-protocol-forwarder
 	install -D --compare "$(ROOT_DIR)/agent-protocol-forwarder" "$@"
 
 $(PROCESS_USER_DATA): always
-	cd "$(ROOT_DIR)" && ARCH=$(DEB_ARCH) $(MAKE) process-user-data
+	cd "$(ROOT_DIR)" && ARCH=$(ARCH) $(MAKE) process-user-data
 	install -D --compare "$(ROOT_DIR)/process-user-data" "$@"
 
 $(KATA_AGENT): $(FORCE_TARGET)
@@ -201,7 +194,7 @@ $(UMOCI_SRC)/umoci: $(UMOCI_SRC)
 	cd "$(UMOCI_SRC)" && CC= $(MAKE)
 
 $(PAUSE_SRC): $(SKOPEO_BIN)
-	$(SKOPEO_BIN) --override-arch $(DEB_ARCH) --policy "$(FILES_DIR)/etc/containers/policy.json" copy \
+	$(SKOPEO_BIN) --override-arch $(DISTRO_ARCH) --policy "$(FILES_DIR)/etc/containers/policy.json" copy \
 		$(if $(AUTHFILE),--authfile $(AUTHFILE)) "docker://$(PAUSE_REPO):$(PAUSE_VERSION)" "oci:$(PAUSE_SRC):$(PAUSE_VERSION)"
 
 $(PAUSE): | $(PAUSE_SRC) $(UMOCI_SRC)/umoci

--- a/src/cloud-api-adaptor/podvm/hack/cross-build-extras.sh
+++ b/src/cloud-api-adaptor/podvm/hack/cross-build-extras.sh
@@ -6,9 +6,6 @@
 # If ARCH is not set, exit
 [[ -z $ARCH ]] && exit 0
 
-# Normalise ARCH (if input is amd64 use x86_64)
-ARCH=${ARCH/amd64/x86_64}
-
 # If ARCH is equal to HOST, exit
 [[ $ARCH = $(uname -m) ]] && exit 0
 

--- a/src/cloud-api-adaptor/podvm/qcow2/misc-settings.sh
+++ b/src/cloud-api-adaptor/podvm/qcow2/misc-settings.sh
@@ -40,7 +40,7 @@ then
     esac
 fi
 
-if [[ "$CLOUD_PROVIDER" == "azure" || "$CLOUD_PROVIDER" == "generic" ]] && [[ "$PODVM_DISTRO" == "ubuntu" ]]; then
+if [[ "$CLOUD_PROVIDER" == "azure" || "$CLOUD_PROVIDER" == "generic" ]] && [[ "$PODVM_DISTRO" == "ubuntu" ]] && [[ "$ARCH" == "x86_64" ]]; then
     export DEBIAN_FRONTEND=noninteractive
     curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
     echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/intel-sgx.list

--- a/src/cloud-api-adaptor/podvm/qcow2/ubuntu/qemu-ubuntu.pkr.hcl
+++ b/src/cloud-api-adaptor/podvm/qcow2/ubuntu/qemu-ubuntu.pkr.hcl
@@ -1,7 +1,7 @@
 locals {
   machine_type = "${var.os_arch}" == "x86_64" && "${var.is_uefi}" ? "q35" : "${var.machine_type}"
   use_pflash   = "${var.os_arch}" == "x86_64" && "${var.is_uefi}" ? "true" : "false"
-  firmware     = "${var.os_arch}" == "x86_64" && "${var.is_uefi}" ? "${var.uefi_firmware}" : ""
+  firmware     = "${var.is_uefi}" ? "${var.uefi_firmware}" : ""
   se_qemuargs = [
     ["-drive", "file=se-${var.qemu_image_name},if=none,cache=writeback,discard=ignore,format=qcow2,id=se-virtio-drive"],
     ["-device", "virtio-blk,drive=se-virtio-drive,id=virtio-disk1"]
@@ -25,31 +25,37 @@ locals {
       ["-serial", "mon:stdio"]
     ]
   )
+  efi_boot       = "${var.is_uefi}" ? "true" : "false"
   final_qemuargs = "${var.se_boot}" == "true" ? concat(local.qemuargs, local.se_qemuargs) : local.qemuargs
 }
 
 source "qemu" "ubuntu" {
-  disable_vnc      = true
-  disk_compression = true
-  disk_image       = true
-  disk_size        = "${var.disk_size}"
-  format           = "qcow2"
-  headless         = true
-  iso_checksum     = "${var.cloud_image_checksum}"
-  iso_url          = "${var.cloud_image_url}"
-  output_directory = "${var.output_directory}"
-  qemuargs         = "${local.final_qemuargs}"
-  ssh_password     = "${var.ssh_password}"
-  ssh_port         = 22
-  ssh_username     = "${var.ssh_username}"
-  ssh_timeout      = "${var.ssh_timeout}"
-  boot_wait        = "${var.boot_wait}"
-  vm_name          = "${var.qemu_image_name}"
-  shutdown_command = "sudo shutdown -h now"
-  qemu_binary      = "${var.qemu_binary}"
-  machine_type     = "${local.machine_type}"
-  use_pflash       = "${local.use_pflash}"
-  firmware         = "${local.firmware}"
+  disable_vnc       = true
+  disk_compression  = true
+  disk_image        = true
+  disk_size         = "${var.disk_size}"
+  format            = "qcow2"
+  headless          = true
+  iso_checksum      = "${var.cloud_image_checksum}"
+  iso_url           = "${var.cloud_image_url}"
+  output_directory  = "${var.output_directory}"
+  qemuargs          = "${local.final_qemuargs}"
+  ssh_password      = "${var.ssh_password}"
+  ssh_port          = 22
+  ssh_username      = "${var.ssh_username}"
+  ssh_timeout       = "${var.ssh_timeout}"
+  boot_wait         = "${var.boot_wait}"
+  vm_name           = "${var.qemu_image_name}"
+  shutdown_command  = "sudo shutdown -h now"
+  qemu_binary       = "${var.qemu_binary}"
+  machine_type      = "${local.machine_type}"
+  use_pflash        = "${local.use_pflash}"
+  firmware          = "${local.firmware}"
+  efi_boot          = "${local.efi_boot}"
+  efi_firmware_code = "${var.os_arch}" == "aarch64" ? "/usr/share/AAVMF/AAVMF_CODE.fd" : ""
+  efi_firmware_vars = "${var.os_arch}" == "aarch64" ? "/usr/share/AAVMF/AAVMF_VARS.fd" : ""
+  cpu_model         = "${var.os_arch}" == "aarch64" ? "cortex-a57" : ""
+
 }
 
 build {
@@ -92,7 +98,8 @@ build {
     remote_folder = "~"
     environment_vars = [
       "CLOUD_PROVIDER=${var.cloud_provider}",
-      "PODVM_DISTRO=${var.podvm_distro}"
+      "PODVM_DISTRO=${var.podvm_distro}",
+      "ARCH=${var.target_arch}"
     ]
     inline = [
       "sudo -E bash ~/misc-settings.sh"


### PR DESCRIPTION
Support podvm build on aarch64/ARM64 platform.

a. about `ARCH` changes:
1. `ARCH` are centrilized and normalized in `Makefile.defaults`. It's set to accept both styles as well: `ifneq "$(filter $(ARCH),x86_64 amd64)" ""`.
2. `ARCH` can't switch style for compatibility with existing usage in [readme](https://github.com/confidential-containers/cloud-api-adaptor/tree/main/src/cloud-api-adaptor/podvm#building-a-builder-image): `ARCH=s390x make -C .. podvm-builder`, and it's passed to various dockerfiles and back to the Makefile itself.. (recursive).
3. Due to above constraint, `GO_ARCH` and `DISTRO_ARCH` are added to preserve `ARCH`, more clean and flexible as well.
4. `ARCH` in CAA is moved to ENV as can be overridden in Makefile ([ref](https://gist.github.com/aprell/5dae170cecb68853968c0395ee2e21fa)), because it's the same Makefile for building both cloud-api-adaptor and podvm image: `RUN CC=gcc ARCH=$TARGETARCH make ...`

b. about `packer` changes:
1. Added `efi_firmware_code/vars` and `cpu_model` for `tcg` on `aarch64`, rest changes are for passing lint check.
2. Only added `aarch64` for Ubuntu in packer's `OPTS`. RHEL needs to be done separately due to it's limited access.
3. This patch was done back from `v0.9.0` and both packer & mkosi worked on ARM64 server for all prior releases.
4. Leave `x86_64's OPTS` unchanged (checked packer's [code](https://github.com/hashicorp/packer-plugin-qemu/blob/0e9effa1e5b591ee956e43c8cfecf0bfe19edd17/builder/qemu/step_run.go#L114) for this), `s390x/ppc64le` would need more local tests.
5. Skip `intel-sgx` package for `non-x86_64` which saves 10mins' build time in my full emulated `aarch64 tcg qemu` (recently the podvm's Ubuntu-20 was bumped in #3708 to 24 adding more time also like 30s).

c. dependence on `guest-components`
1. There was a dependency on [guest-component #844](https://github.com/confidential-containers/guest-components/pull/844). Thank Seunguk for the arm64 artifacts.
2. GC's version is bumped already in [#2240](https://github.com/confidential-containers/cloud-api-adaptor/pull/2240), so no need to modify this time.

