### PR TITLE
workflow: podvm_mkosi: Fix docker image registry

### DIFF
--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -198,6 +198,6 @@ jobs:
           PODVM_TAG=${tag} make push-image-container
           arch=$(uname -m)
           arch=${arch/x86_64/amd64}
-          echo "image=${{ inputs.registry }}/${{ github.repository }}/podvm-docker-image-${arch}:${tag}" >> "$GITHUB_OUTPUT"
+          echo "image=${{ inputs.registry }}/podvm-docker-image-${arch}:${tag}" >> "$GITHUB_OUTPUT"
         env:
-          REGISTRY: ${{ inputs.registry }}/${{ github.repository }}
+          REGISTRY: ${{ inputs.registry }}


### PR DESCRIPTION
We were appending the repo name to the registry name, which ended up with
<quay/ghcr>.io/confidential-containers/confidential-containers/cloud-api-adaptor/podvm-docker-image-amd64 
(e.g. https://github.com/confidential-containers/cloud-api-adaptor/actions/runs/14127006902/job/39578237720)
which is too long, so remove the repo to match the format of the oras push