### PR TITLE
caa: Refactor DISABLECVM setting

### DIFF
--- a/src/cloud-api-adaptor/entrypoint.sh
+++ b/src/cloud-api-adaptor/entrypoint.sh
@@ -33,6 +33,7 @@ optionals+=""
 [[ "${SECURE_COMMS_PP_OUTBOUNDS}" ]] && optionals+="-secure-comms-pp-outbounds ${SECURE_COMMS_PP_OUTBOUNDS} "
 [[ "${SECURE_COMMS_KBS_ADDR}" ]] && optionals+="-secure-comms-kbs ${SECURE_COMMS_KBS_ADDR} "
 [[ "${PEERPODS_LIMIT_PER_NODE}" ]] && optionals+="-peerpods-limit-per-node ${PEERPODS_LIMIT_PER_NODE} "
+[[ "${DISABLECVM}" == "true" ]] && optionals+="-disable-cvm "
 
 test_vars() {
     for i in "$@"; do
@@ -62,7 +63,6 @@ aws() {
     [[ "${TAGS}" ]] && optionals+="-tags ${TAGS} "                                     # Custom tags applied to pod vm
     [[ "${USE_PUBLIC_IP}" == "true" ]] && optionals+="-use-public-ip "                 # Use public IP for pod vm
     [[ "${ROOT_VOLUME_SIZE}" ]] && optionals+="-root-volume-size ${ROOT_VOLUME_SIZE} " # Specify root volume size for pod vm
-    [[ "${DISABLECVM}" == "true" ]] && optionals+="-disable-cvm "
     [[ "${EXTERNAL_NETWORK_VIA_PODVM}" ]] && optionals+="-ext-network-via-podvm  "
     [[ "${POD_SUBNET_CIDRS}" ]] && optionals+="-pod-subnet-cidrs ${POD_SUBNET_CIDRS} "
 
@@ -78,7 +78,6 @@ azure() {
     test_vars AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID AZURE_RESOURCE_GROUP AZURE_SUBNET_ID AZURE_IMAGE_ID
 
     [[ "${SSH_USERNAME}" ]] && optionals+="-ssh-username ${SSH_USERNAME} "
-    [[ "${DISABLECVM}" == "true" ]] && optionals+="-disable-cvm "
     [[ "${AZURE_INSTANCE_SIZES}" ]] && optionals+="-instance-sizes ${AZURE_INSTANCE_SIZES} "
     [[ "${TAGS}" ]] && optionals+="-tags ${TAGS} " # Custom tags applied to pod vm
     [[ "${ENABLE_SECURE_BOOT}" == "true" ]] && optionals+="-enable-secure-boot "
@@ -109,7 +108,6 @@ gcp() {
     [[ "${GCP_DISK_TYPE}" ]] && optionals+="-disk-type ${GCP_DISK_TYPE} "                          # defaults to 'pd-standard'
     [[ "${GCP_CONFIDENTIAL_TYPE}" ]] && optionals+="-confidential-type ${GCP_CONFIDENTIAL_TYPE} "  # if not set raise exception only when disablecvm = false
     [[ "${ROOT_VOLUME_SIZE}" ]] && optionals+="-root-volume-size ${ROOT_VOLUME_SIZE} "             # Specify root volume size for pod vm
-    [[ "${DISABLECVM}" == "true" ]] && optionals+="-disable-cvm "                                  # defaults to false
 
     set -x
 
@@ -125,8 +123,6 @@ gcp() {
 
 ibmcloud() {
     one_of IBMCLOUD_API_KEY IBMCLOUD_IAM_PROFILE_ID
-
-    [[ "${DISABLECVM}" = "true" ]] && optionals+="-disable-cvm "
 
     set -x
     exec cloud-api-adaptor ibmcloud \
@@ -172,7 +168,6 @@ ibmcloud_powervs() {
 libvirt() {
     test_vars LIBVIRT_URI
 
-    [[ "${DISABLECVM}" = "true" ]] && optionals+="-disable-cvm "
     set -x
     exec cloud-api-adaptor libvirt \
         -pods-dir "${PEER_PODS_DIR}" \

--- a/src/cloud-api-adaptor/install/overlays/docker/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/docker/kustomization.yaml
@@ -18,6 +18,7 @@ configMapGenerator:
     literals:
       - CLOUD_PROVIDER="docker"
       - CLOUD_CONFIG_VERIFY="false" # It's better set as true to enable could config verify in production env
+    #- DISABLECVM="true" # set as false to enable confidential VM
     #- DOCKER_HOST="unix:///var/run/docker.sock" # Uncomment and set if you want to use a specific docker host
     #- DOCKER_API_VERSION="1.44" # Uncomment and set if you want to use a specific docker api version
     #- DOCKER_TLS_VERIFY="false" # Uncomment and set if you want to use tls


### PR DESCRIPTION
Given that five of the cloud providers were running the same logic to check `DISABLECVM` from peer-pod-cm and use that to set a flag, it feels like refactoring it out into the shared code for all cloud providers makes sense