### PR TITLE
tests/e2e:running all testcommands, erroring if pod not found

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/assessment_helpers.go
+++ b/src/cloud-api-adaptor/test/e2e/assessment_helpers.go
@@ -542,47 +542,68 @@ func AssessPodRequestAndLimit(ctx context.Context, client klient.Client, pod *v1
 
 }
 
-func AssessPodTestCommands(ctx context.Context, client klient.Client, pod *v1.Pod, testCommands []TestCommand) (string, error) {
-	var podlist v1.PodList
-	if err := client.Resources(pod.Namespace).List(ctx, &podlist); err != nil {
-		return "Failed to list pod", err
+func findPod(ctx context.Context, client klient.Client, pod *v1.Pod) (*v1.Pod, error) {
+	var podList v1.PodList
+	if err := client.Resources(pod.Namespace).List(ctx, &podList); err != nil {
+		return nil, fmt.Errorf("Failed to list pod, error : %s", err.Error())
 	}
-	for _, testCommand := range testCommands {
-		log.Tracef("Running test command: %v", testCommand)
-		var stdout, stderr bytes.Buffer
-		for _, podItem := range podlist.Items {
-			if podItem.ObjectMeta.Name == pod.Name {
-				//adding sleep time to intialize container and ready for Executing commands
-				time.Sleep(5 * time.Second)
-				if err := client.Resources(pod.Namespace).ExecInPod(ctx, pod.Namespace, pod.Name, testCommand.ContainerName, testCommand.Command, &stdout, &stderr); err != nil {
-					if testCommand.TestErrorFn != nil {
-						if !testCommand.TestErrorFn(err) {
-							return err.Error(), fmt.Errorf("command %v running in container %s produced unexpected output on error: %s, stderr: %s", testCommand.Command, testCommand.ContainerName, err.Error(), stderr.String())
-						}
-					} else {
-						return err.Error(), fmt.Errorf("command %v running in container %s produced unexpected output on error: %s, stderr: %s", testCommand.Command, testCommand.ContainerName, err.Error(), stderr.String())
-					}
-				} else if testCommand.TestErrorFn != nil {
-					return "", fmt.Errorf("We expected an error from Pod %s, but it was not found", pod.Name)
-				}
-				if testCommand.TestCommandStderrFn != nil {
-					if !testCommand.TestCommandStderrFn(stderr) {
-						return stderr.String(), fmt.Errorf("Command %v running in container %s produced unexpected output on stderr: %s, stdout: %s", testCommand.Command, testCommand.ContainerName, stderr.String(), stdout.String())
-					} else {
-						return stderr.String(), nil
-					}
-				}
-				if testCommand.TestCommandStdoutFn != nil {
-					if !testCommand.TestCommandStdoutFn(stdout) {
-						return stdout.String(), fmt.Errorf("Command %v running in container %s produced unexpected output on stdout: %s, stderr: %s", testCommand.Command, testCommand.ContainerName, stdout.String(), stderr.String())
-					} else {
-						return stdout.String(), nil
-					}
-				}
-			}
+	for _, podItem := range podList.Items {
+		if podItem.ObjectMeta.Name == pod.Name {
+			return &podItem, nil
 		}
 	}
-	return "", nil
+	return nil, fmt.Errorf("Pod not found with name %s in namespace %s", pod.Name, pod.Namespace)
+}
+
+func AssessPodTestCommands(t *testing.T, ctx context.Context, client klient.Client, pod *v1.Pod, testCommands []TestCommand) error {
+	pod, err := findPod(ctx, client, pod)
+	if err != nil {
+		return err
+	}
+	//adding sleep time to intialize container and ready for Executing commands
+	time.Sleep(5 * time.Second)
+	for _, testCommand := range testCommands {
+		err := assessPodTestCommand(t, ctx, client, pod, testCommand)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func assessPodTestCommand(t *testing.T, ctx context.Context, client klient.Client, pod *v1.Pod, testCommand TestCommand) error {
+	log.Tracef("Running test command: %v", testCommand)
+	var stdout, stderr bytes.Buffer
+	if err := client.Resources(pod.Namespace).ExecInPod(ctx, pod.Namespace, pod.Name, testCommand.ContainerName, testCommand.Command, &stdout, &stderr); err != nil {
+		if testCommand.TestErrorFn != nil {
+			if !testCommand.TestErrorFn(err) {
+				t.Logf("Output when execute test command : %s", err.Error())
+				return fmt.Errorf("Command %v running in container %s produced unexpected output on error: %s, stderr: %s", testCommand.Command, testCommand.ContainerName, err.Error(), stderr.String())
+			}
+		} else {
+			t.Logf("Output when execute test command : %s", err.Error())
+			return fmt.Errorf("Command %v running in container %s produced unexpected output on error: %s, stderr: %s", testCommand.Command, testCommand.ContainerName, err.Error(), stderr.String())
+		}
+	} else if testCommand.TestErrorFn != nil {
+		return fmt.Errorf("We expected an error from Pod %s, but it was not found", pod.Name)
+	}
+	if testCommand.TestCommandStderrFn != nil {
+		if !testCommand.TestCommandStderrFn(stderr) {
+			t.Logf("Output when execute test command : %s", stderr.String())
+			return fmt.Errorf("Command %v running in container %s produced unexpected output on stderr: %s, stdout: %s", testCommand.Command, testCommand.ContainerName, stderr.String(), stdout.String())
+		} else {
+			t.Logf("Output when execute test command : %s", stderr.String())
+		}
+	}
+	if testCommand.TestCommandStdoutFn != nil {
+		if !testCommand.TestCommandStdoutFn(stdout) {
+			t.Logf("Output when execute test command : %s", stdout.String())
+			return fmt.Errorf("Command %v running in container %s produced unexpected output on stdout: %s, stderr: %s", testCommand.Command, testCommand.ContainerName, stdout.String(), stderr.String())
+		} else {
+			t.Logf("Output when execute test command : %s", stdout.String())
+		}
+	}
+	return nil
 }
 
 func ProvisionPod(ctx context.Context, client klient.Client, t *testing.T, pod *v1.Pod, podState v1.PodPhase, testCommands []TestCommand) error {

--- a/src/cloud-api-adaptor/test/e2e/assessment_runner.go
+++ b/src/cloud-api-adaptor/test/e2e/assessment_runner.go
@@ -349,9 +349,9 @@ func (tc *TestCase) Run() {
 
 				if tc.podState == v1.PodRunning {
 					if len(tc.testCommands) > 0 {
-						logString, err := AssessPodTestCommands(ctx, client, tc.pod, tc.testCommands)
+						err := AssessPodTestCommands(t, ctx, client, tc.pod, tc.testCommands)
 						if err != nil {
-							t.Errorf("AssessPodTestCommands failed, with output: %s and error: %v", logString, err)
+							t.Errorf("AssessPodTestCommands failed with error: %v", err)
 						}
 					}
 
@@ -401,11 +401,11 @@ func (tc *TestCase) Run() {
 					}
 					if extraPod.podState == v1.PodRunning {
 						if len(extraPod.testCommands) > 0 {
-							logString, err := AssessPodTestCommands(ctx, client, extraPod.pod, extraPod.testCommands)
-							t.Logf("Output when execute test commands:%s", logString)
+							err := AssessPodTestCommands(t, ctx, client, extraPod.pod, extraPod.testCommands)
 							if err != nil {
-								t.Error(err)
+								t.Errorf("AssessPodTestCommands failed with error: %v", err)
 							}
+
 						}
 						tc.assert.HasPodVM(t, extraPod.pod.Name)
 					}


### PR DESCRIPTION
The current logic returns on some branches of processing each command, so if multiple commands are passed it, it could skip some of the tests and thereby give a false positive

It is not erroring out when pod is not found and skipping testcommand execution

enhanced to overcome above issues

Signed-off-by: PrakashMuddana **<Jyoti.Prakash.Muddanna@ibm.com>**