### PR TITLE
podvm: provide attested measurements in OCI

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -24,6 +24,8 @@ on:
 permissions:
   id-token: write
   contents: read
+  packages: write
+  attestations: write
 
 env:
   AZURE_PODVM_IMAGE_DEF_NAME: "${{ vars.AZURE_PODVM_IMAGE_DEF_NAME }}"
@@ -52,7 +54,7 @@ jobs:
     - name: Install build dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y qemu-utils
+        sudo apt-get install -y qemu-utils swtpm qemu-system-x86
         sudo snap install yq
 
     - name: Read properties from versions.yaml
@@ -61,7 +63,7 @@ jobs:
 
     - name: Install uplosi
       run: |
-        wget "https://github.com/edgelesssys/uplosi/releases/download/v${UPLOSI_VERSION}/uplosi_${UPLOSI_VERSION}_linux_amd64.tar.gz"
+        wget -q "https://github.com/edgelesssys/uplosi/releases/download/v${UPLOSI_VERSION}/uplosi_${UPLOSI_VERSION}_linux_amd64.tar.gz"
         sha256sum -c <(echo "$UPLOSI_SHA256"  "uplosi_${UPLOSI_VERSION}_linux_amd64.tar.gz")
         tar xzf uplosi_0.3.0_linux_amd64.tar.gz uplosi
         sudo mv uplosi /usr/local/bin
@@ -109,3 +111,44 @@ jobs:
         uplosi upload build/system.raw
         echo "successfully built $IMAGE_ID"
         echo "image-id=${IMAGE_ID}" >> "$GITHUB_OUTPUT"
+
+    - uses: oras-project/setup-oras@v1
+      with:
+        version: 1.2.0
+
+    - name: Scrape PodVM measurements
+      run: |
+        wget -q http://security.debian.org/debian-security/pool/updates/main/e/edk2/ovmf_2022.11-6+deb12u1_all.deb
+        mkdir -p ovmf-pkg
+        dpkg-deb -x ovmf_2022.11-6+deb12u1_all.deb ovmf-pkg/
+        cp ovmf-pkg/usr/share/OVMF/OVMF_CODE.fd .
+        ../hack/podvm-measure.sh swtpm &
+        sudo ../hack/podvm-measure.sh -i build/system.raw launch &
+        ../hack/podvm-measure.sh wait
+        ../hack/podvm-measure.sh scrape > measurements.json
+        ../hack/podvm-measure.sh stop
+        # verify json
+        jq -e . measurements.json
+
+    - uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Publish measurements
+      id: publish-measurements
+      env:
+        OCI_NAME: ghcr.io/${{ github.repository }}/measurements/azure/podvm
+        OCI_TAG: ${{ inputs.image-version }}
+      run: |
+        oras push "${OCI_NAME}:${OCI_TAG}" measurements.json
+        OCI_DIGEST=$(oras resolve "${OCI_NAME}:${OCI_TAG}")
+        echo "oci-name=${OCI_NAME}" >> "$GITHUB_OUTPUT"
+        echo "oci-digest=${OCI_DIGEST}" >> "$GITHUB_OUTPUT"
+
+    - uses: actions/attest-build-provenance@v1
+      with:
+        subject-name: ${{ steps.publish-measurements.outputs.oci-name }}
+        subject-digest: ${{ steps.publish-measurements.outputs.oci-digest }}
+        push-to-registry: true

--- a/src/cloud-api-adaptor/hack/podvm-measure.sh
+++ b/src/cloud-api-adaptor/hack/podvm-measure.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Usage function
+usage() {
+	cat <<EOF
+Usage: $(basename "$0") [-h] <command> [args]
+
+Available commands:
+    launch Launch a QEMU guest; -i <image_file> (required); -o <ovmf_code>
+    swtpm  Set up a software TPM
+    wait   Wait for guest boot completion
+    scrape Scrape guest output or logs
+    stop   Stop the QEMU guest
+
+Options:
+    -h          Display this help message
+
+Example:
+    $(basename "$0") launch
+EOF
+	exit 1
+}
+
+# Parse global options
+while getopts "i:o:h" opt; do
+	case ${opt} in
+	i)
+		image="$OPTARG"
+		;;
+	o)
+		ovmf="$OPTARG"
+		;;
+	h)
+		usage
+		;;
+	\?)
+		echo "Invalid option" >&2
+		usage
+		;;
+	esac
+done
+shift $((OPTIND - 1))
+
+# Subcommand: launch
+launch_guest() {
+	if [[ -z "${image:-}" ]]; then
+		usage
+	fi
+	echo "Launching QEMU guest..."
+	qemu-system-x86_64 \
+		-machine type=q35,accel=kvm,smm=off \
+		-m 1024 \
+		-cpu host \
+		-drive file="${ovmf:-./OVMF_CODE.fd},format=raw,if=pflash" \
+		-drive file="${image},format=${image##*.}" \
+		-chardev socket,id=chrtpm,path=./vtpm/swtpm.sock \
+		-tpmdev emulator,id=tpm0,chardev=chrtpm \
+		-device tpm-tis,tpmdev=tpm0 \
+		-nographic \
+		-serial file:serial.log \
+		-monitor telnet::45454,server,nowait
+}
+
+# Subcommand: stop
+stop_guest() {
+	echo "Stopping QEMU guest..."
+	echo q | nc localhost 45454
+}
+
+# Subcommand: swtpm
+setup_swtpm() {
+	echo "Setting up software TPM..."
+	mkdir -p vtpm
+	swtpm socket \
+		--tpmstate dir=./vtpm \
+		--ctrl type=unixio,path=./vtpm/swtpm.sock \
+		--tpm2
+}
+
+# Subcommand: wait
+wait_for_guest() {
+	echo "Waiting for guest to boot..."
+	timeout=60
+	elapsed=0
+	touch serial.log
+	while ! grep -q "login:" serial.log; do
+		sleep 2
+		elapsed="$((elapsed + 2))"
+		if [ "$elapsed" -ge "$timeout" ]; then
+			echo "Guest failed to boot within ${timeout}s." >&2
+			exit 1
+		fi
+	done
+}
+
+# Subcommand: scrape
+scrape_logs() {
+	# Extract the PCR block from the log.
+
+	# This assumes the block starts with "Detected vTPM PCR values:"
+	# and ends when a non-indented line appears.
+	pcr_block=$(sed -n '/Detected vTPM PCR values:/,/^[^[:space:]]/p' serial.log)
+
+	# detect line "sha***:"
+	alg=$(echo "$pcr_block" | grep -E "^[[:space:]]*sha.*:" | awk -F':' '{print $1}' | tr -d '[:space:]')
+	echo -n "{\"measurements\":{\"${alg}\":{"
+	# Now filter for PCRs 3, 9, and 11.
+	echo "$pcr_block" | grep -E "^[[:space:]]*(3|9|11)[[:space:]]*:" | while read -r line; do
+		# Use awk to split the line at the colon.
+		index=$(echo "$line" | awk -F':' '{print $1}' | tr -d '[:space:]')
+		value=$(echo "$line" | awk -F':' '{print tolower($2)}' | tr -d '[:space:]')
+		echo -n "${need_sep:+,}\"pcr$(printf "%02d" "$index")\":\"$value\""
+		need_sep=1
+	done
+	echo "}}}"
+}
+
+# Main command dispatch
+main() {
+	[[ $# -lt 1 ]] && usage
+
+	cmd="$1"
+	shift
+
+	case "$cmd" in
+	launch)
+		launch_guest "$@"
+		;;
+	stop)
+		stop_guest "$@"
+		;;
+	swtpm)
+		setup_swtpm "$@"
+		;;
+	wait)
+		wait_for_guest "$@"
+		;;
+	scrape)
+		scrape_logs "$@"
+		;;
+	*)
+		echo "Unknown command: $cmd" >&2
+		usage
+		;;
+	esac
+}
+
+main "$@"


### PR DESCRIPTION
For mkosi images on x86_64 we can retrieve the golden measurements for a podvm image by booting it with swtpm and scraping serial output.

We then store the measurement record in OCI and add an attestation for it.

note: this workflow will not run on a PR branch. a test run on a fork run can be seen [here](https://github.com/mkulke/cloud-api-adaptor/actions/runs/14310191072)