### PR TITLE
ibmcloud: add INITDATA to CLI peerpod properties

### DIFF
--- a/src/cloud-api-adaptor/install/overlays/ibmcloud/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/ibmcloud/kustomization.yaml
@@ -31,6 +31,7 @@ configMapGenerator:
   - IBMCLOUD_VPC_ID="" #set
   - CRI_RUNTIME_ENDPOINT="/run/cri-runtime/containerd.sock"
   - DISABLECVM="true" # Set to false to enable confidential VM
+  - INITDATA="" # set default initdata for podvm
   #- PAUSE_IMAGE="" # Uncomment and set if you want to use a specific pause image
   #- TUNNEL_TYPE="" # Uncomment and set if you want to use a specific tunnel type. Defaults to vxlan
   #- VXLAN_PORT="" # Uncomment and set if you want to use a specific vxlan port. Defaults to 4789

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_common.go
@@ -977,6 +977,7 @@ func (p *IBMCloudProvisioner) GetProperties(ctx context.Context, cfg *envconf.Co
 		"TUNNEL_TYPE":                          IBMCloudProps.TunnelType,
 		"VXLAN_PORT":                           IBMCloudProps.VxlanPort,
 		"DISABLECVM":                           strconv.FormatBool(IBMCloudProps.DisableCVM),
+		"INITDATA":                             IBMCloudProps.InitData,
 	}
 }
 

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_initializer.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_initializer.go
@@ -31,6 +31,7 @@ type IBMCloudProperties struct {
 	SecurityGroupID   string
 	IamServiceURL     string
 	IksServiceURL     string
+	InitData          string
 	InstanceProfile   string
 	KubeVersion       string
 	PodvmImageID      string
@@ -76,6 +77,7 @@ func InitIBMCloudProperties(properties map[string]string) error {
 		CosServiceURL:     properties["COS_SERVICE_URL"],
 		IamServiceURL:     properties["IAM_SERVICE_URL"],
 		IksServiceURL:     properties["IKS_SERVICE_URL"],
+		InitData:          properties["INITDATA"],
 		InstanceProfile:   properties["INSTANCE_PROFILE_NAME"],
 		KubeVersion:       properties["KUBE_VERSION"],
 		PodvmImageID:      properties["PODVM_IMAGE_ID"],

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_kustomize.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_kustomize.go
@@ -61,6 +61,8 @@ func isKustomizeConfigMapKey(key string) bool {
 		return true
 	case "DISABLECVM":
 		return true
+	case "INITDATA":
+		return true
 	default:
 		return false
 	}


### PR DESCRIPTION
Add new CLI property to set the INITDATA field in the peer-pods-cm configmap.