### PR TITLE
podvm: Remove libtdx library install

### DIFF
--- a/src/cloud-api-adaptor/podvm/qcow2/misc-settings.sh
+++ b/src/cloud-api-adaptor/podvm/qcow2/misc-settings.sh
@@ -42,11 +42,8 @@ fi
 
 if [[ "$CLOUD_PROVIDER" == "azure" || "$CLOUD_PROVIDER" == "generic" ]] && [[ "$PODVM_DISTRO" == "ubuntu" ]]; then
     export DEBIAN_FRONTEND=noninteractive
-    curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
-    echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/intel-sgx.list
-
     sudo apt-get update
-    sudo apt-get install -y --no-install-recommends libtss2-tctildr0 libtdx-attest
+    sudo apt-get install -y --no-install-recommends libtss2-tctildr0
 fi
 
 # Install iptables for all providers except docker/vsphere.
@@ -86,7 +83,7 @@ END
 fi
 
 if [ -n "${FORWARDER_PORT}" ]; then
-    cat <<END >> /etc/default/agent-protocol-forwarder 
+    cat <<END >> /etc/default/agent-protocol-forwarder
 OPTIONS=-listen 0.0.0.0:${FORWARDER_PORT}
 END
 fi


### PR DESCRIPTION
The need for libtdx has been removed, so we can drop this code