### PR TITLE
ibmcloud: pod annotation to override image id

### DIFF
--- a/src/cloud-providers/ibmcloud/provider.go
+++ b/src/cloud-providers/ibmcloud/provider.go
@@ -263,9 +263,12 @@ func (p *ibmcloudVPCProvider) CreateInstance(ctx context.Context, podName, sandb
 		return nil, err
 	}
 
-	imageID, err := p.selectImage(ctx, spec, instanceProfile)
-	if err != nil {
-		return nil, err
+	imageID := spec.Image
+	if imageID == "" {
+		imageID, err = p.selectImage(ctx, spec, instanceProfile)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	prototype := p.getInstancePrototype(instanceName, userData, instanceProfile, imageID)


### PR DESCRIPTION
Update ibmcloud api provider to use image id provided in pod annotation to override the configured image id.
```
annotations:
  io.katacontainers.config.hypervisor.image: "<your image id>"
```