### PR TITLE
fix: add netns@podns.service dependency to setup-nat-for-imds

### DIFF
--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/setup-nat-for-imds.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/setup-nat-for-imds.service
@@ -1,11 +1,15 @@
 # this should be enabled by misc-settings.sh
 [Unit]
+StartLimitIntervalSec=60
+StartLimitBurst=3
 Description=Setup NAT for IMDS
 After=agent-protocol-forwarder.service
 Wants=agent-protocol-forwarder.service
 DefaultDependencies=no
 
 [Service]
+Restart=on-failure
+RestartSec=5s
 Type=oneshot
 ExecStart=/usr/local/bin/setup-nat-for-imds.sh
 


### PR DESCRIPTION
The `setup-nat-for-imds` service was failing to start because it attempted to access the `podns` network namespace before it was created.

This change explicitly adds a dependency on `netns@podns.service` to ensure the namespace is available before `setup-nat-for-imds` runs.

Fixes: #2385