### PR TITLE
podvm: add dependency and default images to rhel Dockerfiles

### DIFF
--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm.rhel
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm.rhel
@@ -4,8 +4,8 @@
 #
 # Builds pod vm image inside container
 #
-ARG BUILDER_IMG
-ARG BINARIES_IMG
+ARG BUILDER_IMG="quay.io/confidential-containers/podvm-builder-rhel"
+ARG BINARIES_IMG="quay.io/confidential-containers/podvm-binaries-rhel-amd64"
 
 FROM ${BINARIES_IMG} AS podvm_binaries
 FROM ${BUILDER_IMG} AS podvm_builder

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_binaries.rhel
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_binaries.rhel
@@ -4,7 +4,7 @@
 #
 # Builds pod vm image inside container
 #
-ARG BUILDER_IMG
+ARG BUILDER_IMG="quay.io/confidential-containers/podvm-builder-rhel"
 
 FROM ${BUILDER_IMG} AS podvm_builder
 

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.rhel
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.rhel
@@ -43,7 +43,7 @@ RUN subscription-manager repos --enable codeready-builder-for-rhel-9-${ARCH/amd6
     dnf groupinstall -y 'Development Tools'; \
     dnf install -y yum-utils gnupg git --allowerasing curl pkg-config clang perl libseccomp-devel gpgme-devel \
     device-mapper-devel qemu-kvm unzip wget libassuan-devel genisoimage cloud-utils-growpart cloud-init \
-    perl-FindBin openssl-devel tpm2-tss-devel jq
+    perl-FindBin openssl-devel tpm2-tss-devel jq xz
 
 RUN curl -L -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${YQ_ARCH} \
     && echo "${YQ_CHECKSUM#sha256:}  /usr/local/bin/yq" | sha256sum -c -


### PR DESCRIPTION
Add missing xz dependency and default values for BUILDER_IMG and BINARIES_IMG in rhel Dockerfiles.

For make command like:
```
PODVM_DISTRO=rhel ACTIVATION_KEY=<key> ORG_ID=<org id> IMAGE_URL=<path to base image>.qcow make podvm-builder podvm-binaries podvm-image
```