### PR TITLE
gcp: allow users to set podvm labels

### DIFF
--- a/src/cloud-api-adaptor/entrypoint.sh
+++ b/src/cloud-api-adaptor/entrypoint.sh
@@ -108,6 +108,7 @@ gcp() {
     [[ "${GCP_DISK_TYPE}" ]] && optionals+="-disk-type ${GCP_DISK_TYPE} "                          # defaults to 'pd-standard'
     [[ "${GCP_CONFIDENTIAL_TYPE}" ]] && optionals+="-confidential-type ${GCP_CONFIDENTIAL_TYPE} "  # if not set raise exception only when disablecvm = false
     [[ "${ROOT_VOLUME_SIZE}" ]] && optionals+="-root-volume-size ${ROOT_VOLUME_SIZE} "             # Specify root volume size for pod vm
+    [[ "${LABELS}" ]] && optionals+="-labels ${LABELS} "                                           # Custom labels applied to pod vm
 
     set -x
 

--- a/src/cloud-api-adaptor/install/overlays/gcp/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/gcp/kustomization.yaml
@@ -31,6 +31,7 @@ configMapGenerator:
   #- ROOT_VOLUME_SIZE="10" # Uncomment and set if you want to use a specific root volume size. Defaults to 10
   #- TUNNEL_TYPE="" # Uncomment and set if you want to use a specific tunnel type. Defaults to vxlan
   #- VXLAN_PORT="" # Uncomment and set if you want to use a specific vxlan port. Defaults to 4789
+  #- LABELS="" # Uncomment and add key1=value1,key2=value2 etc if you want to use specific labels for podvm
 ##TLS_SETTINGS
   #- CACERT_FILE="/etc/certificates/ca.crt" # for TLS
   #- CERT_FILE="/etc/certificates/client.crt" # for TLS

--- a/src/cloud-providers/gcp/manager.go
+++ b/src/cloud-providers/gcp/manager.go
@@ -29,6 +29,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	flags.BoolVar(&gcpcfg.DisableCVM, "disable-cvm", false, "Use non-CVMs for peer pods")
 	flags.StringVar(&gcpcfg.ConfidentialType, "confidential-type", "", "Used when DisableCVM=false. i.e: TDX, SEV or SEV_SNP. Check if the machine type is compatible.")
 	flags.IntVar(&gcpcfg.RootVolumeSize, "root-volume-size", 10, "Root volume size (in GiB) for the Pod VMs")
+	flags.Var(&gcpcfg.Labels, "labels", "Custom labels (key=value pairs) to be used for the Pod VMs, comma separated")
 }
 
 func (_ *Manager) LoadEnv() {

--- a/src/cloud-providers/gcp/provider.go
+++ b/src/cloud-providers/gcp/provider.go
@@ -178,6 +178,7 @@ func (p *gcpProvider) CreateInstance(ctx context.Context, podName, sandboxID str
 				StackType: proto.String("IPV4_Only"),
 			},
 		},
+		Labels: p.serviceConfig.Labels,
 	}
 
 	if !p.serviceConfig.DisableCVM {

--- a/src/cloud-providers/gcp/types.go
+++ b/src/cloud-providers/gcp/types.go
@@ -4,6 +4,7 @@
 package gcp
 
 import (
+	provider "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers/util"
 )
 
@@ -18,6 +19,7 @@ type Config struct {
 	DisableCVM       bool
 	ConfidentialType string
 	RootVolumeSize   int
+	Labels           provider.KeyValueFlag
 }
 
 func (c Config) Redact() Config {


### PR DESCRIPTION
Adds the "Labels" field to allow users specifying custom labels on PodVMs. In GCP, "labels" are used for resource organization, while "tags" are reserved for network purposes. Because of this distinction, I chose to use "labels" instead of "tags" as in other providers.