### PR TITLE
ci: Skip checklinks job

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -13,6 +13,9 @@ concurrency:
 
 jobs:
   checklinks:
+    # Lychee isn't working, so skip this job for now until we have a new plan
+    # see https://github.com/confidential-containers/confidential-containers/issues/301
+    if: false
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code


### PR DESCRIPTION
The lychee action isn't working properly, so
skip the job until we have a CoCo wide strategy
see https://github.com/confidential-containers/confidential-containers/issues/301