### PR TITLE
caa: publish the cloud-api-adaptor image with ibmcloud_powervs provider

### DIFF
--- a/.github/workflows/peerpod-ctrl_image.yaml
+++ b/.github/workflows/peerpod-ctrl_image.yaml
@@ -75,4 +75,4 @@ jobs:
           file: src/peerpod-ctrl/Dockerfile
           platforms: linux/amd64, linux/s390x, linux/ppc64le
           build-args: |
-            GOFLAGS=-tags=aws,azure,ibmcloud,vsphere,libvirt
+            GOFLAGS=-tags=aws,azure,ibmcloud,ibmcloud_powervs,vsphere,libvirt

--- a/src/cloud-api-adaptor/Makefile
+++ b/src/cloud-api-adaptor/Makefile
@@ -25,9 +25,9 @@ RUN_TESTS ?= ''
 RESOURCE_CTRL ?= true
 # BUILTIN_CLOUD_PROVIDERS is used for binary build -- what providers are built in the binaries.
 ifeq ($(RELEASE_BUILD),true)
-	BUILTIN_CLOUD_PROVIDERS ?= aws azure gcp ibmcloud vsphere
+	BUILTIN_CLOUD_PROVIDERS ?= aws azure gcp ibmcloud ibmcloud_powervs vsphere
 else
-	BUILTIN_CLOUD_PROVIDERS ?= aws azure gcp ibmcloud vsphere libvirt docker
+	BUILTIN_CLOUD_PROVIDERS ?= aws azure gcp ibmcloud ibmcloud_powervs vsphere libvirt docker
 endif
 
 all: build


### PR DESCRIPTION
This PRs adds ibmcloud_powervs to the list of providers to be added while building and publishing the caa image.