### PR TITLE
initdata: skip double encoding if initdata is already encoded

### DIFF
--- a/src/cloud-api-adaptor/pkg/initdata/initdata.go
+++ b/src/cloud-api-adaptor/pkg/initdata/initdata.go
@@ -96,7 +96,19 @@ func Encode(initdataStr string) (string, error) {
 	return val.String(), nil
 }
 
-// Used in e2e testing
+func IsEncoded(annotation string) bool {
+	reader := strings.NewReader(annotation)
+	initdataToml, err := decode(reader)
+	if err != nil {
+		return false
+	}
+
+	body := &InitDataBody{}
+	err = toml.Unmarshal(initdataToml, body)
+
+	return err == nil
+}
+
 func DecodeAnnotation(annotation string) ([]byte, error) {
 	reader := strings.NewReader(annotation)
 	return decode(reader)

--- a/src/cloud-api-adaptor/pkg/util/cloud.go
+++ b/src/cloud-api-adaptor/pkg/util/cloud.go
@@ -91,10 +91,15 @@ func GetPodvmResourcesFromAnnotation(annotations map[string]string) (int64, int6
 
 // Method to get initdata from annotation. Initdata is delivered as raw
 // string by kata runtime, so we want to compress and base64 it again.
+// For peerpods string may be already compressed and encrypted so return it as is.
 func GetInitdataFromAnnotation(annotations map[string]string) (string, error) {
 	str := annotations["io.katacontainers.config.runtime.cc_init_data"]
 	if str == "" {
 		return "", nil
+	}
+
+	if initdata.IsEncoded(str) {
+		return str, nil
 	}
 
 	initdataEnc, err := initdata.Encode(str)


### PR DESCRIPTION
Peerpods can use annotation io.katacontainers.config.runtime.cc_init_data which should be gzip + base64. This fix skip double encoding if annotation already contains base64 string.