### PR TITLE
caa: Fix typo in `initdata` documentation

### DIFF
--- a/src/cloud-api-adaptor/docs/initdata.md
+++ b/src/cloud-api-adaptor/docs/initdata.md
@@ -5,7 +5,7 @@ The document describes the implementation of the [initdata](https://github.com/c
 
 ## Initdata example
 
-[attestation-agent](https://github.com/confidential-containers/guest-components/tree/main/attestation-agent) config file `aa.toml`, [confidential-data-hub](https://github.com/confidential-containers/guest-components/tree/main/confidential-data-hub) config file `cdh.toml` and a lightweight policy file `polciy.rego` can be passed into PeerPod via initdata.
+[attestation-agent](https://github.com/confidential-containers/guest-components/tree/main/attestation-agent) config file `aa.toml`, [confidential-data-hub](https://github.com/confidential-containers/guest-components/tree/main/confidential-data-hub) config file `cdh.toml` and a lightweight policy file `policy.rego` can be passed into PeerPod via initdata.
 
 Example:
 ```toml
@@ -192,4 +192,4 @@ kind: ConfigMap
 ```
 
 ## TODO
-A large policy bodies that cannot be provisioned via IMDS user-data, the limitation depends on providers IMDS limitation. We need add checking and limitations according to test result future. 
+A large policy bodies that cannot be provisioned via IMDS user-data, the limitation depends on providers IMDS limitation. We need add checking and limitations according to test result future.


### PR DESCRIPTION
Fix typo (swapped letters) in `policy.rego`.