### PR TITLE
podvm: fix Makefile not working

### DIFF
--- a/src/cloud-api-adaptor/Makefile
+++ b/src/cloud-api-adaptor/Makefile
@@ -208,11 +208,11 @@ podvm-binaries:
 
 podvm-image:
 ifeq ($(PODVM_DISTRO),rhel)
-	ifeq ($(shell test -f $(IMAGE_URL) && echo 1 || echo 0),1)
-		cp ${IMAGE_URL} ./rhel.img
-		$(eval IMAGE_URL=cloud-api-adaptor/rhel.img)
-		@echo "### Copied IMAGE_URL file to $(IMAGE_URL) in order to suite the docker context"
-	endif
+ifeq ($(shell test -f $(IMAGE_URL) && echo 1 || echo 0),1)
+	cp ${IMAGE_URL} ./rhel.img
+	$(eval IMAGE_URL=cloud-api-adaptor/rhel.img)
+	@echo "### Copied IMAGE_URL file to $(IMAGE_URL) in order to suite the docker context"
+endif
 endif
 	cp -rf ../../.git .git
 	cd ../ && docker buildx build -t $(PODVM_IMAGE) -f cloud-api-adaptor/podvm/$(PODVM_DOCKERFILE) \

--- a/src/cloud-api-adaptor/podvm/Makefile
+++ b/src/cloud-api-adaptor/podvm/Makefile
@@ -14,10 +14,10 @@ IMAGE_URL := $(or $(IMAGE_URL),$($(PODVM_DISTRO)_$(DISTRO_ARCH)_IMAGE_URL))
 IMAGE_CHECKSUM := $(or $(IMAGE_CHECKSUM),$($(PODVM_DISTRO)_$(DISTRO_ARCH)_IMAGE_CHECKSUM))
 
 ifndef IMAGE_URL
-	$(error "IMAGE_URL is not defined")
+$(error "IMAGE_URL is not defined")
 endif
 ifndef IMAGE_CHECKSUM
-	$(error "IMAGE_CHECKSUM is not defined")
+$(error "IMAGE_CHECKSUM is not defined")
 endif
 
 AGENT_PROTOCOL_FORWARDER_SRC := ../
@@ -58,15 +58,15 @@ else ifeq ($(PODVM_DISTRO),alinux)
 else ifeq ($(PODVM_DISTRO),rhel)
 	@echo defined
 	$(eval OPTS := -var disk_size=11144)
-	ifeq ($(ARCH),s390x)
-		$(eval OPTS += -var se_boot=${SE_BOOT})
-		$(eval OPTS += -var machine_type=${QEMU_MACHINE_TYPE_${ARCH}})
-		$(eval OPTS += -var cpu_type=max)
-		$(eval OPTS += -var os_arch=s390x)
-		ifndef QEMU_BINARY
-			$(eval OPTS += -var qemu_binary=qemu-system-${ARCH})
-		endif
-	endif
+ifeq ($(ARCH),s390x)
+	$(eval OPTS += -var se_boot=${SE_BOOT})
+	$(eval OPTS += -var machine_type=${QEMU_MACHINE_TYPE_${ARCH}})
+	$(eval OPTS += -var cpu_type=max)
+	$(eval OPTS += -var os_arch=s390x)
+ifndef QEMU_BINARY
+	$(eval OPTS += -var qemu_binary=qemu-system-${ARCH})
+endif
+endif
 else
 	$(error PODVM_DISTRO is invalid or not defined)
 endif
@@ -78,9 +78,9 @@ endif
 # UEFI for x86_64
 ifeq ($(UEFI),true)
 	$(eval OPTS += -var is_uefi=true -var os_arch="x86_64" )
-	ifdef UEFI_FIRMWARE_LOCATION
-		$(eval OPTS += -var uefi_firmware=${UEFI_FIRMWARE_LOCATION} )
-	endif
+ifdef UEFI_FIRMWARE_LOCATION
+	$(eval OPTS += -var uefi_firmware=${UEFI_FIRMWARE_LOCATION} )
+endif
 endif
 
 $(IMAGE_FILE): $(BINARIES) $(FILES) setopts


### PR DESCRIPTION
Revert "lint: improve Makefile readability by adjusting indentation"

This reverts commit 258bff83585b3af1d8e6c1a7608027d851a991a8.

The above formatting change causes the Makefile to fail because ifeq indented with a tab makes make treat it as part of a recipe (i.e., a shell command), rather than a Makefile directive.
```
130.2 make[1]: Leaving directory '/src/cloud-api-adaptor'
130.2 install -D --compare "./..//process-user-data" "/src/cloud-api-adaptor/podvm/files/usr/local/bin/process-user-data"
130.3 defined
130.3 ifeq (x86_64,s390x)
130.3 /bin/bash: -c: line 1: syntax error near unexpected token `x86_64,s390x'
130.3 /bin/bash: -c: line 1: `ifeq (x86_64,s390x)'
130.3 make: *** [Makefile:61: setopts] Error 2
------

```