### PR TITLE
podvm: Buletproof setup-nat-for-imds

### DIFF
--- a/src/cloud-api-adaptor/podvm/files/usr/local/bin/setup-nat-for-imds.sh
+++ b/src/cloud-api-adaptor/podvm/files/usr/local/bin/setup-nat-for-imds.sh
@@ -67,6 +67,24 @@ function setup_proxy_arp() {
   fi
 }
 
+echo "Waiting for net namespace '$NETNS'..."
+SECONDS=0
+while :; do
+  if ip netns list | grep -qw "$NETNS"; then
+    echo "Namespace $NETNS is ready, proceeding..."
+    break
+  fi
+  if (( SECONDS > 60 )); then
+	  echo "Namespace $NETNS is not ready after ${SECONDS}s"
+	  echo "ip netns list:"
+	  ip netns list || true
+	  echo "ip netns exec:"
+	  ip netns exec "$NETNS" ip link show "$VETH_HOST" || true
+	  exit 1
+  fi
+  sleep 1
+done
+
 echo "Configuring the NAT..."
 # Allow re-tries in case the netns is still initializing
 SECONDS=0

--- a/src/cloud-api-adaptor/podvm/files/usr/local/bin/setup-nat-for-imds.sh
+++ b/src/cloud-api-adaptor/podvm/files/usr/local/bin/setup-nat-for-imds.sh
@@ -67,5 +67,18 @@ function setup_proxy_arp() {
   fi
 }
 
-# Execute functions
-setup_proxy_arp
+echo "Configuring the NAT..."
+# Allow re-tries in case the netns is still initializing
+SECONDS=0
+while :; do
+	if setup_proxy_arp; then
+		break
+	fi
+	if (( SECONDS > 60 )); then
+		echo "Failed to setup proxy in ${SECONDS}s"
+		exit 2
+	fi
+	sleep 1
+done
+
+echo "Successfully configured in ${SECONDS}s"

--- a/src/cloud-api-adaptor/podvm/files/usr/local/bin/setup-nat-for-imds.sh
+++ b/src/cloud-api-adaptor/podvm/files/usr/local/bin/setup-nat-for-imds.sh
@@ -1,42 +1,70 @@
 #!/bin/bash
 # This script sets up NAT for IMDS on Azure/AWS
-# This is required for IMDS to work on Azure/AWS
-# This script is executed as a oneshot systemd service
-# during first boot
+# It can be safely re-executed to complete or fix a partial setup.
 
 set -euo pipefail
 
 IMDS_IP="169.254.169.254"
 DUMMY_IP="169.254.99.99"
+VETH_HOST="veth1"
+VETH_NS="veth2"
+NETNS="podns"
 
 # trap errors
 trap 'echo "Error: $0:$LINENO stopped"; exit 1' ERR INT
 
-# Function to setup veth pair
+# Function to check if a network device exists
+function link_exists() {
+  ip link show "$1" &>/dev/null
+}
+
+# Function to setup veth pair and routing/NAT
 function setup_proxy_arp() {
   local pod_ip
-  pod_ip=$(ip netns exec podns ip route get "$IMDS_IP" | awk '{ for(i=1; i<=NF; i++) { if($i == "src") { print $(i+1); break; } } }')
+  pod_ip=$(ip netns exec "$NETNS" ip route get "$IMDS_IP" | awk '{ for(i=1; i<=NF; i++) { if($i == "src") { print $(i+1); break; } } }')
 
-  ip link add veth2 type veth peer name veth1
-  # Proxy arp does not get enabled when no IP address is assigned
-  ip address add "$DUMMY_IP/32" dev veth1
-  ip link set up dev veth1
+  # Create veth pair only if it doesn't exist
+  if ! link_exists "$VETH_HOST"; then
+    ip link add "$VETH_NS" type veth peer name "$VETH_HOST"
+  fi
 
-  sysctl -w net.ipv4.ip_forward=1
-  sysctl -w net.ipv4.conf.veth1.proxy_arp=1
-  sysctl -w net.ipv4.neigh.veth1.proxy_delay=0
+  # Assign IP to veth1 if not already assigned
+  if ! ip address show dev "$VETH_HOST" | grep -q "$DUMMY_IP"; then
+    ip address add "$DUMMY_IP/32" dev "$VETH_HOST"
+  fi
 
-  ip link set veth2 netns podns
-  ip netns exec podns ip link set up dev veth2
-  ip netns exec podns ip route add "$IMDS_IP/32" dev veth2
+  ip link set up dev "$VETH_HOST"
 
-  ip route add "$pod_ip/32" dev veth1
+  sysctl -w net.ipv4.ip_forward=1 >/dev/null
+  sysctl -w net.ipv4.conf."$VETH_HOST".proxy_arp=1 >/dev/null
+  sysctl -w net.ipv4.neigh."$VETH_HOST".proxy_delay=0 >/dev/null
 
+  # Move veth2 into the pod namespace if not already
+  if ! ip netns exec "$NETNS" ip link show "$VETH_NS" &>/dev/null; then
+    ip link set "$VETH_NS" netns "$NETNS"
+  fi
+
+  ip netns exec "$NETNS" ip link set up dev "$VETH_NS"
+
+  # Add route to IMDS via veth2 if not present
+  if ! ip netns exec "$NETNS" ip route show | grep -q "$IMDS_IP"; then
+    ip netns exec "$NETNS" ip route add "$IMDS_IP/32" dev "$VETH_NS"
+  fi
+
+  # Route pod IP via veth1
+  if ! ip route get "$pod_ip" | grep -q "dev $VETH_HOST"; then
+    ip route add "$pod_ip/32" dev "$VETH_HOST"
+  fi
+
+  # Set static ARP entry
   local hwaddr
-  hwaddr=$(ip netns exec podns ip -br link show veth2 | awk 'NR==1 { print $3 }')
-  ip neigh replace "$pod_ip" dev veth1 lladdr "$hwaddr"
+  hwaddr=$(ip netns exec "$NETNS" ip -br link show "$VETH_NS" | awk 'NR==1 { print $3 }')
+  ip neigh replace "$pod_ip" dev "$VETH_HOST" lladdr "$hwaddr"
 
-  iptables -t nat -A POSTROUTING -s "$pod_ip/32" -d "$IMDS_IP/32" -j MASQUERADE
+  # Add iptables NAT rule only if not present
+  if ! iptables -t nat -C POSTROUTING -s "$pod_ip/32" -d "$IMDS_IP/32" -j MASQUERADE 2>/dev/null; then
+    iptables -t nat -A POSTROUTING -s "$pod_ip/32" -d "$IMDS_IP/32" -j MASQUERADE
+  fi
 }
 
 # Execute functions


### PR DESCRIPTION
The setup-nat-for-imds requires the podvm network namespace not only be present, but already initialized and ready to be configured. This might take a while and as of my knowledge there is no way to check. This series makes the script idempotent and then adds a mechanism to re-execute it from within the script. An alternative would be to keep the first commit but use systemd's `Restart=on-failure`.

From my testing the last commit doesn't seem much useful so I'd actually suggest not including it.

Supersedes: https://github.com/confidential-containers/cloud-api-adaptor/pull/2386

Log:

```
[root@fedora ~]# journalctl -u setup-nat-for-imds | cat
Jun 04 17:58:56 fedora systemd[1]: Starting setup-nat-for-imds.service - Setup NAT for IMDS...
Jun 04 17:58:57 fedora setup-nat-for-imds.sh[431]: Waiting for net namespace 'podns'...
Jun 04 17:58:59 fedora setup-nat-for-imds.sh[431]: Namespace podns is ready, proceeding...
Jun 04 17:58:59 fedora setup-nat-for-imds.sh[431]: Configuring the NAT...
Jun 04 17:58:59 fedora setup-nat-for-imds.sh[718]: RTNETLINK answers: Network is unreachable
Jun 04 17:58:59 fedora setup-nat-for-imds.sh[742]: Error: any valid prefix is expected rather than "".
Jun 04 17:58:59 fedora setup-nat-for-imds.sh[744]: Error: any valid prefix is expected rather than "/32".
Jun 04 17:58:59 fedora setup-nat-for-imds.sh[748]: Error: any valid address is expected rather than "".
Jun 04 17:58:59 fedora setup-nat-for-imds.sh[752]: iptables v1.8.10 (legacy): host/network `' not found
Jun 04 17:58:59 fedora setup-nat-for-imds.sh[752]: Try `iptables -h' or 'iptables --help' for more information.
Jun 04 17:59:00 fedora setup-nat-for-imds.sh[768]: Error: any valid prefix is expected rather than "".
Jun 04 17:59:00 fedora setup-nat-for-imds.sh[770]: Error: any valid prefix is expected rather than "/32".
Jun 04 17:59:00 fedora setup-nat-for-imds.sh[774]: Error: any valid address is expected rather than "".
Jun 04 17:59:00 fedora setup-nat-for-imds.sh[776]: iptables v1.8.10 (legacy): host/network `' not found
Jun 04 17:59:00 fedora setup-nat-for-imds.sh[776]: Try `iptables -h' or 'iptables --help' for more information.
Jun 04 17:59:01 fedora setup-nat-for-imds.sh[792]: Error: any valid prefix is expected rather than "".
Jun 04 17:59:01 fedora setup-nat-for-imds.sh[794]: Error: any valid prefix is expected rather than "/32".
Jun 04 17:59:01 fedora setup-nat-for-imds.sh[798]: Error: any valid address is expected rather than "".
Jun 04 17:59:01 fedora setup-nat-for-imds.sh[800]: iptables v1.8.10 (legacy): host/network `' not found
Jun 04 17:59:01 fedora setup-nat-for-imds.sh[800]: Try `iptables -h' or 'iptables --help' for more information.
Jun 04 17:59:02 fedora setup-nat-for-imds.sh[431]: Successfully configured in 3s
Jun 04 17:59:02 fedora systemd[1]: setup-nat-for-imds.service: Deactivated successfully.
Jun 04 17:59:02 fedora systemd[1]: Finished setup-nat-for-imds.service - Setup NAT for IMDS.
```