### PR TITLE
Makefile: promote readibility by add idents

### DIFF
--- a/src/cloud-api-adaptor/Makefile
+++ b/src/cloud-api-adaptor/Makefile
@@ -208,11 +208,11 @@ podvm-binaries:
 
 podvm-image:
 ifeq ($(PODVM_DISTRO),rhel)
-ifeq ($(shell test -f $(IMAGE_URL) && echo 1 || echo 0),1)
-	cp ${IMAGE_URL} ./rhel.img
-	$(eval IMAGE_URL=cloud-api-adaptor/rhel.img)
-	@echo "### Copied IMAGE_URL file to $(IMAGE_URL) in order to suite the docker context"
-endif
+    ifeq ($(shell test -f $(IMAGE_URL) && echo 1 || echo 0),1)
+		cp ${IMAGE_URL} ./rhel.img
+		$(eval IMAGE_URL=cloud-api-adaptor/rhel.img)
+		@echo "### Copied IMAGE_URL file to $(IMAGE_URL) in order to suite the docker context"
+    endif
 endif
 	cp -rf ../../.git .git
 	cd ../ && docker buildx build -t $(PODVM_IMAGE) -f cloud-api-adaptor/podvm/$(PODVM_DOCKERFILE) \

--- a/src/cloud-api-adaptor/podvm/Makefile
+++ b/src/cloud-api-adaptor/podvm/Makefile
@@ -41,35 +41,36 @@ setopts:
 ifeq ($(PODVM_DISTRO),ubuntu)
 	@echo defined
 	$(eval OPTS := -var se_boot=${SE_BOOT})
-ifneq ($(ARCH),x86_64)
-	$(eval OPTS += -var machine_type=${QEMU_MACHINE_TYPE_${ARCH}})
-ifndef QEMU_BINARY
-	$(eval OPTS += -var qemu_binary=qemu-system-${ARCH})
-endif
+    ifneq ($(ARCH),x86_64)
+		$(eval OPTS += -var machine_type=${QEMU_MACHINE_TYPE_${ARCH}})
+        ifndef QEMU_BINARY
+			$(eval OPTS += -var qemu_binary=qemu-system-${ARCH})
+        endif
 # UEFI for aarch64 on ubuntu
-ifeq ($(ARCH),aarch64)
-	$(eval OPTS += -var is_uefi=true -var os_arch="aarch64")
-	$(eval OPTS += -var uefi_firmware="/usr/share/qemu-efi-aarch64/QEMU_EFI.fd")
-endif
-endif
-else ifeq ($(PODVM_DISTRO),alinux)
-	@echo defined
-	$(eval OPTS := -var disk_size=22323)
-else ifeq ($(PODVM_DISTRO),rhel)
-	@echo defined
-	$(eval OPTS := -var disk_size=11144)
-ifeq ($(ARCH),s390x)
-	$(eval OPTS += -var se_boot=${SE_BOOT})
-	$(eval OPTS += -var machine_type=${QEMU_MACHINE_TYPE_${ARCH}})
-	$(eval OPTS += -var cpu_type=max)
-	$(eval OPTS += -var os_arch=s390x)
-ifndef QEMU_BINARY
-	$(eval OPTS += -var qemu_binary=qemu-system-${ARCH})
-endif
+        ifeq ($(ARCH),aarch64)
+			$(eval OPTS += -var is_uefi=true -var os_arch="aarch64")
+			$(eval OPTS += -var uefi_firmware="/usr/share/qemu-efi-aarch64/QEMU_EFI.fd")
+        endif
+    endif
+    else ifeq ($(PODVM_DISTRO),alinux)
+		@echo defined
+		$(eval OPTS := -var disk_size=22323)
+    else ifeq ($(PODVM_DISTRO),rhel)
+		@echo defined
+		$(eval OPTS := -var disk_size=11144)
+    ifeq ($(ARCH),s390x)
+		$(eval OPTS += -var se_boot=${SE_BOOT})
+		$(eval OPTS += -var machine_type=${QEMU_MACHINE_TYPE_${ARCH}})
+		$(eval OPTS += -var cpu_type=max)
+		$(eval OPTS += -var os_arch=s390x)
+    ifndef QEMU_BINARY
+		$(eval OPTS += -var qemu_binary=qemu-system-${ARCH})
+    endif
 endif
 else
 	$(error PODVM_DISTRO is invalid or not defined)
 endif
+
 
 ifdef QEMU_BINARY
 	$(eval OPTS += -var qemu_binary=${QEMU_BINARY} )
@@ -78,9 +79,9 @@ endif
 # UEFI for x86_64
 ifeq ($(UEFI),true)
 	$(eval OPTS += -var is_uefi=true -var os_arch="x86_64" )
-ifdef UEFI_FIRMWARE_LOCATION
-	$(eval OPTS += -var uefi_firmware=${UEFI_FIRMWARE_LOCATION} )
-endif
+    ifdef UEFI_FIRMWARE_LOCATION
+		$(eval OPTS += -var uefi_firmware=${UEFI_FIRMWARE_LOCATION} )
+    endif
 endif
 
 $(IMAGE_FILE): $(BINARIES) $(FILES) setopts


### PR DESCRIPTION
This patch adds \t before shell commands and adds four ' ' before make commands when there is a nested sentence block in the Makefile. This would help to promote the readibility of the code.

Due to [Makefile spec](https://www.gnu.org/software/make/manual/make.html#Recipe-Syntax)
```
Each line in the recipe must start with a tab
```
and
```
Extra spaces are allowed and ignored at the beginning of the conditional directive line, but a tab is not allowed. (If the line begins with a tab, it will be considered part of a recipe for a rule.) 
```

cc @stevenhorsman @frankbu @Idoktor