### PR TITLE
aws: deprecate centos image

### DIFF
--- a/src/csi-wrapper/examples/aws/dynamic-provisioning/pod.yaml
+++ b/src/csi-wrapper/examples/aws/dynamic-provisioning/pod.yaml
@@ -22,7 +22,7 @@ spec:
 
   containers:
   - name: app
-    image: centos
+    image: quay.io/centos/centos:latest
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
     volumeMounts:


### PR DESCRIPTION
From the [CentOS docker repository](https://hub.docker.com/_/centos)


> ### DEPRECATION NOTICE
> All tags of this image are EOL ([June 30, 2024⁠](https://www.redhat.com/en/topics/linux/centos-linux-eol)
 / https://github.com/docker-library/official-images/pull/17094, although the last meaningful update was November 16, 2020, long before the EOL date: https://github.com/docker-library/official-images/pull/9102; see also [https://www.centos.org/centos-linux-eol/⁠](https://www.centos.org/centos-linux-eol/) and https://github.com/docker-library/docs/pull/2205). Please adjust your usage accordingly.

The CSI driver example deployment file (`csi-wrapper/examples/aws/dynamic-provisioning/pod.yaml`) does not work out of the box. Changing it to an alternate image (`rockylinux/rockylinux:8`) makes the example work as expected.