### PR TITLE
workflows: Remove docker hub support

### DIFF
--- a/.github/workflows/podvm_binaries.yaml
+++ b/.github/workflows/podvm_binaries.yaml
@@ -46,14 +46,6 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
-    - name: Login to Docker container Registry
-      if: ${{ startsWith(inputs.registry, 'docker.io') }}
-      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
-      with:
-        registry: docker.io
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-
     - name: Login to Quay container Registry
       if: ${{ startsWith(inputs.registry, 'quay.io') }}
       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3

--- a/.github/workflows/podvm_builder.yaml
+++ b/.github/workflows/podvm_builder.yaml
@@ -47,14 +47,6 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
-    - name: Login to Docker container Registry
-      if: ${{ startsWith(inputs.registry, 'docker.io') }}
-      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
-      with:
-        registry: docker.io
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-
     - name: Login to Quay container Registry
       if: ${{ startsWith(inputs.registry, 'quay.io') }}
       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3

--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -39,13 +39,6 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
-    - name: Login to Docker container Registry
-      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
-      with:
-        registry: docker.io
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-
     - name: Login to Quay container Registry
       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
       with:


### PR DESCRIPTION
We don't use docker hub in any of our
workflows and there are rate limiting issues,
so remove the secrets and logic to login