### PR TITLE
caa: handle unavailable VM IPs

### DIFF
--- a/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
@@ -392,6 +392,10 @@ func (s *cloudService) StartVM(ctx context.Context, req *pb.StartVMRequest) (res
 
 	logger.Printf("created an instance %s for sandbox %s", instance.Name, sid)
 
+	if len(instance.IPs) == 0 {
+		return nil, fmt.Errorf("instance IP is not available")
+	}
+
 	instanceIP := instance.IPs[0].String()
 	forwarderPort := s.serverConfig.ForwarderPort
 


### PR DESCRIPTION
This PR checks whether one VM IP is available before indexing array to avoid crashing in extreme situations.

Fixes: https://github.com/confidential-containers/cloud-api-adaptor/issues/2453