### PR TITLE
azure: implement root-volume-size support

### DIFF
--- a/src/cloud-api-adaptor/entrypoint.sh
+++ b/src/cloud-api-adaptor/entrypoint.sh
@@ -82,6 +82,7 @@ azure() {
     [[ "${TAGS}" ]] && optionals+="-tags ${TAGS} " # Custom tags applied to pod vm
     [[ "${ENABLE_SECURE_BOOT}" == "true" ]] && optionals+="-enable-secure-boot "
     [[ "${USE_PUBLIC_IP}" == "true" ]] && optionals+="-use-public-ip "
+    [[ "${ROOT_VOLUME_SIZE}" ]] && optionals+="-root-volume-size ${ROOT_VOLUME_SIZE} " # Specify root volume size for pod vm
 
     set -x
     exec cloud-api-adaptor azure \

--- a/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
@@ -54,6 +54,7 @@ type ServerConfig struct {
 	SecureCommsPpOutbounds  string
 	SecureCommsKbsAddress   string
 	PeerPodsLimitPerNode    int
+	RootVolumeSize          int
 }
 
 var logger = log.New(log.Writer(), "[adaptor/cloud] ", log.LstdFlags|log.Lmsgprefix)

--- a/src/cloud-providers/azure/manager.go
+++ b/src/cloud-providers/azure/manager.go
@@ -38,6 +38,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	flags.Var(&azurecfg.Tags, "tags", "Custom tags (key=value pairs) to be used for the Pod VMs, comma separated")
 	flags.BoolVar(&azurecfg.EnableSecureBoot, "enable-secure-boot", false, "Enable secure boot for the VMs")
 	flags.BoolVar(&azurecfg.UsePublicIP, "use-public-ip", false, "Assign public IP to the PoD VM and use to connect to kata-agent")
+	flags.IntVar(&azurecfg.RootVolumeSize, "root-volume-size", 0, "Root volume size in GB. Default is 0, which implies the default image disk size")
 }
 
 func (_ *Manager) LoadEnv() {

--- a/src/cloud-providers/azure/types.go
+++ b/src/cloud-providers/azure/types.go
@@ -49,6 +49,7 @@ type Config struct {
 	// Secure boot brings no additional security.
 	EnableSecureBoot bool
 	UsePublicIP      bool
+	RootVolumeSize   int
 }
 
 func (c Config) Redact() Config {


### PR DESCRIPTION
Add root volume size configuration for Azure VMs to match AWS/GCP functionality.
Set Environment variable ROOT_VOLUME_SIZE in peer-pods-cm, defaults to 0, which
implies the default image disk size.

This is the splitting of the following PR:
https://github.com/confidential-containers/cloud-api-adaptor/pull/2212

Signed-off-by: Magnus Kulke <magnuskulke@microsoft.com>
Signed-off-by: Snir Sheriber <ssheribe@redhat.com>