### PR TITLE
Golang 1.23.10 part2

### DIFF
--- a/src/cloud-api-adaptor/Dockerfile
+++ b/src/cloud-api-adaptor/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILD_TYPE=dev
-ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.23.8-40
+ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.23.10-41
 ARG BASE=registry.fedoraproject.org/fedora:41
 
 # This dockerfile uses Go cross-compilation to build the binary,

--- a/src/cloud-api-adaptor/docs/addnewprovider.md
+++ b/src/cloud-api-adaptor/docs/addnewprovider.md
@@ -217,7 +217,7 @@ go mod tidy
 
 ```bash
 cat > Dockerfile <<EOF
-ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.23.8-40
+ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.23.10-41
 FROM --platform="\$TARGETPLATFORM" \$BUILDER_BASE AS builder
 RUN dnf install -y libvirt-devel && dnf clean all
 WORKDIR /work

--- a/src/csi-wrapper/Dockerfile.csi_wrappers
+++ b/src/csi-wrapper/Dockerfile.csi_wrappers
@@ -7,13 +7,13 @@
 ARG SOURCE_FROM=remote
 
 ##### Builder Dev Image #####
-FROM --platform=${BUILDPLATFORM} quay.io/confidential-containers/golang-fedora:1.23.8-40 AS builder-local
+FROM --platform=${BUILDPLATFORM} quay.io/confidential-containers/golang-fedora:1.23.10-41 AS builder-local
 WORKDIR /src
 COPY csi-wrapper ./cloud-api-adaptor/src/csi-wrapper/
 COPY cloud-api-adaptor ./cloud-api-adaptor/src/cloud-api-adaptor
 
 ##### Builder Release Image #####
-FROM --platform=${BUILDPLATFORM} quay.io/confidential-containers/golang-fedora:1.23.8-40 AS builder-remote
+FROM --platform=${BUILDPLATFORM} quay.io/confidential-containers/golang-fedora:1.23.10-41 AS builder-remote
 ARG BINARY
 ARG CAA_SRC="https://github.com/confidential-containers/cloud-api-adaptor"
 ARG CAA_SRC_REF="main"

--- a/src/peerpod-ctrl/Dockerfile
+++ b/src/peerpod-ctrl/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$TARGETPLATFORM quay.io/confidential-containers/golang-fedora:1.23.8-40 AS builder
+FROM --platform=$TARGETPLATFORM quay.io/confidential-containers/golang-fedora:1.23.10-41 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG CGO_ENABLED=1


### PR DESCRIPTION
 versions: Bump the builder image
    
Update the builder base of the Docker files to pick up the 1.23.10 gloang and fedora 41 based image

Depends on #2467 