### PR TITLE
azure: add az-copy-image tool

### DIFF
--- a/src/cloud-api-adaptor/Makefile
+++ b/src/cloud-api-adaptor/Makefile
@@ -13,7 +13,7 @@ RELEASE_BUILD ?= false
 CLOUD_PROVIDER ?=
 GOOPTIONS   ?= GOOS=linux GOARCH=$(GO_ARCH) CGO_ENABLED=0
 GOFLAGS     ?=
-BINARIES    := cloud-api-adaptor agent-protocol-forwarder process-user-data
+BINARIES    := cloud-api-adaptor agent-protocol-forwarder process-user-data az-copy-image
 SOURCEDIRS  := ./cmd ./pkg
 PACKAGES    := $(shell go list $(addsuffix /...,$(SOURCEDIRS)))
 SOURCES     := $(shell find $(SOURCEDIRS) -name '*.go' -print)

--- a/src/cloud-api-adaptor/cmd/az-copy-image/README.md
+++ b/src/cloud-api-adaptor/cmd/az-copy-image/README.md
@@ -1,0 +1,49 @@
+# az-copy-image
+
+The tool exports an Azure Community Gallery image version into your own Shared Image Gallery. It creates a temporary managed disk and managed image from the source community image and publishes an image version under the specified gallery and image definition.
+
+Temporary resources are removed automatically when the command completes.
+
+The whole ceremony is required b/c as of the time of writing, the Azure API doesn't support creating cvm-enabled image-versions directly from community gallery images. In the future this tool may be superseded by the `az sig image-version create` command.
+
+## Building
+
+Run `make az-copy-image` from the `src/cloud-api-adaptor` directory to build the binary.
+
+## Usage
+
+```bash
+az-copy-image \
+  -resource-group <name> \
+  -image-gallery <gallery> \
+  -image-definition <definition> \
+  -community-image-id <community image version id>
+  [-subscription-id <id>] \
+  [-location <location>] \
+  [-target-regions <region1,region2,...>]
+```
+
+The subscription is taken from the current Azure CLI configuration if not explicitly provided with `-subscription-id` or `AZURE_SUBSCRIPTION_ID`. The location is inferred from the resource-group, unless specified with `-location` or `AZURE_LOCATION`.
+
+### Examples
+
+Copy a community image into gallery `mygallery`, definition `mydef` and create version `0.0.1` in resource group `myrg`:
+
+```bash
+AZURE_LOCATION=eastus az-copy-image \
+    -community-image-id "/CommunityGalleries/cococommunity-42d8482d-92cd-415b-b332-7648bd978eff/Images/peerpod-podvm-fedora-debug/Versions/0.12.0" \
+    -image-gallery mygallery \
+    -image-definition mydef \
+    -resource-group myrg
+```
+
+Select target regions explicitly:
+
+```bash
+az-copy-image \
+  ...
+  -target-regions westeurope,eastus \
+  -community-image-id /CommunityGalleries/....
+```
+
+Environment variables `AZURE_SUBSCRIPTION_ID`, `AZURE_RESOURCE_GROUP` and `AZURE_LOCATION` can be used to override the defaults.

--- a/src/cloud-api-adaptor/cmd/az-copy-image/main.go
+++ b/src/cloud-api-adaptor/cmd/az-copy-image/main.go
@@ -1,0 +1,238 @@
+// Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
+	"github.com/google/uuid"
+)
+
+func defaultSubscriptionID(ctx context.Context) (string, error) {
+	out, err := exec.CommandContext(ctx, "az", "account", "show", "--query", "id", "-o", "tsv").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func groupLocation(ctx context.Context, group string) (string, error) {
+	out, err := exec.CommandContext(ctx, "az", "group", "show", "-n", group, "--query", "location", "-o", "tsv").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func main() {
+	var (
+		subscriptionID        string
+		resourceGroup         string
+		location              string
+		imageGallery          string
+		imageDefinition       string
+		imageVersion          string
+		communityGalleryImage string
+		targetRegionsStr      string
+	)
+
+	flag.StringVar(&subscriptionID, "subscription-id", os.Getenv("AZURE_SUBSCRIPTION_ID"), "Azure subscription ID")
+	flag.StringVar(&resourceGroup, "resource-group", os.Getenv("AZURE_RESOURCE_GROUP"), "Resource group name")
+	flag.StringVar(&location, "location", os.Getenv("AZURE_LOCATION"), "Azure location")
+	flag.StringVar(&imageGallery, "image-gallery", "", "Image gallery name")
+	flag.StringVar(&imageDefinition, "image-definition", "", "Image definition name")
+	flag.StringVar(&imageVersion, "image-version", "0.0.1", "Image version (major.minor.patch)")
+	flag.StringVar(&communityGalleryImage, "community-image-id", "", "Community gallery image version resource ID")
+	flag.StringVar(&targetRegionsStr, "target-regions", "eastus2,northeurope,westeurope,eastus", "Comma separated target regions")
+
+	flag.Parse()
+
+	re := regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+	if !re.MatchString(imageVersion) {
+		log.Fatalf("–version %q is invalid; expected something like 1.2.3", imageVersion)
+	}
+
+	ctx := context.Background()
+
+	if subscriptionID == "" {
+		var err error
+		subscriptionID, err = defaultSubscriptionID(ctx)
+		if err != nil {
+			log.Fatalf("cannot determine subscription ID: %v", err)
+		}
+	}
+
+	if resourceGroup == "" || communityGalleryImage == "" {
+		fmt.Fprintln(os.Stderr, "required parameters: resource-group,community-image-id,image-gallery,image-definition")
+		os.Exit(1)
+	}
+
+	if location == "" {
+		var err error
+		location, err = groupLocation(ctx, resourceGroup)
+		if err != nil {
+			log.Fatalf("cannot determine location: %v", err)
+		}
+	}
+
+	managedDiskName := "tmp-disk-" + uuid.New().String()
+	userImageName := "tmp-img-" + uuid.New().String()
+
+	regions := strings.Split(targetRegionsStr, ",")
+	var targets []*armcompute.TargetRegion
+	for _, r := range regions {
+		r = strings.TrimSpace(r)
+		if r == "" {
+			continue
+		}
+		targets = append(targets, &armcompute.TargetRegion{Name: to.Ptr(r)})
+	}
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		log.Fatalf("creating credential: %v", err)
+	}
+
+	diskClient, err := armcompute.NewDisksClient(subscriptionID, cred, nil)
+	if err != nil {
+		log.Fatalf("creating disks client: %v", err)
+	}
+
+	log.Printf("creating managed disk %s from community image", managedDiskName)
+	diskPoller, err := diskClient.BeginCreateOrUpdate(ctx, resourceGroup, managedDiskName, armcompute.Disk{
+		Location: to.Ptr(location),
+		Properties: &armcompute.DiskProperties{
+			CreationData: &armcompute.CreationData{
+				CreateOption: to.Ptr(armcompute.DiskCreateOptionFromImage),
+				GalleryImageReference: &armcompute.ImageDiskReference{
+					CommunityGalleryImageID: to.Ptr(communityGalleryImage),
+				},
+			},
+		},
+	}, nil)
+	if err != nil {
+		log.Fatalf("creating disk: %v", err)
+	}
+	if _, err = diskPoller.PollUntilDone(ctx, nil); err != nil {
+		log.Fatalf("waiting for disk: %v", err)
+	}
+
+	defer func() {
+		log.Printf("deleting temporary managed disk %s", managedDiskName)
+		delDiskPoller, err := diskClient.BeginDelete(ctx, resourceGroup, managedDiskName, nil)
+		if err == nil {
+			_, _ = delDiskPoller.PollUntilDone(ctx, nil)
+		}
+	}()
+
+	diskID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/%s", subscriptionID, resourceGroup, managedDiskName)
+
+	imagesClient, err := armcompute.NewImagesClient(subscriptionID, cred, nil)
+	if err != nil {
+		log.Fatalf("creating images client: %v", err)
+	}
+
+	log.Printf("creating managed image %s from managed disk", userImageName)
+	imgPoller, err := imagesClient.BeginCreateOrUpdate(ctx, resourceGroup, userImageName, armcompute.Image{
+		Location: to.Ptr(location),
+		Properties: &armcompute.ImageProperties{
+			StorageProfile: &armcompute.ImageStorageProfile{
+				OSDisk: &armcompute.ImageOSDisk{
+					OSType:      to.Ptr(armcompute.OperatingSystemTypesLinux),
+					OSState:     to.Ptr(armcompute.OperatingSystemStateTypesGeneralized),
+					ManagedDisk: &armcompute.SubResource{ID: to.Ptr(diskID)},
+				},
+			},
+		},
+	}, nil)
+	if err != nil {
+		log.Fatalf("creating managed image: %v", err)
+	}
+	if _, err = imgPoller.PollUntilDone(ctx, nil); err != nil {
+		log.Fatalf("waiting for managed image: %v", err)
+	}
+
+	defer func() {
+		log.Printf("deleting temporary managed image %s", userImageName)
+		delImgPoller, err := imagesClient.BeginDelete(ctx, resourceGroup, userImageName, nil)
+		if err == nil {
+			_, _ = delImgPoller.PollUntilDone(ctx, nil)
+		}
+	}()
+
+	imageID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/images/%s", subscriptionID, resourceGroup, userImageName)
+
+	galleriesClient, err := armcompute.NewGalleriesClient(subscriptionID, cred, nil)
+	if err != nil {
+		log.Fatalf("creating galleries client: %v", err)
+	}
+
+	galPoller, err := galleriesClient.BeginCreateOrUpdate(ctx, resourceGroup, imageGallery, armcompute.Gallery{Location: to.Ptr(location)}, nil)
+	if err != nil {
+		log.Fatalf("creating gallery: %v", err)
+	}
+	if _, err = galPoller.PollUntilDone(ctx, nil); err != nil {
+		log.Fatalf("waiting for gallery: %v", err)
+	}
+
+	imgDefClient, err := armcompute.NewGalleryImagesClient(subscriptionID, cred, nil)
+	if err != nil {
+		log.Fatalf("creating gallery images client: %v", err)
+	}
+	imgDefPoller, err := imgDefClient.BeginCreateOrUpdate(ctx, resourceGroup, imageGallery, imageDefinition, armcompute.GalleryImage{
+		Location: to.Ptr(location),
+		Properties: &armcompute.GalleryImageProperties{
+			OSType:           to.Ptr(armcompute.OperatingSystemTypesLinux),
+			OSState:          to.Ptr(armcompute.OperatingSystemStateTypesGeneralized),
+			HyperVGeneration: to.Ptr(armcompute.HyperVGenerationV2),
+			Identifier: &armcompute.GalleryImageIdentifier{
+				Publisher: to.Ptr("cvm-publisher"),
+				Offer:     to.Ptr("cvm-offer"),
+				SKU:       to.Ptr("cvm-sku"),
+			},
+			Features: []*armcompute.GalleryImageFeature{{
+				Name:  to.Ptr("SecurityType"),
+				Value: to.Ptr("ConfidentialVmSupported"),
+			}},
+		},
+	}, nil)
+	if err != nil {
+		log.Fatalf("creating image definition: %v", err)
+	}
+	if _, err = imgDefPoller.PollUntilDone(ctx, nil); err != nil {
+		log.Fatalf("waiting for image definition: %v", err)
+	}
+
+	versionClient, err := armcompute.NewGalleryImageVersionsClient(subscriptionID, cred, nil)
+	if err != nil {
+		log.Fatalf("creating gallery image versions client: %v", err)
+	}
+	log.Printf("creating gallery image version %s from managed image", imageVersion)
+	verPoller, err := versionClient.BeginCreateOrUpdate(ctx, resourceGroup, imageGallery, imageDefinition, imageVersion, armcompute.GalleryImageVersion{
+		Location: to.Ptr(location),
+		Properties: &armcompute.GalleryImageVersionProperties{
+			PublishingProfile: &armcompute.GalleryImageVersionPublishingProfile{TargetRegions: targets},
+			StorageProfile: &armcompute.GalleryImageVersionStorageProfile{
+				Source: &armcompute.GalleryArtifactVersionFullSource{ID: to.Ptr(imageID)},
+			},
+		},
+	}, nil)
+	if err != nil {
+		log.Fatalf("creating image version: %v", err)
+	}
+	if _, err = verPoller.PollUntilDone(ctx, nil); err != nil {
+		log.Fatalf("waiting for image version: %v", err)
+	}
+
+	log.Printf("image %s/%s/%s created successfully", imageGallery, imageDefinition, imageVersion)
+}


### PR DESCRIPTION
The tool allows users to copy the community gallery images into their image galleries. This is necessary because we do not publish the community gallery images in all available regions.