### PR TITLE
ibmcloud-powervs: install iptables during podvm image build

### DIFF
--- a/src/cloud-api-adaptor/ibmcloud-powervs/README.md
+++ b/src/cloud-api-adaptor/ibmcloud-powervs/README.md
@@ -30,7 +30,7 @@ pvsadm image qcow2ova --prep-template-default > image-prep.template
 
 Add the following snippet to `image-prep.template`
 ```
-yum install -y gcc gcc-c++ git make wget perl
+yum install -y gcc gcc-c++ git make wget
 export PATH=${PATH}:/usr/local/go/bin:${HOME}/.cargo/bin
 wget https://github.com/mikefarah/yq/releases/download/v4.42.1/yq_linux_ppc64le
 chmod +x yq_linux_ppc64le && mv yq_linux_ppc64le /usr/local/bin/yq

--- a/src/cloud-api-adaptor/ibmcloud-powervs/image/prereq.sh
+++ b/src/cloud-api-adaptor/ibmcloud-powervs/image/prereq.sh
@@ -10,7 +10,7 @@ GO_VERSION="$(yq '.tools.golang' "${VERSIONS_YAML_PATH}")"
 ORAS_VERSION="$(yq '.tools.oras' "${VERSIONS_YAML_PATH}")"
 
 # Install dependencies
-yum install -y curl libseccomp-devel openssl openssl-devel skopeo clang clang-devel
+yum install -y curl libseccomp-devel openssl openssl-devel skopeo clang clang-devel perl iptables
 
 wget https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_ppc64le.tar.gz
 rm -rf /usr/local/bin/oras && tar -C /usr/local/bin -xzf oras_${ORAS_VERSION}_linux_ppc64le.tar.gz && rm -f oras_${ORAS_VERSION}_linux_ppc64le.tar.gz


### PR DESCRIPTION
agent-protocol-forwarder was failing to start with the error `"iptables": executable file not found in $PATH` while setting up the pod network.

```
agent-protocol-forwarder: error running a service *forwarder.daemon: failed to set up pod network: failed to set up tunnel "vxlan": failed to initialize iptables: exec: "iptables": executable file not found in $PATH
```

This PR adds instructions to install iptables during the build to fix the issue.