### PR TITLE
e2e-test: add id-token: write when invoking wf's

### DIFF
--- a/.github/workflows/azure-nightly-build.yml
+++ b/.github/workflows/azure-nightly-build.yml
@@ -47,6 +47,8 @@ jobs:
     uses: ./.github/workflows/azure-e2e-test.yml
     needs:
     - build-podvm-image
+    permissions:
+      id-token: write
     with:
       podvm-image-id: ${{ needs.build-podvm-image.outputs.image-id }}
     secrets:


### PR DESCRIPTION
The updated workflow permission in b02ef1ea need further adjustments, since azure-e2e-test is invoked as a nested workflow and requires `id-token: write` permissions.