### PR TITLE
versions: Bump to kata 3.18.0

### DIFF
--- a/.github/workflows/podvm_smoketest.yaml
+++ b/.github/workflows/podvm_smoketest.yaml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Install kata-agent-ctl
         run: |
-          oras pull "${KATA_REG}/agent-ctl:${KATA_REF}-x86_64"
+          oras pull "${KATA_REG}/agent-ctl:latest-main-x86_64"
           tar xf kata-static-agent-ctl.tar.xz
           cp opt/kata/bin/kata-agent-ctl /usr/local/bin
 

--- a/src/cloud-api-adaptor/go.mod
+++ b/src/cloud-api-adaptor/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/coreos/go-iptables v0.6.0
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0
-	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250521110624-a897bce29f3c
+	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250627024506-a43e06e0ebd5
 	github.com/opencontainers/runtime-spec v1.2.0
 	github.com/stretchr/testify v1.10.0
 	github.com/vishvananda/netlink v1.2.1-beta.2

--- a/src/cloud-api-adaptor/go.sum
+++ b/src/cloud-api-adaptor/go.sum
@@ -415,8 +415,8 @@ github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250521110624-a897bce29f3c h1:rS5zT2DEWTSZhzjPtXp5NwsM4b/29dMkHZpqKx/BLlE=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250521110624-a897bce29f3c/go.mod h1:n5xbY8R3GVf48ETNisJH/ZP+Ms004FN4Wvma4ihDIx8=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250627024506-a43e06e0ebd5 h1:WZlZxkH0UZG/mRaBTbIGNtsyr0WMCzJJnuO+wwRX1a8=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250627024506-a43e06e0ebd5/go.mod h1:n5xbY8R3GVf48ETNisJH/ZP+Ms004FN4Wvma4ihDIx8=
 github.com/kdomanski/iso9660 v0.4.0 h1:BPKKdcINz3m0MdjIMwS0wx1nofsOjxOq8TOr45WGHFg=
 github.com/kdomanski/iso9660 v0.4.0/go.mod h1:OxUSupHsO9ceI8lBLPJKWBTphLemjrCQY8LPXM7qSzU=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=

--- a/src/cloud-api-adaptor/podvm/files/etc/agent-config.toml
+++ b/src/cloud-api-adaptor/podvm/files/etc/agent-config.toml
@@ -1,3 +1,2 @@
 server_addr = "unix:///run/kata-containers/agent.sock"
 guest_components_procs = "none"
-image_registry_auth = "file:///run/peerpod/auth.json"

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/confidential-data-hub.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/confidential-data-hub.service
@@ -5,6 +5,7 @@ After=network.target cloud-init.service process-user-data.service
 [Service]
 Type=simple
 Environment=OCICRYPT_KEYPROVIDER_CONFIG=/etc/ocicrypt_config.json
+Environment="CDH_DEFAULT_IMAGE_AUTHENTICATED_REGISTRY_CREDENTIALS=file:///run/peerpod/auth.json"
 ExecStart=/bin/bash -c \
     'if [ -f /run/peerpod/cdh.toml ]; \
     then /usr/local/bin/confidential-data-hub -c /run/peerpod/cdh.toml; \

--- a/src/cloud-api-adaptor/test/e2e/libvirt_test.go
+++ b/src/cloud-api-adaptor/test/e2e/libvirt_test.go
@@ -252,7 +252,7 @@ func TestLibvirtCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t *t
 
 func TestLibvirtCreateWithCpuAndMemRequestLimit(t *testing.T) {
 	assert := LibvirtAssert{}
-	DoTestPodWithCpuMemLimitsAndRequests(t, testEnv, assert, "100m", "100Mi", "200m", "1000Mi")
+	DoTestPodWithCpuMemLimitsAndRequests(t, testEnv, assert, "100m", "100Mi", "200m", "1200Mi")
 }
 
 func TestLibvirtPodVMwithAnnotationsCPUMemory(t *testing.T) {

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -49,7 +49,7 @@ git:
     reference: v1.5.0
   kbs:
     url: https://github.com/confidential-containers/trustee
-    reference: d9eb5e0cb0aca97abe35b58908e061850ff60a51
+    reference: 8462025ed2d2a94281344e63405bbe7500bd4484
 # If a tag is given it will attempt to pull the oci image by tag. if a
 # reference is specified the corresponding tag will be constructed using
 # the reference and suffixes like architecture or tee.
@@ -59,7 +59,7 @@ oci:
     tag: 3.9
   kata-containers:
     registry: ghcr.io/kata-containers/cached-artefacts
-    reference: 3.17.0
+    reference: a43e06e0ebd52b8224cced6a65c04118ba980fbb
   guest-components:
     registry: ghcr.io/confidential-containers/guest-components
-    reference: 0a06ef241190780840fbb0542e51b198f1f72b0b
+    reference: 4cd62c3f8a6475a556eceb5f4538e523e9491400

--- a/src/csi-wrapper/go.mod
+++ b/src/csi-wrapper/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang/glog v1.2.4
 	github.com/golang/protobuf v1.5.4
-	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250521110624-a897bce29f3c
+	github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250627024506-a43e06e0ebd5
 	golang.org/x/net v0.41.0
 	google.golang.org/grpc v1.72.0
 	k8s.io/apimachinery v0.30.0

--- a/src/csi-wrapper/go.sum
+++ b/src/csi-wrapper/go.sum
@@ -53,8 +53,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250521110624-a897bce29f3c h1:rS5zT2DEWTSZhzjPtXp5NwsM4b/29dMkHZpqKx/BLlE=
-github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250521110624-a897bce29f3c/go.mod h1:n5xbY8R3GVf48ETNisJH/ZP+Ms004FN4Wvma4ihDIx8=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250627024506-a43e06e0ebd5 h1:WZlZxkH0UZG/mRaBTbIGNtsyr0WMCzJJnuO+wwRX1a8=
+github.com/kata-containers/kata-containers/src/runtime v0.0.0-20250627024506-a43e06e0ebd5/go.mod h1:n5xbY8R3GVf48ETNisJH/ZP+Ms004FN4Wvma4ihDIx8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=


### PR DESCRIPTION
Bump the kata-agent and runtime to 3.18.0
along with the matching guest-components
and trustee, to pick up the new image pull
in cdh approach