### PR TITLE
Add disk storage support for container image store

### DIFF
--- a/.github/workflows/podvm_smoketest.yaml
+++ b/.github/workflows/podvm_smoketest.yaml
@@ -58,7 +58,7 @@ jobs:
           echo "TLS_OPTIONS=-disable-tls" > ./resources/binaries-tree/etc/default/agent-protocol-forwarder
 
       - name: Build image
-        run: make image
+        run: make image-debug
 
       - name: Install kata-agent-ctl
         run: |

--- a/.github/workflows/podvm_smoketest.yaml
+++ b/.github/workflows/podvm_smoketest.yaml
@@ -10,6 +10,16 @@ jobs:
     # We're pinning the runner to 22.04 b/c libvirt struggles with the
     # OVMF_CODE_4M firmware that is default on 24.04.
     runs-on: 'ubuntu-22.04'
+    
+    strategy:
+      matrix:
+        test-mode:
+          - name: podvm-mkosi
+            mode: basic
+          - name: podvm-mkosi-with-scratch-space
+            mode: scratch-space
+          - name: podvm-mkosi-with-encrypted-scratch-space
+            mode: encrypted-scratch-space
 
     defaults:
       run:
@@ -66,6 +76,6 @@ jobs:
           tar xf kata-static-agent-ctl.tar.xz
           cp opt/kata/bin/kata-agent-ctl /usr/local/bin
 
-      - name: Run smoke test
+      - name: Run smoke test (${{ matrix.test-mode.name }})
         run: |
-          ../podvm/hack/smoke_test.sh -d build/podvm-fedora-amd64.qcow2
+          ../podvm/hack/smoke_test.sh -m ${{ matrix.test-mode.mode }} build/podvm-fedora-amd64.qcow2

--- a/src/cloud-api-adaptor/cmd/cloud-api-adaptor/main.go
+++ b/src/cloud-api-adaptor/cmd/cloud-api-adaptor/main.go
@@ -130,6 +130,8 @@ func (cfg *daemonConfig) Setup() (cmd.Starter, error) {
 		flags.StringVar(&cfg.serverConfig.Initdata, "initdata", "", "Default initdata for all Pods")
 		flags.BoolVar(&cfg.serverConfig.EnableCloudConfigVerify, "cloud-config-verify", false, "Enable cloud config verify - should use it for production")
 		flags.IntVar(&cfg.serverConfig.PeerPodsLimitPerNode, "peerpods-limit-per-node", 10, "peer pods limit per node (default=10)")
+		flags.BoolVar(&cfg.serverConfig.EnableScratchDisk, "enable-scratch-disk", false, "Enable scratch disk for pod VMs")
+		flags.BoolVar(&cfg.serverConfig.EnableScratchEncryption, "enable-scratch-encryption", false, "Enable encryption for scratch disk")
 
 		cloud.ParseCmd(flags)
 	})

--- a/src/cloud-api-adaptor/entrypoint.sh
+++ b/src/cloud-api-adaptor/entrypoint.sh
@@ -34,6 +34,8 @@ optionals+=""
 [[ "${SECURE_COMMS_KBS_ADDR}" ]] && optionals+="-secure-comms-kbs ${SECURE_COMMS_KBS_ADDR} "
 [[ "${PEERPODS_LIMIT_PER_NODE}" ]] && optionals+="-peerpods-limit-per-node ${PEERPODS_LIMIT_PER_NODE} "
 [[ "${DISABLECVM}" == "true" ]] && optionals+="-disable-cvm "
+[[ "${ENABLE_SCRATCH_DISK}" == "true" ]] && optionals+="-enable-scratch-disk "
+[[ "${ENABLE_SCRATCH_ENCRYPTION}" == "true" ]] && optionals+="-enable-scratch-encryption "
 
 test_vars() {
     for i in "$@"; do

--- a/src/cloud-api-adaptor/install/overlays/aws/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/aws/kustomization.yaml
@@ -41,6 +41,8 @@ configMapGenerator:
   #- PEERPODS_LIMIT_PER_NODE="10" # Max number of peer pods that can be created per node. Default is 10
   #- REMOTE_HYPERVISOR_ENDPOINT="/run/peerpod/hypervisor.sock" # Path to Kata remote hypervisor socket. Default is /run/peerpod/hypervisor.sock
   #- PEER_PODS_DIR="/run/peerpod/pods" # Path to peer pods directory. Default is /run/peerpod/pods
+  #- ENABLE_SCRATCH_DISK="false"  # Enable scratch disk. Default is false
+  #- ENABLE_SCRATCH_ENCRYPTION="false" # Enable scratch disk encryption. Default is false
 ##TLS_SETTINGS
   #- CACERT_FILE="/etc/certificates/ca.crt" # for TLS
   #- CERT_FILE="/etc/certificates/client.crt" # for TLS

--- a/src/cloud-api-adaptor/install/overlays/azure/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/azure/kustomization.yaml
@@ -45,6 +45,9 @@ configMapGenerator:
   #- PEERPODS_LIMIT_PER_NODE="10" # Max number of peer pods that can be created per node. Default is 10
   #- REMOTE_HYPERVISOR_ENDPOINT="/run/peerpod/hypervisor.sock" # Path to Kata remote hypervisor socket. Default is /run/peerpod/hypervisor.sock
   #- PEER_PODS_DIR="/run/peerpod/pods" # Path to peer pods directory. Default is /run/peerpod/pods
+  #- ROOT_VOLUME_SIZE="" # Uncomment and set if you want to use a specific root volume size. Default depends on the image used
+  #- ENABLE_SCRATCH_DISK="false"  # Enable scratch disk. Default is false
+  #- ENABLE_SCRATCH_ENCRYPTION="false" # Enable scratch disk encryption. Default is false
 ##TLS_SETTINGS
   #- CACERT_FILE="/etc/certificates/ca.crt" # for TLS
   #- CERT_FILE="/etc/certificates/client.crt" # for TLS

--- a/src/cloud-api-adaptor/install/overlays/gcp/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/gcp/kustomization.yaml
@@ -32,6 +32,8 @@ configMapGenerator:
   #- TUNNEL_TYPE="" # Uncomment and set if you want to use a specific tunnel type. Defaults to vxlan
   #- VXLAN_PORT="" # Uncomment and set if you want to use a specific vxlan port. Defaults to 4789
   #- TAGS="" # Uncomment and add key1=value1,key2=value2 etc if you want to use specific tags for podvm. Tags must already exist in the GCP project
+  #- ENABLE_SCRATCH_DISK="false"  # Enable scratch disk. Default is false
+  #- ENABLE_SCRATCH_ENCRYPTION="false" # Enable scratch disk encryption. Default is false
 ##TLS_SETTINGS
   #- CACERT_FILE="/etc/certificates/ca.crt" # for TLS
   #- CERT_FILE="/etc/certificates/client.crt" # for TLS

--- a/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
@@ -55,6 +55,8 @@ type ServerConfig struct {
 	SecureCommsKbsAddress   string
 	PeerPodsLimitPerNode    int
 	RootVolumeSize          int
+	EnableScratchDisk       bool
+	EnableScratchEncryption bool
 }
 
 var logger = log.New(log.Writer(), "[adaptor/cloud] ", log.LstdFlags|log.Lmsgprefix)
@@ -282,6 +284,16 @@ func (s *cloudService) CreateVM(ctx context.Context, req *pb.CreateVMRequest) (r
 			daemonConfig.SecureCommsInbounds = s.serverConfig.SecureCommsPpInbounds
 			daemonConfig.SecureComms = true
 		}
+	}
+
+	// Set scratch disk configuration
+	// If EnableScratchEncryption is set, then automatically set EnableScratchDisk
+	// as well and log it
+	daemonConfig.EnableScratchDisk = s.serverConfig.EnableScratchDisk
+	if s.serverConfig.EnableScratchEncryption {
+		daemonConfig.EnableScratchDisk = true
+		daemonConfig.EnableScratchEncryption = true
+		logger.Printf("EnableScratchEncryption is set, enabling scratch disk as well")
 	}
 
 	daemonJSON, err := json.MarshalIndent(daemonConfig, "", "    ")

--- a/src/cloud-api-adaptor/pkg/forwarder/forwarder.go
+++ b/src/cloud-api-adaptor/pkg/forwarder/forwarder.go
@@ -43,11 +43,13 @@ type Config struct {
 	TLSServerCert string `json:"tls-server-cert,omitempty"`
 	TLSClientCA   string `json:"tls-client-ca,omitempty"`
 
-	PpPrivateKey         []byte `json:"sc-pp-prv,omitempty"`
-	WnPublicKey          []byte `json:"sc-wn-pub,omitempty"`
-	SecureCommsInbounds  string `json:"sc-inbounds,omitempty"`
-	SecureCommsOutbounds string `json:"sc-outbounds,omitempty"`
-	SecureComms          bool   `json:"sc,omitempty"`
+	PpPrivateKey            []byte `json:"sc-pp-prv,omitempty"`
+	WnPublicKey             []byte `json:"sc-wn-pub,omitempty"`
+	SecureCommsInbounds     string `json:"sc-inbounds,omitempty"`
+	SecureCommsOutbounds    string `json:"sc-outbounds,omitempty"`
+	SecureComms             bool   `json:"sc,omitempty"`
+	EnableScratchDisk       bool   `json:"enable-scratch-disk,omitempty"`
+	EnableScratchEncryption bool   `json:"enable-scratch-encryption,omitempty"`
 }
 
 type Daemon interface {

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-debug.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-debug.conf
@@ -19,3 +19,4 @@ Packages=
     wget
     ncurses
     less
+    qemu-guest-agent

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora.conf
@@ -23,6 +23,8 @@ Packages=
     iptables
     afterburn
     fastfetch
+    e2fsprogs
+    cryptsetup
 
 RemoveFiles=/etc/issue
 RemoveFiles=/etc/issue.net

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/repart.d/30-scratch.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/repart.d/30-scratch.conf
@@ -1,0 +1,4 @@
+[Partition]
+Type=linux-generic
+Label=trusted_store
+Format=ext4

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system-preset/30-coco.preset
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system-preset/30-coco.preset
@@ -9,3 +9,4 @@ enable setup-nat-for-imds.service
 
 enable gen-issue.service
 enable image-env.service
+enable scratch-storage.service

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/kata-agent.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/kata-agent.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Kata Agent
 BindsTo=netns@podns.service
-After=netns@podns.service process-user-data.service
+After=netns@podns.service process-user-data.service scratch-storage.service
+Wants=scratch-storage.service
 
 [Service]
 ExecStartPre=mkdir -p /run/kata-containers

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/scratch-storage.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/scratch-storage.service
@@ -1,0 +1,1 @@
+../scratch-storage.service

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/scratch-storage.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/scratch-storage.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Configurable Scratch Storage Setup for Kata Agent
+After=systemd-repart.service process-user-data.service
+# It must complete before the kata-agent starts
+Before=kata-agent.service
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/setup-scratch-storage
+
+[Install]
+WantedBy=multi-user.target

--- a/src/cloud-api-adaptor/podvm/files/usr/local/bin/luks-encrypt-storage
+++ b/src/cloud-api-adaptor/podvm/files/usr/local/bin/luks-encrypt-storage
@@ -1,0 +1,153 @@
+#!/bin/bash
+#
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+[ -n "${DEBUG:-}" ] && set -o xtrace
+
+handle_error() {
+        local exit_code="${?}"
+        local line_number="${1:-}"
+        echo "error:"
+        echo "Failed at $line_number: ${BASH_COMMAND}"
+        exit "${exit_code}"
+}
+trap 'handle_error $LINENO' ERR
+
+die()
+{
+	local msg="$*"
+	echo >&2 "ERROR: $msg"
+	exit 1
+}
+
+setup()
+{
+	local cmds=()
+
+	cmds+=("cryptsetup" "mkfs.ext4" "mount")
+
+	local cmd
+	for cmd in "${cmds[@]}"
+	do
+		command -v "$cmd" &>/dev/null || die "need command: '$cmd'"
+	done
+}
+
+setup
+
+device_num=${1:-}
+if [ -z "$device_num" ]; then
+	die "invalid arguments, at least one param for device num"
+fi
+
+is_encrypted="false"
+if [ -n "${2-}" ]; then
+        is_encrypted="$2"
+fi
+
+mount_point="/tmp/target_path"
+if [ -n "${3-}" ]; then
+        mount_point="$3"
+fi
+
+storage_key_path="/run/encrypt_storage.key"
+if [ -n "${4-}" ]; then
+        storage_key_path="$4"
+fi
+
+data_integrity="true"
+if [ -n "${5-}" ]; then
+        data_integrity="$5"
+fi
+
+device_name=$(sed -e 's/DEVNAME=//g;t;d' "/sys/dev/block/${device_num}/uevent")
+device_path="/dev/$device_name"
+
+opened_device_name=$(mktemp -u "encrypted_disk_XXXXX")
+
+if [[ -n "$device_name" && -b "$device_path" ]]; then
+
+	if [ "$is_encrypted" == "false" ]; then
+
+		if [ "$data_integrity" == "false" ]; then
+			cryptsetup --batch-mode luksFormat --type luks2 "$device_path" --sector-size 4096 \
+				--cipher aes-xts-plain64 "$storage_key_path"
+		else
+				# Wiping a device is a time consuming operation. To avoid a full wipe, integritysetup
+				# and crypt setup provide a --no-wipe option.
+				# However, an integrity device that is not wiped will have invalid checksums. Normally
+				# this should not be a problem since a page must first be written to before it can be read
+				# (otherwise the data would be arbitrary). The act of writing would populate the checksum
+				# for the page.
+				# However, tools like mkfs.ext4 read pages before they are written; sometimes the read
+				# of an unwritten page happens due to kernel buffering.
+				# See https://gitlab.com/cryptsetup/cryptsetup/-/issues/525 for explanation and fix.
+				# The way to properly format the non-wiped dm-integrity device is to figure out which pages
+				# mkfs.ext4 will write to and then to write to those pages before hand so that they will
+				# have valid integrity tags.
+			cryptsetup --batch-mode luksFormat --type luks2 "$device_path" --sector-size 4096 \
+				--cipher aes-xts-plain64 --integrity hmac-sha256 "$storage_key_path" \
+				--integrity-no-wipe
+		fi
+	fi
+
+	cryptsetup luksOpen -d "$storage_key_path" "$device_path" "$opened_device_name"
+	rm "$storage_key_path"
+
+	if [ "$data_integrity" == "false" ]; then
+		mkfs.ext4 "/dev/mapper/$opened_device_name" -E lazy_journal_init
+	else
+		# mkfs.ext4 doesn't perform whole sector writes and this will cause checksum failures
+		# with an unwiped integrity device. Therefore, first perform a dry run.
+		output=$(mkfs.ext4 "/dev/mapper/$opened_device_name" -F -n)
+
+		# The above command will produce output like
+		# mke2fs 1.46.5 (30-Dec-2021)
+		# Creating filesystem with 268435456 4k blocks and 67108864 inodes
+		# Filesystem UUID: 4a5ff012-91c0-47d9-b4bb-8f83e830825f
+		# Superblock backups stored on blocks:
+		#         32768, 98304, 163840, 229376, 294912, 819200, 884736, 1605632, 2654208,
+		#         4096000, 7962624, 11239424, 20480000, 23887872, 71663616, 78675968,
+		#         102400000, 214990848
+		delimiter="Superblock backups stored on blocks:"
+		blocks_list=$([[ $output =~ $delimiter(.*) ]] && echo "${BASH_REMATCH[1]}")
+
+		# Find list of blocks
+		block_nums=$(echo  "$blocks_list" | grep -Eo '[0-9]{4,}' | sort -n)
+
+		if [ -z "$block_nums" ]; then
+			die "Block numbers not found"
+		fi
+
+		# Add zero to list of blocks
+		block_nums="0 $block_nums"
+
+		# Iterate through each block and write to it to ensure that it has valid checksum
+		for block_num in $block_nums
+		do
+		echo "Clearing page at $block_num"
+		# Zero out the page
+		dd if=/dev/zero bs=4k count=1 oflag=direct \
+		of="/dev/mapper/$opened_device_name" seek="$block_num"
+		done
+
+		# Now perform the actual ext4 format. Use lazy_journal_init so that the journal is
+		# initialized on demand. This is safe for ephemeral storage since we don't expect
+		# ephemeral storage to survive a power cycle.
+		mkfs.ext4 "/dev/mapper/$opened_device_name" -E lazy_journal_init
+	fi
+
+	[ ! -d "$mount_point" ] && mkdir -p "$mount_point"
+
+	mount "/dev/mapper/$opened_device_name" "$mount_point"
+else
+	die "Invalid device: '$device_path'"
+fi

--- a/src/cloud-api-adaptor/podvm/files/usr/local/bin/setup-scratch-storage
+++ b/src/cloud-api-adaptor/podvm/files/usr/local/bin/setup-scratch-storage
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+[ -n "${DEBUG:-}" ] && set -o xtrace
+
+handle_error() {
+    local exit_code="${?}"
+    local line_number="${1:-}"
+    echo "error:"
+    echo "Failed at $line_number: ${BASH_COMMAND}"
+    exit "${exit_code}"
+}
+trap 'handle_error $LINENO' ERR
+
+die() {
+    local msg="$*"
+    echo >&2 "ERROR: $msg"
+    exit 1
+}
+
+# Check if daemon.json exists and parse configuration
+DAEMON_CONFIG_PATH="/run/peerpod/daemon.json"
+SCRATCH_ENABLED="false"
+ENCRYPTION_ENABLED="false"
+
+if [ -f "$DAEMON_CONFIG_PATH" ]; then
+    if grep -q '"enable-scratch-disk":.*true' "$DAEMON_CONFIG_PATH"; then
+        SCRATCH_ENABLED="true"
+    fi
+    if grep -q '"enable-scratch-encryption":.*true' "$DAEMON_CONFIG_PATH"; then
+        ENCRYPTION_ENABLED="true"
+    fi
+
+fi
+
+echo "Scratch disk enabled: $SCRATCH_ENABLED"
+echo "Scratch encryption enabled: $ENCRYPTION_ENABLED"
+
+# Exit early if scratch disk is not enabled
+if [ "$SCRATCH_ENABLED" != "true" ]; then
+    echo "Scratch disk is disabled. Exiting."
+    exit 0
+fi
+
+# Check if the trusted_store device exists
+DISK_LABEL="trusted_store"
+DEV_PATH="/dev/disk/by-label/$DISK_LABEL"
+
+if [ ! -L "$DEV_PATH" ]; then
+    echo "Device for label $DISK_LABEL not found. Exiting."
+    exit 1
+fi
+
+# Resolve the device path
+DEV_PATH=$(readlink -f "$DEV_PATH")
+if [ ! -b "$DEV_PATH" ]; then
+    echo "Device $DEV_PATH is not a block device. Exiting."
+    exit 1
+fi
+
+# Create mount point
+MOUNT_POINT="/run/kata-containers/image"
+mkdir -p "$MOUNT_POINT"
+
+# Get device number for the encryption script
+# Using xargs to strip leading/trailing whitespace
+DEV_NUM=$(lsblk -no MAJ:MIN "$DEV_PATH" | xargs)
+
+if [ "$ENCRYPTION_ENABLED" = "true" ]; then
+    # Generate encryption key and use LUKS encryption
+    echo "Setting up LUKS encrypted scratch storage"
+    head -c 4096 /dev/urandom >/run/encrypt_storage.key
+    /usr/local/bin/luks-encrypt-storage "$DEV_NUM" false "$MOUNT_POINT" /run/encrypt_storage.key
+else
+    # Use plain ext4 without encryption
+    echo "Setting up plain scratch storage"
+    mkfs.ext4 "$DEV_PATH" -F
+    mount "$DEV_PATH" "$MOUNT_POINT"
+fi
+
+echo "Scratch storage setup completed"

--- a/src/cloud-api-adaptor/podvm/hack/smoke_test.sh
+++ b/src/cloud-api-adaptor/podvm/hack/smoke_test.sh
@@ -8,201 +8,7 @@ set -euo pipefail
 SOCAT_PID=""
 DESTRUCTIVE=0
 IMG=""
-
-usage() {
-	echo "Usage: $0 [-d] IMG"
-	echo "  IMG     : Required positional argument for the image file."
-	echo "  -d      : Destructive, it moves the image and avoids any cleanup (0)."
-	exit 1
-}
-
-while getopts ":d" opt; do
-	case ${opt} in
-		d)
-			DESTRUCTIVE=1
-			;;
-		\?)
-			echo "Invalid option: -$OPTARG" >&2
-			usage
-			;;
-		:)
-			echo "Option -$OPTARG requires an argument." >&2
-			usage
-			;;
-	esac
-done
-
-shift $((OPTIND-1))
-IMG=$(realpath "$1")
-
-if [ -z "$IMG" ]; then
-	echo "Error: Please specify the IMAGE as a positional argument."
-	exit 1
-fi
-FMT=${IMG##*.}
-
-WORKDIR="$(mktemp -d)"
-SCRIPTDIR=$(dirname "$(realpath "$0")")
-
-
-cleanup() {
-	# Cleanup (only when DESTRUCTIVE!=1)
-	if [ "${DESTRUCTIVE}" -ne 1 ]; then
-		set +e
-		popd
-		[ -n "${SOCAT_PID}" ] && kill "${SOCAT_PID}"
-		sudo virsh destroy smoketest
-		rm -Rf "${WORKDIR}"
-	fi
-}
-
-trap 'cleanup' EXIT ERR
-
-# Ensure we have kata-agent-ctl
-KATACTL=$(which kata-agent-ctl 2>/dev/null || true)
-if [ -z "${KATACTL}" ]; then
-	if [ -e kata-agent-ctl ]; then
-		KATACTL=$(realpath kata-agent-ctl)
-		chmod +x "$KATACTL"
-		echo "::debug:: Using kata-agent-ctl from this directory"
-	fi
-else
-	echo "::debug:: Using kata-agent-ctl from PATH ${KATACTL}"
-fi
-pushd "$WORKDIR"
-if [ -z "$KATACTL" ]; then
-	if [ "$(uname -m)" != "x86_64" ]; then
-		echo "::error:: kata-agent-ctl command not cached for $(uname -m), please compile it yourself and put into PATH or current dir."
-		exit 1
-	fi
-	KATA_REF=$(yq -e '.oci.kata-containers.reference' ${SCRIPTDIR}/../../versions.yaml)
-	KATA_REG=$(yq -e '.oci.kata-containers.registry' ${SCRIPTDIR}/../../versions.yaml)
-	echo "::debug:: Pulling kata-ctl from ${KATA_REG}/agent-ctl:${KATA_REF}-x86_64"
-	oras pull "${KATA_REG}/agent-ctl:${KATA_REF}-x86_64"
-	tar -xJvf kata-static-agent-ctl.tar.xz ./opt/kata/bin/kata-agent-ctl --transform='s/opt\/kata\/bin\/kata-agent-ctl/kata-agent-ctl/'
-	rm kata-static-agent-ctl.tar.xz
-	KATACTL=$(realpath kata-agent-ctl)
-	chmod +x "$KATACTL"
-fi
-
-# Create cloud-init iso
-echo "::debug:: Preparing cloud-init iso"
-mkdir cloud-init
-touch cloud-init/meta-data
-cat <<EOF > cloud-init/user-data
-#cloud-config
-
-write_files:
-- path: /run/peerpod/daemon.json
-  content: |
-    {
-        "pod-network": {
-            "podip": "10.244.1.21/24",
-            "pod-hw-addr": "32:b9:59:6b:f0:d5",
-            "interface": "eth0",
-            "worker-node-ip": "10.224.0.5/16",
-            "tunnel-type": "vxlan",
-            "routes": [
-                {
-                    "dst": "0.0.0.0/0",
-                    "gw": "10.244.1.1",
-                    "dev": "eth0",
-                    "protocol": "boot"
-                },
-                {
-                    "dst": "10.244.1.0/24",
-                    "gw": "",
-                    "dev": "eth0",
-                    "protocol": "kernel",
-                    "scope": "link"
-                }
-            ],
-            "neighbors": null,
-            "mtu": 1500,
-            "index": 2,
-            "vxlan-port": 8472,
-            "vxlan-id": 555002,
-            "dedicated": false
-        },
-        "pod-namespace": "default",
-        "pod-name": "smoketest",
-        "enable-scratch-disk": true,
-        "enable-scratch-encryption": true
-    }
-EOF
-genisoimage -output cloud-init.iso -volid cidata -joliet -rock cloud-init/user-data cloud-init/meta-data
-
-# Move files to libvirt-accessible location
-echo "::debug:: Moving files to libvirt-accessible location"
-IMAGE=$(realpath "./podvm.${FMT}")
-if [ "${DESTRUCTIVE}" -eq 1 ]; then
-	mv "${IMG}" "${IMAGE}"
-else
-	cp "${IMG}" "${IMAGE}"
-fi
-chmod a+rwx "${WORKDIR}"
-sudo chown -R libvirt-qemu "${WORKDIR}" || true
-sudo chmod +x "${WORKDIR}"
-
-# Resize the VM disk image to add free space
-sudo qemu-img resize -f "${FMT}" "${IMAGE}" +1G
-
-# Start the VM
-echo "::debug:: Starting VM"
-# TODO: Add AAVMF for arm
-[ -e "/usr/share/OVMF/OVMF_CODE.fd" ] && OVMF="/usr/share/OVMF/OVMF_CODE.fd"
-sudo virt-install \
-	--name smoketest \
-	--ram 1024 \
-	--vcpus 2 \
-	--disk "path=${IMAGE},format=${FMT}" \
-	--disk "path=${WORKDIR}/cloud-init.iso,device=cdrom" \
-	--import \
-	--network network=default \
-	--os-variant detect=on,require=off \
-	--graphics none \
-	--virt-type=kvm \
-	--boot loader="${OVMF}" \
-	--transient \
-	--noautoconsole \
-	--channel unix,mode=bind,path=${WORKDIR}/smoketest.agent,target_type=virtio,name=org.qemu.guest_agent.0
-
-SECONDS=0
-while [ $SECONDS -lt 120 ]; do
-	sleep 5
-	VM_IP="$(sudo virsh -q domifaddr smoketest | awk '{print $4}' | cut -d/ -f1)"
-	[ -n "${VM_IP}" ] && break
-done
-if [ -z "${VM_IP}" ]; then
-	echo "::error:: Failed to get ipaddr in 120s"
-	exit 1
-fi
-
-# Perform smoke test
-echo "::debug:: Performing the test"
-HOST_PORT="${VM_IP}:15150"
-SOCK="./agent.sock"
-echo "bridge ${HOST_PORT} to ${SOCK}"
-socat "UNIX-LISTEN:${SOCK},fork" "TCP:${HOST_PORT}" &
-SOCAT_PID=$!
-
-( for _ in {1..5}; do
-	$KATACTL connect \
-		--server-address "unix://${SOCK}" \
-		--cmd Check && exit || true
-	sleep 5
-	false
-done) || { echo "::error:: Failed to connect to peer-pod"; exit 1; }
-
-if ! $KATACTL connect --server-address "unix://${SOCK}" --cmd CreateSandbox; then
-	echo "::error:: Failed to CreateSandbox"
-	exit 1;
-fi
-
-if ! $KATACTL connect --server-address "unix://${SOCK}" --cmd DestroySandbox; then
-	echo "::error:: Failed to DestroySandbox"
-	exit 1;
-fi
+TEST_MODE="basic"
 
 # Check encrypted disk mount
 # Connect to qemu-ga to run lsblk and process o/p
@@ -269,8 +75,313 @@ check_encrypted_disk_mount() {
   fi
 }
 
-if ! check_encrypted_disk_mount smoketest; then
-   echo "::error:: Encrypted disk not found"
-   exit 1
+check_scratch_disk_mount() {
+  local domain="$1"  # e.g., "smoketest"
+  local exec_output exec_pid exec_status base64_data decoded_output
+
+  # Run lsblk via guest-exec
+  exec_output=$(sudo virsh qemu-agent-command "$domain" '{"execute": "guest-exec", "arguments": { "path": "/usr/bin/lsblk", "capture-output": true }}')
+  exec_pid=$(echo "$exec_output" | jq -r '.return.pid')
+
+  if [[ -z "$exec_pid" || "$exec_pid" == "null" ]]; then
+    echo "Failed to get PID from guest-exec."
+    return 1
+  fi
+
+  # Wait for the command to finish
+  exec_status=$(sudo virsh qemu-agent-command "$domain" \
+       --timeout 5 \
+      "{\"execute\": \"guest-exec-status\", \"arguments\": { \"pid\": $exec_pid }}")
+
+  exited=$(echo "$exec_status" | jq -r '.return.exited')
+
+  if [[ "$exited" != "true" ]]; then
+    echo "Command did not exit in time."
+    return 1
+  fi
+
+  # Decode the output
+  base64_data=$(echo "$exec_status" | jq -r '.return["out-data"]')
+  if [[ -z "$base64_data" || "$base64_data" == "null" ]]; then
+    echo "No output from lsblk."
+    return 1
+  fi
+
+  decoded_output=$(echo "$base64_data" | base64 -d)
+
+  # Check if any device is mounted at /run/kata-containers/image
+  if echo "$decoded_output" | grep -q "/run/kata-containers/image"; then
+    echo "Scratch disk is mounted at /run/kata-containers/image"
+    return 0
+  else
+    echo "Scratch disk is NOT mounted at /run/kata-containers/image"
+    return 1
+  fi
+}
+
+usage() {
+	echo "Usage: $0 [-d] [-m MODE] IMG"
+	echo "  IMG     : Required positional argument for the image file."
+	echo "  -d      : Destructive, it moves the image and avoids any cleanup (0)."
+	echo "  -m MODE : Test mode: basic, scratch-space, encrypted-scratch-space (basic)."
+	exit 1
+}
+
+cleanup() {
+	# Cleanup (only when DESTRUCTIVE!=1)
+	if [ "${DESTRUCTIVE}" -ne 1 ]; then
+		set +e
+		popd >/dev/null 2>&1 || true
+		[ -n "${SOCAT_PID}" ] && kill "${SOCAT_PID}" >/dev/null 2>&1 || true
+		sudo virsh destroy "${VM_NAME:-smoketest}" >/dev/null 2>&1 || true
+		rm -Rf "${WORKDIR}" || true
+	fi
+}
+
+trap 'cleanup' EXIT ERR
+
+while getopts ":dm:" opt; do
+	case ${opt} in
+		d)
+			DESTRUCTIVE=1
+			;;
+		m)
+			TEST_MODE="$OPTARG"
+			;;
+		\?)
+			echo "Invalid option: -$OPTARG" >&2
+			usage
+			;;
+		:)
+			echo "Option -$OPTARG requires an argument." >&2
+			usage
+			;;
+	esac
+done
+
+shift $((OPTIND-1))
+IMG=$(realpath "$1")
+
+if [ -z "$IMG" ]; then
+	echo "Error: Please specify the IMAGE as a positional argument."
+	exit 1
 fi
 
+# Validate test mode
+case "$TEST_MODE" in
+	basic|scratch-space|encrypted-scratch-space)
+		;;
+	*)
+		echo "Error: Invalid test mode '$TEST_MODE'. Valid modes: basic, scratch-space, encrypted-scratch-space"
+		exit 1
+		;;
+esac
+
+echo "::debug:: Running smoke test in mode: $TEST_MODE"
+FMT=${IMG##*.}
+
+WORKDIR="$(mktemp -d)"
+SCRIPTDIR=$(dirname "$(realpath "$0")")
+
+
+# Ensure we have kata-agent-ctl
+KATACTL=$(which kata-agent-ctl 2>/dev/null || true)
+if [ -z "${KATACTL}" ]; then
+	if [ -e kata-agent-ctl ]; then
+		KATACTL=$(realpath kata-agent-ctl)
+		chmod +x "$KATACTL"
+		echo "::debug:: Using kata-agent-ctl from this directory"
+	fi
+else
+	echo "::debug:: Using kata-agent-ctl from PATH ${KATACTL}"
+fi
+pushd "$WORKDIR"
+if [ -z "$KATACTL" ]; then
+	if [ "$(uname -m)" != "x86_64" ]; then
+		echo "::error:: kata-agent-ctl command not cached for $(uname -m), please compile it yourself and put into PATH or current dir."
+		exit 1
+	fi
+	KATA_REF=$(yq -e '.oci.kata-containers.reference' ${SCRIPTDIR}/../../versions.yaml)
+	KATA_REG=$(yq -e '.oci.kata-containers.registry' ${SCRIPTDIR}/../../versions.yaml)
+	echo "::debug:: Pulling kata-ctl from ${KATA_REG}/agent-ctl:${KATA_REF}-x86_64"
+	oras pull "${KATA_REG}/agent-ctl:${KATA_REF}-x86_64"
+	tar -xJvf kata-static-agent-ctl.tar.xz ./opt/kata/bin/kata-agent-ctl --transform='s/opt\/kata\/bin\/kata-agent-ctl/kata-agent-ctl/'
+	rm kata-static-agent-ctl.tar.xz
+	KATACTL=$(realpath kata-agent-ctl)
+	chmod +x "$KATACTL"
+fi
+
+# Create cloud-init iso
+echo "::debug:: Preparing cloud-init iso for mode: $TEST_MODE"
+mkdir cloud-init
+touch cloud-init/meta-data
+
+# Set scratch disk and encryption options based on test mode
+ENABLE_SCRATCH_DISK="false"
+ENABLE_SCRATCH_ENCRYPTION="false"
+
+case "$TEST_MODE" in
+	basic)
+		ENABLE_SCRATCH_DISK="false"
+		ENABLE_SCRATCH_ENCRYPTION="false"
+		;;
+	scratch-space)
+		ENABLE_SCRATCH_DISK="true"
+		ENABLE_SCRATCH_ENCRYPTION="false"
+		;;
+	encrypted-scratch-space)
+		ENABLE_SCRATCH_DISK="true"
+		ENABLE_SCRATCH_ENCRYPTION="true"
+		;;
+esac
+
+cat <<EOF > cloud-init/user-data
+#cloud-config
+
+write_files:
+- path: /run/peerpod/daemon.json
+  content: |
+    {
+        "pod-network": {
+            "podip": "10.244.1.21/24",
+            "pod-hw-addr": "32:b9:59:6b:f0:d5",
+            "interface": "eth0",
+            "worker-node-ip": "10.224.0.5/16",
+            "tunnel-type": "vxlan",
+            "routes": [
+                {
+                    "dst": "0.0.0.0/0",
+                    "gw": "10.244.1.1",
+                    "dev": "eth0",
+                    "protocol": "boot"
+                },
+                {
+                    "dst": "10.244.1.0/24",
+                    "gw": "",
+                    "dev": "eth0",
+                    "protocol": "kernel",
+                    "scope": "link"
+                }
+            ],
+            "neighbors": null,
+            "mtu": 1500,
+            "index": 2,
+            "vxlan-port": 8472,
+            "vxlan-id": 555002,
+            "dedicated": false
+        },
+        "pod-namespace": "default",
+        "pod-name": "smoketest",
+        "enable-scratch-disk": $ENABLE_SCRATCH_DISK,
+        "enable-scratch-encryption": $ENABLE_SCRATCH_ENCRYPTION
+    }
+EOF
+genisoimage -output cloud-init.iso -volid cidata -joliet -rock cloud-init/user-data cloud-init/meta-data
+
+# Move files to libvirt-accessible location
+echo "::debug:: Moving files to libvirt-accessible location"
+# Create unique image name for each test mode to avoid conflicts
+IMAGE_SUFFIX="${TEST_MODE//-/_}"  # Replace hyphens with underscores for filename
+IMAGE=$(realpath "./podvm_${IMAGE_SUFFIX}.${FMT}")
+if [ "${DESTRUCTIVE}" -eq 1 ]; then
+	mv "${IMG}" "${IMAGE}"
+else
+	cp "${IMG}" "${IMAGE}"
+fi
+chmod a+rwx "${WORKDIR}"
+sudo chown -R libvirt-qemu "${WORKDIR}" || true
+sudo chmod +x "${WORKDIR}"
+
+# Resize the VM disk image to add free space
+sudo qemu-img resize -f "${FMT}" "${IMAGE}" +1G
+
+# Start the VM
+echo "::debug:: Starting VM for test mode: $TEST_MODE"
+VM_NAME="smoketest_${IMAGE_SUFFIX}"
+# TODO: Add AAVMF for arm
+[ -e "/usr/share/OVMF/OVMF_CODE.fd" ] && OVMF="/usr/share/OVMF/OVMF_CODE.fd"
+sudo virt-install \
+	--name "${VM_NAME}" \
+	--ram 1024 \
+	--vcpus 2 \
+	--disk "path=${IMAGE},format=${FMT}" \
+	--disk "path=${WORKDIR}/cloud-init.iso,device=cdrom" \
+	--import \
+	--network network=default \
+	--os-variant detect=on,require=off \
+	--graphics none \
+	--virt-type=kvm \
+	--boot loader="${OVMF}" \
+	--transient \
+	--noautoconsole \
+	--channel unix,mode=bind,path=${WORKDIR}/${VM_NAME}.agent,target_type=virtio,name=org.qemu.guest_agent.0
+
+SECONDS=0
+while [ $SECONDS -lt 120 ]; do
+	sleep 5
+	VM_IP="$(sudo virsh -q domifaddr "${VM_NAME}" | awk '{print $4}' | cut -d/ -f1)"
+	[ -n "${VM_IP}" ] && break
+done
+if [ -z "${VM_IP}" ]; then
+	echo "::error:: Failed to get ipaddr in 120s"
+	exit 1
+fi
+
+
+# Perform smoke test
+echo "::debug:: Performing the test"
+HOST_PORT="${VM_IP}:15150"
+SOCK="./agent.sock"
+echo "bridge ${HOST_PORT} to ${SOCK}"
+socat "UNIX-LISTEN:${SOCK},fork" "TCP:${HOST_PORT}" &
+SOCAT_PID=$!
+
+( for _ in {1..5}; do
+	$KATACTL connect \
+		--server-address "unix://${SOCK}" \
+		--cmd Check && exit || true
+	sleep 5
+	false
+done) || { echo "::error:: Failed to connect to peer-pod"; exit 1; }
+
+if ! $KATACTL connect --server-address "unix://${SOCK}" --cmd CreateSandbox; then
+	echo "::error:: Failed to CreateSandbox"
+	exit 1;
+fi
+
+if ! $KATACTL connect --server-address "unix://${SOCK}" --cmd DestroySandbox; then
+	echo "::error:: Failed to DestroySandbox"
+	exit 1;
+fi
+
+if [ "$TEST_MODE" = "scratch-space" ]; then
+	if ! check_scratch_disk_mount "${VM_NAME}"; then
+		echo "::error:: Scratch disk not found"
+		exit 1
+	fi
+	echo "::debug:: Scratch disk check passed for $TEST_MODE mode"
+fi
+
+if [ "$TEST_MODE" = "encrypted-scratch-space" ]; then
+	if ! check_encrypted_disk_mount "${VM_NAME}"; then
+		echo "::error:: Encrypted disk not found"
+		exit 1
+	fi	
+
+	# Copy a unique string to the VM under /run/kata-containers/image using virsh qemu-agent-command
+	# Search for the string in the VM image from the host (only for scratch space modes)
+	echo "::debug:: Testing encrypted disk space by writing a unique string"
+	UNIQUE_STRING="smoketest-podvm-123456"
+
+	sudo virsh qemu-agent-command "${VM_NAME}" \
+	 '{"execute": "guest-exec", "arguments": { "path": "/bin/bash", "arg": [ "-c", "echo smoketest-podvm-123456 > /run/kata-containers/image/smoketest.txt && sync" ], "capture-output": false }}'
+
+	grep -qa "${UNIQUE_STRING}" "${IMAGE}"
+	if [ $? -eq 0 ]; then
+		echo "::error:: Unique string written to encrypted disk is visible from the host"
+		exit 1
+	fi
+
+	echo "::debug:: Encrypted disk check passed for $TEST_MODE mode"
+
+fi


### PR DESCRIPTION
The disk may be LUKS encrypted depending on the option. Default is to continue using tmpfs based storage for container images

Two new global parameters are introduced
- ENABLE_SCRATCH_DISK: A boolean to indicate if scratch space (partition) need to be created from the root disk.
- ENABLE_SCRATCH_ENCRYPTION: A boolean to indicate if LUKS encryption needs to be performed for the scratch space. The key is random and stored in tmpfs.

These two parameters are available as `enable-scratch-disk` and `enable-scratch-encryption` respectively inside the pod VM in daemon.json file.

In the current implementation, the disk storage comes from the primary root disk. If `ENABLE_SCRATCH_DISK` option is enabled, then a new partition is created consisting of all the freespace in the root disk, using systemd-repart. The default root disk size will be based on the respective cloud provider image used. However it's possible to change it during instantiation of the VM based on setting the global param ROOT_VOLUME_SIZE.

So if you need more scratch space than what is provided as default via the image, ensure you set the ROOT_VOLUME_SIZE to the required value in the peer-pods-cm configmap.

We use systemd-repart to create a partition with a specified label (trusted_store). The setup-scratch-storage system unit reads the daemon.json for the `enable-scratch-disk` and `enable-scratch-encryption` option. If `enable-scratch-encryption` is true, then it invokes the luks-encrypt-storage script to create a LUKS-encrypted partition.



This PR supersedes https://github.com/confidential-containers/cloud-api-adaptor/pull/2212


