### PR TITLE
podvm: add OCICRYPT CONFIG for image pulling

### DIFF
--- a/src/cloud-api-adaptor/podvm/files/etc/ocicrypt_config.json
+++ b/src/cloud-api-adaptor/podvm/files/etc/ocicrypt_config.json
@@ -1,0 +1,7 @@
+{
+    "key-providers": {
+        "attestation-agent": {
+            "ttrpc": "unix:///run/confidential-containers/cdh.sock"
+        }
+    }
+}

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/confidential-data-hub.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/confidential-data-hub.service
@@ -4,6 +4,7 @@ After=network.target cloud-init.service process-user-data.service
 
 [Service]
 Type=simple
+Environment=OCICRYPT_KEYPROVIDER_CONFIG=/etc/ocicrypt_config.json
 ExecStart=/bin/bash -c \
     'if [ -f /run/peerpod/cdh.toml ]; \
     then /usr/local/bin/confidential-data-hub -c /run/peerpod/cdh.toml; \

--- a/src/cloud-api-adaptor/podvm/qcow2/copy-files.sh
+++ b/src/cloud-api-adaptor/podvm/qcow2/copy-files.sh
@@ -5,6 +5,7 @@
 sudo mkdir -p /etc/containers
 sudo cp /tmp/files/etc/agent-config.toml /etc/agent-config.toml
 sudo cp /tmp/files/etc/aa-offline_fs_kbc-keys.json /etc/aa-offline_fs_kbc-keys.json
+sudo cp /tmp/files/etc/ocicrypt_config.json /etc/ocicrypt_config.json
 sudo cp -a /tmp/files/etc/containers/* /etc/containers/
 sudo cp -a /tmp/files/etc/systemd/* /etc/systemd/
 if [ -e /tmp/files/etc/aa-offline_fs_kbc-resources.json ]; then


### PR DESCRIPTION
OCICRYPT CONFIG is a configuration file that defines the key-provider which provides the image decryption key. In PeerPod/CoCo, both the key provider and the image decryptor are both CDH, thus we set the OCICRYPT_KEYPROVIDER_CONFIG env upon CDH process. Then when CDH pulls an encrypted image, it will try to get the key from key provider (CDH itself) due to the configuration file set via env.