### PR TITLE
agent-protocol-forwarder: daemon.json => apf.json

### DIFF
--- a/src/cloud-api-adaptor/docs/initdata.md
+++ b/src/cloud-api-adaptor/docs/initdata.md
@@ -143,10 +143,10 @@ spec:
 ```
 
 ## Structure in `write_files`
-cloud-api-adaptor will read the annotation and write it to [write_files](../../cloud-providers/util/cloudinit/cloudconfig.go). Note: files unrelated to initdata (like network tunnel configuration in `/run/peerpod/daemon.json`) are also part of the `write_files` directive.
+cloud-api-adaptor will read the annotation and write it to [write_files](../../cloud-providers/util/cloudinit/cloudconfig.go). Note: files unrelated to initdata (like network tunnel configuration in `/run/peerpod/apf.json`) are also part of the `write_files` directive.
 ```yaml
 write_files:
-- path: /run/peerpod/daemon.json
+- path: /run/peerpod/apf.json
   content:
 - path: /run/peerpod/auth.json
   content:

--- a/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
@@ -296,23 +296,23 @@ func (s *cloudService) CreateVM(ctx context.Context, req *pb.CreateVMRequest) (r
 		logger.Printf("EnableScratchEncryption is set, enabling scratch disk as well")
 	}
 
-	daemonJSON, err := json.MarshalIndent(daemonConfig, "", "    ")
+	apfJSON, err := json.MarshalIndent(daemonConfig, "", "    ")
 	if err != nil {
 		return nil, fmt.Errorf("generating JSON data: %w", err)
 	}
 
-	// Store daemon.json in worker node for debugging
-	daemonJSONPath := filepath.Join(podDir, "daemon.json")
-	if err := os.WriteFile(daemonJSONPath, daemonJSON, 0o666); err != nil {
-		return nil, fmt.Errorf("storing %s: %w", daemonJSONPath, err)
+	// Store apf.json in worker node for debugging
+	apfJSONPath := filepath.Join(podDir, "apf.json")
+	if err := os.WriteFile(apfJSONPath, apfJSON, 0o666); err != nil {
+		return nil, fmt.Errorf("storing %s: %w", apfJSONPath, err)
 	}
-	logger.Printf("stored %s", daemonJSONPath)
+	logger.Printf("stored %s", apfJSONPath)
 
 	cloudConfig := &cloudinit.CloudConfig{
 		WriteFiles: []cloudinit.WriteFile{
 			{
 				Path:    forwarder.DefaultConfigPath,
-				Content: string(daemonJSON),
+				Content: string(apfJSON),
 			},
 		},
 	}

--- a/src/cloud-api-adaptor/pkg/forwarder/forwarder.go
+++ b/src/cloud-api-adaptor/pkg/forwarder/forwarder.go
@@ -27,7 +27,7 @@ const (
 	DefaultListenHost          = "0.0.0.0"
 	DefaultListenPort          = "15150"
 	DefaultListenAddr          = DefaultListenHost + ":" + DefaultListenPort
-	DefaultConfigPath          = "/run/peerpod/daemon.json"
+	DefaultConfigPath          = "/run/peerpod/apf.json"
 	DefaultPodNetworkSpecPath  = "/run/peerpod/podnetwork.json"
 	DefaultKataAgentSocketPath = "/run/kata-containers/agent.sock"
 	DefaultPodNamespace        = "/run/netns/podns"

--- a/src/cloud-api-adaptor/pkg/paths/paths.go
+++ b/src/cloud-api-adaptor/pkg/paths/paths.go
@@ -6,6 +6,6 @@ const (
 	CDHCfgPath       = "/run/peerpod/cdh.toml"
 	InitDataPath     = "/run/peerpod/initdata"
 	AgentCfgPath     = "/run/peerpod/agent-config.toml"
-	ForwarderCfgPath = "/run/peerpod/daemon.json"
+	ForwarderCfgPath = "/run/peerpod/apf.json"
 	UserDataPath     = "/media/cidata/user-data"
 )

--- a/src/cloud-api-adaptor/pkg/userdata/provision_test.go
+++ b/src/cloud-api-adaptor/pkg/userdata/provision_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 )
 
-var testDaemonConfig string = `{
+var testAPFConfig string = `{
 	"pod-network": {
 		"podip": "10.244.0.19/24",
 		"pod-hw-addr": "0e:8f:62:f3:81:ad",
@@ -289,7 +289,7 @@ func (p *TestProvider) GetRetryDelay() time.Duration {
 	return 1 * time.Millisecond
 }
 
-// TestRetrieveCloudConfig tests retrieving and parsing of a daemon config
+// TestRetrieveCloudConfig tests retrieving and parsing of a apf config
 func TestRetrieveCloudConfig(t *testing.T) {
 	var provider TestProvider
 
@@ -333,10 +333,10 @@ func TestProcessCloudConfig(t *testing.T) {
 
 	var aaCfgPath = filepath.Join(tempDir, "aa.toml")
 	var cdhCfgPath = filepath.Join(tempDir, "cdh.toml")
-	var daemonPath = filepath.Join(tempDir, "daemon.json")
+	var apfCfgPath = filepath.Join(tempDir, "apf.json")
 	var authPath = filepath.Join(tempDir, "auth.json")
 	var initdataPath = filepath.Join(tempDir, "initdata")
-	var writeFilesList = []string{aaCfgPath, cdhCfgPath, daemonPath, authPath, initdataPath}
+	var writeFilesList = []string{aaCfgPath, cdhCfgPath, apfCfgPath, authPath, initdataPath}
 
 	content := fmt.Sprintf(`#cloud-config
 write_files:
@@ -360,8 +360,8 @@ write_files:
 		indentTextBlock(testAAConfig, 4),
 		cdhCfgPath,
 		indentTextBlock(testCDHConfig, 4),
-		daemonPath,
-		indentTextBlock(testDaemonConfig, 4),
+		apfCfgPath,
+		indentTextBlock(testAPFConfig, 4),
 		authPath,
 		indentTextBlock(testAuthJson, 4),
 		initdataPath,
@@ -399,10 +399,10 @@ write_files:
 		t.Fatalf("file content does not match cdh config fixture: got %q", fileContent)
 	}
 
-	data, _ = os.ReadFile(daemonPath)
+	data, _ = os.ReadFile(apfCfgPath)
 	fileContent = string(data)
-	if fileContent != testDaemonConfig {
-		t.Fatalf("file content does not match daemon config fixture: got %q", fileContent)
+	if fileContent != testAPFConfig {
+		t.Fatalf("file content does not match apf config fixture: got %q", fileContent)
 	}
 
 	data, _ = os.ReadFile(authPath)
@@ -424,10 +424,10 @@ func TestProcessCloudConfigWithMalicious(t *testing.T) {
 
 	var aaCfgPath = filepath.Join(tempDir, "aa.toml")
 	var cdhCfgPath = filepath.Join(tempDir, "cdh.toml")
-	var daemonPath = filepath.Join(tempDir, "daemon.json")
+	var apfCfgPath = filepath.Join(tempDir, "apf.json")
 	var authPath = filepath.Join(tempDir, "auth.json")
 	var malicious = filepath.Join(tempDir, "malicious")
-	var writeFilesList = []string{aaCfgPath, cdhCfgPath, daemonPath, authPath}
+	var writeFilesList = []string{aaCfgPath, cdhCfgPath, apfCfgPath, authPath}
 
 	content := fmt.Sprintf(`#cloud-config
 write_files:
@@ -451,8 +451,8 @@ write_files:
 		indentTextBlock(testAAConfig, 4),
 		cdhCfgPath,
 		indentTextBlock(testCDHConfig, 4),
-		daemonPath,
-		indentTextBlock(testDaemonConfig, 4),
+		apfCfgPath,
+		indentTextBlock(testAPFConfig, 4),
 		authPath,
 		indentTextBlock(testAuthJson, 4),
 		malicious,
@@ -490,10 +490,10 @@ write_files:
 		t.Fatalf("file content does not match cdh config fixture: got %q", fileContent)
 	}
 
-	data, _ = os.ReadFile(daemonPath)
+	data, _ = os.ReadFile(apfCfgPath)
 	fileContent = string(data)
-	if fileContent != testDaemonConfig {
-		t.Fatalf("file content does not match daemon config fixture: got %q", fileContent)
+	if fileContent != testAPFConfig {
+		t.Fatalf("file content does not match apf config fixture: got %q", fileContent)
 	}
 
 	data, _ = os.ReadFile(authPath)

--- a/src/cloud-api-adaptor/podvm/files/usr/local/bin/setup-scratch-storage
+++ b/src/cloud-api-adaptor/podvm/files/usr/local/bin/setup-scratch-storage
@@ -22,16 +22,16 @@ die() {
     exit 1
 }
 
-# Check if daemon.json exists and parse configuration
-DAEMON_CONFIG_PATH="/run/peerpod/daemon.json"
+# Check if apf.json exists and parse configuration
+APF_CONFIG_PATH="/run/peerpod/apf.json"
 SCRATCH_ENABLED="false"
 ENCRYPTION_ENABLED="false"
 
-if [ -f "$DAEMON_CONFIG_PATH" ]; then
-    if grep -q '"enable-scratch-disk":.*true' "$DAEMON_CONFIG_PATH"; then
+if [ -f "$APF_CONFIG_PATH" ]; then
+    if grep -q '"enable-scratch-disk":.*true' "$APF_CONFIG_PATH"; then
         SCRATCH_ENABLED="true"
     fi
-    if grep -q '"enable-scratch-encryption":.*true' "$DAEMON_CONFIG_PATH"; then
+    if grep -q '"enable-scratch-encryption":.*true' "$APF_CONFIG_PATH"; then
         ENCRYPTION_ENABLED="true"
     fi
 

--- a/src/cloud-api-adaptor/podvm/hack/smoke_test.sh
+++ b/src/cloud-api-adaptor/podvm/hack/smoke_test.sh
@@ -239,7 +239,7 @@ cat <<EOF > cloud-init/user-data
 #cloud-config
 
 write_files:
-- path: /run/peerpod/daemon.json
+- path: /run/peerpod/apf.json
   content: |
     {
         "pod-network": {

--- a/src/cloud-providers/docker/provider.go
+++ b/src/cloud-providers/docker/provider.go
@@ -73,8 +73,8 @@ func (p *dockerProvider) CreateInstance(ctx context.Context, podName, sandboxID 
 	// Create volume binding for the container
 
 	// mount userdata to /media/cidata/user-data
-	// This file will be read by process-user-data and daemon.json will be written to
-	// /run/peerpods/daemon.json at runtime
+	// This file will be read by process-user-data and apf.json will be written to
+	// /run/peerpods/apf.json at runtime
 	volumeBinding := []string{
 		// note: we are not importing that path from the CAA package to avoid circular dependencies
 		fmt.Sprintf("%s:%s", instanceUserdataFile, "/media/cidata/user-data"),

--- a/src/cloud-providers/docker/provider_test.go
+++ b/src/cloud-providers/docker/provider_test.go
@@ -19,7 +19,7 @@ func Test_dockerProvider_CreateInstance(t *testing.T) {
 		Client *client.Client
 	}
 
-	testDaemonConfigJson := `{
+	testAPFConfigJson := `{
 		"pod-network": {
 			"podip": "10.244.0.19/24",
 			"pod-hw-addr": "0e:8f:62:f3:81:ad",
@@ -46,11 +46,11 @@ func Test_dockerProvider_CreateInstance(t *testing.T) {
 		"tls-client-ca": "-----BEGIN CERTIFICATE-----\n....\n-----END CERTIFICATE-----\n"
 	}`
 
-	// Write tempDaemonConfigJSON to cloud-init config file
+	// Write tempAPFConfigJSON to cloud-init config file
 	// Create a CloudConfig struct
 	cloudConfig := &cloudinit.CloudConfig{
 		WriteFiles: []cloudinit.WriteFile{
-			{Path: "/run/peerpod/daemon.json", Content: string(testDaemonConfigJson)},
+			{Path: "/run/peerpod/apf.json", Content: string(testAPFConfigJson)},
 		},
 	}
 

--- a/src/cloud-providers/util/cloudinit/cloudconfig_test.go
+++ b/src/cloud-providers/util/cloudinit/cloudconfig_test.go
@@ -12,7 +12,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-const forwarderConfigPath = "/peerpod/daemon.json"
+const forwarderConfigPath = "/peerpod/apf.json"
 const authJSONPath = "/run/peerpod/auth.json"
 
 func TestUserData(t *testing.T) {
@@ -45,11 +45,11 @@ func TestUserData(t *testing.T) {
 	}
 }
 
-// Add a test to create a cloud-init config with daemon.json and auth.json file
-// The test should verify that the config has both the daemon.json and the auth.json
+// Add a test to create a cloud-init config with apf.json and auth.json file
+// The test should verify that the config has both the apf.json and the auth.json
 // files in the write_files section.
-func TestUserDataWithDaemonAndAuth(t *testing.T) {
-	testDaemonConfigJson := `{
+func TestUserDataWithAPFConfigAndAuth(t *testing.T) {
+	testAPFConfigJson := `{
 		"pod-network": {
 			"podip": "10.244.0.19/24",
 			"pod-hw-addr": "0e:8f:62:f3:81:ad",
@@ -88,11 +88,11 @@ func TestUserDataWithDaemonAndAuth(t *testing.T) {
 
 	testResourcesJson := AuthJSONToResourcesJSON(string(testAuthJson))
 
-	// Write tempDaemonConfigJSON to cloud-init config file
+	// Write tempAPFConfigJSON to cloud-init config file
 	// Create a CloudConfig struct
 	cloudConfig := &CloudConfig{
 		WriteFiles: []WriteFile{
-			{Path: forwarderConfigPath, Content: string(testDaemonConfigJson)},
+			{Path: forwarderConfigPath, Content: string(testAPFConfigJson)},
 			{Path: authJSONPath, Content: testResourcesJson},
 		},
 	}
@@ -106,7 +106,7 @@ func TestUserDataWithDaemonAndAuth(t *testing.T) {
 	// Pretty print the userData
 	fmt.Printf("userData: %s\n", userData)
 
-	// Verify that the userData has the daemon.json and auth.json files
+	// Verify that the userData has the apf.json and auth.json files
 	// in the write_files section
 	if !strings.Contains(userData, forwarderConfigPath) {
 		t.Fatalf("Expect %q, got %q", forwarderConfigPath, userData)
@@ -125,10 +125,10 @@ func TestUserDataWithDaemonAndAuth(t *testing.T) {
 	// Pretty print the userData output
 	fmt.Printf("userData: %s\n", output)
 
-	// Verify that the output yaml has the testDaemonConfigJson and testb64AuthJson contents
+	// Verify that the output yaml has the testAPFConfigJson and testb64AuthJson contents
 	// in the write_files section
-	if !strings.Contains(output.WriteFiles[0].Content, testDaemonConfigJson) {
-		t.Fatalf("Expect %q, got %q", testDaemonConfigJson, output.WriteFiles[0].Content)
+	if !strings.Contains(output.WriteFiles[0].Content, testAPFConfigJson) {
+		t.Fatalf("Expect %q, got %q", testAPFConfigJson, output.WriteFiles[0].Content)
 	}
 
 	if !strings.Contains(output.WriteFiles[1].Content, testResourcesJson) {


### PR DESCRIPTION
daemon.json is not the most descriptive name and it can be confusing when depicting the project's architectures, since it's only one config file next to others and scoped to agent-protocol-forwarder.

There is one exception: daemon.json is now also used in the just-merged scratch-space script. But arguably daemon is not a fitting name for this script either. I'd address it in a follow up PR, we can probably just use a discrete file `scratch.json`.

This change renames it to `apf.json` to align with the convention for the rest of the configfiles.