### PR TITLE
podvm_mkosi: Update s390x run_mkosi_in_container

### DIFF
--- a/src/cloud-api-adaptor/podvm-mkosi/Makefile
+++ b/src/cloud-api-adaptor/podvm-mkosi/Makefile
@@ -36,8 +36,8 @@ define run_mkosi_in_container
 	docker run --rm --privileged \
 		-v "$(shell pwd)":/workspace \
 		-w /workspace \
-		fedora:40 \
-		bash -c "dnf install -y mkosi && mkosi --tools-tree=default --tools-tree-release=41 $(1)"
+		fedora:41 \
+		bash -c "dnf install -y bubblewrap coreutils git python3; mkdir -p /build; git clone -b $(MKOSI_VERSION) https://github.com/systemd/mkosi /build/mkosi; export PATH="/build/mkosi/bin:$$PATH"; mkosi --tools-tree=default --tools-tree-release=41 $(1)"
 endef
 
 binaries:


### PR DESCRIPTION
- Bump the container image being used to fedora:41 as 40 is EOL
- Install the pinned version of mkosi from git, as the dnf version isn't compatible