### PR TITLE
docker: Bump Fedora image to 42

### DIFF
--- a/hack/Dockerfile.golang
+++ b/hack/Dockerfile.golang
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.5-labs
 
-ARG BASE_IMAGE=registry.fedoraproject.org/fedora:41
+ARG BASE_IMAGE=registry.fedoraproject.org/fedora:42
 FROM --platform=$TARGETPLATFORM ${BASE_IMAGE} AS base
 
 # DO NOT UPDATE THIS BY HAND !!

--- a/src/cloud-api-adaptor/Dockerfile
+++ b/src/cloud-api-adaptor/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_TYPE=dev
 ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.23.10-41
-ARG BASE=registry.fedoraproject.org/fedora:41
+ARG BASE=registry.fedoraproject.org/fedora:42
 
 # This dockerfile uses Go cross-compilation to build the binary,
 # we build on the host platform ($BUILDPLATFORM) and then copy the

--- a/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.mkosi
+++ b/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.mkosi
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.5.0-labs
-FROM fedora:41 AS builder
+FROM fedora:42 AS builder
 
 ARG MKOSI_VERSION="v22"
 ARG PROFILE="debug"

--- a/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.podvm_docker_provider
+++ b/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.podvm_docker_provider
@@ -1,6 +1,6 @@
 # Adapted from https://github.com/kubernetes-sigs/kind/blob/main/images/base/Dockerfile
 
-ARG BASE_IMAGE=registry.fedoraproject.org/fedora:41
+ARG BASE_IMAGE=registry.fedoraproject.org/fedora:42
 
 FROM $BASE_IMAGE AS iptables
 

--- a/src/cloud-api-adaptor/podvm-mkosi/Makefile
+++ b/src/cloud-api-adaptor/podvm-mkosi/Makefile
@@ -37,7 +37,7 @@ define run_mkosi_in_container
 		-v "$(shell pwd)":/workspace \
 		-w /workspace \
 		fedora:40 \
-		bash -c "dnf install -y mkosi && mkosi --tools-tree=default --tools-tree-release=41 $(1)"
+		bash -c "dnf install -y mkosi && mkosi --tools-tree=default --tools-tree-release=42 $(1)"
 endef
 
 binaries:

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_binaries.fedora
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_binaries.fedora
@@ -5,7 +5,7 @@
 #
 # Build binaries for mkosi podvm image
 #
-FROM registry.fedoraproject.org/fedora:41 AS builder
+FROM registry.fedoraproject.org/fedora:42 AS builder
 
 ARG ARCH="x86_64"
 ARG GO_ARCH="amd64"

--- a/src/peerpod-ctrl/Dockerfile
+++ b/src/peerpod-ctrl/Dockerfile
@@ -30,7 +30,7 @@ COPY peerpod-ctrl/controllers/ controllers/
 RUN CC=gcc CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build ${GOFLAGS} -a -o manager main.go
 
 # Target Image
-FROM --platform=$TARGETPLATFORM registry.fedoraproject.org/fedora:41
+FROM --platform=$TARGETPLATFORM registry.fedoraproject.org/fedora:42
 ARG CGO_ENABLED=1
 
 RUN if [ "$CGO_ENABLED" = 1 ] ; then dnf install -y libvirt-libs openssh-clients && dnf clean all; fi


### PR DESCRIPTION
We are having the following issue on the s390x runners:

```
Failed to download metadata (metalink: "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f41&arch=s390x") for repository "updates"
```

Let's bump the image to 42 to check if the update resolves the issue.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>