### PR TITLE
versions: Bump umoci to 0.5.0

### DIFF
--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -43,7 +43,7 @@ git:
     reference: main
   umoci:
     url: https://github.com/opencontainers/umoci
-    reference: v0.4.7
+    reference: v0.5.0
   skopeo:
     url: https://github.com/containers/skopeo
     reference: v1.5.0


### PR DESCRIPTION
Bump the umoci package to v0.5.0 to reflect the latest umoci release and security fixes

Umoci 0.5.0 security fix:
```
A security flaw was found in the OCI image-spec, where it is possible to
cause a blob with one media-type to be interpreted as a different media-type.
As umoci is not a registry nor does it handle signatures, this vulnerability
had no real impact on umoci but for safety we implemented the now-recommended
media-type embedding and verification. https://github.com/advisories/GHSA-mc8v-mgrf-8f4m
```

Reference release: https://github.com/opencontainers/umoci/releases/tag/v0.5.0