### PR TITLE
versions: Bump kcli

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -186,6 +186,7 @@ jobs:
         env:
           AUTHENTICATED_REGISTRY_IMAGE: ${{ vars.AUTHENTICATED_REGISTRY_IMAGE }}
           REGISTRY_CREDENTIAL_ENCODED: ${{ secrets.REGISTRY_CREDENTIAL_ENCODED }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export CLOUD_PROVIDER=libvirt
           export CONTAINER_RUNTIME="${{ inputs.container_runtime }}"

--- a/.github/workflows/podvm.yaml
+++ b/.github/workflows/podvm.yaml
@@ -84,3 +84,4 @@ jobs:
         PODVM_TAG: ${{ inputs.image_tag }}
         PODVM_DISTRO: ${{ matrix.os }}
         CLOUD_PROVIDER: ${{ matrix.provider }}
+        PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/cloud-api-adaptor/Makefile
+++ b/src/cloud-api-adaptor/Makefile
@@ -229,6 +229,7 @@ endif
 	--build-arg PAUSE_REPO=$(PAUSE_REPO) \
 	--build-arg PAUSE_VERSION=$(PAUSE_VERSION) \
 	--build-arg PAUSE_BIN=$(PAUSE_BIN) \
+	--build-arg PACKER_GITHUB_API_TOKEN=$(PACKER_GITHUB_API_TOKEN) \
 	$(if $(AUTHFILE),--build-arg AUTHFILE=$(AUTHFILE),) \
 	$(DOCKER_OPTS) .
 	rm -rf .git

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm
@@ -33,6 +33,7 @@ ENV PODVM_DISTRO=${PODVM_DISTRO}
 ENV ARCH=${ARCH}
 ENV UEFI=${UEFI}
 ENV SE_BOOT=${SE_BOOT}
+ENV PACKER_GITHUB_API_TOKEN=${PACKER_GITHUB_API_TOKEN}
 
 # Defaults to Ubuntu noble amd64 release image. These variables can be overriden as needed
 ARG IMAGE_URL

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -30,7 +30,7 @@ tools:
   bats: 1.10.0
   iptables-wrapper: v0.0.0-20240819165702-06cad2ec6cb5
   golang: 1.23.10
-  kcli: 99.0.202504041449
+  kcli: 99.0.202507200957
   mkosi: v22
   protoc: 3.16.0
   packer: v1.9.4


### PR DESCRIPTION
We keep hitting rate limits in the kcli install, so bump to a version that should include https://github.com/karmab/kcli/commit/d640e9ecc5bba5138df7f6c81e4cb04a8c3de00c in an attempt to help this.