### PR TITLE
test: Rename test names to follow a well defined pattern

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -54,6 +54,39 @@ you should export an unanchored regular expression in the `RUN_TESTS` variable t
 $ RUN_TESTS=CreateSimplePod TEST_PROVISION=yes TEST_PODVM_IMAGE="path/to/podvm-base.qcow2" CLOUD_PROVIDER=libvirt make test-e2e
 ```
 
+## Running tests by category
+
+The E2E tests are organized into categories using the naming convention `Test<Category><Provider><TestCaseName>`. This allows you to run specific types of tests across all providers or for specific providers.
+
+### Test Categories
+
+- **Basic** (37 tests) - Core pod operations like creation, deletion, ConfigMaps, Secrets, Jobs, and Deployments
+- **Net** (14 tests) - Network functionality including external IP access, service communication, and mTLS
+- **Sec** (13 tests) - Security features such as authenticated images, device annotations, and access control
+- **Conf** (10 tests) - Confidential computing features including image decryption, attestation, and KBS integration
+- **Res** (32 tests) - Resource management including CPU/memory limits, annotations, and logging
+- **Img** (6 tests) - Image handling including large images and alternate images
+- **Store** (2 tests) - Storage functionality such as Persistent Volume Claims (PVC)
+
+### Category-based filtering examples
+
+```bash
+# Run all basic tests for libvirt provider
+$ RUN_TESTS='^TestBasic' CLOUD_PROVIDER=libvirt make test-e2e
+
+# Run all networking tests for azure provider
+$ RUN_TESTS='^TestNet' CLOUD_PROVIDER=azure make test-e2e
+
+# Run all confidential computing tests for libvirt provider
+$ RUN_TESTS='^TestConf' CLOUD_PROVIDER=libvirt make test-e2e
+
+# Run all security tests for aws provider
+$ RUN_TESTS='^TestSec' CLOUD_PROVIDER=aws make test-e2e
+
+# Run all resource management tests for azure provider
+$ RUN_TESTS='^TestRes' CLOUD_PROVIDER=azure make test-e2e
+```
+
 ## Attestation and KBS specific
 
 We need artifacts from the trustee repo when doing the attestation tests.

--- a/src/cloud-api-adaptor/test/e2e/aws_test.go
+++ b/src/cloud-api-adaptor/test/e2e/aws_test.go
@@ -12,108 +12,108 @@ import (
 	_ "github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/test/provisioner/aws"
 )
 
-func TestAwsCreateSimplePod(t *testing.T) {
+func TestBasicAwsCreateSimplePod(t *testing.T) {
 	assert := NewAWSAssert()
 	DoTestCreateSimplePod(t, testEnv, assert)
 }
 
-func TestAwsCreatePodWithConfigMap(t *testing.T) {
+func TestBasicAwsCreatePodWithConfigMap(t *testing.T) {
 	assert := NewAWSAssert()
 
 	DoTestCreatePodWithConfigMap(t, testEnv, assert)
 }
 
-func TestAwsCreatePodWithSecret(t *testing.T) {
+func TestBasicAwsCreatePodWithSecret(t *testing.T) {
 	t.Skip("Test not passing")
 	assert := NewAWSAssert()
 
 	DoTestCreatePodWithSecret(t, testEnv, assert)
 }
 
-func TestAwsCreatePeerPodContainerWithExternalIPAccess(t *testing.T) {
+func TestNetAwsCreatePeerPodContainerWithExternalIPAccess(t *testing.T) {
 	t.Skip("Test not passing")
 	assert := NewAWSAssert()
 
 	DoTestCreatePeerPodContainerWithExternalIPAccess(t, testEnv, assert)
 }
 
-func TestAwsCreatePeerPodWithJob(t *testing.T) {
+func TestBasicAwsCreatePeerPodWithJob(t *testing.T) {
 	assert := NewAWSAssert()
 
 	DoTestCreatePeerPodWithJob(t, testEnv, assert)
 }
 
-func TestAwsCreatePeerPodAndCheckUserLogs(t *testing.T) {
+func TestResAwsCreatePeerPodAndCheckUserLogs(t *testing.T) {
 	assert := NewAWSAssert()
 
 	DoTestCreatePeerPodAndCheckUserLogs(t, testEnv, assert)
 }
 
-func TestAwsCreatePeerPodAndCheckWorkDirLogs(t *testing.T) {
+func TestResAwsCreatePeerPodAndCheckWorkDirLogs(t *testing.T) {
 	assert := NewAWSAssert()
 
 	DoTestCreatePeerPodAndCheckWorkDirLogs(t, testEnv, assert)
 }
 
-func TestAwsCreatePeerPodAndCheckEnvVariableLogsWithImageOnly(t *testing.T) {
+func TestResAwsCreatePeerPodAndCheckEnvVariableLogsWithImageOnly(t *testing.T) {
 	assert := NewAWSAssert()
 
 	DoTestCreatePeerPodAndCheckEnvVariableLogsWithImageOnly(t, testEnv, assert)
 }
 
-func TestAwsCreatePeerPodAndCheckEnvVariableLogsWithDeploymentOnly(t *testing.T) {
+func TestResAwsCreatePeerPodAndCheckEnvVariableLogsWithDeploymentOnly(t *testing.T) {
 	assert := NewAWSAssert()
 
 	DoTestCreatePeerPodAndCheckEnvVariableLogsWithDeploymentOnly(t, testEnv, assert)
 }
 
-func TestAwsCreatePeerPodAndCheckEnvVariableLogsWithImageAndDeployment(t *testing.T) {
+func TestResAwsCreatePeerPodAndCheckEnvVariableLogsWithImageAndDeployment(t *testing.T) {
 	assert := NewAWSAssert()
 
 	DoTestCreatePeerPodAndCheckEnvVariableLogsWithImageAndDeployment(t, testEnv, assert)
 }
 
-func TestAwsCreatePeerPodWithLargeImage(t *testing.T) {
+func TestImgAwsCreatePeerPodWithLargeImage(t *testing.T) {
 	assert := NewAWSAssert()
 
 	DoTestCreatePeerPodWithLargeImage(t, testEnv, assert)
 }
 
-func TestAwsCreatePeerPodWithPVC(t *testing.T) {
+func TestStoreAwsCreatePeerPodWithPVC(t *testing.T) {
 	t.Skip("To be implemented")
 }
 
-func TestAwsCreatePeerPodWithAuthenticatedImagewithValidCredentials(t *testing.T) {
+func TestSecAwsCreatePeerPodWithAuthenticatedImageValidCredentials(t *testing.T) {
 	t.Skip("To be implemented")
 }
 
-func TestAwsCreatePeerPodWithAuthenticatedImageWithInvalidCredentials(t *testing.T) {
+func TestSecAwsCreatePeerPodWithAuthenticatedImageInvalidCredentials(t *testing.T) {
 	t.Skip("To be implemented")
 }
 
-func TestAwsCreatePeerPodWithAuthenticatedImageWithoutCredentials(t *testing.T) {
+func TestSecAwsCreatePeerPodWithAuthenticatedImageWithoutCredentials(t *testing.T) {
 	t.Skip("To be implemented")
 }
 
-func TestAwsDeletePod(t *testing.T) {
+func TestBasicAwsDeletePod(t *testing.T) {
 	assert := NewAWSAssert()
 	DoTestDeleteSimplePod(t, testEnv, assert)
 }
 
-func TestAwsCreateNginxDeployment(t *testing.T) {
+func TestBasicAwsCreateNginxDeployment(t *testing.T) {
 	t.Skip("Test not passing")
 	assert := NewAWSAssert()
 	DoTestNginxDeployment(t, testEnv, assert)
 }
 
-func TestAwsCreatePeerPodContainerWithInvalidAlternateImage(t *testing.T) {
+func TestImgAwsCreatePeerPodContainerWithInvalidAlternateImage(t *testing.T) {
 	assert := NewAWSAssert()
 	nonExistingImageName := "ami-123456"
 	expectedErrorMessage := fmt.Sprintf("InvalidAMIID.NotFound: The image id '[%s]' does not exist: not found", nonExistingImageName)
 	DoTestCreatePeerPodContainerWithInvalidAlternateImage(t, testEnv, assert, nonExistingImageName, expectedErrorMessage)
 }
 
-func TestAwsPodWithInitContainer(t *testing.T) {
+func TestBasicAwsPodWithInitContainer(t *testing.T) {
 	assert := NewAWSAssert()
 	DoTestPodWithInitContainer(t, testEnv, assert)
 }

--- a/src/cloud-api-adaptor/test/e2e/azure_test.go
+++ b/src/cloud-api-adaptor/test/e2e/azure_test.go
@@ -20,49 +20,49 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
-func TestDeletePodAzure(t *testing.T) {
+func TestBasicAzureDeletePod(t *testing.T) {
 	t.Parallel()
 	DoTestDeleteSimplePod(t, testEnv, assert)
 }
 
-func TestCreateSimplePodAzure(t *testing.T) {
+func TestBasicAzureCreateSimplePod(t *testing.T) {
 	t.Parallel()
 	DoTestCreateSimplePod(t, testEnv, assert)
 }
 
-func TestCreatePodWithConfigMapAzure(t *testing.T) {
+func TestBasicAzureCreatePodWithConfigMap(t *testing.T) {
 	t.Parallel()
 	DoTestCreatePodWithConfigMap(t, testEnv, assert)
 }
 
-func TestCreatePodWithSecretAzure(t *testing.T) {
+func TestBasicAzureCreatePodWithSecret(t *testing.T) {
 	t.Parallel()
 	DoTestCreatePodWithSecret(t, testEnv, assert)
 }
 
-func TestCreateNginxDeploymentAzure(t *testing.T) {
+func TestBasicAzureCreateNginxDeployment(t *testing.T) {
 	t.Parallel()
 	DoTestNginxDeployment(t, testEnv, assert)
 }
 
-func TestPodToServiceCommunicationAzure(t *testing.T) {
+func TestNetAzurePodToServiceCommunication(t *testing.T) {
 	t.Parallel()
 	DoTestPodToServiceCommunication(t, testEnv, assert)
 }
 
-func TestPodsMTLSCommunicationAzure(t *testing.T) {
+func TestNetAzurePodsMTLSCommunication(t *testing.T) {
 	t.Parallel()
 	DoTestPodsMTLSCommunication(t, testEnv, assert)
 }
 
-func TestPodVMwithAnnotationsInstanceTypeAzure(t *testing.T) {
+func TestResAzurePodVMwithAnnotationsInstanceType(t *testing.T) {
 	SkipTestOnCI(t)
 	t.Parallel()
 	instanceSize := "Standard_DC2as_v5"
 	DoTestPodVMwithAnnotationsInstanceType(t, testEnv, assert, instanceSize)
 }
 
-func TestPodVMwithAnnotationsInvalidInstanceTypeAzure(t *testing.T) {
+func TestResAzurePodVMwithAnnotationsInvalidInstanceType(t *testing.T) {
 	t.Parallel()
 	// Using an instance type that's not configured in the AZURE_INSTANCE_SIZE
 	instanceSize := "Standard_D8as_v5"
@@ -70,7 +70,7 @@ func TestPodVMwithAnnotationsInvalidInstanceTypeAzure(t *testing.T) {
 }
 
 // Test with device annotation
-func TestPodWithCrioDeviceAnnotationAzure(t *testing.T) {
+func TestSecAzurePodWithCrioDeviceAnnotation(t *testing.T) {
 	if !isTestOnCrio() {
 		t.Skip("Skipping test as it is not running on CRI-O")
 	}
@@ -79,7 +79,7 @@ func TestPodWithCrioDeviceAnnotationAzure(t *testing.T) {
 }
 
 // Negative test with device annotation
-func TestPodWithIncorrectDeviceAnnotationAzure(t *testing.T) {
+func TestSecAzurePodWithIncorrectDeviceAnnotation(t *testing.T) {
 	if !isTestOnCrio() {
 		t.Skip("Skipping test as it is not running on CRI-O")
 	}
@@ -88,14 +88,14 @@ func TestPodWithIncorrectDeviceAnnotationAzure(t *testing.T) {
 }
 
 // Test with init container
-func TestPodWithInitContainerAzure(t *testing.T) {
+func TestBasicAzurePodWithInitContainer(t *testing.T) {
 	t.Parallel()
 	DoTestPodWithInitContainer(t, testEnv, assert)
 }
 
 // Test to check the presence if pod can access files from internet
 // Use DoTestPodWithSpecificCommands and provide the commands to be executed in the pod
-func TestPodToDownloadExternalFileAzure(t *testing.T) {
+func TestNetAzurePodToDownloadExternalFile(t *testing.T) {
 	t.Parallel()
 	// Create TestCommand struct with the command to download index.html
 	command1 := TestCommand{
@@ -125,13 +125,13 @@ func TestPodToDownloadExternalFileAzure(t *testing.T) {
 }
 
 // Method to check external IP access using ping
-func TestCreatePeerPodContainerWithExternalIPAccessAzure(t *testing.T) {
+func TestNetAzureCreatePeerPodContainerWithExternalIPAccess(t *testing.T) {
 	SkipTestOnCI(t)
 	t.Parallel()
 	DoTestCreatePeerPodContainerWithExternalIPAccess(t, testEnv, assert)
 }
 
-func TestKbsKeyRelease(t *testing.T) {
+func TestConfAzureKbsKeyRelease(t *testing.T) {
 	if !isTestWithKbs() {
 		t.Skip("Skipping kbs related test as kbs is not deployed")
 	}
@@ -146,7 +146,7 @@ func TestKbsKeyRelease(t *testing.T) {
 	DoTestKbsKeyRelease(t, testEnv, assert, kbsEndpoint, resourcePath, testSecret)
 }
 
-func TestRemoteAttestation(t *testing.T) {
+func TestConfAzureRemoteAttestation(t *testing.T) {
 	t.Parallel()
 	var kbsEndpoint string
 	if ep := os.Getenv("KBS_ENDPOINT"); ep != "" {
@@ -163,7 +163,7 @@ func TestRemoteAttestation(t *testing.T) {
 	DoTestRemoteAttestation(t, testEnv, assert, kbsEndpoint)
 }
 
-func TestTrusteeOperatorKeyReleaseForSpecificKey(t *testing.T) {
+func TestConfAzureTrusteeOperatorKeyReleaseForSpecificKey(t *testing.T) {
 	if !isTestWithTrusteeOperator() {
 		t.Skip("Skipping kbs related test as Trustee Operator is not deployed")
 	}
@@ -175,7 +175,7 @@ func TestTrusteeOperatorKeyReleaseForSpecificKey(t *testing.T) {
 	DoTestKbsKeyRelease(t, testEnv, assert, kbsEndpoint, "default/kbsres1/key1", "res1val1")
 }
 
-func TestAzureImageDecryption(t *testing.T) {
+func TestConfAzureImageDecryption(t *testing.T) {
 	if !isTestWithKbs() {
 		t.Skip("Skipping kbs related test as kbs is not deployed")
 	}
@@ -187,7 +187,7 @@ func TestAzureImageDecryption(t *testing.T) {
 // This test is to verify that the initdata is measured correctly. The digest algorith in the initdata fixture
 // is sha384. The initdata spec requires the digest to be truncated/padded to the TEE's requirement. In this case,
 // the az tpm attester requires the digest to be sha256 and is hence truncated
-func TestInitDataMeasurement(t *testing.T) {
+func TestConfAzureInitDataMeasurement(t *testing.T) {
 	kbsEndpoint := "http://some.endpoint"
 	annotation, err := buildInitdataAnnotation(kbsEndpoint, testInitdata)
 	if err != nil {

--- a/src/cloud-api-adaptor/test/e2e/docker_test.go
+++ b/src/cloud-api-adaptor/test/e2e/docker_test.go
@@ -13,45 +13,45 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
-func TestDockerCreateSimplePod(t *testing.T) {
+func TestBasicDockerCreateSimplePod(t *testing.T) {
 	assert := DockerAssert{}
 	DoTestCreateSimplePod(t, testEnv, assert)
 }
 
-func TestDockerCreatePodWithConfigMap(t *testing.T) {
+func TestBasicDockerCreatePodWithConfigMap(t *testing.T) {
 	SkipTestOnCI(t)
 	assert := DockerAssert{}
 	DoTestCreatePodWithConfigMap(t, testEnv, assert)
 }
 
-func TestDockerCreatePodWithSecret(t *testing.T) {
+func TestBasicDockerCreatePodWithSecret(t *testing.T) {
 	assert := DockerAssert{}
 	DoTestCreatePodWithSecret(t, testEnv, assert)
 }
 
-func TestDockerCreatePeerPodContainerWithExternalIPAccess(t *testing.T) {
+func TestNetDockerCreatePeerPodContainerWithExternalIPAccess(t *testing.T) {
 	SkipTestOnCI(t)
 	assert := DockerAssert{}
 	DoTestCreatePeerPodContainerWithExternalIPAccess(t, testEnv, assert)
 
 }
 
-func TestDockerCreatePeerPodWithJob(t *testing.T) {
+func TestBasicDockerCreatePeerPodWithJob(t *testing.T) {
 	assert := DockerAssert{}
 	DoTestCreatePeerPodWithJob(t, testEnv, assert)
 }
 
-func TestDockerCreatePeerPodAndCheckUserLogs(t *testing.T) {
+func TestResDockerCreatePeerPodAndCheckUserLogs(t *testing.T) {
 	assert := DockerAssert{}
 	DoTestCreatePeerPodAndCheckUserLogs(t, testEnv, assert)
 }
 
-func TestDockerCreatePeerPodAndCheckWorkDirLogs(t *testing.T) {
+func TestResDockerCreatePeerPodAndCheckWorkDirLogs(t *testing.T) {
 	assert := DockerAssert{}
 	DoTestCreatePeerPodAndCheckWorkDirLogs(t, testEnv, assert)
 }
 
-func TestDockerCreatePeerPodAndCheckEnvVariableLogsWithImageOnly(t *testing.T) {
+func TestResDockerCreatePeerPodAndCheckEnvVariableLogsWithImageOnly(t *testing.T) {
 	// This test is causing issues on CI with instability, so skip until we can resolve this.
 	// See https://github.com/confidential-containers/cloud-api-adaptor/issues/1831
 	SkipTestOnCI(t)
@@ -59,19 +59,19 @@ func TestDockerCreatePeerPodAndCheckEnvVariableLogsWithImageOnly(t *testing.T) {
 	DoTestCreatePeerPodAndCheckEnvVariableLogsWithImageOnly(t, testEnv, assert)
 }
 
-func TestDockerCreatePeerPodAndCheckEnvVariableLogsWithDeploymentOnly(t *testing.T) {
+func TestResDockerCreatePeerPodAndCheckEnvVariableLogsWithDeploymentOnly(t *testing.T) {
 	assert := DockerAssert{}
 	DoTestCreatePeerPodAndCheckEnvVariableLogsWithDeploymentOnly(t, testEnv, assert)
 }
 
-func TestDockerCreatePeerPodAndCheckEnvVariableLogsWithImageAndDeployment(t *testing.T) {
+func TestResDockerCreatePeerPodAndCheckEnvVariableLogsWithImageAndDeployment(t *testing.T) {
 	// This test is causing issues on CI with instability, so skip until we can resolve this.
 	// See https://github.com/confidential-containers/cloud-api-adaptor/issues/1831
 	assert := DockerAssert{}
 	DoTestCreatePeerPodAndCheckEnvVariableLogsWithImageAndDeployment(t, testEnv, assert)
 }
 
-func TestDockerCreateNginxDeployment(t *testing.T) {
+func TestBasicDockerCreateNginxDeployment(t *testing.T) {
 	assert := DockerAssert{}
 	DoTestNginxDeployment(t, testEnv, assert)
 }
@@ -84,22 +84,22 @@ func TestDockerCreatePeerPodWithLargeImage(t *testing.T) {
 }
 */
 
-func TestDockerDeletePod(t *testing.T) {
+func TestBasicDockerDeletePod(t *testing.T) {
 	assert := DockerAssert{}
 	DoTestDeleteSimplePod(t, testEnv, assert)
 }
 
-func TestDockerPodToServiceCommunication(t *testing.T) {
+func TestNetDockerPodToServiceCommunication(t *testing.T) {
 	assert := DockerAssert{}
 	DoTestPodToServiceCommunication(t, testEnv, assert)
 }
 
-func TestDockerPodsMTLSCommunication(t *testing.T) {
+func TestNetDockerPodsMTLSCommunication(t *testing.T) {
 	assert := DockerAssert{}
 	DoTestPodsMTLSCommunication(t, testEnv, assert)
 }
 
-func TestDockerKbsKeyRelease(t *testing.T) {
+func TestConfDockerKbsKeyRelease(t *testing.T) {
 	if !isTestWithKbs() {
 		t.Skip("Skipping kbs related test as kbs is not deployed")
 	}
@@ -127,7 +127,7 @@ func TestDockerKbsKeyRelease(t *testing.T) {
 	DoTestKbsKeyRelease(t, testEnv, assert, kbsEndpoint, resourcePath, testSecret)
 }
 
-func TestDockerCreatePeerPodWithAuthenticatedImageWithoutCredentials(t *testing.T) {
+func TestSecDockerCreatePeerPodWithAuthenticatedImageWithoutCredentials(t *testing.T) {
 	assert := DockerAssert{}
 	if os.Getenv("AUTHENTICATED_REGISTRY_IMAGE") != "" {
 		DoTestCreatePeerPodWithAuthenticatedImageWithoutCredentials(t, testEnv, assert)
@@ -136,7 +136,7 @@ func TestDockerCreatePeerPodWithAuthenticatedImageWithoutCredentials(t *testing.
 	}
 }
 
-func TestDockerCreatePeerPodWithAuthenticatedImageWithImagePullSecretInServiceAccount(t *testing.T) {
+func TestSecDockerCreatePeerPodWithAuthenticatedImageWithImagePullSecretInServiceAccount(t *testing.T) {
 	assert := DockerAssert{}
 	if os.Getenv("REGISTRY_CREDENTIAL_ENCODED") != "" && os.Getenv("AUTHENTICATED_REGISTRY_IMAGE") != "" {
 		DoTestCreatePeerPodWithAuthenticatedImageWithImagePullSecretInServiceAccount(t, testEnv, assert)
@@ -145,7 +145,7 @@ func TestDockerCreatePeerPodWithAuthenticatedImageWithImagePullSecretInServiceAc
 	}
 }
 
-func TestDockerCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t *testing.T) {
+func TestSecDockerCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t *testing.T) {
 	assert := DockerAssert{}
 	if os.Getenv("REGISTRY_CREDENTIAL_ENCODED") != "" && os.Getenv("AUTHENTICATED_REGISTRY_IMAGE") != "" {
 		DoTestCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t, testEnv, assert)
@@ -154,28 +154,28 @@ func TestDockerCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t *te
 	}
 }
 
-func TestDockerCreateWithCpuLimit(t *testing.T) {
+func TestResDockerCreateWithCpuLimit(t *testing.T) {
 	// This test is covered as part of unit test and hence skipping to optimise CI time
 	SkipTestOnCI(t)
 	assert := DockerAssert{}
 	DoTestPodWithCpuMemLimitsAndRequests(t, testEnv, assert, "", "", "200m", "")
 }
 
-func TestDockerCreateWithMemLimit(t *testing.T) {
+func TestResDockerCreateWithMemLimit(t *testing.T) {
 	// This test is covered as part of unit test and hence skipping to optimise CI time
 	SkipTestOnCI(t)
 	assert := DockerAssert{}
 	DoTestPodWithCpuMemLimitsAndRequests(t, testEnv, assert, "", "", "", "200Mi")
 }
 
-func TestDockerCreateWithCpuAndMemLimit(t *testing.T) {
+func TestResDockerCreateWithCpuAndMemLimit(t *testing.T) {
 	// This test is covered as part of unit test and hence skipping to optimise CI time
 	SkipTestOnCI(t)
 	assert := DockerAssert{}
 	DoTestPodWithCpuMemLimitsAndRequests(t, testEnv, assert, "", "", "200m", "200Mi")
 }
 
-func TestDockerCreateWithCpuAndMemRequestLimit(t *testing.T) {
+func TestResDockerCreateWithCpuAndMemRequestLimit(t *testing.T) {
 	assert := DockerAssert{}
 	DoTestPodWithCpuMemLimitsAndRequests(t, testEnv, assert, "100m", "100Mi", "200m", "200Mi")
 }

--- a/src/cloud-api-adaptor/test/e2e/gcp_test.go
+++ b/src/cloud-api-adaptor/test/e2e/gcp_test.go
@@ -10,22 +10,22 @@ import (
 	"testing"
 )
 
-func TestDeletePodGCP(t *testing.T) {
+func TestBasicGcpDeletePod(t *testing.T) {
 	assert := GCPCloudAssert{}
 	DoTestDeleteSimplePod(t, testEnv, assert)
 }
 
-func TestCreateSimplePodGCP(t *testing.T) {
+func TestBasicGcpCreateSimplePod(t *testing.T) {
 	assert := GCPCloudAssert{}
 	DoTestCreateSimplePod(t, testEnv, assert)
 }
 
-func TestCreatePodWithConfigMapGCP(t *testing.T) {
+func TestBasicGcpCreatePodWithConfigMap(t *testing.T) {
 	assert := GCPCloudAssert{}
 	DoTestCreatePodWithConfigMap(t, testEnv, assert)
 }
 
-func TestCreatePodWithSecretGCP(t *testing.T) {
+func TestBasicGcpCreatePodWithSecret(t *testing.T) {
 	assert := GCPCloudAssert{}
 	DoTestCreatePodWithSecret(t, testEnv, assert)
 }

--- a/src/cloud-api-adaptor/test/e2e/ibmcloud_test.go
+++ b/src/cloud-api-adaptor/test/e2e/ibmcloud_test.go
@@ -16,14 +16,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestCreateSimplePod(t *testing.T) {
+func TestBasicIbmCreateSimplePod(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	DoTestCreateSimplePod(t, testEnv, assert)
 }
 
-func TestCaaDaemonsetRollingUpdate(t *testing.T) {
+func TestBasicIbmCaaDaemonsetRollingUpdate(t *testing.T) {
 	if os.Getenv("TEST_CAA_ROLLING_UPDATE") == "yes" {
 		assert := IBMRollingUpdateAssert{
 			VPC: pv.IBMCloudProps.VPC,
@@ -34,7 +34,7 @@ func TestCaaDaemonsetRollingUpdate(t *testing.T) {
 	}
 }
 
-func TestCreateConfidentialPod(t *testing.T) {
+func TestConfIbmCreateConfidentialPod(t *testing.T) {
 	instanceProfile := pv.IBMCloudProps.InstanceProfile
 	if strings.HasPrefix(instanceProfile, "bz2e") {
 		log.Infof("Test SE pod")
@@ -49,77 +49,77 @@ func TestCreateConfidentialPod(t *testing.T) {
 
 }
 
-func TestCreatePodWithConfigMap(t *testing.T) {
+func TestBasicIbmCreatePodWithConfigMap(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	DoTestCreatePodWithConfigMap(t, testEnv, assert)
 }
 
-func TestCreatePodWithSecret(t *testing.T) {
+func TestBasicIbmCreatePodWithSecret(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	DoTestCreatePodWithSecret(t, testEnv, assert)
 }
 
-func TestCreatePeerPodContainerWithExternalIPAccess(t *testing.T) {
+func TestNetIbmCreatePeerPodContainerWithExternalIPAccess(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	DoTestCreatePeerPodContainerWithExternalIPAccess(t, testEnv, assert)
 }
 
-func TestCreatePeerPodWithJob(t *testing.T) {
+func TestBasicIbmCreatePeerPodWithJob(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	DoTestCreatePeerPodWithJob(t, testEnv, assert)
 }
 
-func TestCreatePeerPodAndCheckUserLogs(t *testing.T) {
+func TestResIbmCreatePeerPodAndCheckUserLogs(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	DoTestCreatePeerPodAndCheckUserLogs(t, testEnv, assert)
 }
 
-func TestCreatePeerPodAndCheckWorkDirLogs(t *testing.T) {
+func TestResIbmCreatePeerPodAndCheckWorkDirLogs(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	DoTestCreatePeerPodAndCheckWorkDirLogs(t, testEnv, assert)
 }
 
-func TestCreatePeerPodAndCheckEnvVariableLogsWithImageOnly(t *testing.T) {
+func TestResIbmCreatePeerPodAndCheckEnvVariableLogsWithImageOnly(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	DoTestCreatePeerPodAndCheckEnvVariableLogsWithImageOnly(t, testEnv, assert)
 }
 
-func TestCreatePeerPodAndCheckEnvVariableLogsWithDeploymentOnly(t *testing.T) {
+func TestResIbmCreatePeerPodAndCheckEnvVariableLogsWithDeploymentOnly(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	DoTestCreatePeerPodAndCheckEnvVariableLogsWithDeploymentOnly(t, testEnv, assert)
 }
 
-func TestCreatePeerPodAndCheckEnvVariableLogsWithImageAndDeployment(t *testing.T) {
+func TestResIbmCreatePeerPodAndCheckEnvVariableLogsWithImageAndDeployment(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	DoTestCreatePeerPodAndCheckEnvVariableLogsWithImageAndDeployment(t, testEnv, assert)
 }
 
-func TestCreatePeerPodWithLargeImage(t *testing.T) {
+func TestImgIbmCreatePeerPodWithLargeImage(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	DoTestCreatePeerPodWithLargeImage(t, testEnv, assert)
 }
 
-func TestCreatePeerPodWithPVC(t *testing.T) {
+func TestStoreIbmCreatePeerPodWithPVC(t *testing.T) {
 	if os.Getenv("TEST_CSI_WRAPPER") == "yes" {
 		assert := IBMCloudAssert{
 			VPC: pv.IBMCloudProps.VPC,
@@ -146,7 +146,7 @@ func TestCreatePeerPodWithPVC(t *testing.T) {
 	}
 }
 
-func TestIBMCloudCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t *testing.T) {
+func TestSecIbmCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
@@ -157,7 +157,7 @@ func TestIBMCloudCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t *
 	}
 }
 
-func TestIBMCloudCreatePeerPodWithAuthenticatedImageWithImagePullSecretInServiceAccount(t *testing.T) {
+func TestSecIbmCreatePeerPodWithAuthenticatedImageWithImagePullSecretInServiceAccount(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
@@ -168,7 +168,7 @@ func TestIBMCloudCreatePeerPodWithAuthenticatedImageWithImagePullSecretInService
 	}
 }
 
-func TestCreatePeerPodWithAuthenticatedImageWithoutCredentials(t *testing.T) {
+func TestSecIbmCreatePeerPodWithAuthenticatedImageWithoutCredentials(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
@@ -179,68 +179,68 @@ func TestCreatePeerPodWithAuthenticatedImageWithoutCredentials(t *testing.T) {
 	}
 }
 
-func TestDeletePod(t *testing.T) {
+func TestBasicIbmDeletePod(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	DoTestDeleteSimplePod(t, testEnv, assert)
 }
 
-func TestPodVMwithNoAnnotations(t *testing.T) {
+func TestResIbmPodVMwithNoAnnotations(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	DoTestPodVMwithNoAnnotations(t, testEnv, assert, GetIBMInstanceProfileType("b", "2x8"))
 }
 
-func TestPodVMwithAnnotationsInstanceType(t *testing.T) {
+func TestResIbmPodVMwithAnnotationsInstanceType(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	DoTestPodVMwithAnnotationsInstanceType(t, testEnv, assert, GetIBMInstanceProfileType("c", "2x4"))
 }
 
-func TestPodVMwithAnnotationsCPUMemory(t *testing.T) {
+func TestResIbmPodVMwithAnnotationsCPUMemory(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	DoTestPodVMwithAnnotationsCPUMemory(t, testEnv, assert, GetIBMInstanceProfileType("m", "2x16"))
 }
 
-func TestPodVMwithAnnotationsInvalidInstanceType(t *testing.T) {
+func TestResIbmPodVMwithAnnotationsInvalidInstanceType(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	DoTestPodVMwithAnnotationsInvalidInstanceType(t, testEnv, assert, GetIBMInstanceProfileType("b", "2x4"))
 }
-func TestPodVMwithAnnotationsLargerMemory(t *testing.T) {
+func TestResIbmPodVMwithAnnotationsLargerMemory(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	DoTestPodVMwithAnnotationsLargerMemory(t, testEnv, assert)
 }
-func TestPodVMwithAnnotationsLargerCPU(t *testing.T) {
+func TestResIbmPodVMwithAnnotationsLargerCPU(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	DoTestPodVMwithAnnotationsLargerCPU(t, testEnv, assert)
 }
 
-func TestIBMCreateNginxDeployment(t *testing.T) {
+func TestBasicIbmCreateNginxDeployment(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	DoTestNginxDeployment(t, testEnv, assert)
 }
 
-func TestPodToServiceCommunication(t *testing.T) {
+func TestNetIbmPodToServiceCommunication(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	DoTestPodToServiceCommunication(t, testEnv, assert)
 }
 
-func TestPodsMTLSCommunication(t *testing.T) {
+func TestNetIbmPodsMTLSCommunication(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}

--- a/src/cloud-api-adaptor/test/e2e/libvirt_test.go
+++ b/src/cloud-api-adaptor/test/e2e/libvirt_test.go
@@ -13,27 +13,27 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
-func TestLibvirtCreateSimplePod(t *testing.T) {
+func TestBasicLibvirtCreateSimplePod(t *testing.T) {
 	assert := LibvirtAssert{}
 	DoTestCreateSimplePod(t, testEnv, assert)
 }
 
-func TestLibvirtCreateSimplePodWithSecureCommsIsValid(t *testing.T) {
+func TestBasicLibvirtCreateSimplePodWithSecureCommsIsValid(t *testing.T) {
 	assert := LibvirtAssert{}
 	DoTestLibvirtCreateSimplePodWithSecureCommsIsValid(t, testEnv, assert)
 }
 
-func TestLibvirtCreatePodWithConfigMap(t *testing.T) {
+func TestBasicLibvirtCreatePodWithConfigMap(t *testing.T) {
 	assert := LibvirtAssert{}
 	DoTestCreatePodWithConfigMap(t, testEnv, assert)
 }
 
-func TestLibvirtCreatePodWithSecret(t *testing.T) {
+func TestBasicLibvirtCreatePodWithSecret(t *testing.T) {
 	assert := LibvirtAssert{}
 	DoTestCreatePodWithSecret(t, testEnv, assert)
 }
 
-func TestLibvirtCreatePeerPodContainerWithExternalIPAccess(t *testing.T) {
+func TestNetLibvirtCreatePeerPodContainerWithExternalIPAccess(t *testing.T) {
 	SkipTestOnCI(t)
 	if isTestOnCrio() {
 		t.Skip("Fails with CRI-O (confidential-containers/cloud-api-adaptor#2100)")
@@ -43,19 +43,19 @@ func TestLibvirtCreatePeerPodContainerWithExternalIPAccess(t *testing.T) {
 
 }
 
-func TestLibvirtCreatePeerPodContainerWithValidAlternateImage(t *testing.T) {
+func TestImgLibvirtCreatePeerPodContainerWithValidAlternateImage(t *testing.T) {
 	assert := LibvirtAssert{}
 	DoTestCreatePeerPodContainerWithValidAlternateImage(t, testEnv, assert, libvirt.AlternateVolumeName)
 }
 
-func TestLibvirtCreatePeerPodContainerWithInvalidAlternateImage(t *testing.T) {
+func TestImgLibvirtCreatePeerPodContainerWithInvalidAlternateImage(t *testing.T) {
 	assert := LibvirtAssert{}
 	nonExistingImageName := "non-existing-image"
 	expectedErrorMessage := "Error in creating volume: Can't retrieve volume " + nonExistingImageName
 	DoTestCreatePeerPodContainerWithInvalidAlternateImage(t, testEnv, assert, nonExistingImageName, expectedErrorMessage)
 }
 
-func TestLibvirtCreatePeerPodWithJob(t *testing.T) {
+func TestBasicLibvirtCreatePeerPodWithJob(t *testing.T) {
 	assert := LibvirtAssert{}
 	DoTestCreatePeerPodWithJob(t, testEnv, assert)
 }
@@ -97,23 +97,23 @@ func TestLibvirtCreatePeerPodAndCheckEnvVariableLogsWithImageAndDeployment(t *te
 	DoTestCreatePeerPodAndCheckEnvVariableLogsWithImageAndDeployment(t, testEnv, assert)
 }
 
-func TestLibvirtCreateNginxDeployment(t *testing.T) {
+func TestBasicLibvirtCreateNginxDeployment(t *testing.T) {
 	assert := LibvirtAssert{}
 	DoTestNginxDeployment(t, testEnv, assert)
 }
 
-func TestLibvirtCreatePeerPodWithLargeImage(t *testing.T) {
+func TestImgLibvirtCreatePeerPodWithLargeImage(t *testing.T) {
 	SkipTestOnCI(t)
 	assert := LibvirtAssert{}
 	DoTestCreatePeerPodWithLargeImage(t, testEnv, assert)
 }
 
-func TestLibvirtDeletePod(t *testing.T) {
+func TestBasicLibvirtDeletePod(t *testing.T) {
 	assert := LibvirtAssert{}
 	DoTestDeleteSimplePod(t, testEnv, assert)
 }
 
-func TestLibvirtPodToServiceCommunication(t *testing.T) {
+func TestNetLibvirtPodToServiceCommunication(t *testing.T) {
 	// This test is causing issues on CI with instability, so skip until we can resolve this.
 	if isTestOnCrio() {
 		t.Skip("Fails with CRI-O (confidential-containers/cloud-api-adaptor#2100)")
@@ -122,7 +122,7 @@ func TestLibvirtPodToServiceCommunication(t *testing.T) {
 	DoTestPodToServiceCommunication(t, testEnv, assert)
 }
 
-func TestLibvirtPodsMTLSCommunication(t *testing.T) {
+func TestNetLibvirtPodsMTLSCommunication(t *testing.T) {
 	// This test is causing issues on CI with instability, so skip until we can resolve this.
 	if isTestOnCrio() {
 		t.Skip("Fails with CRI-O (confidential-containers/cloud-api-adaptor#2100)")
@@ -131,7 +131,7 @@ func TestLibvirtPodsMTLSCommunication(t *testing.T) {
 	DoTestPodsMTLSCommunication(t, testEnv, assert)
 }
 
-func TestLibvirtImageDecryption(t *testing.T) {
+func TestConfLibvirtImageDecryption(t *testing.T) {
 	if !isTestWithKbs() {
 		t.Skip("Skipping kbs related test as kbs is not deployed")
 	}
@@ -144,7 +144,7 @@ func TestLibvirtImageDecryption(t *testing.T) {
 	DoTestImageDecryption(t, testEnv, assert, keyBrokerService)
 }
 
-func TestLibvirtSealedSecret(t *testing.T) {
+func TestConfLibvirtSealedSecret(t *testing.T) {
 	if !isTestWithKbs() {
 		t.Skip("Skipping kbs related test as kbs is not deployed")
 	}
@@ -167,7 +167,7 @@ func TestLibvirtSealedSecret(t *testing.T) {
 	DoTestSealedSecret(t, testEnv, assert, kbsEndpoint, resourcePath, testSecret)
 }
 
-func TestLibvirtKbsKeyRelease(t *testing.T) {
+func TestConfLibvirtKbsKeyRelease(t *testing.T) {
 	if !isTestWithKbs() {
 		t.Skip("Skipping kbs related test as kbs is not deployed")
 	}
@@ -213,12 +213,12 @@ func TestLibvirtKbsKeyRelease(t *testing.T) {
 	}
 }
 
-func TestLibvirtRestrictivePolicyBlocksExec(t *testing.T) {
+func TestSecLibvirtRestrictivePolicyBlocksExec(t *testing.T) {
 	assert := LibvirtAssert{}
 	DoTestRestrictivePolicyBlocksExec(t, testEnv, assert)
 }
 
-func TestLibvirtPermissivePolicyAllowsExec(t *testing.T) {
+func TestSecLibvirtPermissivePolicyAllowsExec(t *testing.T) {
 	assert := LibvirtAssert{}
 	DoTestPermissivePolicyAllowsExec(t, testEnv, assert)
 }
@@ -250,27 +250,27 @@ func TestLibvirtCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t *t
 	}
 }
 
-func TestLibvirtCreateWithCpuAndMemRequestLimit(t *testing.T) {
+func TestResLibvirtCreateWithCpuAndMemRequestLimit(t *testing.T) {
 	assert := LibvirtAssert{}
 	DoTestPodWithCpuMemLimitsAndRequests(t, testEnv, assert, "100m", "100Mi", "200m", "1200Mi")
 }
 
-func TestLibvirtPodVMwithAnnotationsCPUMemory(t *testing.T) {
+func TestResLibvirtPodVMwithAnnotationsCPUMemory(t *testing.T) {
 	assert := LibvirtAssert{}
 	DoTestPodVMwithAnnotationsCPUMemory(t, testEnv, assert, CreateInstanceProfileFromCPUMemory(2, 12288))
 }
 
-func TestLibvirtPodVMwithAnnotationCPU(t *testing.T) {
+func TestResLibvirtPodVMwithAnnotationCPU(t *testing.T) {
 	assert := LibvirtAssert{}
 	DoTestPodVMwithAnnotationCPU(t, testEnv, assert, CreateInstanceProfileFromCPUMemory(4, libvirt.DefaultMemory))
 }
 
-func TestLibvirtPodVMwithAnnotationMemory(t *testing.T) {
+func TestResLibvirtPodVMwithAnnotationMemory(t *testing.T) {
 	assert := LibvirtAssert{}
 	DoTestPodVMwithAnnotationMemory(t, testEnv, assert, CreateInstanceProfileFromCPUMemory(libvirt.DefaultCPU, 7168))
 }
 
-func TestLibvirtPodVMwithNoAnnotations(t *testing.T) {
+func TestResLibvirtPodVMwithNoAnnotations(t *testing.T) {
 	assert := LibvirtAssert{}
 	DoTestPodVMwithNoAnnotations(t, testEnv, assert, CreateInstanceProfileFromCPUMemory(libvirt.DefaultCPU, libvirt.DefaultMemory))
 }


### PR DESCRIPTION
Tests are named using the pattern Test<Category><Provider><TestName> This helps to filter tests and run specific categories as needed.