### PR TITLE
scratch-space: Update old references

### DIFF
--- a/src/cloud-api-adaptor/entrypoint.sh
+++ b/src/cloud-api-adaptor/entrypoint.sh
@@ -34,7 +34,7 @@ optionals+=""
 [[ "${SECURE_COMMS_KBS_ADDR}" ]] && optionals+="-secure-comms-kbs ${SECURE_COMMS_KBS_ADDR} "
 [[ "${PEERPODS_LIMIT_PER_NODE}" ]] && optionals+="-peerpods-limit-per-node ${PEERPODS_LIMIT_PER_NODE} "
 [[ "${DISABLECVM}" == "true" ]] && optionals+="-disable-cvm "
-[[ "${ENABLE_SCRATCH_DISK}" == "true" ]] && optionals+="-enable-scratch-disk "
+[[ "${ENABLE_SCRATCH_SPACE}" == "true" ]] && optionals+="-enable-scratch-space "
 
 test_vars() {
     for i in "$@"; do
@@ -194,7 +194,7 @@ libvirt() {
 
     [[ "${LIBVIRT_CPU}" ]] && optionals+="-cpu ${LIBVIRT_CPU} "
     [[ "${LIBVIRT_MEMORY}" ]] && optionals+="-memory ${LIBVIRT_MEMORY} "
-    
+
     set -x
     exec cloud-api-adaptor libvirt \
         -pods-dir "${PEER_PODS_DIR}" \

--- a/src/cloud-api-adaptor/install/overlays/aws/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/aws/kustomization.yaml
@@ -41,8 +41,7 @@ configMapGenerator:
   #- PEERPODS_LIMIT_PER_NODE="10" # Max number of peer pods that can be created per node. Default is 10
   #- REMOTE_HYPERVISOR_ENDPOINT="/run/peerpod/hypervisor.sock" # Path to Kata remote hypervisor socket. Default is /run/peerpod/hypervisor.sock
   #- PEER_PODS_DIR="/run/peerpod/pods" # Path to peer pods directory. Default is /run/peerpod/pods
-  #- ENABLE_SCRATCH_DISK="false"  # Enable scratch disk. Default is false
-  #- ENABLE_SCRATCH_ENCRYPTION="false" # Enable scratch disk encryption. Default is false
+  #- ENABLE_SCRATCH_SPACE="false"  # Enable scratch space for pod VMs. Default is false
 ##TLS_SETTINGS
   #- CACERT_FILE="/etc/certificates/ca.crt" # for TLS
   #- CERT_FILE="/etc/certificates/client.crt" # for TLS

--- a/src/cloud-api-adaptor/install/overlays/azure/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/azure/kustomization.yaml
@@ -46,8 +46,7 @@ configMapGenerator:
   #- REMOTE_HYPERVISOR_ENDPOINT="/run/peerpod/hypervisor.sock" # Path to Kata remote hypervisor socket. Default is /run/peerpod/hypervisor.sock
   #- PEER_PODS_DIR="/run/peerpod/pods" # Path to peer pods directory. Default is /run/peerpod/pods
   #- ROOT_VOLUME_SIZE="" # Uncomment and set if you want to use a specific root volume size. Default depends on the image used
-  #- ENABLE_SCRATCH_DISK="false"  # Enable scratch disk. Default is false
-  #- ENABLE_SCRATCH_ENCRYPTION="false" # Enable scratch disk encryption. Default is false
+  #- ENABLE_SCRATCH_SPACE="false"  # Enable scratch space for pod VMs. Default is false
 ##TLS_SETTINGS
   #- CACERT_FILE="/etc/certificates/ca.crt" # for TLS
   #- CERT_FILE="/etc/certificates/client.crt" # for TLS

--- a/src/cloud-api-adaptor/install/overlays/gcp/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/gcp/kustomization.yaml
@@ -32,8 +32,7 @@ configMapGenerator:
   #- TUNNEL_TYPE="" # Uncomment and set if you want to use a specific tunnel type. Defaults to vxlan
   #- VXLAN_PORT="" # Uncomment and set if you want to use a specific vxlan port. Defaults to 4789
   #- TAGS="" # Uncomment and add key1=value1,key2=value2 etc if you want to use specific tags for podvm. Tags must already exist in the GCP project
-  #- ENABLE_SCRATCH_DISK="false"  # Enable scratch disk. Default is false
-  #- ENABLE_SCRATCH_ENCRYPTION="false" # Enable scratch disk encryption. Default is false
+  #- ENABLE_SCRATCH_SPACE="false"  # Enable scratch space for pod VMs. Default is false
 ##TLS_SETTINGS
   #- CACERT_FILE="/etc/certificates/ca.crt" # for TLS
   #- CERT_FILE="/etc/certificates/client.crt" # for TLS


### PR DESCRIPTION
In #2495 the encrypted-scratch-disk flag was changed to enable-scratch-space, but not all the references were changed, so I don't think it will work any more.