### PR TITLE
test/e2e: Add DoTestPodWithInitContainer to libvirt

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/libvirt_test.go
+++ b/src/cloud-api-adaptor/test/e2e/libvirt_test.go
@@ -274,3 +274,9 @@ func TestLibvirtPodVMwithNoAnnotations(t *testing.T) {
 	assert := LibvirtAssert{}
 	DoTestPodVMwithNoAnnotations(t, testEnv, assert, CreateInstanceProfileFromCPUMemory(libvirt.DefaultCPU, libvirt.DefaultMemory))
 }
+
+// Test with init container
+func TestLibvirtPodWithInitContainer(t *testing.T) {
+	assert := LibvirtAssert{}
+	DoTestPodWithInitContainer(t, testEnv, assert)
+}


### PR DESCRIPTION
Add init pod test to libvirt e2e as part of https://github.com/confidential-containers/cloud-api-adaptor/issues/1604