### PR TITLE
aws: add support to use temporary credentials

### DIFF
--- a/src/cloud-api-adaptor/aws/image/Dockerfile
+++ b/src/cloud-api-adaptor/aws/image/Dockerfile
@@ -62,7 +62,9 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 
 RUN --mount=type=secret,id=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=AWS_SECRET_ACCESS_KEY \
+    --mount=type=secret,id=AWS_SESSION_TOKEN \
     export AWS_ACCESS_KEY_ID=$(cat /run/secrets/AWS_ACCESS_KEY_ID) && \
     export AWS_SECRET_ACCESS_KEY=$(cat /run/secrets/AWS_SECRET_ACCESS_KEY) && \
+    export AWS_SESSION_TOKEN=$(cat /run/secrets/AWS_SESSION_TOKEN 2>/dev/null || echo "") && \
     cd cloud-api-adaptor/src/cloud-api-adaptor/aws/image && \
     BINARIES= PAUSE_BUNDLE= CLOUD_PROVIDER=aws PODVM_DISTRO=$PODVM_DISTRO make image

--- a/src/cloud-api-adaptor/install/overlays/aws/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/aws/kustomization.yaml
@@ -55,6 +55,7 @@ secretGenerator:
   # This file should look like this (w/o quotes!):
   # AWS_ACCESS_KEY_ID=...
   # AWS_SECRET_ACCESS_KEY=...
+  # AWS_SESSION_TOKEN=... (optional, for temporary credentials)
   envs:
     - aws-cred.env
 ##TLS_SETTINGS

--- a/src/cloud-providers/aws/ec2.go
+++ b/src/cloud-providers/aws/ec2.go
@@ -21,7 +21,7 @@ func NewEC2Client(cloudCfg Config) (*ec2.Client, error) {
 
 	if cloudCfg.AccessKeyId != "" && cloudCfg.SecretKey != "" {
 		cfg, err = config.LoadDefaultConfig(context.TODO(),
-			config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(cloudCfg.AccessKeyId, cloudCfg.SecretKey, "")), config.WithRegion(cloudCfg.Region))
+			config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(cloudCfg.AccessKeyId, cloudCfg.SecretKey, cloudCfg.SessionToken)), config.WithRegion(cloudCfg.Region))
 		if err != nil {
 			return nil, fmt.Errorf("configuration error when using creds: %s", err)
 		}

--- a/src/cloud-providers/aws/manager.go
+++ b/src/cloud-providers/aws/manager.go
@@ -21,6 +21,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 
 	flags.StringVar(&awscfg.AccessKeyId, "aws-access-key-id", "", "Access Key ID, defaults to `AWS_ACCESS_KEY_ID`")
 	flags.StringVar(&awscfg.SecretKey, "aws-secret-key", "", "Secret Key, defaults to `AWS_SECRET_ACCESS_KEY`")
+	flags.StringVar(&awscfg.SessionToken, "aws-session-token", "", "Session Token, defaults to `AWS_SESSION_TOKEN`")
 	flags.StringVar(&awscfg.Region, "aws-region", "", "Region")
 	flags.StringVar(&awscfg.LoginProfile, "aws-profile", "", "AWS Login Profile")
 	flags.StringVar(&awscfg.LaunchTemplateName, "aws-lt-name", "kata", "AWS Launch Template Name")
@@ -45,6 +46,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 func (_ *Manager) LoadEnv() {
 	provider.DefaultToEnv(&awscfg.AccessKeyId, "AWS_ACCESS_KEY_ID", "")
 	provider.DefaultToEnv(&awscfg.SecretKey, "AWS_SECRET_ACCESS_KEY", "")
+	provider.DefaultToEnv(&awscfg.SessionToken, "AWS_SESSION_TOKEN", "")
 	provider.DefaultToEnv(&awscfg.InstanceType, "PODVM_INSTANCE_TYPE", "m6a.large")
 }
 

--- a/src/cloud-providers/aws/types.go
+++ b/src/cloud-providers/aws/types.go
@@ -39,6 +39,7 @@ func (i *instanceTypes) Set(value string) error {
 type Config struct {
 	AccessKeyId          string
 	SecretKey            string
+	SessionToken         string
 	Region               string
 	LoginProfile         string
 	LaunchTemplateName   string
@@ -58,5 +59,5 @@ type Config struct {
 }
 
 func (c Config) Redact() Config {
-	return *util.RedactStruct(&c, "AccessKeyId", "SecretKey").(*Config)
+	return *util.RedactStruct(&c, "AccessKeyId", "SecretKey", "SessionToken").(*Config)
 }


### PR DESCRIPTION
Amazon recommends workloads to use temporary credentials to access AWS whenever possible, in its best practices document (https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#bp-workloads-use-roles). The current caa implementation for AWS, however, relies only on the access key ID and secret access key to establish connection to AWS. It doesn't work with temporary credentials such as these generated by AWS STS API because it's missing one parameter: the session token. This PR fixes that problem by passing the session token (AWS_SESSION_TOKEN) all the way down to the cloud-api-adaptor program at launch time.

---

I faced that problem while working on enabling e2e daily CI for AWS. I've configured openID connect in AWS (https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws) to obtain a short-lived credentials, to replace the current credentials stored as Github secrets.

Without this PR the caa daemon crashes on launch with error like (in https://github.com/wainersm/cc-cloud-api-adaptor/actions/runs/17122987923/job/48569185144):
```
+ exec cloud-api-adaptor aws -pods-dir /run/peerpod/pods -socket /run/peerpod/hypervisor.sock -disable-cvm -securitygroupids sg-014fb899c4def38a2 -imageid ami-0129268a361a6cb9f -instance-type t3.small -keyname caa-e2e-test -subnetid subnet-0599d4241bf1d32c2 -aws-region us-east-1 -use-public-ip
  cloud-api-adaptor version unknown
    commit: 40b613fbdc498ded16aa43ffeb838a113a60e25f
    go: go1.23.10
  cloud-api-adaptor: starting Cloud API Adaptor daemon for "aws"
  2025/08/21 10:19:29 [adaptor/cloud] Cloud provider external plugin loading is disabled, skipping plugin loading
  2025/08/21 10:19:29 [adaptor/cloud/aws] aws config: aws.Config{AccessKeyId:"**********", SecretKey:"**********", Region:"us-east-1", LoginProfile:"", LaunchTemplateName:"kata", ImageId:"ami-0129268a361a6cb9f", InstanceType:"t3.small", KeyName:"caa-e2e-test", SubnetId:"subnet-0599d4241bf1d32c2", SecurityGroupIds:aws.securityGroupIds{"sg-014fb899c4def38a2"}, UseLaunchTemplate:false, InstanceTypes:aws.instanceTypes(nil), InstanceTypeSpecList:[]provider.InstanceTypeSpec(nil), Tags:provider.KeyValueFlag(nil), UsePublicIP:true, RootVolumeSize:30, RootDeviceName:"", DisableCVM:true}
  2025/08/21 10:19:29 [adaptor/cloud/aws] NewMetadataRetriever is initialized without mac (operation error ec2imds: GetMetadata, failed to get API token, operation error ec2imds: getToken, http response error StatusCode: 400, request to EC2 IMDS failed)
  2025/08/21 10:19:29 [adaptor/cloud/aws] failed to describe image ami-0129268a361a6cb9f: operation error EC2: DescribeImages, https response error StatusCode: 401, RequestID: 7c30d634-c9fa-4de9-9dd3-f86c63f211e9, api error AuthFailure: AWS was not able to validate the provided access credentials
  cloud-api-adaptor: operation error EC2: DescribeImages, https response error StatusCode: 401, RequestID: 7c30d634-c9fa-4de9-9dd3-f86c63f211e9, api error AuthFailure: AWS was not able to validate the provided access credentials
```

Notice the message `AuthFailure: AWS was not able to validate the provided access credentials` on the snippet above. However, with this PR applied the e2e tests will get caa running and tests are effectively executed as in  
https://github.com/wainersm/cc-cloud-api-adaptor/actions/runs/17385264868/job/49351100954

---

**Assisted-by**: Cursor (the changes were generated by AI, based on the implementation of the other credentials parameters such as AWS_ACCESS_KEY_ID. I reviewed and tested myself, and added a missing change only).