### PR TITLE
Introduce CI for AWS - part 2

### DIFF
--- a/.github/workflows/daily-e2e-tests.yaml
+++ b/.github/workflows/daily-e2e-tests.yaml
@@ -32,7 +32,6 @@ jobs:
       packages: write
       attestations: write
     secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_IAM_ROLE_ARN: ${{ secrets.AWS_IAM_ROLE_ARN }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
       REGISTRY_CREDENTIAL_ENCODED: ${{ secrets.REGISTRY_CREDENTIAL_ENCODED }}

--- a/.github/workflows/e2e_aws.yaml
+++ b/.github/workflows/e2e_aws.yaml
@@ -180,3 +180,13 @@ jobs:
           export TEST_E2E_TIMEOUT="90m"
 
           make test-e2e
+
+        # In case the tests execution failed and deprovision code from e2e
+        # didn't run, let's try to delete any resources created.
+      - name: Force AWS clean-up
+        if: failure() && steps.runTests.outcome == 'failure'
+        working-directory: ./
+        run: |
+          ./hack/ci-e2e-aws-cleanup.sh
+        # Avoid running with `set -e` as command fails should be allowed
+        shell: bash {0}

--- a/.github/workflows/e2e_aws.yaml
+++ b/.github/workflows/e2e_aws.yaml
@@ -137,6 +137,7 @@ jobs:
         run: |
           cat <<EOF>>aws.properties
           CAA_IMAGE="${{ inputs.caa_image }}"
+          container_runtime="${{ inputs.container_runtime }}"
           disablecvm="true"
           cluster_type="${{ inputs.cluster_type }}"
           ssh_kp_name="caa-e2e-test"

--- a/.github/workflows/e2e_aws.yaml
+++ b/.github/workflows/e2e_aws.yaml
@@ -34,19 +34,17 @@ on:
         required: false
         type: string
     secrets:
-      AWS_ACCESS_KEY_ID:
+      AWS_IAM_ROLE_ARN:
         required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
+
+permissions: {}
 
 env:
   CLOUD_PROVIDER: aws
   DEBIAN_FRONTEND: noninteractive
 
-permissions: {}
-
 jobs:
-  # Check the org/repository has AWS secrets (AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY). On absence of
+  # Check the org/repository has AWS secrets (AWS_IAM_ROLE_ARN). On absence of
   # secrets it should skip the execution of the test job.
   aws-credentials:
     runs-on: ubuntu-22.04
@@ -56,7 +54,7 @@ jobs:
       - name: Check secrets
         id: check_secrets
         run: |
-         if [[ -n "${{ secrets.AWS_ACCESS_KEY_ID }}" && -n "${{ secrets.AWS_SECRET_ACCESS_KEY }}" ]]; then
+         if [[ -n "${{ secrets.AWS_IAM_ROLE_ARN }}" ]]; then
            echo "has_secrets=true" >> "$GITHUB_OUTPUT"
          else
            echo "has_secrets=false" >> "$GITHUB_OUTPUT"
@@ -69,6 +67,9 @@ jobs:
     defaults:
       run:
         working-directory: src/cloud-api-adaptor
+    permissions:
+      id-token: write # Required by aws-actions/configure-aws-credentials
+      contents: read  # Required by aws-actions/configure-aws-credentials
     steps:
       - name: Checkout Code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -147,12 +148,11 @@ jobs:
           cat aws.properties
           echo "::endgroup::"
 
-        # Note: aws cli is already installed on github's runner image.
-      - name: Config aws CLI
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }} --profile default
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }} --profile default
-          aws configure set region us-east-1 --profile default
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE_ARN }}
 
       - name: Create on-prem cluster
         if: inputs.cluster_type == 'onprem'

--- a/.github/workflows/e2e_aws.yaml
+++ b/.github/workflows/e2e_aws.yaml
@@ -83,6 +83,11 @@ jobs:
         run: |
           ./hack/ci-helper.sh rebase-atop-of-the-latest-target-branch
 
+      - name: Remove unnecessary directories to free up space
+        working-directory: ./
+        run: |
+          sudo ./hack/ci-helper.sh clean-up-runner
+
       - name: Read properties from versions.yaml
         run: |
           sudo snap install yq
@@ -95,6 +100,7 @@ jobs:
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/go.sum"
 
       - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
         with:
@@ -102,9 +108,12 @@ jobs:
 
       - name: Extract qcow2 from ${{ inputs.podvm_image }}
         if: ${{ !inputs.oras }}
+        env:
+          PODVM_IMAGE: "${{ inputs.podvm_image }}"
         run: |
-           qcow2=$(echo "${{ inputs.podvm_image }}" | sed -e "s#.*/\(.*\):.*#\1.qcow2#")
-           ./hack/download-image.sh "${{ inputs.podvm_image }}" . -o "${qcow2}"
+           # shellcheck disable=SC2001 
+           qcow2=$(echo "${PODVM_IMAGE}" | sed -e "s#.*/\(.*\):.*#\1.qcow2#")
+           ./hack/download-image.sh "${PODVM_IMAGE}" . -o "${qcow2}" --clean-up
            echo "PODVM_QCOW2=$(pwd)/${qcow2}" >> "$GITHUB_ENV"
            # Clean up docker images to make space
            docker system prune -a -f

--- a/.github/workflows/e2e_aws.yaml
+++ b/.github/workflows/e2e_aws.yaml
@@ -181,6 +181,14 @@ jobs:
 
           make test-e2e
 
+      - name: Debug tests failure
+        if: failure() && steps.runTests.outcome == 'failure'
+        working-directory: ./
+        run: |
+          ./hack/ci-e2e-debug-fail.sh
+        # Avoid running with `set -e` as command fails should be allowed
+        shell: bash {0}
+
         # In case the tests execution failed and deprovision code from e2e
         # didn't run, let's try to delete any resources created.
       - name: Force AWS clean-up

--- a/.github/workflows/e2e_on_pull.yaml
+++ b/.github/workflows/e2e_on_pull.yaml
@@ -54,7 +54,6 @@ jobs:
       packages: write
       attestations: write
     secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_IAM_ROLE_ARN: ${{ secrets.AWS_IAM_ROLE_ARN }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
       REGISTRY_CREDENTIAL_ENCODED: ${{ secrets.REGISTRY_CREDENTIAL_ENCODED }}

--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -26,9 +26,7 @@ on:
         required: true
         type: string
     secrets:
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
+      AWS_IAM_ROLE_ARN:
         required: true
       QUAY_PASSWORD:
         required: true
@@ -230,6 +228,9 @@ jobs:
           - generic
         arch:
           - amd64
+    permissions:
+      id-token: write # Required by aws-actions/configure-aws-credentials
+      contents: read  # Required by aws-actions/configure-aws-credentials
     uses: ./.github/workflows/e2e_aws.yaml
     with:
       caa_image: ${{ inputs.registry }}/cloud-api-adaptor:${{ inputs.caa_image_tag }}
@@ -238,8 +239,7 @@ jobs:
       git_ref: ${{ inputs.git_ref }}
       oras: false
     secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_IAM_ROLE_ARN: ${{ secrets.AWS_IAM_ROLE_ARN }}
 
   # Run libvirt e2e tests if pull request labeled 'test_e2e_libvirt'
   libvirt:

--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -222,6 +222,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        container_runtime:
+          - crio
         os:
           - ubuntu
         provider:
@@ -231,6 +233,7 @@ jobs:
     uses: ./.github/workflows/e2e_aws.yaml
     with:
       caa_image: ${{ inputs.registry }}/cloud-api-adaptor:${{ inputs.caa_image_tag }}
+      container_runtime: ${{ matrix.container_runtime }}
       podvm_image: ${{ inputs.registry }}/podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ matrix.arch }}:${{ inputs.podvm_image_tag }}
       git_ref: ${{ inputs.git_ref }}
       oras: false

--- a/hack/ci-e2e-aws-cleanup.sh
+++ b/hack/ci-e2e-aws-cleanup.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# (C) Copyright Confidential Containers Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Primarily used on Github workflows to remove dangling resources from AWS
+#
+
+script_dir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+
+
+delete_vpcs() {
+  local tag_vpc="caa-e2e-test-vpc"
+  read -r -a vpcs <<< "$(aws  ec2 describe-vpcs --filters Name=tag:Name,Values=$tag_vpc --query 'Vpcs[*].VpcId' --output text)"
+
+  if [ ${#vpcs[@]} -eq 0 ]; then
+    echo "There aren't VPCs to delete"
+    return
+  fi
+
+  for vpc in "${vpcs[@]}"; do
+    echo "aws_vpc_id=\"$vpc\"" > "$TEST_PROVISION_FILE"
+
+    # Find related subnets
+    read -r -a subnets <<< "$(aws ec2 describe-subnets --filter "Name=vpc-id,Values=$vpc" --query 'Subnets[*].SubnetId' --output text)"
+    for net in "${subnets[@]}"; do
+      echo "aws_vpc_subnet_id=\"$net\"" >> "$TEST_PROVISION_FILE"
+    done
+
+    # Find related security groups
+    read -r -a sgs <<< "$(aws ec2 describe-security-groups --filters "Name=vpc-id,Values=$vpc" "Name=tag:Name,Values=caa-e2e-test-sg" --query 'SecurityGroups[*].GroupId' --output text)"
+    for sg in "${sgs[@]}"; do
+      echo "aws_vpc_sg_id=\"$sg\"" >> "$TEST_PROVISION_FILE"
+    done
+
+    # Find related route tables and internet gateways
+    read -r -a rtbs <<< "$(aws ec2 describe-route-tables --filters "Name=vpc-id,Values=$vpc" "Name=tag:Name,Values=caa-e2e-test-rtb" --query 'RouteTables[*].RouteTableId' --output text)"
+    for rtb in "${rtbs[@]}"; do
+      echo "aws_vpc_rt_id=\"$rtb\"" >> "$TEST_PROVISION_FILE"
+      read -r -a igws <<< "$(aws ec2 describe-route-tables --filter "Name=route-table-id,Values=$rtb" --query 'RouteTables[0].Routes[*].GatewayId' --output text)"
+      for igw in "${igws[@]}"; do
+        [ "$igw" != "local" ] && echo "aws_vpc_igw_id=\"$igw\"" >> "$TEST_PROVISION_FILE"
+      done
+    done
+
+    echo "Delete VPC=$vpc"
+    ./caa-provisioner-cli -action deprovision
+  done
+}
+
+delete_amis() {
+  local tag_ami="caa-e2e-test-img"
+
+  read -r -a amis <<< "$(aws ec2 describe-images --owners self --filters "Name=tag:Name,Values=$tag_ami" --query 'Images[*].ImageId' --output text)"
+
+  if [ ${#amis[@]} -eq 0 ]; then
+    echo "There aren't AMIs to delete."
+    return
+  fi
+
+  for ami in "${amis[@]}"; do
+    echo "Deregistering AMI: $ami"
+    # Find related snapshots
+    snap_ids=$(aws ec2 describe-images --image-ids "$ami" --query 'Images[*].BlockDeviceMappings[*].Ebs.SnapshotId' --output text)
+    aws ec2 deregister-image --image-id "$ami"
+    for snap in $snap_ids; do
+      echo "Deleting snapshot: $snap"
+      aws ec2 delete-snapshot --snapshot-id "$snap"
+    done
+  done
+}
+
+main() {
+  TEST_PROVISION_FILE="$(pwd)/aws.properties"
+  export TEST_PROVISION_FILE
+
+  CLOUD_PROVIDER="aws"
+  export CLOUD_PROVIDER
+
+  echo "Build the caa-provisioner-cli tool"
+  cd "${script_dir}/../src/cloud-api-adaptor/test/tools" || exit 1
+  make
+
+  delete_vpcs
+  delete_amis
+}
+
+main

--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -131,6 +131,7 @@ Use the properties on the table below for AWS:
 |aws_vpc_sg_id|AWS VPC Security Groups ID||
 |aws_vpc_subnet_id|AWS VPC Subnet ID||
 |cluster_type|Kubernetes cluster type. Either **onprem** or **eks** (see Notes below) |onprem|
+|container_runtime|Test cluster configured container runtime. Either **containerd** or **crio** |containerd|
 |disablecvm|Set to `true` to disable confidential VM||
 |pause_image|Kubernetes pause image||
 |podvm_aws_ami_id|AWS AMI ID of the podvm||

--- a/src/cloud-api-adaptor/test/e2e/aws_test.go
+++ b/src/cloud-api-adaptor/test/e2e/aws_test.go
@@ -74,6 +74,10 @@ func TestAwsCreatePeerPodAndCheckEnvVariableLogsWithImageAndDeployment(t *testin
 }
 
 func TestAwsCreatePeerPodWithLargeImage(t *testing.T) {
+	// This test running on default Github runner makes the disk full
+	// (`System.IO.IOException: No space left on device`) to the point
+	// the job gets aborted.
+	SkipTestOnCI(t)
 	assert := NewAWSAssert()
 
 	DoTestCreatePeerPodWithLargeImage(t, testEnv, assert)

--- a/src/cloud-api-adaptor/test/e2e/aws_test.go
+++ b/src/cloud-api-adaptor/test/e2e/aws_test.go
@@ -111,6 +111,7 @@ func TestAwsCreateNginxDeployment(t *testing.T) {
 }
 
 func TestAwsCreatePeerPodContainerWithInvalidAlternateImage(t *testing.T) {
+	SkipTestOnCI(t)
 	assert := NewAWSAssert()
 	nonExistingImageName := "ami-123456"
 	expectedErrorMessage := fmt.Sprintf("InvalidAMIID.NotFound: The image id '[%s]' does not exist: not found", nonExistingImageName)

--- a/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
@@ -101,20 +101,21 @@ type OnPremCluster struct {
 
 // AWSProvisioner implements the CloudProvision interface.
 type AWSProvisioner struct {
-	AwsConfig  aws.Config
-	iamClient  *iam.Client
-	Cluster    Cluster
-	Disablecvm string
-	ec2Client  *ec2.Client
-	s3Client   *s3.Client
-	Bucket     *S3Bucket
-	PauseImage string
-	Image      *AMIImage
-	Vpc        *Vpc
-	PublicIP   string
-	TunnelType string
-	VxlanPort  string
-	SshKpName  string
+	AwsConfig        aws.Config
+	iamClient        *iam.Client
+	containerRuntime string // Name of the container runtime
+	Cluster          Cluster
+	Disablecvm       string
+	ec2Client        *ec2.Client
+	s3Client         *s3.Client
+	Bucket           *S3Bucket
+	PauseImage       string
+	Image            *AMIImage
+	Vpc              *Vpc
+	PublicIP         string
+	TunnelType       string
+	VxlanPort        string
+	SshKpName        string
 }
 
 // AwsInstallOverlay implements the InstallOverlay interface
@@ -163,15 +164,16 @@ func NewAWSProvisioner(properties map[string]string) (pv.CloudProvisioner, error
 			Name:   "peer-pods-tests",
 			Key:    "", // To be defined when the file is uploaded
 		},
-		Cluster:    cluster,
-		Image:      NewAMIImage(ec2Client, properties),
-		Disablecvm: properties["disablecvm"],
-		PauseImage: properties["pause_image"],
-		Vpc:        vpc,
-		PublicIP:   properties["use_public_ip"],
-		TunnelType: properties["tunnel_type"],
-		VxlanPort:  properties["vxlan_port"],
-		SshKpName:  properties["ssh_kp_name"],
+		containerRuntime: properties["container_runtime"],
+		Cluster:          cluster,
+		Image:            NewAMIImage(ec2Client, properties),
+		Disablecvm:       properties["disablecvm"],
+		PauseImage:       properties["pause_image"],
+		Vpc:              vpc,
+		PublicIP:         properties["use_public_ip"],
+		TunnelType:       properties["tunnel_type"],
+		VxlanPort:        properties["vxlan_port"],
+		SshKpName:        properties["ssh_kp_name"],
 	}
 
 	return AWSProps, nil
@@ -275,6 +277,7 @@ func (a *AWSProvisioner) GetProperties(ctx context.Context, cfg *envconf.Config)
 	credentials, _ := a.AwsConfig.Credentials.Retrieve(context.TODO())
 
 	return map[string]string{
+		"CONTAINER_RUNTIME":    a.containerRuntime,
 		"disablecvm":           a.Disablecvm,
 		"pause_image":          a.PauseImage,
 		"podvm_launchtemplate": "",


### PR DESCRIPTION
Continuing [part 1](https://github.com/confidential-containers/cloud-api-adaptor/pull/2274) in this PR I've got:

- more failing tests are disabled
- securing the AWS account by leveraging OIDC short-lived credentials. The job will effectively run if `AWS_IAM_ROLE_ARN` secret is configured in the repository and some magic done on AWS account (https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws). Contain two commits that are being reviewed in https://github.com/confidential-containers/cloud-api-adaptor/pull/2551 that adds support to use temporary credentials
- added a post step to run clean up code for the case where the e2e tests were interrupted or crashed and the native teardown routine didn't run. Long-term I'm considering to remove that in favor of some regular clean-up routines on AWS account
 
On merging this PR I plan to enable the nightly job and leave future improvements to afterwards. Intentionally I'm not enabling AWS CI on pull requests yet because 1) want to have nightly running and stable first; and 2) still need to prepare the code to run in parallel jobs

