### PR TITLE
test/e2e: adding pvc options and refactoring pvc/secret binding

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/assessment_runner.go
+++ b/src/cloud-api-adaptor/test/e2e/assessment_runner.go
@@ -25,6 +25,7 @@ import (
 
 const WAIT_POD_RUNNING_TIMEOUT = time.Second * 600
 const WAIT_JOB_RUNNING_TIMEOUT = time.Second * 600
+const WAIT_PVC_RUNNING_TIMEOUT = time.Second * 30
 
 // TestCommand is a list of commands to execute inside the pod container,
 // each with a function to test if the command outputs the value the test
@@ -197,6 +198,9 @@ func (tc *TestCase) Run() {
 			if tc.pvc != nil {
 				if err = client.Resources().Create(ctx, tc.pvc); err != nil {
 					t.Fatal(err)
+				}
+				if err = WaitForPVCBound(client, tc.pvc, WAIT_PVC_RUNNING_TIMEOUT); err != nil {
+					t.Log(err)
 				}
 			}
 

--- a/src/cloud-api-adaptor/test/e2e/common_suite.go
+++ b/src/cloud-api-adaptor/test/e2e/common_suite.go
@@ -95,7 +95,7 @@ func DoTestCreatePodWithSecret(t *testing.T, e env.Environment, assert CloudAsse
 	password := "password"
 	passwordPath := podKubeSecretsDir + passwordFileName
 	secretData := map[string][]byte{passwordFileName: []byte(password), usernameFileName: []byte(username)}
-	pod := NewPod(E2eNamespace, podName, containerName, imageName, WithSecretBinding(podKubeSecretsDir, secretName), WithCommand([]string{"/bin/sh", "-c", "sleep 3600"}))
+	pod := NewPod(E2eNamespace, podName, containerName, imageName, WithSecretBinding(t, podKubeSecretsDir, secretName, containerName), WithCommand([]string{"/bin/sh", "-c", "sleep 3600"}))
 	secret := NewSecret(E2eNamespace, secretName, secretData, v1.SecretTypeOpaque)
 
 	testCommands := []TestCommand{
@@ -458,7 +458,7 @@ func DoTestPodsMTLSCommunication(t *testing.T, e env.Environment, assert CloudAs
 	clientSecret := NewSecret(E2eNamespace, clientSecretName, clientSecretData, v1.SecretTypeOpaque)
 	clientPod := NewExtraPod(
 		E2eNamespace, clientPodName, clientContainerName, clientImageName,
-		WithSecretBinding(clientSecretDir, clientSecretName),
+		WithSecretBinding(t, clientSecretDir, clientSecretName, clientContainerName),
 		WithRestartPolicy(v1.RestartPolicyNever),
 		WithCommand([]string{"/bin/sh", "-c", "sleep 3600"}),
 	)
@@ -496,7 +496,7 @@ func DoTestPodsMTLSCommunication(t *testing.T, e env.Environment, assert CloudAs
 	labels := map[string]string{
 		"app": "mtls-server",
 	}
-	serverPod := NewPod(E2eNamespace, serverPodName, serverContainerName, serverImageName, WithSecureContainerPort(443), WithSecretBinding(serverSecretDir, serverSecretName), WithLabel(labels), WithConfigMapBinding(podKubeConfigmapDir, configMapName))
+	serverPod := NewPod(E2eNamespace, serverPodName, serverContainerName, serverImageName, WithSecureContainerPort(443), WithSecretBinding(t, serverSecretDir, serverSecretName, serverContainerName), WithLabel(labels), WithConfigMapBinding(podKubeConfigmapDir, configMapName))
 	configMap := NewConfigMap(E2eNamespace, configMapName, configMapData)
 
 	serviceUrl := fmt.Sprintf("https://%s", serviceName)

--- a/src/cloud-api-adaptor/test/e2e/ibmcloud_test.go
+++ b/src/cloud-api-adaptor/test/e2e/ibmcloud_test.go
@@ -138,8 +138,8 @@ func TestCreatePeerPodWithPVC(t *testing.T) {
 		csiContainerName := "ibm-vpc-block-podvm-node-driver"
 		csiImageName := "gcr.io/k8s-staging-cloud-provider-ibm/ibm-vpc-block-csi-driver:v5.2.0"
 
-		myPVC := NewPVC(nameSpace, pvcName, storageClassName, storageSize, corev1.ReadWriteOnce)
-		myPodwithPVC := NewPodWithPVCFromIBMVPCBlockDriver(nameSpace, podName, containerName, imageName, csiContainerName, csiImageName, WithPVCBinding(mountPath, pvcName))
+		myPVC := NewPVC(nameSpace, pvcName, storageSize, corev1.ReadWriteOnce, WithStorageClass(storageClassName))
+		myPodwithPVC := NewPodWithPVCFromIBMVPCBlockDriver(nameSpace, podName, containerName, imageName, csiContainerName, csiImageName, WithPVCBinding(t, mountPath, pvcName, containerName))
 		DoTestCreatePeerPodWithPVCAndCSIWrapper(t, testEnv, assert, myPVC, myPodwithPVC, mountPath)
 	} else {
 		t.Skip("Ignore PeerPod with PVC (CSI wrapper) test")


### PR DESCRIPTION
Enhanced `WithSecretBinding` and `WithPVCBinding` to handle multi-container scenario.

Enhanced `NewPVC` to handle different type of volumes by using PVCOptions. 

Introduced a delay function while creating PVC, as it takes few seconds to bound to Persistent Volume. Without this delay we get a warning in PodEvents as the PVC will not be ready before the pod creation. Which causes the testcases to fail because of a transient warning.