### PR TITLE
test/e2e: fix undefined types.ContainerListOptions error in docker_common.go

### DIFF
--- a/.github/workflows/e2e_docker.yaml
+++ b/.github/workflows/e2e_docker.yaml
@@ -109,6 +109,7 @@ jobs:
           DOCKER_HOST="unix:///var/run/docker.sock"
           DOCKER_NETWORK_NAME="kind"
           CONTAINER_RUNTIME="${{ inputs.container_runtime }}"
+          DOCKER_API_VERSION="1.44"
           EOF
           # For debugging
           cat docker.properties

--- a/src/cloud-api-adaptor/test/e2e/docker_common.go
+++ b/src/cloud-api-adaptor/test/e2e/docker_common.go
@@ -26,7 +26,7 @@ func (c DockerAssert) DefaultTimeout() time.Duration {
 }
 
 func (l DockerAssert) HasPodVM(t *testing.T, id string) {
-	conn, err := client.NewClientWithOpts(client.FromEnv)
+	conn, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/cloud-api-adaptor/test/provisioner/docker/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/docker/provision_common.go
@@ -75,8 +75,11 @@ func NewDockerProvisioner(properties map[string]string) (pv.CloudProvisioner, er
 
 	// set environment variables
 	os.Setenv("DOCKER_HOST", DockerProps.DockerHost)
+	if DockerProps.ApiVer != "" {
+		os.Setenv("DOCKER_API_VERSION", DockerProps.ApiVer)
+	}
 
-	conn, err := client.NewClientWithOpts(client.FromEnv)
+	conn, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		log.Errorf("Error creating the Docker client: %v", err)
 		return nil, err

--- a/src/cloud-api-adaptor/test/provisioner/docker/provision_docker.properties
+++ b/src/cloud-api-adaptor/test/provisioner/docker/provision_docker.properties
@@ -3,6 +3,7 @@ CLUSTER_NAME="peer-pods"
 DOCKER_HOST="unix:///var/run/docker.sock"
 DOCKER_PODVM_IMAGE="quay.io/confidential-containers/podvm-docker-image"
 DOCKER_NETWORK_NAME="kind"
+DOCKER_API_VERSION="1.44"
 CAA_IMAGE=""
 CAA_IMAGE_TAG=""
 

--- a/src/cloud-providers/docker/manager.go
+++ b/src/cloud-providers/docker/manager.go
@@ -33,7 +33,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 
 func (m *Manager) LoadEnv() {
 	provider.DefaultToEnv(&dockerCfg.DockerHost, "DOCKER_HOST", "unix:///var/run/docker.sock")
-	provider.DefaultToEnv(&dockerCfg.DockerAPIVersion, "DOCKER_API_VERSION", "1.40")
+	provider.DefaultToEnv(&dockerCfg.DockerAPIVersion, "DOCKER_API_VERSION", "1.44")
 	provider.DefaultToEnv(&dockerCfg.DockerCertPath, "DOCKER_CERT_PATH", "")
 	dockerTLSVerify := os.Getenv("DOCKER_TLS_VERIFY")
 	if dockerTLSVerify == "1" || dockerTLSVerify == "true" {

--- a/src/cloud-providers/docker/provider.go
+++ b/src/cloud-providers/docker/provider.go
@@ -32,10 +32,20 @@ func NewProvider(config *Config) (*dockerProvider, error) {
 
 	logger.Printf("docker config: %#v", config)
 
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion(config.DockerAPIVersion))
 	if err != nil {
 		return nil, err
 	}
+
+	// Log Docker client and server versions for debugging
+	ctx := context.Background()
+	serverVersion, err := cli.ServerVersion(ctx)
+	if err != nil {
+		logger.Printf("Warning: failed to get Docker server version: %v", err)
+	} else {
+		logger.Printf("Docker server version: %s, API version: %s", serverVersion.Version, serverVersion.APIVersion)
+	}
+	logger.Printf("Docker client API version: %s", cli.ClientVersion())
 
 	// Create the data directory if it doesn't exist
 	err = os.MkdirAll(config.DataDir, 0755)


### PR DESCRIPTION
The error was introduced by commit a2443986 which updated Docker Go SDK from v25.0.6 to v28.3.3 to remediate CVE-2025-54410. In Docker Go SDK v28, types.ContainerListOptions was moved from github.com/docker/docker/api/types to github.com/docker/docker/api/types/container
and renamed to container.ListOptions.

Assisted-by: Cursor

---

The nightly e2e tests for docker as failed due that problem since https://github.com/confidential-containers/cloud-api-adaptor/actions/runs/17117056929 . We never noticed because the workflow has `continue-on-error` enabled. It's continue-on-error since when the workflow was introduced last week, at that time I wanted to have it stable before fully enabling. Ok, I looked at the 5 jobs before that fail and all passed, so maybe we can consider the workflow stable and remove the continue-on-error flag?

A: I added commit ea497e892b8421c76532d7aec23d4b73bd180e9e to remove the `continue-on-error`

---

Cherry-picked 60b561a3973500b2091687d3122417da6950f6d9 from https://github.com/confidential-containers/cloud-api-adaptor/pull/2540