### PR TITLE
cloud-providers: fix AWS and docker unit tests

### DIFF
--- a/src/cloud-providers/aws/provider_test.go
+++ b/src/cloud-providers/aws/provider_test.go
@@ -167,7 +167,21 @@ func (m mockEC2Client) DescribeAddresses(ctx context.Context,
 	params *ec2.DescribeAddressesInput,
 	optFns ...func(*ec2.Options)) (*ec2.DescribeAddressesOutput, error) {
 
-	return nil, nil
+	// Return a mock Elastic IP address
+	mockAssociationId := "eipassoc-12345678"
+	mockAllocationId := "eipalloc-12345678"
+	mockPublicIp := "192.168.100.1"
+
+	return &ec2.DescribeAddressesOutput{
+		Addresses: []types.Address{
+			{
+				AssociationId: &mockAssociationId,
+				AllocationId:  &mockAllocationId,
+				PublicIp:      &mockPublicIp,
+				InstanceId:    aws.String("i-1234567890abcdef0"),
+			},
+		},
+	}, nil
 }
 
 // Create a mock for EC2 DisassociateAddress method

--- a/src/cloud-providers/docker/provider.go
+++ b/src/cloud-providers/docker/provider.go
@@ -20,7 +20,7 @@ import (
 var logger = log.New(log.Writer(), "[adaptor/cloud/docker] ", log.LstdFlags|log.Lmsgprefix)
 
 type dockerProvider struct {
-	Client           *client.Client
+	Client           dockerClient
 	DataDir          string
 	PodVMDockerImage string
 	NetworkName      string

--- a/src/cloud-providers/docker/provider_test.go
+++ b/src/cloud-providers/docker/provider_test.go
@@ -85,8 +85,10 @@ func Test_dockerProvider_CreateInstance(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
 			p := &dockerProvider{
-				Client: tt.fields.Client,
+				Client:  tt.fields.Client,
+				DataDir: tempDir,
 			}
 			got, err := p.CreateInstance(tt.args.ctx, tt.args.podName, tt.args.sandboxID, cloudConfig, tt.args.spec)
 			if (err != nil) != tt.wantErr {

--- a/src/cloud-providers/go.mod
+++ b/src/cloud-providers/go.mod
@@ -126,7 +126,7 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/onsi/ginkgo/v2 v2.8.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.0 // indirect
+	github.com/opencontainers/image-spec v1.1.0
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect


### PR DESCRIPTION
Fixed the following unit tests errors:

```
2025-08-25T14:50:32.7895498Z === RUN   TestDeleteInstance/DeleteInstance
2025-08-25T14:50:32.7896042Z --- FAIL: TestDeleteInstance (0.00s)
2025-08-25T14:50:32.7896704Z     --- FAIL: TestDeleteInstance/DeleteInstance (0.00s)
2025-08-25T14:50:32.7897523Z panic: runtime error: invalid memory address or nil pointer dereference [recovered]
2025-08-25T14:50:32.7898472Z 	panic: runtime error: invalid memory address or nil pointer dereference
2025-08-25T14:50:32.7905250Z [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x326ccb6]
```

```
2025-08-25T14:50:33.1288007Z --- FAIL: Test_dockerProvider_CreateInstance (0.00s)
2025-08-25T14:50:33.1290716Z     --- FAIL: Test_dockerProvider_CreateInstance/Test_CreateInstance (0.00s)
```