### PR TITLE
e2e: disable tdx e2e tests on azure temporarily

### DIFF
--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -82,9 +82,9 @@ jobs:
     strategy:
       matrix:
         parameters:
-          - id: "tdx"
-            machine_type: "Standard_DC2es_v5"
-            jitter: 0
+          # - id: "tdx"
+          #   machine_type: "Standard_DC2es_v5"
+          #   jitter: 0
           - id: "snp"
             machine_type: "Standard_DC2as_v5"
             jitter: 10


### PR DESCRIPTION
The public preview of TDX v5 instance sizes is ending this week, to be superseded with a public preview of TDX v6. Since the new instance types will be different in some regards (OpenHCL, NVMe, limited region availability initally) we need to perform the necessary adjustments. In the meantime, to avoid a broken CI, the TDX tests are disabled.