### PR TITLE
e2e: disable remaining tdx e2e jobs in az e2e test

### DIFF
--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -172,8 +172,8 @@ jobs:
     strategy:
       matrix:
         parameters:
-          - id: "tdx"
-            machine_type: "Standard_DC2es_v5"
+          # - id: "tdx"
+          #   machine_type: "Standard_DC2es_v5"
           - id: "snp"
             machine_type: "Standard_DC2as_v5"
     permissions:
@@ -262,9 +262,9 @@ jobs:
     strategy:
       matrix:
         parameters:
-          - id: "tdx"
-            machine_type: "Standard_DC2es_v5"
-            jitter: 0
+          # - id: "tdx"
+          #   machine_type: "Standard_DC2es_v5"
+          #   jitter: 0
           - id: "snp"
             machine_type: "Standard_DC2as_v5"
             jitter: 10


### PR DESCRIPTION
unfortunately the changes in d1e1916 were not sufficient to disable the tdx branch, I assumed they were chained by dependencies but apparently that's not the case.