### PR TITLE
ci(zizmor):adding GHA scan targets for PR events

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,33 @@
+name: GitHub Actions Security Analysis with 🌈zizmor
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+  schedule:
+  - cron: "0 3 * * 1" # Every Monday Weekly
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-22.04
+    permissions:
+      security-events: write # Require writing security events to upload results to security tab
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        persist-credentials: false
+        fetch-depth: 0
+
+    - name: Run zizmor
+      uses: zizmorcore/zizmor-action@5ca5fc7a4779c5263a3ffa0e1f693009994446d1 # v0.1.2
+      with:
+        persona: auditor


### PR DESCRIPTION
Partially resolve: https://github.com/confidential-containers/cloud-api-adaptor/issues/2485

Run zizmor scan as part of github actions ci, to find security issues with the code and create issues based on the results of the scan.
Signed-off-by: Eshant Gupta <eshant.gupta3@ibm.com>

