### PR TITLE
test/e2e: Increase memory limit

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/libvirt_test.go
+++ b/src/cloud-api-adaptor/test/e2e/libvirt_test.go
@@ -252,7 +252,7 @@ func TestLibvirtCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t *t
 
 func TestLibvirtCreateWithCpuAndMemRequestLimit(t *testing.T) {
 	assert := LibvirtAssert{}
-	DoTestPodWithCpuMemLimitsAndRequests(t, testEnv, assert, "100m", "100Mi", "200m", "1200Mi")
+	DoTestPodWithCpuMemLimitsAndRequests(t, testEnv, assert, "100m", "100Mi", "200m", "1792Mi")
 }
 
 func TestLibvirtPodVMwithAnnotationsCPUMemory(t *testing.T) {


### PR DESCRIPTION
In our nightly runs, we quite often see failure in the `TestLibvirtCreateWithCpuAndMemRequestLimit`
test, where the containers doesn't seem to start.
Given that it has a much more restricted memory
than all the other pods, try increasing the limit to see if this helps with stability.