### PR TITLE
podvm: place scratch-space condition correctly

### DIFF
--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/scratch-storage.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/scratch-storage.service
@@ -4,11 +4,11 @@ After=systemd-repart.service process-user-data.service
 # It must complete before the kata-agent starts
 Before=kata-agent.service
 DefaultDependencies=no
+ConditionPathExists=/run/peerpod/scratch-space.marker
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ConditionPathExists=/run/peerpod/scratch-space.marker
 ExecStart=/usr/local/bin/setup-scratch-storage
 
 [Install]


### PR DESCRIPTION
fixes #2516

The scratch-storage unit was always enabled, as the ConditionPathExists= clause was not put in the `[Unit]` hierarchy. Hence large images couldn't be pulled: A very small dmcrypt partition was created (~200M) and mounted as backing storage for the pod sandbox.