### PR TITLE
ci: update terraform spec for nvme images on azure

### DIFF
--- a/src/cloud-api-adaptor/ci-infra/azure/main.tf
+++ b/src/cloud-api-adaptor/ci-infra/azure/main.tf
@@ -92,6 +92,7 @@ resource "azurerm_shared_image" "podvm_image" {
     offer     = "coco-caa"
     sku       = "coco-caa"
   }
-  hyper_v_generation        = "V2"
-  confidential_vm_supported = true
+  hyper_v_generation                = "V2"
+  confidential_vm_supported         = true
+  disk_controller_type_nvme_enabled = true
 }

--- a/src/cloud-api-adaptor/ci-infra/azure/providers.tf
+++ b/src/cloud-api-adaptor/ci-infra/azure/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.70"
+      version = "=4.45.0"
     }
   }
 


### PR DESCRIPTION
This is one of the required tasks to support the v6 TDX instance sizes on Azure. v6 images are require the `DiskControllerType` to be `NVMe`. This support is currently behind a feature flag for azure image galleries:

- https://learn.microsoft.com/en-us/azure/virtual-machines/nvme-overview#scsi-to-nvme

- https://learn.microsoft.com/en-us/azure/virtual-machines/enable-nvme-remote-faqs
