### PR TITLE
ci: add azure workflow + infra for podvm release

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -6,6 +6,20 @@ on:
       image-version:
         type: string
         required: true
+      image-variant:
+        type: string
+        default: production
+      image-gallery:
+        type: string
+      image-definition:
+        type: string
+      community-gallery-name:
+        type: string
+      resource-group:
+        type: string
+      git-ref:
+        type: string
+        default: 'main'
     secrets:
       AZURE_CLIENT_ID:
         required: true
@@ -23,20 +37,17 @@ on:
       image-version:
         type: string
         description: x.y.z
+        required: true
+      image-variant:
+        type: string
+        default: production
+        description: image variant
       git-ref:
         type: string
         default: 'main'
         description: tag, branch, sha
 
 permissions: {}
-
-env:
-  AZURE_PODVM_IMAGE_DEF_NAME: "${{ vars.AZURE_PODVM_IMAGE_DEF_NAME }}"
-  AZURE_PODVM_IMAGE_VERSION: "${{ inputs.image-version }}"
-  PODVM_IMAGE_NAME: "peerpod-image-${{ github.run_id }}-${{ github.run_attempt }}"
-  UPLOSI_VERSION: "0.3.0"
-  UPLOSI_SHA256: "687bcab7398ab0fda65a3809492e8cd4d6a25aad1573927be5ec75ac1c4cbc35"
-  IMAGE_ID: "/CommunityGalleries/${{ vars.AZURE_COMMUNITY_GALLERY_NAME }}/Images/${{ vars.AZURE_PODVM_IMAGE_DEF_NAME }}/Versions/${{ inputs.image-version }}"
 
 jobs:
   build-podvm-image:
@@ -56,7 +67,7 @@ jobs:
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         path: cloud-api-adaptor
-        ref: "${{ inputs.git-ref || 'main' }}"
+        ref: ${{ inputs.git-ref }}
 
     - name: Install build dependencies
       run: |
@@ -69,6 +80,9 @@ jobs:
         echo "MKOSI_VERSION=$(yq -e '.tools.mkosi' ../versions.yaml)" >> "$GITHUB_ENV"
 
     - name: Install uplosi
+      env:
+        UPLOSI_VERSION: "0.3.0"
+        UPLOSI_SHA256: "687bcab7398ab0fda65a3809492e8cd4d6a25aad1573927be5ec75ac1c4cbc35"
       run: |
         wget -q "https://github.com/edgelesssys/uplosi/releases/download/v${UPLOSI_VERSION}/uplosi_${UPLOSI_VERSION}_linux_amd64.tar.gz"
         sha256sum -c <(echo "$UPLOSI_SHA256"  "uplosi_${UPLOSI_VERSION}_linux_amd64.tar.gz")
@@ -83,7 +97,12 @@ jobs:
         make binaries
 
     - name: Build image
+      if: inputs.image-variant == 'production'
       run: make image
+
+    - name: Build debug image
+      if: inputs.image-variant != 'production'
+      run: make image-debug
 
     - uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
       name: 'Az CLI login'
@@ -94,19 +113,27 @@ jobs:
 
     - name: upload image
       id: upload-image
+      env:
+        SUBSCRIPTION_ID: "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
+        IMAGE_VERSION: "${{ inputs.image-version }}"
+        RESOURCE_GROUP: "${{ inputs.resource-group || vars.AZURE_RESOURCE_GROUP }}"
+        IMAGE_GALLERY: "${{ inputs.image-gallery || vars.AZURE_PODVM_GALLERY_NAME }}"
+        IMAGE_DEFINITION: "${{ inputs.image-definition || vars.AZURE_PODVM_IMAGE_DEF_NAME }}"
+        COMMUNITY_GALLERY_NAME: "${{ inputs.community-gallery-name || vars.AZURE_COMMUNITY_GALLERY_NAME }}"
       run: |
-        SHARING_NAME_PREFIX="$(echo ${{ vars.AZURE_COMMUNITY_GALLERY_NAME }} | cut -d'-' -f1)"
+        IMAGE_ID="/CommunityGalleries/${IMAGE_GALLERY}/Images/${IMAGE_DEFINITION}/Versions/${IMAGE_VERSION}"
+        SHARING_NAME_PREFIX="$(echo "$COMMUNITY_GALLERY_NAME" | cut -d'-' -f1)"
         cat <<EOF> uplosi.conf
         [base]
-        imageVersion = "$AZURE_PODVM_IMAGE_VERSION"
-        name = "$AZURE_PODVM_IMAGE_DEF_NAME"
+        imageVersion = "$IMAGE_VERSION"
+        name         = "$IMAGE_DEFINITION"
 
         [base.azure]
-        subscriptionID = "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
-        location = "eastus"
-        resourceGroup = "${{ vars.AZURE_RESOURCE_GROUP }}"
-        sharedImageGallery = "${{ vars.AZURE_PODVM_GALLERY_NAME }}"
-        sharingNamePrefix = "$SHARING_NAME_PREFIX"
+        subscriptionID     = "$SUBSCRIPTION_ID"
+        location           = "eastus"
+        resourceGroup      = "$RESOURCE_GROUP"
+        sharedImageGallery = "$IMAGE_GALLERY"
+        sharingNamePrefix  = "$SHARING_NAME_PREFIX"
 
         [variant.default]
         provider = "azure"
@@ -144,6 +171,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Publish measurements
+      if: inputs.image-variant == 'production'
       id: publish-measurements
       env:
         OCI_NAME: ghcr.io/${{ github.repository }}/measurements/azure/podvm
@@ -155,6 +183,7 @@ jobs:
         echo "oci-digest=${OCI_DIGEST}" >> "$GITHUB_OUTPUT"
 
     - uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+      if: inputs.image-variant == 'production'
       with:
         subject-name: ${{ steps.publish-measurements.outputs.oci-name }}
         subject-digest: ${{ steps.publish-measurements.outputs.oci-digest }}

--- a/.github/workflows/azure-podvm-release.yml
+++ b/.github/workflows/azure-podvm-release.yml
@@ -1,0 +1,36 @@
+name: azure-podvm-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: x.y.z
+
+permissions: {}
+
+jobs:
+  build-podvm-image:
+    strategy:
+      matrix:
+        parameters:
+        - variant: production
+        - variant: debug
+    uses: ./.github/workflows/azure-podvm-image-build.yml
+    permissions:
+      id-token: write      # for OIDC to Azure
+      contents: read       # to fetch the code
+      packages: write      # to push measurements to OCI
+      attestations: write  # to create the attestation
+    with:
+      git-ref: "v${{ github.event.inputs.version }}"
+      image-version: ${{ github.event.inputs.version }}
+      image-variant: ${{ matrix.parameters.variant }}
+      image-gallery: ${{ vars.AZURE_RELEASE_PODVM_GALLERY_NAME }}
+      image-definition: ${{ matrix.parameters.variant == 'production' && vars.AZURE_RELEASE_PODVM_IMAGE_DEF_NAME || vars.AZURE_RELEASE_PODVM_IMAGE_DEF_NAME_DEBUG }}
+      community-gallery-name: ${{ vars.AZURE_RELEASE_COMMUNITY_GALLERY_NAME }}
+      resource-group: ${{ vars.AZURE_RELEASE_RESOURCE_GROUP }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/src/cloud-api-adaptor/ci-infra/azure/release.tf
+++ b/src/cloud-api-adaptor/ci-infra/azure/release.tf
@@ -1,0 +1,89 @@
+# These resources manage the image gallery that holds the PodVM release images.
+
+resource "azurerm_resource_group" "release_rg" {
+  name     = var.release_rg
+  location = var.location
+}
+
+resource "azurerm_shared_image_gallery" "release_podvm_image_gallery" {
+  name                = var.release_image_gallery
+  resource_group_name = azurerm_resource_group.release_rg.name
+  location            = azurerm_resource_group.release_rg.location
+
+  sharing {
+    permission = "Community"
+    community_gallery {
+      prefix          = "cococommunity"
+      eula            = "https://raw.githubusercontent.com/confidential-containers/confidential-containers/main/LICENSE"
+      publisher_uri   = "https://github.com/confidential-containers/confidential-containers"
+      publisher_email = "magnuskulke@microsoft.com"
+    }
+  }
+}
+
+resource "azurerm_shared_image" "release_podvm_image" {
+  name                = var.release_image_definition
+  gallery_name        = resource.azurerm_shared_image_gallery.release_podvm_image_gallery.name
+  resource_group_name = azurerm_resource_group.release_rg.name
+  location            = azurerm_resource_group.release_rg.location
+  os_type             = "Linux"
+  identifier {
+    publisher = "coco-caa"
+    offer     = "coco-caa"
+    sku       = "coco-caa"
+  }
+  hyper_v_generation        = "V2"
+  confidential_vm_supported = true
+}
+
+resource "azurerm_shared_image" "release_podvm_image_debug" {
+  name                = var.release_image_definition_debug
+  gallery_name        = resource.azurerm_shared_image_gallery.release_podvm_image_gallery.name
+  resource_group_name = azurerm_resource_group.release_rg.name
+  location            = azurerm_resource_group.release_rg.location
+  os_type             = "Linux"
+  identifier {
+    publisher = "coco-caa"
+    offer     = "coco-caa"
+    sku       = "coco-caa-debug"
+  }
+  hyper_v_generation        = "V2"
+  confidential_vm_supported = true
+}
+
+resource "azurerm_role_assignment" "release_gallery_publisher_role_binding" {
+  scope                = azurerm_shared_image_gallery.release_podvm_image_gallery.id
+  role_definition_name = "Compute Gallery Artifacts Publisher"
+  principal_id         = azurerm_user_assigned_identity.gh_action_user_identity.principal_id
+}
+
+resource "random_uuid" "release_disk_role_id" {}
+
+# uplosi requires those, apart from the gallery publisher role
+resource "azurerm_role_definition" "release_disk_role" {
+  name               = "read/write/delete disks"
+  role_definition_id = random_uuid.release_disk_role_id.result
+
+  scope       = data.azurerm_subscription.current.id
+  description = "Allow read/write/delete on Microsoft.Compute/disks"
+
+  permissions {
+    actions = [
+      "Microsoft.Compute/disks/read",
+      "Microsoft.Compute/disks/write",
+      "Microsoft.Compute/disks/delete",
+      "Microsoft.Compute/disks/beginGetAccess/action",
+      "Microsoft.Compute/disks/endGetAccess/action",
+      "Microsoft.Compute/images/read",
+      "Microsoft.Compute/images/write",
+      "Microsoft.Compute/images/delete",
+    ]
+    not_actions = []
+  }
+}
+
+resource "azurerm_role_assignment" "release_disk_role_binding" {
+  scope              = azurerm_resource_group.release_rg.id
+  role_definition_id = azurerm_role_definition.release_disk_role.role_definition_resource_id
+  principal_id       = azurerm_user_assigned_identity.gh_action_user_identity.principal_id
+}

--- a/src/cloud-api-adaptor/ci-infra/azure/variables.tf
+++ b/src/cloud-api-adaptor/ci-infra/azure/variables.tf
@@ -55,3 +55,27 @@ variable "gh_repo" {
   description = "GitHub repository that has permissions to run workloads on Azure. The value should be in the format `orgName/repoName`"
   default     = "confidential-containers/cloud-api-adaptor"
 }
+
+variable "release_rg" {
+  type        = string
+  default     = "coco-images"
+  description = "Resource group for release podvm images"
+}
+
+variable "release_image_gallery" {
+  type        = string
+  description = "Image gallery for release podvm images"
+  default     = "cocoimages"
+}
+
+variable "release_image_definition" {
+  type        = string
+  description = "Image definition for release podvm images"
+  default     = "peerpod-podvm-fedora"
+}
+
+variable "release_image_definition_debug" {
+  type        = string
+  description = "Image definition for release podvm images"
+  default     = "peerpod-podvm-fedora-debug"
+}


### PR DESCRIPTION
PodVM release images should be built on the CI using a workflow. This is preferable over manual steps, but also useful since we have provenance attestation for the measurements. The measurements can only be verified to be valid if we generate them on the CI.

The required terraform infra has been added, which allows github actions to write to the image gallery that holds release images.

A azure-podvm-release.yml workflow has been added that overrides a couple of defaults in the azure-podvm-build.yml workflow.

drive-by-fix: the podvm build workflow has been adjusted to expand input/secret/vars fields in a step's env block (to avoid injections problems).

(the workflow has been tested in a fork [here](https://github.com/mkulke/cloud-api-adaptor/actions/runs/17946385520))