### PR TITLE
e2e-test: verify reference values

### DIFF
--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -259,8 +259,41 @@ jobs:
         AZURE_SUBNET_ID="$subnet_id"
         EOF
 
-    - name: Checkout KBS Repository
+    - name: Configure KBS
       run: test/utils/checkout_kbs.sh
+
+    - name: Populate RVPS reference-values.json
+      env:
+        OCI_NAME: "ghcr.io/${{ github.repository }}/measurements/azure/podvm"
+        AZURE_IMAGE_ID: "${{ inputs.podvm-image-id }}"
+        TEE_KEY: "az${{ matrix.parameters.id }}vtpm"
+        GH_REPO: "${{ github.repository }}"
+        GIT_SHA: "${{ github.sha }}"
+        GH_TOKEN: "${{ github.token }}"
+      run: |
+        # resolve the measurement tag to digest, assert proper provenance, pull measurements.json
+        image_version="$(basename "$AZURE_IMAGE_ID")"
+        oci_digest="$(oras resolve "${OCI_NAME}:${image_version}")"
+        oci_registry="${OCI_NAME}@${oci_digest}"
+        gh attestation verify -R "$GH_REPO" "oci://${oci_registry}" --source-digest "$GIT_SHA"
+        oras pull "$oci_registry"
+
+        # convert measurements.json to reference-values.json
+        expiry="$(date -u -d '+1 year' '+%Y-%m-%dT%H:%M:%SZ')"
+        jq --arg tee_key "$TEE_KEY" --arg expiry "$expiry" '
+          .measurements.sha256
+          | to_entries
+          | map({
+              name: ($tee_key + ".tpm." + .key),
+              expired: $expiry,
+              "hash-value": [
+                {
+                  alg: "sha256",
+                  value: (.value | ltrimstr("0x") | ascii_downcase)
+                }
+              ]
+            })
+        ' measurements.json > ./test/trustee/kbs/config/kubernetes/base/reference-values.json
 
     - name: Run e2e test
       id: runTests

--- a/src/cloud-api-adaptor/test/utils/checkout_kbs.sh
+++ b/src/cloud-api-adaptor/test/utils/checkout_kbs.sh
@@ -31,8 +31,15 @@ TOML_FILE="kbs/config/kubernetes/base/kbs-config.toml"
 
 sed -i '/insecure_http = true/c\
 insecure_api = true \
-private_key = "/etc/kbs2/https-key.pem" \
-certificate = "/etc/kbs1/https-cert.pem"' "$TOML_FILE"
+private_key = "/etc/https/key.pem" \
+certificate = "/etc/https/cert.pem"' "$TOML_FILE"
+
+# Append section for LocalJson reference values
+cat <<EOF >> "$TOML_FILE"
+[attestation_service.rvps_config.storage]
+type = "LocalJson"
+file_path = "/etc/rvps/reference-values.json"
+EOF
 
 cat "$TOML_FILE"
 
@@ -42,6 +49,9 @@ pushd kbs/config/kubernetes/base/
 
 touch https-key.pem
 touch https-cert.pem
+
+# Create empty reference values file
+echo -n "[]" > reference-values.json
 
 cat <<EOF > kbs-patch.yaml
 apiVersion: apps/v1
@@ -54,24 +64,38 @@ spec:
       containers:
       - name: kbs
         volumeMounts:
-        - name: kbs-https-certificate
-          mountPath: /etc/kbs1
-        - name: kbs-https-key
-          mountPath: /etc/kbs2
+        - name: https-cert
+          mountPath: /etc/https/cert.pem
+          subPath: https-cert.pem
+        - name: https-key
+          mountPath: /etc/https/key.pem
+          subPath: https-key.pem
+        - name: reference-values
+          mountPath: /etc/rvps
+          readOnly: true
       volumes:
-      - name: kbs-https-certificate
+      - name: https-cert
         secret:
-          secretName: kbs-https-certificate
-      - name: kbs-https-key
+          secretName: https-cert
+      - name: https-key
         secret:
-          secretName: kbs-https-key
+          secretName: https-key
+      - name: reference-values
+        configMap:
+          name: reference-values
+          items:
+          - key: reference-values.json
+            path: reference-values.json
 EOF
 ls
 # Trustee only updates their staging image reliably with sha tags,
 # so switch to use that and convert the version to the sha
 kustomize edit add patch --path kbs-patch.yaml
-kustomize edit add secret kbs-https-key --from-file=https-key.pem
-kustomize edit add secret kbs-https-certificate --from-file=https-cert.pem
+
+kustomize edit add secret    https-key        --from-file=https-key.pem
+kustomize edit add secret    https-cert       --from-file=https-cert.pem
+kustomize edit add configmap reference-values --from-file=reference-values.json
+
 kustomize edit set image kbs-container-image=ghcr.io/confidential-containers/staged-images/kbs:"${KBS_SHA}"
 # For debugging
 echo "Trustee deployment: $(cat kustomization.yaml). Images: $(grep -A 5 images: kustomization.yaml)"


### PR DESCRIPTION
This is in preperation of a verification of reference values that we can populate with signed measurements in OCI.

The kbs config is altered to support the LocalJSON ref store and we attach a reference-values.json file to the kustomize patch so the file is mounted into the kbs pod.

By default, there is a dummy reference-values.json. This can be overridden in a TEE's e2e test if we have reference values available. Trustee should then automatically verify the values in a test that uses remote attestation and consider this in the claim.

[Here](https://github.com/confidential-containers/cloud-api-adaptor/actions/runs/17982869769/job/51163328138?pr=2585) would be an azure e2e-test run that is setting reference values from OCI.