### PR TITLE
workflows: e2e_docker: Clean up space

### DIFF
--- a/.github/workflows/e2e_docker.yaml
+++ b/.github/workflows/e2e_docker.yaml
@@ -60,6 +60,11 @@ jobs:
         run: |
           ./hack/ci-helper.sh rebase-atop-of-the-latest-target-branch
 
+      - name: Remove unnecessary directories to free up space
+        working-directory: ./
+        run: |
+          sudo ./hack/ci-helper.sh clean-up-runner
+
       - name: Login to quay Container Registry
         if: ${{ startsWith(inputs.podvm_image, 'quay.io') }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0

--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -77,23 +77,9 @@ jobs:
           ./hack/ci-helper.sh rebase-atop-of-the-latest-target-branch
 
       - name: Remove unnecessary directories to free up space
+        working-directory: ./
         run: |
-          sudo rm -rf /usr/local/.ghcup
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          sudo rm -rf /usr/lib/jvm
-          sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/local/share/powershell
-          sudo rm -rf /usr/local/julia*
-          sudo rm -rf /opt/az
-          sudo rm -rf /usr/local/share/chromium
-          sudo rm -rf /opt/microsoft
-          sudo rm -rf /opt/google
-          sudo rm -rf /usr/lib/firefox
+          sudo ./hack/ci-helper.sh clean-up-runner
 
       - name: Read properties from versions.yaml
         run: |

--- a/hack/ci-helper.sh
+++ b/hack/ci-helper.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # Copyright (c) 2023 Intel Corporation
+# Copyright (c) 2025 IBM Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -38,15 +39,37 @@ function rebase_atop_of_the_latest_target_branch() {
 	fi
 }
 
+# Remove unnecessary directories on the github runner to relieve disk space issues
+function clean_up_runner() {
+	rm -rf /usr/local/.ghcup
+	rm -rf /opt/hostedtoolcache/CodeQL
+	rm -rf /usr/local/lib/android
+	rm -rf /usr/share/dotnet
+	rm -rf /opt/ghc
+	rm -rf /usr/local/share/boost
+	rm -rf "$AGENT_TOOLSDIRECTORY"
+	rm -rf /usr/lib/jvm
+	rm -rf /usr/share/swift
+	rm -rf /usr/local/share/powershell
+	rm -rf /usr/local/julia*
+	rm -rf /opt/az
+	rm -rf /usr/local/share/chromium
+	rm -rf /opt/microsoft
+	rm -rf /opt/google
+	rm -rf /usr/lib/firefox
+}
+
+
 function main() {
-    action="${1:-}"
+	action="${1:-}"
 
 	 add_git_config_info
 
-    case "${action}" in
-	rebase-atop-of-the-latest-target-branch) rebase_atop_of_the_latest_target_branch;;
-        *) >&2 echo "Invalid argument"; exit 2 ;;
-    esac
+	case "${action}" in
+		clean-up-runner) clean_up_runner;;
+		rebase-atop-of-the-latest-target-branch) rebase_atop_of_the_latest_target_branch;;
+		*) >&2 echo "Invalid argument"; exit 2 ;;
+	esac
 }
 
 main "$@"


### PR DESCRIPTION
The docker e2e test has been consistently failing
and Wainer spotted that sometimes there is a space issue, so port the clean up we have in the libvirt e2e tests to try it out.

To make this easier to modify in future, refactor this out of the `pull_request_target` triggered workflows