### PR TITLE
podvm(aws): add missing extra kernel module for Ubuntu 24.04

### DIFF
--- a/src/cloud-api-adaptor/podvm/qcow2/misc-settings.sh
+++ b/src/cloud-api-adaptor/podvm/qcow2/misc-settings.sh
@@ -106,4 +106,12 @@ if [[ -n "${ACTIVATION_KEY}" && -n "${ORG_ID}" ]]; then \
     subscription-manager unregister
 fi
 
+if [[ "${CLOUD_PROVIDER}" == "aws" ]]; then
+    case "${PODVM_DISTRO}" in
+        ubuntu)
+            DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes linux-modules-extra-$(uname -r)
+            ;;
+    esac
+fi
+
 exit 0


### PR DESCRIPTION
This PR installs the distro package 'linux-modules-extra-<kernel version>', which includes the sev-guest.ko module. This is required to enable SEV guest support on AWS.