### PR TITLE
e2e-test: fix azure community gallery name

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -121,7 +121,7 @@ jobs:
         IMAGE_DEFINITION: "${{ inputs.image-definition || vars.AZURE_PODVM_IMAGE_DEF_NAME }}"
         COMMUNITY_GALLERY_NAME: "${{ inputs.community-gallery-name || vars.AZURE_COMMUNITY_GALLERY_NAME }}"
       run: |
-        IMAGE_ID="/CommunityGalleries/${IMAGE_GALLERY}/Images/${IMAGE_DEFINITION}/Versions/${IMAGE_VERSION}"
+        IMAGE_ID="/CommunityGalleries/${COMMUNITY_GALLERY_NAME}/Images/${IMAGE_DEFINITION}/Versions/${IMAGE_VERSION}"
         SHARING_NAME_PREFIX="$(echo "$COMMUNITY_GALLERY_NAME" | cut -d'-' -f1)"
         cat <<EOF> uplosi.conf
         [base]


### PR DESCRIPTION
The wrong env was used when constructing the imageid, making the podvm deployments fail.