### PR TITLE
versions: Pin operator version

### DIFF
--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -39,8 +39,8 @@ tools:
 git:
   coco-operator:
     url: https://github.com/confidential-containers/operator
-    config: default
-    reference: main
+    config: release
+    reference: v0.16.0
   umoci:
     url: https://github.com/opencontainers/umoci
     reference: v0.5.0


### PR DESCRIPTION
Pin the operator version to v0.16.0 to ensure that people deploying the peer pods v0.16.0 release get a fixed and compatible version of the kata runtime deployed.