### PR TITLE
workflows: trigger AWS on 'schedule' event

### DIFF
--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -215,6 +215,7 @@ jobs:
   aws:
     name: aws
     if: |
+      github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch'
     needs: [podvm, image, prep_install]
     strategy:


### PR DESCRIPTION
To that AWS CI will be triggered on nightly (currently it's getting skipped).