### PR TITLE
ibmcloud: avoid duplication in ibmcloudVPCConfig lists

### DIFF
--- a/src/cloud-providers/ibmcloud/manager.go
+++ b/src/cloud-providers/ibmcloud/manager.go
@@ -53,18 +53,6 @@ func (_ *Manager) LoadEnv() {
 	provider.DefaultToEnv(&ibmcloudVPCConfig.PrimarySecurityGroupID, "IBMCLOUD_VPC_SG_ID", "")
 	provider.DefaultToEnv(&ibmcloudVPCConfig.KeyID, "IBMCLOUD_SSH_KEY_ID", "")
 	provider.DefaultToEnv(&ibmcloudVPCConfig.VpcID, "IBMCLOUD_VPC_ID", "")
-
-	var instanceProfilesStr string
-	provider.DefaultToEnv(&instanceProfilesStr, "IBMCLOUD_PODVM_INSTANCE_PROFILE_LIST", "")
-	if instanceProfilesStr != "" {
-		_ = ibmcloudVPCConfig.InstanceProfiles.Set(instanceProfilesStr)
-	}
-
-	var imageIDsStr string
-	provider.DefaultToEnv(&imageIDsStr, "IBMCLOUD_PODVM_IMAGE_ID", "")
-	if imageIDsStr != "" {
-		_ = ibmcloudVPCConfig.Images.Set(imageIDsStr)
-	}
 }
 
 func (_ *Manager) NewProvider() (provider.Provider, error) {


### PR DESCRIPTION
All flags are provided via environment variables in entrypoint.sh. Previously, InstanceProfiles and Images were also set in the LoadEnv() method, causing duplication due to how the Set() method handles these types. To resolve this, parsing of these fields was removed from LoadEnv(), aligning with how other providers handle comma-separated lists.