### PR TITLE
azure: automatically generate ssh keys if missing

### DIFF
--- a/src/cloud-providers/azure/manager.go
+++ b/src/cloud-providers/azure/manager.go
@@ -29,7 +29,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	flags.StringVar(&azurecfg.Size, "instance-size", "Standard_DC2as_v5", "Instance size")
 	flags.StringVar(&azurecfg.ImageId, "imageid", "", "Image Id")
 	flags.StringVar(&azurecfg.SubscriptionId, "subscriptionid", "", "Subscription ID")
-	flags.StringVar(&azurecfg.SSHKeyPath, "ssh-key-path", "$HOME/.ssh/id_rsa.pub", "Path to SSH public key")
+	flags.StringVar(&azurecfg.SSHKeyPath, "ssh-key-path", "", "Path to SSH public key")
 	flags.StringVar(&azurecfg.SSHUserName, "ssh-username", "peerpod", "SSH User Name")
 	flags.BoolVar(&azurecfg.DisableCVM, "disable-cvm", false, "Use non-CVMs for peer pods")
 	// Add a List parameter to indicate different types of instance sizes to be used for the Pod VMs

--- a/src/cloud-providers/azure/types_test.go
+++ b/src/cloud-providers/azure/types_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"golang.org/x/crypto/ssh"
 )
 
 func TestAzureMasking(t *testing.T) {
@@ -38,4 +40,20 @@ func TestAzureMasking(t *testing.T) {
 
 	checkLine("%v")
 	checkLine("%s")
+}
+
+func TestGenerateSSHKeyPair(t *testing.T) {
+	publicKeyBytes, err := generateSSHPublicKey()
+	if err != nil {
+		t.Fatalf("Failed to generate SSH key pair: %v", err)
+	}
+
+	if len(publicKeyBytes) == 0 {
+		t.Error("Generated public key bytes are empty")
+	}
+
+	_, _, _, _, err = ssh.ParseAuthorizedKey(publicKeyBytes)
+	if err != nil {
+		t.Errorf("Failed to parse generated public key: %v", err)
+	}
 }


### PR DESCRIPTION
Such ssh keys are useless, they are required by Azure but the VMs created by CAA have ssh disabled.