### PR TITLE
azure: clean SSHKeyPath only if it isn't empty

### DIFF
--- a/src/cloud-providers/azure/provider.go
+++ b/src/cloud-providers/azure/provider.go
@@ -45,7 +45,9 @@ func NewProvider(config *Config) (provider.Provider, error) {
 	logger.Printf("azure config %+v", config.Redact())
 
 	// Clean the config.SSHKeyPath to avoid bad paths
-	config.SSHKeyPath = filepath.Clean(config.SSHKeyPath)
+	if config.SSHKeyPath != "" {
+		config.SSHKeyPath = filepath.Clean(config.SSHKeyPath)
+	}
 
 	azureClient, err := NewAzureClient(*config)
 	if err != nil {


### PR DESCRIPTION
If SSHKeyPath is empty (meaning that the ssh key has to be generated internally), filepath.Clean() will transform "" into ".", which in turn will trick the SSH key generation code to look for an existing ssh key called "." instead of generating a new one.

Let's call Clean() only if SSHKeyPath is not empty.

Fixes https://github.com/confidential-containers/cloud-api-adaptor/pull/2621