### PR TITLE
e2e: readd tdx to azure e2e tests

### DIFF
--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -82,10 +82,10 @@ jobs:
     strategy:
       matrix:
         parameters:
-          # - id: "tdx"
-          #   machine_type: "Standard_DC2es_v5"
-          #   location: "westeurope"
-          #   jitter: 0
+          - id: "tdx"
+            machine_type: "Standard_DC2es_v6"
+            location: "eastus"
+            jitter: 0
           - id: "snp"
             machine_type: "Standard_DC2as_v5"
             location: "northeurope"
@@ -175,9 +175,9 @@ jobs:
     strategy:
       matrix:
         parameters:
-          # - id: "tdx"
-          #   machine_type: "Standard_DC2es_v5"
-          #   location: "westeurope"
+          - id: "tdx"
+            machine_type: "Standard_DC2es_v6"
+            location: "eastus"
           - id: "snp"
             machine_type: "Standard_DC2as_v5"
             location: "northeurope"
@@ -269,10 +269,10 @@ jobs:
     strategy:
       matrix:
         parameters:
-          # - id: "tdx"
-          #   machine_type: "Standard_DC2es_v5"
-          #   location: "westeurope"
-          #   jitter: 0
+          - id: "tdx"
+            machine_type: "Standard_DC2es_v6"
+            location: "eastus"
+            jitter: 0
           - id: "snp"
             machine_type: "Standard_DC2as_v5"
             location: "northeurope"


### PR DESCRIPTION
The TDX v6 instance sizes are available in the subscription now, hence we can re-enable the tests. We don't need further adjustments