### PR TITLE
CI: promote libvirt CRI-O jobs to stable but secure_comms unstable

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -61,6 +61,8 @@ jobs:
   test:
     runs-on: ${{ inputs.runner }}
     name: "Libvirt e2e tests: (${{ inputs.runner }}, ${{ inputs.container_runtime }}, secure_comms: ${{ inputs.secure_comms }}, mkosi: ${{ inputs.oras }}"
+    # TODO: remove this when secure_comms is stable again (issue #2635)
+    continue-on-error: ${{ inputs.secure_comms != 'none' && true || false }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
The nightly libvirt e2e jobs for CRI-O can be considered stable, except when configured to run with secure_comms. As well as containerd configured with secure_comms are now unstable.

Let's keep running the jobs with secure_comms but disregards their finish status until we don't have a fix.

Refers to #2635 