### PR TITLE
workflows: do not persist credentials on checkout

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install actionlint gh extension
         run: gh extension install https://github.com/cschleiden/gh-actionlint

--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -47,6 +47,8 @@ jobs:
       id-token: write
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        persist-credentials: false
 
     - uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
       name: 'Az CLI login'
@@ -94,6 +96,8 @@ jobs:
       id-token: write
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        persist-credentials: false
 
     - name: Extract go version number
       run: echo "GO_VERSION=$(yq -e '.tools.golang' versions.yaml)" >> "$GITHUB_ENV"
@@ -181,6 +185,8 @@ jobs:
       id-token: write
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        persist-credentials: false
 
     - name: Extract version numbers
       run: |

--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -68,6 +68,7 @@ jobs:
       with:
         path: cloud-api-adaptor
         ref: ${{ inputs.git-ref }}
+        persist-credentials: false
 
     - name: Install build dependencies
       run: |

--- a/.github/workflows/build-golang-fedora.yaml
+++ b/.github/workflows/build-golang-fedora.yaml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout cloud-api-adaptor repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Container tags from input and repository state
         id: tags

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Read properties from versions.yaml
         run: |
           go_version="$(yq '.tools.golang' versions.yaml)"
@@ -87,6 +89,8 @@ jobs:
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Read properties from versions.yaml
         run: |
@@ -132,6 +136,8 @@ jobs:
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Read properties from versions.yaml
         run: |
@@ -179,6 +185,8 @@ jobs:
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Read properties from versions.yaml
         run: |
@@ -229,6 +237,8 @@ jobs:
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Read properties from versions.yaml
         run: |

--- a/.github/workflows/caa_build_and_push.yaml
+++ b/.github/workflows/caa_build_and_push.yaml
@@ -68,6 +68,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: "${{ inputs.git_ref }}"
 
       - name: Rebase the code

--- a/.github/workflows/caa_build_and_push_per_arch.yaml
+++ b/.github/workflows/caa_build_and_push_per_arch.yaml
@@ -42,6 +42,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: "${{ inputs.git_ref }}"
+          persist-credentials: false
 
       - name: Create tags.txt
         run: |
@@ -89,6 +90,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: "${{ inputs.git_ref }}"
+          persist-credentials: false
 
       - name: Read properties from versions.yaml
         run: |
@@ -171,6 +173,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: "${{ inputs.git_ref }}"
+          persist-credentials: false
 
       - name: Download release tags.txt
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0

--- a/.github/workflows/csi_wrapper_images.yaml
+++ b/.github/workflows/csi_wrapper_images.yaml
@@ -48,6 +48,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: "${{ inputs.git_ref }}"
+          persist-credentials: false
       - name: Read properties from versions.yaml
         run: |
           go_version="$(yq '.tools.golang' src/cloud-api-adaptor/versions.yaml)"

--- a/.github/workflows/e2e_aws.yaml
+++ b/.github/workflows/e2e_aws.yaml
@@ -84,8 +84,8 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-          persist-credentials: true
           ref: ${{ inputs.git_ref }}
+          persist-credentials: false
 
       - name: Rebase the code
         if: github.event_name == 'pull_request_target'

--- a/.github/workflows/e2e_docker.yaml
+++ b/.github/workflows/e2e_docker.yaml
@@ -53,6 +53,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
+          persist-credentials: false
 
       - name: Rebase the code
         if: github.event_name == 'pull_request_target'

--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -69,6 +69,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
+          persist-credentials: false
 
       - name: Rebase the code
         if: github.event_name == 'pull_request_target'

--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -165,6 +165,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ inputs.git_ref }}
 
       - name: Rebase the code
@@ -305,6 +306,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ inputs.git_ref }}
 
       - name: Rebase the code

--- a/.github/workflows/lib-codeql.yaml
+++ b/.github/workflows/lib-codeql.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       with:
         go-version-file: ./src/cloud-api-adaptor/go.mod

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Restore lychee cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Read properties from versions.yaml
         run: |
           go_version="$(yq '.tools.golang' src/cloud-api-adaptor/versions.yaml)"
@@ -54,6 +56,8 @@ jobs:
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Read properties from versions.yaml
         run: |
           go_version="$(yq '.tools.golang' src/cloud-api-adaptor/versions.yaml)"
@@ -96,6 +100,8 @@ jobs:
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Run shellcheck
         run: make shellcheck
 
@@ -105,6 +111,8 @@ jobs:
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Read properties from versions.yaml
         run: |
           go_version="$(yq '.tools.golang' src/cloud-api-adaptor/versions.yaml)"
@@ -124,6 +132,8 @@ jobs:
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Read properties from versions.yaml
         run: |
           go_version="$(yq '.tools.golang' src/cloud-api-adaptor/versions.yaml)"
@@ -149,6 +159,8 @@ jobs:
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Run packer check
         run: make packer-check
 
@@ -159,5 +171,7 @@ jobs:
     steps:
       - name: Checkout the pull request code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Run terraform check
         run: make terraform-check

--- a/.github/workflows/peerpod-ctrl_image.yaml
+++ b/.github/workflows/peerpod-ctrl_image.yaml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: "${{ inputs.git_ref }}"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1

--- a/.github/workflows/podvm.yaml
+++ b/.github/workflows/podvm.yaml
@@ -48,6 +48,7 @@ jobs:
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         fetch-depth: 0
+        persist-credentials: false
         ref: "${{ inputs.git_ref }}"
 
     - name: Rebase the code

--- a/.github/workflows/podvm_binaries.yaml
+++ b/.github/workflows/podvm_binaries.yaml
@@ -43,6 +43,7 @@ jobs:
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         fetch-depth: 0
+        persist-credentials: false
         ref: "${{ inputs.git_ref }}"
 
     - name: Rebase the code

--- a/.github/workflows/podvm_builder.yaml
+++ b/.github/workflows/podvm_builder.yaml
@@ -44,6 +44,7 @@ jobs:
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         fetch-depth: 0
+        persist-credentials: false
         ref: "${{ inputs.git_ref }}"
 
     - name: Rebase the code

--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -84,6 +84,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: "${{ inputs.git_ref }}"
 
       # Required by rootless mkosi

--- a/.github/workflows/podvm_smoketest.yaml
+++ b/.github/workflows/podvm_smoketest.yaml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       # Required by rootless mkosi on Ubuntu 24.04
       - name: Un-restrict user namespaces
@@ -78,6 +80,8 @@ jobs:
             mode: scratch-space
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Install test dependencies
         run: |

--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -22,6 +22,8 @@ jobs:
       matrix: ${{ env.MATRIX }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - id: set-matrix
         run: echo "MATRIX=$(find test/e2e/fixtures/Dockerfile.* | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_ENV"
   build:
@@ -39,6 +41,8 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        persist-credentials: false
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1

--- a/.github/workflows/webhook_image.yaml
+++ b/.github/workflows/webhook_image.yaml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: "${{ inputs.git_ref }}"
       - name: Read properties from versions.yaml
         run: |


### PR DESCRIPTION
zizmor flags that code checkout with persist credentials is a security risk. Default behavior of actions/checkout is to always persist so zizmor has complained about that in a lot of our workflows. We don't need to persist the credentials, hence, explicitly setting `persist-credentials: false` in all workflows that checkout code.

---

This is a follow up of https://github.com/confidential-containers/cloud-api-adaptor/pull/2607 (discussed in https://github.com/confidential-containers/cloud-api-adaptor/pull/2607#discussion_r2406284461) . I was supposed to set `persist-credentials: false` only on e2e_aws workflow but then zizmor would be complaining about the same issue in a bunch of workflows. So I'm applying that fix on all workflows that checkout code.

This is also a split of https://github.com/confidential-containers/cloud-api-adaptor/pull/2641
