### PR TITLE
Introduce CI for AWS - part 4

### DIFF
--- a/.github/workflows/e2e_aws.yaml
+++ b/.github/workflows/e2e_aws.yaml
@@ -76,6 +76,7 @@ jobs:
         CLUSTER_TYPE: "${{ inputs.cluster_type }}"
         CONTAINER_RUNTIME: "${{ inputs.container_runtime }}"
         PODVM_IMAGE: "${{ inputs.podvm_image }}"
+        RESOURCES_BASENAME: "ci-caa-${{ github.run_id }}-${{ github.run_attempt }}"
     permissions:
       id-token: write # Required by aws-actions/configure-aws-credentials
       contents: read  # Required by aws-actions/configure-aws-credentials
@@ -159,7 +160,7 @@ jobs:
           disablecvm="true"
           cluster_type="${CLUSTER_TYPE}"
           ssh_kp_name="caa-e2e-test"
-          resources_basename="ci-caa-${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}"
+          resources_basename="${RESOURCES_BASENAME}"
           EOF
           # For debugging
           echo "::group::aws.properties"
@@ -213,8 +214,6 @@ jobs:
         # didn't run, let's try to delete any resources created.
       - name: Force AWS clean-up
         if: failure() && steps.runTests.outcome == 'failure'
-        env:
-          res_basename: "ci-caa-${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}"
         working-directory: ./
         run: |
           ./hack/ci-e2e-aws-cleanup.sh


### PR DESCRIPTION
Contains two fixes that were introduced on [part 3](https://github.com/confidential-containers/cloud-api-adaptor/pull/2607).

I've tested in https://github.com/wainersm/cc-cloud-api-adaptor/actions/runs/18654922544/job/53183162192?pr=73

Now the s3 bucket is created because its name has no underline '_':
```
time="2025-10-20T14:49:28Z" level=info msg="Create bucket 'ci-caa-18654922544-1-bucket'"
```

Also, the cleanup step of the job now can parse the basename correctly:

```
Delete VPC=vpc-0d958ca4f0bad5a34
time="2025-10-20T15:01:01Z" level=info msg="Deleting Cluster..."
time="2025-10-20T15:01:01Z" level=info msg="Deleting VPC..."
time="2025-10-20T15:01:01Z" level=info msg="Delete subnet: subnet-05317f0d3a8ad2bfd"
time="2025-10-20T15:01:02Z" level=info msg="Delete security group: sg-0452118cc2e038a25"
time="2025-10-20T15:01:03Z" level=info msg="Delete vpc: vpc-0d958ca4f0bad5a34"
time="2025-10-20T15:01:04Z" level=info msg="Delete S3 bucket: caa-e2e-test-1760972461-bucket"
There aren't AMIs to delete.
Deleting S3 bucket: ci-caa-18654922544-1-bucket
delete: s3://ci-caa-18654922544-1-bucket/podvm.508621018.raw
```