### PR TITLE
azure: use Standard SSD for CVM storage

### DIFF
--- a/src/cloud-providers/azure/provider.go
+++ b/src/cloud-providers/azure/provider.go
@@ -431,7 +431,7 @@ func (p *azureProvider) getVMParameters(instanceSize, diskName, cloudConfig stri
 	var securityProfile *armcompute.SecurityProfile
 	if !p.serviceConfig.DisableCVM {
 		managedDiskParams = &armcompute.ManagedDiskParameters{
-			StorageAccountType: to.Ptr(armcompute.StorageAccountTypesStandardLRS),
+			StorageAccountType: to.Ptr(armcompute.StorageAccountTypesPremiumLRS),
 			SecurityProfile: &armcompute.VMDiskSecurityProfile{
 				SecurityEncryptionType: to.Ptr(armcompute.SecurityEncryptionTypesVMGuestStateOnly),
 			},
@@ -446,7 +446,7 @@ func (p *azureProvider) getVMParameters(instanceSize, diskName, cloudConfig stri
 		}
 	} else {
 		managedDiskParams = &armcompute.ManagedDiskParameters{
-			StorageAccountType: to.Ptr(armcompute.StorageAccountTypesStandardLRS),
+			StorageAccountType: to.Ptr(armcompute.StorageAccountTypesPremiumLRS),
 		}
 
 		securityProfile = nil


### PR DESCRIPTION
Change the storage account type for Azure Confidential VMs from Standard HDD (Standard_LRS) to Standard SSD (StandardSSD_LRS) for better performance.