### PR TITLE
test/e2e: fix panic in getCaaPodLogForPod()

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/assessment_helpers.go
+++ b/src/cloud-api-adaptor/test/e2e/assessment_helpers.go
@@ -483,12 +483,12 @@ func getCaaPodLogForPod(ctx context.Context, t *testing.T, client klient.Client,
 	date_matcher := "[0-9]{4}/[0-9]{2}/[0-9]{2}"
 	time_matcher := "([0-1]?[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]"
 	pod_matcher := regexp.MustCompile(date_matcher + " " + time_matcher + ` \[adaptor\/cloud\] create a sandbox [0-9|a-f]* for pod ` + pod.Name)
-	index := pod_matcher.FindStringIndex(podLogString)[0]
-	if index < 0 {
+	matches := pod_matcher.FindStringIndex(podLogString)
+	if matches == nil {
 		return "", fmt.Errorf("GetCaaPodLog: couldn't find pod log matcher: %s in CAA log %s", pod_matcher, podLogString)
-	} else {
-		podLogString = podLogString[index:]
 	}
+
+	podLogString = podLogString[matches[0]:]
 
 	return podLogString, nil
 }


### PR DESCRIPTION
getCaaPodLogForPod() assumes that some caa logs exists after the pod is launched, which is not always true. For example, on error below the pod was launched, failed at runtime (before caa gets called), tried to print the logs but panic'ed:

```
--- FAIL: TestAwsCreateSimplePod (1203.78s)
    --- FAIL: TestAwsCreateSimplePod/SimplePeerPod_test (1203.78s)
        --- FAIL: TestAwsCreateSimplePod/SimplePeerPod_test/PodVM_is_created (1.22s)
panic: runtime error: index out of range [0] with length 0 [recovered]
        panic: runtime error: index out of range [0] with length 0

goroutine 379 [running]:
testing.tRunner.func1.2({0x569dbe0, 0xc000f5f560})
        /usr/lib/golang/src/testing/testing.go:1734 +0x21c
testing.tRunner.func1()
        /usr/lib/golang/src/testing/testing.go:1737 +0x35e
panic({0x569dbe0?, 0xc000f5f560?})
        /usr/lib/golang/src/runtime/panic.go:792 +0x132
github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/test/e2e.getCaaPodLogForPod...
```

Assisted-by: Cursor