### PR TITLE
workflows: Set the ppc64le arch explicitly in setup-go

### DIFF
--- a/.github/workflows/caa_build_and_push_per_arch.yaml
+++ b/.github/workflows/caa_build_and_push_per_arch.yaml
@@ -98,6 +98,8 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: "**/go.sum"
+          # Setup-go doesn't work properly with ppc64le: https://github.com/actions/setup-go/issues/648
+          architecture: ${{ matrix.types.arch == 'linux/ppc64le' && 'ppc64le' || '' }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1


### PR DESCRIPTION
The setup-go action incorrectly installs the big-endian version of go, so try and hard-coded the architecture to work around this.