### PR TITLE
Install UKI under BOOTX64 for GCE

### DIFF
--- a/src/cloud-api-adaptor/podvm-mkosi/README.md
+++ b/src/cloud-api-adaptor/podvm-mkosi/README.md
@@ -51,6 +51,14 @@ If you want to use the image with libvirt, run the following to convert to qcow2
 qemu-img convert -f raw -O qcow2 build/system.raw build/system.qcow2
 ```
 
+#### Firmware expectations on GCE
+
+When the pod VM runs on Google Cloud's SEV-capable `n2d-*` instances the
+virtual firmware only probes `\EFI\BOOT\BOOTX64.EFI`.  The mkosi finalize
+step copies the generated Unified Kernel Image from `\EFI\Linux\*.efi` to
+that fallback path automatically, ensuring the VM boots without any manual
+intervention.
+
 ## Debug image
 
 There is a debug variant of the image that provides a specific configuration to debug things within

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.finalize.chroot
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.finalize.chroot
@@ -34,3 +34,14 @@ else
 	systemctl enable process-user-data.service
 	# These units doesn't exist in regular and debug profiles
 fi
+
+# Ensure the Unified Kernel Image is also available under the generic BOOTX64.EFI
+# path that many firmware implementations probe first (e.g. GCE SEV VMs).
+shopt -s nullglob
+UKI_IMAGES=(/efi/EFI/Linux/*.efi)
+if (( ${#UKI_IMAGES[@]} > 0 )); then
+	echo "Copying ${UKI_IMAGES[-1]} to /efi/EFI/BOOT/BOOTX64.EFI for firmware fallback"
+	install -d /efi/EFI/BOOT
+	cp "${UKI_IMAGES[-1]}" /efi/EFI/BOOT/BOOTX64.EFI
+fi
+shopt -u nullglob


### PR DESCRIPTION
## Summary
Google Cloud's SEV-capable `n2d-*` instances only probe `\EFI\BOOT\BOOTX64.EFI`.  The podvm image previously left the Unified Kernel Image solely under `\EFI\Linux\`, so the firmware could not find it and the VM looped with:
```
UEFI: Failed to load image.
Description: UEFI nvme_card-pd
Status: Not Found.
```

This change copies the generated UKI to `\EFI\BOOT\BOOTX64.EFI` during the mkosi finalize step.  The copy only happens if the UKI exists, so it is safe for other environments.  The README now documents why we do this for GCE.

Fixes #2686.

## Testing
- `DOCKER_DEFAULT_PLATFORM=linux/amd64 ARCH=x86_64 make image`
- Uploaded the raw image with `uplosi upload -c . build/system.raw`
- Launched a PeerPod on `n2d-standard-4` and confirmed the VM boots instead of looping in firmware.
