### PR TITLE
GCP: support for using internal instance ips

### DIFF
--- a/src/cloud-api-adaptor/install/overlays/gcp/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/gcp/kustomization.yaml
@@ -23,6 +23,7 @@ configMapGenerator:
   - GCP_MACHINE_TYPE="e2-medium" # replace if needed. caa defaults to e2-medium
   - GCP_NETWORK="global/networks/default" # replace if needed.
   - GCP_CONFIDENTIAL_TYPE="" # Needs to be set when DisableCVM=false. i.e: TDX or SEV_SNP. Check if the machine type is compatible.
+  #- USE_PUBLIC_IP="true" # Uncomment if you want to use public ip for podvm
   #- DISABLECVM="true" # Uncomment it if you want a generic VM
   #- PEERPODS_LIMIT_PER_NODE="10" # Max number of peer pods that can be created per node. Default is 10
   #- REMOTE_HYPERVISOR_ENDPOINT="/run/peerpod/hypervisor.sock" # Path to Kata remote hypervisor socket. Default is /run/peerpod/hypervisor.sock

--- a/src/cloud-providers/gcp/manager.go
+++ b/src/cloud-providers/gcp/manager.go
@@ -32,6 +32,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	reg.BoolWithEnv(&gcpcfg.DisableCVM, "disable-cvm", false, "DISABLECVM", "Use non-CVMs for peer pods")
 	reg.StringWithEnv(&gcpcfg.ConfidentialType, "confidential-type", "", "GCP_CONFIDENTIAL_TYPE", "Used when DisableCVM=false. i.e: TDX, SEV or SEV_SNP. Check if the machine type is compatible.")
 	reg.IntWithEnv(&gcpcfg.RootVolumeSize, "root-volume-size", 10, "ROOT_VOLUME_SIZE", "Root volume size (in GiB) for the Pod VMs")
+	flags.BoolVar(&gcpcfg.UsePublicIP, "use-public-ip", false, "Use Public IP for connecting to the kata-agent inside the Pod VM")
 
 	// Custom flag types (comma-separated lists)
 	reg.CustomTypeWithEnv(&gcpcfg.Tags, "tags", "", "TAGS", "List of tags to be added to the Pod VMs. Tags must already exist in the GCP project. Format: key1=value1,key2=value2")

--- a/src/cloud-providers/gcp/types.go
+++ b/src/cloud-providers/gcp/types.go
@@ -21,6 +21,7 @@ type Config struct {
 	ConfidentialType string
 	RootVolumeSize   int
 	Tags             provider.KeyValueFlag
+	UsePublicIP      bool
 }
 
 func (c Config) Redact() Config {


### PR DESCRIPTION
This PR implements support for using internal IPs of instances or external (NAT) IPs on GCP.

CAA setting `USE_PUBLIC_IP` toggles this behaviour and matches the functionality present in other providers.