### PR TITLE
GHA: Install yq when the package is not installed

### DIFF
--- a/.github/workflows/caa_build_and_push.yaml
+++ b/.github/workflows/caa_build_and_push.yaml
@@ -79,7 +79,9 @@ jobs:
 
       - name: Read properties from versions.yaml
         run: |
-          sudo snap install yq
+          # yq may be pre-installed on self-hosted runners
+          command -v yq || sudo snap install yq
+          yq --version | grep -qE 'v4\.[0-9]+' || { echo "yq version is not 4.x, please install yq 4.x"; exit 1; }
           go_version="$(yq '.tools.golang' versions.yaml)"
           [ -n "$go_version" ]
           echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"

--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -84,7 +84,9 @@ jobs:
 
       - name: Read properties from versions.yaml
         run: |
-          sudo snap install yq
+          # yq may be pre-installed on self-hosted runners
+          command -v yq || sudo snap install yq
+          yq --version | grep -qE 'v4\.[0-9]+' || { echo "yq version is not 4.x, please install yq 4.x"; exit 1; }
           go_version="$(yq '.tools.golang' versions.yaml)"
           [ -n "$go_version" ]
           echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"


### PR DESCRIPTION
Let's install yq only if it is not installed on a runner.

The following error appeared on s390x runners recently (see [log](https://github.com/confidential-containers/cloud-api-adaptor/actions/runs/19692485850/job/56421073055)):

```
cannot confirm that parent process is alive: Operation not permitted
cannot send command 0 to helper process: Broken pipe
../Makefile.defaults:69: *** "yq major version should be 4, is: ".  Stop.
```

I am suspicious a snapd setup (i.e., `/var/lib/snapd/apparmor/profiles/snap.yq.yq`). 
I would like to try the upstream yq (e.g., https://github.com/mikefarah/yq/releases) on the s390x runners. Thanks!

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>