### PR TITLE
version: Complete the bump to go 1.24.11

### DIFF
--- a/src/cloud-api-adaptor/Dockerfile
+++ b/src/cloud-api-adaptor/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILD_TYPE=dev
-ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.24.9-41
+ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.24.11-41
 ARG BASE=registry.fedoraproject.org/fedora:41
 
 # This dockerfile uses Go cross-compilation to build the binary,

--- a/src/cloud-api-adaptor/docs/addnewprovider.md
+++ b/src/cloud-api-adaptor/docs/addnewprovider.md
@@ -219,7 +219,7 @@ go mod tidy
 
 ```bash
 cat > Dockerfile <<EOF
-ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.24.9-41
+ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.24.11-41
 FROM --platform="\$TARGETPLATFORM" \$BUILDER_BASE AS builder
 RUN dnf install -y libvirt-devel && dnf clean all
 WORKDIR /work

--- a/src/cloud-api-adaptor/go.mod
+++ b/src/cloud-api-adaptor/go.mod
@@ -1,8 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor
 
-go 1.24.9
-
-toolchain go1.24.10
+go 1.24.11
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1

--- a/src/csi-wrapper/Dockerfile.csi_wrappers
+++ b/src/csi-wrapper/Dockerfile.csi_wrappers
@@ -7,13 +7,13 @@
 ARG SOURCE_FROM=remote
 
 ##### Builder Dev Image #####
-FROM --platform=${BUILDPLATFORM} quay.io/confidential-containers/golang-fedora:1.24.9-41 AS builder-local
+FROM --platform=${BUILDPLATFORM} quay.io/confidential-containers/golang-fedora:1.24.11-41 AS builder-local
 WORKDIR /src
 COPY csi-wrapper ./cloud-api-adaptor/src/csi-wrapper/
 COPY cloud-api-adaptor ./cloud-api-adaptor/src/cloud-api-adaptor
 
 ##### Builder Release Image #####
-FROM --platform=${BUILDPLATFORM} quay.io/confidential-containers/golang-fedora:1.24.9-41 AS builder-remote
+FROM --platform=${BUILDPLATFORM} quay.io/confidential-containers/golang-fedora:1.24.11-41 AS builder-remote
 ARG BINARY
 ARG CAA_SRC="https://github.com/confidential-containers/cloud-api-adaptor"
 ARG CAA_SRC_REF="main"

--- a/src/csi-wrapper/go.mod
+++ b/src/csi-wrapper/go.mod
@@ -1,8 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/csi-wrapper
 
-go 1.24.9
-
-toolchain go1.24.10
+go 1.24.11
 
 require (
 	github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor v0.0.0-00010101000000-000000000000

--- a/src/peerpod-ctrl/Dockerfile
+++ b/src/peerpod-ctrl/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$TARGETPLATFORM quay.io/confidential-containers/golang-fedora:1.24.9-41 AS builder
+FROM --platform=$TARGETPLATFORM quay.io/confidential-containers/golang-fedora:1.24.11-41 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG CGO_ENABLED=1


### PR DESCRIPTION
Bump the builder image created in #2706 and bump
the go.mod version to actually use the new go version.