### PR TITLE
podvm: Upgrade RHEL base images to ubi10.1

### DIFF
--- a/src/cloud-api-adaptor/Makefile
+++ b/src/cloud-api-adaptor/Makefile
@@ -226,6 +226,7 @@ endif
 	--build-arg IMAGE_URL=$(IMAGE_URL) \
 	--build-arg IMAGE_CHECKSUM=$(IMAGE_CHECKSUM) \
 	--build-arg SE_BOOT=$(SE_BOOT) \
+	--build-arg SE_VERIFY=$(SE_VERIFY) \
 	--build-arg PAUSE_REPO=$(PAUSE_REPO) \
 	--build-arg PAUSE_VERSION=$(PAUSE_VERSION) \
 	--build-arg PAUSE_BIN=$(PAUSE_BIN) \

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm.rhel
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm.rhel
@@ -35,6 +35,7 @@ ENV ARCH=${ARCH}
 ENV UEFI=${UEFI}
 
 ARG SE_BOOT
+ARG SE_VERIFY
 ARG IMAGE_URL
 ARG IMAGE_CHECKSUM
 
@@ -43,6 +44,7 @@ ENV IMAGE_URL=/tmp/rhel.img
 ENV IMAGE_CHECKSUM=${IMAGE_CHECKSUM}
 
 ENV SE_BOOT=${SE_BOOT}
+ENV SE_VERIFY=${SE_VERIFY}
 # workaround to ensure hashicorp packer is called instead
 # of cracklib packer which is installed by default
 ENV PATH="/usr/bin:${PATH}"

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_binaries.rhel
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_binaries.rhel
@@ -40,6 +40,6 @@ RUN LIBC=gnu make binaries
 RUN tar czvf /podvm-binaries.tar.gz -C /src/cloud-api-adaptor/podvm/files usr/ etc/
 RUN tar czvf /pause-bundle.tar.gz -C /src/cloud-api-adaptor/podvm/files pause_bundle/
 
-FROM registry.access.redhat.com/ubi9/ubi:9.4
+FROM registry.access.redhat.com/ubi10/ubi:10.1
 COPY --from=podvm_builder /podvm-binaries.tar.gz /
 COPY --from=podvm_builder /pause-bundle.tar.gz /

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.rhel
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.rhel
@@ -6,7 +6,7 @@
 # Creates a builder container image that should be used to build the Pod VM
 # disk inside a container.
 #
-FROM registry.access.redhat.com/ubi9/ubi:9.4
+FROM registry.access.redhat.com/ubi10/ubi:10.1
 
 ARG ARCH="x86_64"
 ARG GO_ARCH="amd64"
@@ -39,11 +39,13 @@ RUN if [[ -n "${ACTIVATION_KEY}" && -n "${ORG_ID}" ]]; then \
     subscription-manager register --org=${ORG_ID} --activationkey=${ACTIVATION_KEY}; \
     fi
 
-RUN subscription-manager repos --enable codeready-builder-for-rhel-9-${ARCH/amd64/x86_64}-rpms; \
+RUN subscription-manager repos --enable codeready-builder-for-rhel-10-${ARCH/amd64/x86_64}-rpms; \
     dnf -y group install 'Development Tools' && \
     dnf install -y yum-utils gnupg git --allowerasing curl pkg-config clang perl libseccomp-devel gpgme-devel \
-    device-mapper-devel qemu-kvm unzip wget libassuan-devel genisoimage cloud-utils-growpart cloud-init \
+    device-mapper-devel qemu-kvm unzip wget libassuan-devel xorriso cloud-utils-growpart cloud-init \
     perl-FindBin openssl-devel tpm2-tss-devel jq xz zstd
+
+RUN ln -s /usr/bin/xorrisofs /usr/local/bin/genisoimage
 
 RUN curl -L -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${YQ_ARCH} \
     && echo "${YQ_CHECKSUM#sha256:}  /usr/local/bin/yq" | sha256sum -c -


### PR DESCRIPTION
Updated UBI base image to 10.1 in Dockerfile.podvm_builder.rhel.
Updated codeready-builder-for-rhel repository from 9 to 10.
Changed tool name from genisoimage to xorriso dependent to rhel10 
Added missing SE_VERIFY flag in Makefile during Docker build for PodVM image.