### PR TITLE
gcp: use the new registration method for public ip

### DIFF
--- a/src/cloud-providers/gcp/manager.go
+++ b/src/cloud-providers/gcp/manager.go
@@ -32,7 +32,7 @@ func (_ *Manager) ParseCmd(flags *flag.FlagSet) {
 	reg.BoolWithEnv(&gcpcfg.DisableCVM, "disable-cvm", false, "DISABLECVM", "Use non-CVMs for peer pods")
 	reg.StringWithEnv(&gcpcfg.ConfidentialType, "confidential-type", "", "GCP_CONFIDENTIAL_TYPE", "Used when DisableCVM=false. i.e: TDX, SEV or SEV_SNP. Check if the machine type is compatible.")
 	reg.IntWithEnv(&gcpcfg.RootVolumeSize, "root-volume-size", 10, "ROOT_VOLUME_SIZE", "Root volume size (in GiB) for the Pod VMs")
-	flags.BoolVar(&gcpcfg.UsePublicIP, "use-public-ip", false, "Use Public IP for connecting to the kata-agent inside the Pod VM")
+	reg.BoolWithEnv(&gcpcfg.UsePublicIP, "use-public-ip", false, "USE_PUBLIC_IP", "Use Public IP for connecting to the kata-agent inside the Pod VM")
 
 	// Custom flag types (comma-separated lists)
 	reg.CustomTypeWithEnv(&gcpcfg.Tags, "tags", "", "TAGS", "List of tags to be added to the Pod VMs. Tags must already exist in the GCP project. Format: key1=value1,key2=value2")


### PR DESCRIPTION
This was merged after we merged the new registration method.