### PR TITLE
Reapply "versions: Pin operator version"

### DIFF
--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -39,8 +39,8 @@ tools:
 git:
   coco-operator:
     url: https://github.com/confidential-containers/operator
-    config: default
-    reference: main
+    config: release
+    reference: v0.17.0
   umoci:
     url: https://github.com/opencontainers/umoci
     reference: v0.5.0


### PR DESCRIPTION
This reverts commit b3cc5867b3100e58a0d515a231c4f1b2a8712ed4.

No that the operator is not supported and working, we need to pin to a stable version, so pick the last release