### PR TITLE
cloud-providers: cleanup orphaned instances on CreateInstance failure

### DIFF
--- a/src/cloud-providers/alibabacloud/provider.go
+++ b/src/cloud-providers/alibabacloud/provider.go
@@ -194,7 +194,7 @@ func (p *alibabaCloudProvider) getIPs(instanceId string, ecsClient ecsClient) ([
 	return podNodeIPs, nil
 }
 
-func (p *alibabaCloudProvider) CreateInstance(ctx context.Context, podName, sandboxID string, cloudConfig cloudinit.CloudConfigGenerator, spec provider.InstanceTypeSpec) (*provider.Instance, error) {
+func (p *alibabaCloudProvider) CreateInstance(ctx context.Context, podName, sandboxID string, cloudConfig cloudinit.CloudConfigGenerator, spec provider.InstanceTypeSpec) (instance *provider.Instance, err error) {
 	// Public IP address
 	var publicIPAddr *netip.Addr
 
@@ -283,6 +283,12 @@ func (p *alibabaCloudProvider) CreateInstance(ctx context.Context, podName, sand
 	instanceID := *result.Body.InstanceIdSets.InstanceIdSet[0]
 	logger.Printf("created an instance %s for sandbox %s", instanceID, sandboxID)
 
+	// Create partial instance to return on error (allows caller to cleanup)
+	instance = &provider.Instance{
+		ID:   instanceID,
+		Name: instanceName,
+	}
+
 	// Wait instance to create
 	err = p.waitUntilTimeout(time.Duration(time.Minute*1), func() (bool, error) {
 		req := &ecs.DescribeInstanceAttributeRequest{
@@ -304,21 +310,21 @@ func (p *alibabaCloudProvider) CreateInstance(ctx context.Context, podName, sand
 		return false, fmt.Errorf("failed to describe instance %s: %v", instanceID, err)
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to wait for instance %s to be ready: %v", instanceID, err)
+		return instance, fmt.Errorf("failed to wait for instance %s to be ready: %v", instanceID, err)
 	}
 	logger.Printf("Instance %s is ready.", instanceID)
 
 	ips, err := p.getIPs(*result.Body.InstanceIdSets.InstanceIdSet[0], p.ecsClient)
 	if err != nil {
 		logger.Printf("failed to get IPs for the instance : %v ", err)
-		return nil, err
+		return instance, err
 	}
 
 	if p.serviceConfig.UsePublicIP {
 		// Get the public IP address of the instance
 		publicIPAddr, err = p.getPublicIP(ctx, instanceID)
 		if err != nil {
-			return nil, err
+			return instance, err
 		}
 
 		// insert the first IP address with the public IP address
@@ -331,30 +337,26 @@ func (p *alibabaCloudProvider) CreateInstance(ctx context.Context, podName, sand
 		logger.Println("External network connectivity is enabled, trying to setup another NIC with Internet Access.")
 		nIfaceId, err := p.createAddonNICforInstance(instanceID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create NIC: %w", err)
+			return instance, fmt.Errorf("failed to create NIC: %w", err)
 		}
 
 		if p.serviceConfig.UsePublicIP {
 			eipId, _, err := p.createEipInstance()
 			if err != nil {
-				return nil, fmt.Errorf("failed to create EIP instance: %w", err)
+				return instance, fmt.Errorf("failed to create EIP instance: %w", err)
 			}
 
 			p.eips[instanceID] = eipId
 
 			err = p.bindEipToNic(eipId, nIfaceId)
 			if err != nil {
-				return nil, fmt.Errorf("failed to bind Eip %s to NIC %s: %w", *eipId, *nIfaceId, err)
+				return instance, fmt.Errorf("failed to bind Eip %s to NIC %s: %w", *eipId, *nIfaceId, err)
 			}
 		}
 
 	}
 
-	instance := &provider.Instance{
-		ID:   instanceID,
-		Name: instanceName,
-		IPs:  ips,
-	}
+	instance.IPs = ips
 
 	return instance, nil
 }


### PR DESCRIPTION
## Summary

- Add defer-based cleanup to all cloud providers (Azure, AWS, GCP, IBM Cloud, Alibaba Cloud)
- When `CreateInstance` succeeds in creating a VM but fails in subsequent operations (like getting IPs, attaching tags, or creating additional NICs), the VM is now automatically deleted
- The cleanup uses a new context with 30-second timeout to ensure cleanup proceeds even if the original context was cancelled

## Problem

When `CreateInstance` successfully creates a VM but subsequent operations fail, the VM remains orphaned and continues to incur costs. This affects all cloud providers.

Example failure scenario:
```
1. CreateInstance creates VM successfully ✅
2. Get VM IP address fails ❌
3. VM remains running (orphaned) 💸
```

## Solution

Added defer-based cleanup after VM creation in all providers:

```go
func (p *Provider) CreateInstance(...) (instance *provider.Instance, err error) {
    // ... VM creation ...
    vmID := *vm.ID

    // Cleanup the VM if any subsequent operation fails
    defer func() {
        if err != nil {
            logger.Printf("CreateInstance failed, cleaning up VM %s: %v", vmID, err)
            cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
            defer cancel()
            if delErr := p.DeleteInstance(cleanupCtx, vmID); delErr != nil {
                logger.Printf("Failed to cleanup VM %s: %v", vmID, delErr)
            }
        }
    }()

    // Subsequent operations that might fail
    ips, err := p.getIPs(ctx, vm)
    if err != nil {
        return nil, err  // defer will trigger cleanup
    }
    // ...
}
```

## Verification

Tested on Azure by injecting an error after successful VM creation:

| Step | Result |
|------|--------|
| VM creation | ✅ Success |
| IP retrieval | ✅ Success |
| Error injection | ✅ Triggered |
| Cleanup initiated | ✅ Executed |
| VM deleted | ✅ Confirmed |

```log
[adaptor/cloud/azure] created VM successfully: .../podvm-cleanup-error-injection-test-2183b08d
[adaptor/cloud/azure] TESTING: Injecting error after successful VM creation
[adaptor/cloud/azure] CreateInstance failed after VM creation, cleaning up VM ...
```

VM was confirmed deleted via Azure CLI:
```bash
$ az vm show -g cc-dev -n podvm-cleanup-error-injection-test-2183b08d
ERROR: (ResourceNotFound) The Resource ... was not found.
```

## Test plan

- [x] Build passes
- [x] Unit tests pass
- [x] Verified on Azure: cleanup works as expected

Note: If possible, it would be beneficial to verify on other cloud providers (AWS, GCP, IBM Cloud, Alibaba Cloud) as well, though the implementation pattern is consistent across all providers.

Fixes: #2658

Signed-off-by: tak-ka3 <takumi.hiraoka@acompany-ac.com>