### PR TITLE
e2e-test: collect KBS and CAA logs on Azure test failure

### DIFF
--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -248,6 +248,7 @@ jobs:
       run: test/utils/checkout_kbs.sh
 
     - name: Run e2e test
+      id: runTests
       env:
         TEST_PROVISION: "no"
         DEPLOY_KBS: "yes"
@@ -256,6 +257,17 @@ jobs:
       run: |
         az aks get-credentials --resource-group "$RG_NAME" --name "$CLUSTER_NAME"
         make test-e2e RUN_TESTS="^Test\(CreateSimplePodAzure\|RemoteAttestation\|InitDataMeasurement\)$"
+
+    - name: Debug on failure
+      if: failure() && steps.runTests.outcome == 'failure'
+      timeout-minutes: 15
+      working-directory: ./
+      env:
+        CLUSTER_NAME: "${{ format(env.CLUSTER_NAME_TEMPLATE, matrix.parameters.id) }}"
+      run: |
+        az aks get-credentials --resource-group "$RG_NAME" --name "$CLUSTER_NAME" || true
+        ./hack/ci-e2e-debug-fail.sh
+      shell: bash {0}
 
   cleanup:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
Add log collection step that runs on e2e test failure to capture KBS and CAA pod logs.

## Background
Fixes #2746

The Azure e2e tests have been failing since 2025/12/30 with `TestRemoteAttestation` timing out. Currently, KBS pod logs are not collected, making it difficult to diagnose attestation failures.

This PR adds a failure handler that collects:
- KBS pod logs from `coco-tenant` namespace
- KBS pod describe output
- CAA pod logs from `confidential-containers-system` namespace

## Test plan
- [ ] Merge this PR
- [ ] Wait for next nightly build (3:00 UTC daily)
- [ ] On test failure, verify KBS logs are collected in the CI output
- [ ] Use logs to diagnose the attestation failure root cause