### PR TITLE
ci: group shared dependencies in dependabot to prevent failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,15 +23,28 @@ updates:
       aws-sdk-go-v2:
         patterns:
           - "*aws-sdk-go-v2*"
-      azcore:
+      azure-sdk:
         patterns:
-          - "github.com/Azure/azure-sdk-for-go/sdk/azcore"
+          - "github.com/Azure/azure-sdk-for-go/sdk/*"
+      google-cloud:
+        patterns:
+          - "cloud.google.com/go/*"
+      ibm-sdk:
+        patterns:
+          - "github.com/IBM/*"
+          - "github.com/IBM-Cloud/*"
       k8s:
         patterns:
           - "*k8s.io*"
+      libvirt:
+        patterns:
+          - "libvirt.org/go/*"
       protobuf:
         patterns:
           - "google.golang.org/protobuf"
+      vmware:
+        patterns:
+          - "github.com/vmware/govmomi"
       x/extensions:
         patterns:
           - golang.org/x/*


### PR DESCRIPTION
Adds dependency groups to `.github/dependabot.yml` for libraries shared across multiple Go modules to prevent `go mod tidy` CI failures.

Added groups for:
- `azure-sdk`: Azure SDK packages (replaces/expands `azcore`)
- `google-cloud`: Google Cloud packages
- `ibm-sdk`: IBM and IBM-Cloud packages
- `libvirt`: libvirt packages
- `vmware`: VMware govmomi

Fixes #2750