### PR TITLE
e2e-test: workaround for remote-attestation test

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/azure_test.go
+++ b/src/cloud-api-adaptor/test/e2e/azure_test.go
@@ -189,7 +189,7 @@ func TestAzureImageDecryption(t *testing.T) {
 // the az tpm attester requires the digest to be sha256 and is hence truncated
 func TestInitDataMeasurement(t *testing.T) {
 	kbsEndpoint := "http://some.endpoint"
-	annotation, err := buildInitdataAnnotation(kbsEndpoint, testInitdata)
+	annotation, err := buildInitdataAnnotation(kbsEndpoint)
 	if err != nil {
 		log.Fatalf("failed to build initdata %s", err)
 	}

--- a/src/cloud-api-adaptor/test/e2e/common_suite.go
+++ b/src/cloud-api-adaptor/test/e2e/common_suite.go
@@ -595,7 +595,7 @@ func DoTestSealedSecret(t *testing.T, e env.Environment, assert CloudAssert, kbs
 // as test cases might be run in parallel
 func DoTestKbsKeyRelease(t *testing.T, e env.Environment, assert CloudAssert, kbsEndpoint, resourcePath, expectedSecret string) {
 	t.Log("Do test https kbs key release")
-	pod := NewBusyboxPodWithNameWithInitdata(E2eNamespace, "kbs-key-release", kbsEndpoint, testInitdata).GetPodOrFatal(t)
+	pod := NewBusyboxPodWithNameWithInitdata(E2eNamespace, "kbs-key-release", kbsEndpoint).GetPodOrFatal(t)
 	testCommands := []TestCommand{
 		{
 			Command:       []string{"wget", "-q", "-O-", "http://127.0.0.1:8006/cdh/resource/" + resourcePath},
@@ -619,7 +619,7 @@ func DoTestKbsKeyRelease(t *testing.T, e env.Environment, assert CloudAssert, kb
 // as test cases might be run in parallel
 func DoTestKbsKeyReleaseForFailure(t *testing.T, e env.Environment, assert CloudAssert, kbsEndpoint, resourcePath, expectedSecret string) {
 	t.Log("Do test kbs key release failure case")
-	pod := NewBusyboxPodWithNameWithInitdata(E2eNamespace, "kbs-failure", kbsEndpoint, testInitdata).GetPodOrFatal(t)
+	pod := NewBusyboxPodWithNameWithInitdata(E2eNamespace, "kbs-failure", kbsEndpoint).GetPodOrFatal(t)
 	testCommands := []TestCommand{
 		{
 			Command:       []string{"wget", "-q", "-O-", "http://127.0.0.1:8006/cdh/resource/" + resourcePath},

--- a/src/cloud-api-adaptor/test/e2e/remote_attestation.go
+++ b/src/cloud-api-adaptor/test/e2e/remote_attestation.go
@@ -10,10 +10,10 @@ import (
 // the test will retrieve a kbs token to verify a successful remote attestation
 func DoTestRemoteAttestation(t *testing.T, e env.Environment, assert CloudAssert, kbsEndpoint string) {
 	name := "remote-attestation"
-	image := "quay.io/curl/curl:latest"
+	image := "quay.io/confidential-containers/test-images:curl-jq"
 	// fail on non 200 code, silent, but output on failure
 	cmd := []string{"curl", "-f", "-s", "-S", "-o", "/dev/null", "http://127.0.0.1:8006/aa/token?token_type=kbs"}
-	initdata, err := buildInitdataAnnotation(kbsEndpoint, testInitdata)
+	initdata, err := buildInitdataAnnotation(kbsEndpoint)
 	if err != nil {
 		log.Fatalf("failed to build initdata %s", err)
 	}


### PR DESCRIPTION
fixes #2746

The curl image in the test is currently not being handled by image-rs. It was using a latest tag and the image has been updated since.

There is a GC issue for this:

https://github.com/confidential-containers/guest-components/issues/1253

The workaround/fix is to use to a fixed curl image that we already also use in other tests.

Drive-by fix: Changed the initdata string template to a proper go template, so we can test http endpoints without a certificate.