### PR TITLE
e2e-test: improve ibmcloud tests

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/common_suite.go
+++ b/src/cloud-api-adaptor/test/e2e/common_suite.go
@@ -330,7 +330,7 @@ func DoTestPodVMwithAnnotationsInvalidInstanceType(t *testing.T, e env.Environme
 	}
 	pod := NewPod(E2eNamespace, podName, containerName, imageName, WithCommand([]string{"/bin/sh", "-c", "sleep 3600"}), WithAnnotations(annotationData))
 	expectedErrorMessage := `requested instance type ("` + expectedType + `") is not part of supported instance types list`
-	NewTestCase(t, e, "PodVMwithAnnotationsInvalidInstanceType", assert, "Failed to Create PodVM with Annotations Invalid InstanceType").WithPod(pod).WithExpectedPodEventError(expectedErrorMessage).WithCustomPodState(v1.PodFailed).Run()
+	NewTestCase(t, e, "PodVMwithAnnotationsInvalidInstanceType", assert, "Failed to Create PodVM with Annotations Invalid InstanceType").WithPod(pod).WithExpectedPodEventError(expectedErrorMessage).WithCustomPodState(v1.PodPending).Run()
 }
 
 func DoTestPodVMwithAnnotationsLargerMemory(t *testing.T, e env.Environment, assert CloudAssert) {
@@ -343,7 +343,7 @@ func DoTestPodVMwithAnnotationsLargerMemory(t *testing.T, e env.Environment, ass
 	}
 	pod := NewPod(E2eNamespace, podName, containerName, imageName, WithCommand([]string{"/bin/sh", "-c", "sleep 3600"}), WithAnnotations(annotationData))
 	expectedErrorMessage := "failed to get instance type based on vCPU and memory annotations: no instance type found for the given vcpus (2) and memory (22528)"
-	NewTestCase(t, e, "PodVMwithAnnotationsLargerMemory", assert, "Failed to Create PodVM with Annotations Larger Memory").WithPod(pod).WithExpectedPodEventError(expectedErrorMessage).WithCustomPodState(v1.PodFailed).Run()
+	NewTestCase(t, e, "PodVMwithAnnotationsLargerMemory", assert, "Failed to Create PodVM with Annotations Larger Memory").WithPod(pod).WithExpectedPodEventError(expectedErrorMessage).WithCustomPodState(v1.PodPending).Run()
 }
 
 func DoTestPodVMwithAnnotationsLargerCPU(t *testing.T, e env.Environment, assert CloudAssert) {
@@ -356,7 +356,7 @@ func DoTestPodVMwithAnnotationsLargerCPU(t *testing.T, e env.Environment, assert
 	}
 	pod := NewPod(E2eNamespace, podName, containerName, imageName, WithCommand([]string{"/bin/sh", "-c", "sleep 3600"}), WithAnnotations(annotationData))
 	expectedErrorMessage := "no instance type found for the given vcpus (5) and memory (12288)"
-	NewTestCase(t, e, "PodVMwithAnnotationsLargerCPU", assert, "Failed to Create PodVM with Annotations Larger CPU").WithPod(pod).WithExpectedPodEventError(expectedErrorMessage).WithCustomPodState(v1.PodFailed).Run()
+	NewTestCase(t, e, "PodVMwithAnnotationsLargerCPU", assert, "Failed to Create PodVM with Annotations Larger CPU").WithPod(pod).WithExpectedPodEventError(expectedErrorMessage).WithCustomPodState(v1.PodPending).Run()
 }
 
 func DoTestCreatePeerPodContainerWithValidAlternateImage(t *testing.T, e env.Environment, assert CloudAssert, alternateImageName string) {

--- a/src/cloud-api-adaptor/test/e2e/common_suite.go
+++ b/src/cloud-api-adaptor/test/e2e/common_suite.go
@@ -339,10 +339,10 @@ func DoTestPodVMwithAnnotationsLargerMemory(t *testing.T, e env.Environment, ass
 	imageName := getBusyboxTestImage(t)
 	annotationData := map[string]string{
 		"io.katacontainers.config.hypervisor.default_vcpus":  "2",
-		"io.katacontainers.config.hypervisor.default_memory": "18432",
+		"io.katacontainers.config.hypervisor.default_memory": "22528",
 	}
 	pod := NewPod(E2eNamespace, podName, containerName, imageName, WithCommand([]string{"/bin/sh", "-c", "sleep 3600"}), WithAnnotations(annotationData))
-	expectedErrorMessage := "failed to get instance type based on vCPU and memory annotations: no instance type found for the given vcpus (2) and memory (18432)"
+	expectedErrorMessage := "failed to get instance type based on vCPU and memory annotations: no instance type found for the given vcpus (2) and memory (22528)"
 	NewTestCase(t, e, "PodVMwithAnnotationsLargerMemory", assert, "Failed to Create PodVM with Annotations Larger Memory").WithPod(pod).WithExpectedPodEventError(expectedErrorMessage).WithCustomPodState(v1.PodFailed).Run()
 }
 
@@ -351,11 +351,11 @@ func DoTestPodVMwithAnnotationsLargerCPU(t *testing.T, e env.Environment, assert
 	containerName := "busybox"
 	imageName := getBusyboxTestImage(t)
 	annotationData := map[string]string{
-		"io.katacontainers.config.hypervisor.default_vcpus":  "3",
+		"io.katacontainers.config.hypervisor.default_vcpus":  "5",
 		"io.katacontainers.config.hypervisor.default_memory": "12288",
 	}
 	pod := NewPod(E2eNamespace, podName, containerName, imageName, WithCommand([]string{"/bin/sh", "-c", "sleep 3600"}), WithAnnotations(annotationData))
-	expectedErrorMessage := "no instance type found for the given vcpus (3) and memory (12288)"
+	expectedErrorMessage := "no instance type found for the given vcpus (5) and memory (12288)"
 	NewTestCase(t, e, "PodVMwithAnnotationsLargerCPU", assert, "Failed to Create PodVM with Annotations Larger CPU").WithPod(pod).WithExpectedPodEventError(expectedErrorMessage).WithCustomPodState(v1.PodFailed).Run()
 }
 

--- a/src/cloud-api-adaptor/test/e2e/ibmcloud_test.go
+++ b/src/cloud-api-adaptor/test/e2e/ibmcloud_test.go
@@ -190,21 +190,36 @@ func TestPodVMwithNoAnnotations(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
-	DoTestPodVMwithNoAnnotations(t, testEnv, assert, GetIBMInstanceProfileType("b", "2x8"))
+	instanceProfile := pv.IBMCloudProps.InstanceProfile
+	if strings.Contains(instanceProfile, "dc-") {
+		DoTestPodVMwithNoAnnotations(t, testEnv, assert, "bx3dc-2x10")
+	} else {
+		DoTestPodVMwithNoAnnotations(t, testEnv, assert, GetIBMInstanceProfileType("b", "2x8"))
+	}
 }
 
 func TestPodVMwithAnnotationsInstanceType(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
-	DoTestPodVMwithAnnotationsInstanceType(t, testEnv, assert, GetIBMInstanceProfileType("c", "2x4"))
+	instanceProfile := pv.IBMCloudProps.InstanceProfile
+	if strings.Contains(instanceProfile, "dc-") {
+		DoTestPodVMwithAnnotationsInstanceType(t, testEnv, assert, "cx3dc-2x5")
+	} else {
+		DoTestPodVMwithAnnotationsInstanceType(t, testEnv, assert, GetIBMInstanceProfileType("c", "2x4"))
+	}
 }
 
 func TestPodVMwithAnnotationsCPUMemory(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
-	DoTestPodVMwithAnnotationsCPUMemory(t, testEnv, assert, GetIBMInstanceProfileType("m", "2x16"))
+	instanceProfile := pv.IBMCloudProps.InstanceProfile
+	if strings.Contains(instanceProfile, "dc-") {
+		DoTestPodVMwithAnnotationsCPUMemory(t, testEnv, assert, "bx3dc-4x20")
+	} else {
+		DoTestPodVMwithAnnotationsCPUMemory(t, testEnv, assert, GetIBMInstanceProfileType("m", "2x16"))
+	}
 }
 
 func TestPodVMwithAnnotationsInvalidInstanceType(t *testing.T) {

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_common.go
@@ -980,6 +980,7 @@ func (p *IBMCloudProvisioner) GetProperties(ctx context.Context, cfg *envconf.Co
 		"INITDATA":                             IBMCloudProps.InitData,
 		"CLUSTER_ID":                           IBMCloudProps.ClusterID,
 		"TAGS":                                 IBMCloudProps.Tags,
+		"CONTAINER_RUNTIME":                    IBMCloudProps.ContainerRuntime,
 	}
 }
 

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_common.go
@@ -951,8 +951,11 @@ func getProfileList() string {
 			profileList = "bz2-2x8,cz2-2x4,mz2-2x16"
 		}
 	} else {
-		profileList = "bx2-2x8,cx2-2x4,mx2-2x16"
-
+		if strings.Contains(IBMCloudProps.InstanceProfile, "dc-") {
+			profileList = "bx3dc-2x10,cx3dc-2x5,bx3dc-4x20" // Profiles with confidential computing support
+		} else {
+			profileList = "bx2-2x8,cx2-2x4,mx2-2x16"
+		}
 	}
 	return profileList
 }

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_ibmcloud.properties
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_ibmcloud.properties
@@ -14,7 +14,7 @@ COS_APIKEY="${MY_COS_SERVICE_APIKEY}"
 # optional, the default is containerd, you can set this value to containerd or crio
 CONTAINER_RUNTIME=""
 IS_SELF_MANAGED_CLUSTER="no"
-# bz2-2x8 | bx2-2x8 | bz2e-2x8
+# bz2-2x8 | bx2-2x8 | bz2e-2x8 | bx3dc-2x10
 INSTANCE_PROFILE_NAME="bz2-2x8"
 # ibmcloud cs versions
 KUBE_VERSION="1.26.1"

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_ibmcloud.properties
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_ibmcloud.properties
@@ -11,6 +11,8 @@ COS_INSTANCE_ID="crn:v1:bluemix:public:cloud-object-storage:global:a/xxxxxxxxxxx
 COS_SERVICE_URL="s3.jp-tok.cloud-object-storage.appdomain.cloud"
 # Resource list -> storage -> a cos service -> instances -> an cos service instance -> service credentials -> apikey
 COS_APIKEY="${MY_COS_SERVICE_APIKEY}"
+# optional, the default is containerd, you can set this value to containerd or crio
+CONTAINER_RUNTIME=""
 IS_SELF_MANAGED_CLUSTER="no"
 # bz2-2x8 | bx2-2x8 | bz2e-2x8
 INSTANCE_PROFILE_NAME="bz2-2x8"

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_initializer.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_initializer.go
@@ -62,6 +62,8 @@ type IBMCloudProperties struct {
 
 	VPC        *vpcv1.VpcV1
 	ClusterAPI containerv2.Clusters
+
+	ContainerRuntime string
 }
 
 var IBMCloudProps = &IBMCloudProperties{}
@@ -103,6 +105,7 @@ func InitIBMCloudProperties(properties map[string]string) error {
 		VxlanPort:         properties["VXLAN_PORT"],
 		ClusterID:         properties["CLUSTER_ID"],
 		Tags:              properties["TAGS"],
+		ContainerRuntime:  properties["CONTAINER_RUNTIME"],
 	}
 
 	if len(IBMCloudProps.IBMCloudProvider) <= 0 {


### PR DESCRIPTION
This PR introduces improvements to E2E tests and configuration related to IBM Cloud.

- Add CONTAINER_RUNTIME to E2E properties
Enables defining crio as the container runtime instead of containerd (crio is the default on ROKS).
- Add new instance profiles for E2E tests
Introduces profiles supporting confidential computing on x86_64 machines.
Updated memory and CPU annotations in several test cases to match the increased resources of these profiles.
- Fix E2E test assertions for PeerPods state
Adjusted assertions in tests where PeerPods remain in Pending instead of transitioning to Failed.
Although the expected event occurs, the tests were failing due to incorrect state checks.
I only ran these tests on IBM Cloud and never observed a PeerPod going into Failed state, so I assume Pending is the expected behavior. Let me know whether it's a bug or normal behavior.