### PR TITLE
ci: Create images for arm64

### DIFF
--- a/.github/workflows/caa_build_and_push_per_arch.yaml
+++ b/.github/workflows/caa_build_and_push_per_arch.yaml
@@ -72,9 +72,11 @@ jobs:
           { type: dev-amd64,       arch: linux/amd64,   runner: ubuntu-24.04 },
           { type: dev-s390x,       arch: linux/s390x,   runner: ubuntu-24.04-s390x },
           { type: dev-ppc64le,     arch: linux/ppc64le, runner: ubuntu-24.04-ppc64le },
+          { type: dev-arm64,       arch: linux/arm64,   runner: ubuntu-24.04-arm },
           { type: release-amd64,   arch: linux/amd64,   runner: ubuntu-24.04 },
           { type: release-s390x,   arch: linux/s390x,   runner: ubuntu-24.04-s390x },
           { type: release-ppc64le, arch: linux/ppc64le, runner: ubuntu-24.04-ppc64le },
+          { type: release-arm64,   arch: linux/arm64,   runner: ubuntu-24.04-arm },
         ]
     permissions:
       contents: read

--- a/.github/workflows/csi_wrapper_images.yaml
+++ b/.github/workflows/csi_wrapper_images.yaml
@@ -90,7 +90,7 @@ jobs:
           tags: ${{ steps.tags.outputs.tags }}
           push: true
           context: src
-          platforms: linux/amd64, linux/s390x, linux/ppc64le
+          platforms: linux/amd64, linux/s390x, linux/ppc64le, linux/arm64
           file: src/csi-wrapper/Dockerfile.csi_wrappers
           build-args: |
             "BINARY=${{matrix.binary}}"

--- a/.github/workflows/peerpod-ctrl_image.yaml
+++ b/.github/workflows/peerpod-ctrl_image.yaml
@@ -82,6 +82,6 @@ jobs:
           push: true
           context: src
           file: src/peerpod-ctrl/Dockerfile
-          platforms: linux/amd64, linux/s390x, linux/ppc64le
+          platforms: linux/amd64, linux/s390x, linux/ppc64le, linux/arm64
           build-args: |
             GOFLAGS=-tags=aws,azure,ibmcloud,ibmcloud_powervs,libvirt

--- a/.github/workflows/podvm.yaml
+++ b/.github/workflows/podvm.yaml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         os:
           - ubuntu
-        arch: [amd64, s390x]
+        arch: [amd64, s390x, arm64]
         provider: [generic]
         include:
           - os: ubuntu

--- a/.github/workflows/podvm_binaries.yaml
+++ b/.github/workflows/podvm_binaries.yaml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        arch: [amd64, s390x]
+        arch: [amd64, s390x, arm64]
         include:
           - os: ubuntu
     permissions:

--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -70,7 +70,7 @@ permissions: {}
 jobs:
   build-image:
     name: Build mkosi image for ${{ inputs.arch }}
-    runs-on: ${{ inputs.arch == 's390x' && 's390x' || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.arch == 's390x' && 's390x' || inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/podvm_publish.yaml
+++ b/.github/workflows/podvm_publish.yaml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, s390x]
+        arch: [amd64, s390x, arm64]
     with:
       git_ref: ${{ github.sha }}
       image_tag: ${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, s390x]
+        arch: [amd64, s390x, arm64]
     with:
       image_tag: ${{ github.event.release.tag_name }}
       git_ref: ${{ github.ref }}

--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         targets: ${{ fromJson(needs.list-dockerfiles.outputs.matrix) }}
-        arch: [amd64, s390x]
+        arch: [amd64, s390x, arm64]
     permissions:
       contents: read
       packages: write
@@ -66,7 +66,7 @@ jobs:
           quay.io/confidential-containers/test-images:${{env.DOCKER_TAG}}
         push: true
         context: src/cloud-api-adaptor/
-        platforms: linux/s390x,linux/amd64
+        platforms: linux/s390x,linux/amd64,linux/arm64
         file: src/cloud-api-adaptor/${{matrix.targets}}
         build-args: |
           "ARCH=${{ matrix.arch }}"

--- a/src/cloud-api-adaptor/Dockerfile
+++ b/src/cloud-api-adaptor/Dockerfile
@@ -16,7 +16,7 @@ RUN go install github.com/mikefarah/yq/v4@$YQ_VERSION
 FROM --platform=$TARGETPLATFORM $BUILDER_BASE AS builder-dev
 ARG YQ_VERSION
 RUN go install github.com/mikefarah/yq/v4@$YQ_VERSION
-RUN dnf install -y libvirt-devel && dnf clean all
+RUN dnf install -y libvirt-devel binutils-gold && dnf clean all
 
 FROM builder-${BUILD_TYPE} AS builder
 ARG RELEASE_BUILD

--- a/src/cloud-api-adaptor/podvm/hack/cross-build-extras.sh
+++ b/src/cloud-api-adaptor/podvm/hack/cross-build-extras.sh
@@ -9,8 +9,8 @@
 # If ARCH is equal to HOST, exit
 [[ $ARCH = $(uname -m) ]] && exit 0
 
-# Only gnu is available for s390x
-libc=$([[ $ARCH =~ s390x ]] && echo "gnu" || echo "musl")
+# Only gnu is available for s390x and aarch64
+libc=$([[ $ARCH =~ s390x || $ARCH =~ aarch64 ]] && echo "gnu" || echo "musl")
 rustTarget="$ARCH-unknown-linux-$libc"
 
 rustup target add "$rustTarget"

--- a/src/peerpod-ctrl/Dockerfile
+++ b/src/peerpod-ctrl/Dockerfile
@@ -6,7 +6,7 @@ ARG CGO_ENABLED=1
 ARG GOFLAGS
 
 WORKDIR /work
-RUN if [ "$CGO_ENABLED" = 1 ] ; then dnf install -y libvirt-devel && dnf clean all; fi
+RUN if [ "$CGO_ENABLED" = 1 ] ; then dnf install -y libvirt-devel binutils-gold && dnf clean all; fi
 # Copy the Go Modules manifests
 COPY peerpod-ctrl/go.mod peerpod-ctrl/go.mod
 COPY peerpod-ctrl/go.sum peerpod-ctrl/go.sum


### PR DESCRIPTION
Enable the creation of Arm64 images in CI, including:
- cloud-api-adaptor (natve-build)
- csi-wrapper (cross-build)
- peerpod-ctrl (cross-build)
- podvm using packer (cross-build)
- podvm using mkosi (native-build)

cgo-arm64 uses `ld-gold` by default while others use `ld-bfd`, so when building arm64 image, it faces ld missing error. `binutils-gold` is added to avoid this error.

---

Test in forked repo.:
- .github/workflows/caa_build_and_push_per_arch.yaml
  - https://github.com/seungukshin/cloud-api-adaptor/actions/runs/20792789981
    - manifest failed because of token permission
- .github/workflows/csi_wrapper_images.yaml
  - https://github.com/seungukshin/cloud-api-adaptor/actions/runs/20812926513
- .github/workflows/peerpod-ctrl_image.yaml
  - https://github.com/seungukshin/cloud-api-adaptor/actions/runs/20816855231/job/59794611830
- .github/workflows/podvm.yaml
  - https://github.com/seungukshin/cloud-api-adaptor/actions/runs/20752875183
- .github/workflows/podvm_binaries.yaml
  - https://github.com/seungukshin/cloud-api-adaptor/actions/runs/20752875183
- .github/workflows/podvm_mkosi.yaml
  - https://github.com/seungukshin/cloud-api-adaptor/actions/runs/20752875183
- .github/workflows/podvm_publish.yaml
  - https://github.com/seungukshin/cloud-api-adaptor/actions/runs/20752875183
- .github/workflows/release.yaml
  - it just calls cca_build_and_push_per_arch, csi_wrapper_images, peerpod-ctrl_image, podvm_builder, podvm_binaries, podvm, podvm_mkosi, and webhook_image
  - they are all tested individually except webhook_image which is not chnaged
- .github/workflows/test-images.yaml
  - https://github.com/seungukshin/cloud-api-adaptor/actions/runs/20819892359