### PR TITLE
helm/docker: adding socket mounts

### DIFF
--- a/src/cloud-api-adaptor/install/charts/peerpods/templates/daemonset.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/templates/daemonset.yaml
@@ -65,6 +65,12 @@ spec:
         # - mountPath: /cloud-providers
         #   name: provider-dir
         # # setting for cloud provider external plugin
+{{- if eq .Values.provider "docker" }}
+        - mountPath: /var/run/docker.sock
+          name: docker-socket
+        - mountPath: /var/lib/docker
+          name: docker-dir
+{{- end }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       nodeSelector:
@@ -95,3 +101,11 @@ spec:
       #     type: Directory
       #   name: provider-dir
       # # setting for cloud provider external plugin
+{{- if eq .Values.provider "docker" }}
+      - name: docker-socket
+        hostPath:
+          path: /var/run/docker.sock
+      - name: docker-dir
+        hostPath:
+          path: /var/lib/docker
+{{- end }}


### PR DESCRIPTION
Mount /var/run/docker.sock and /var/lib/docker when provider is docker, matching kustomize overlay behavior. Without these, CAA cannot connect to Docker daemon.