### PR TITLE
install/charts: set defaultShim to "remote"

### DIFF
--- a/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
@@ -59,6 +59,11 @@ resourceCtrl:
 kata-deploy:
   snapshotter:
     setup: ["nydus"]
+  defaultShim:
+    amd64: remote
+    arm64: remote
+    s390x: remote
+    ppc64le: remote
   shims:
     clh:
       enabled: false


### PR DESCRIPTION
Kata-deploy install complains that default qemu SHIM doesn't belong to the list of enabled shims:
```
Error: DEFAULT_SHIM 'qemu' must be one of the configured SHIMS for this architecture: [remote]
```

So let's make "remote" the default shim.