### PR TITLE
helm: configure DS updateStrategy for --wait

### DIFF
--- a/src/cloud-api-adaptor/install/charts/peerpods/templates/daemonset.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/templates/daemonset.yaml
@@ -12,7 +12,8 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 1
+      maxUnavailable: {{ .Values.daemonset.updateStrategy.maxUnavailable }}
+      maxSurge: {{ .Values.daemonset.updateStrategy.maxSurge }}
   template:
     metadata:
       labels:

--- a/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
@@ -46,6 +46,19 @@ provider: libvirt
 # Set to "0" for unlimited (not recommended for production)
 limit: "10"
 
+# DaemonSet configuration
+daemonset:
+  # Update strategy controls how the CAA DaemonSet performs rolling updates
+  updateStrategy:
+    # maxUnavailable: Maximum number of pods that can be unavailable during update
+    # maxSurge: Maximum number of extra pods that can be created during update
+    #
+    # Default (maxUnavailable: 0, maxSurge: 1) provides zero downtime updates
+    # and works on both small (1 node) and large clusters.
+    # Override with custom values for specific deployment needs.
+    maxUnavailable: 0
+    maxSurge: 1
+
 # peerpod-ctrl subchart configuration
 # Manages lifecycle of peer pod cloud resources and cleans up dangling VMs
 # Configuration options documented in ../../../peerpod-ctrl/chart/values.yaml


### PR DESCRIPTION
Change DaemonSet updateStrategy from hardcoded maxUnavailable: 1 to
configurable values with defaults maxUnavailable: 0, maxSurge: 1.

With maxUnavailable: 1 on single node cluster, helm --wait can return successfully even when pods are not ready. Example: 1-node cluster with maxUnavailable: 1 means minReady = 0, so helm --wait doesn't actually wait for the pod. This forces tests to implement custom wait logic after helm install.

With maxUnavailable: 0, maxSurge: 1, at least one pod must be ready before helm --wait returns. Works correctly on both small and large clusters, provides zero-downtime rolling updates, and tests can now rely on helm --wait instead of custom waits.

Users can override these values for specific deployment needs.