### PR TITLE
helm: add cert-manager as dependency

### DIFF
--- a/src/cloud-api-adaptor/install/charts/peerpods/README.md
+++ b/src/cloud-api-adaptor/install/charts/peerpods/README.md
@@ -22,6 +22,14 @@ Before installing this chart, ensure you have:
 > (`--set webhook.enabled=false`) is only recommended for development or when
 > worker nodes have sufficient resources.
 
+> [!WARNING]
+> The webhook is enabled by default and requires cert-manager for TLS certificates.
+> By default, cert-manager will be installed automatically (`webhook.certManager.install=true`).
+> If cert-manager is already installed in your cluster, set `--set webhook.certManager.install=false`.
+>
+> Disabling the webhook (`--set webhook.enabled=false`) is only recommended for
+> development or when worker nodes have sufficient resources.
+
 ## Quick Start
 
 ### Option A: Development/Testing (secrets.mode: create)

--- a/src/webhook/chart/Chart.yaml
+++ b/src/webhook/chart/Chart.yaml
@@ -18,3 +18,9 @@ sources:
 maintainers:
   - name: Confidential Containers Community
     url: https://github.com/confidential-containers
+
+dependencies:
+  - name: cert-manager
+    version: "v1.16.2"
+    repository: "oci://quay.io/jetstack/charts"
+    condition: certManager.enabled,certManager.install

--- a/src/webhook/chart/README.md
+++ b/src/webhook/chart/README.md
@@ -10,21 +10,34 @@ Before installing this chart, ensure you have:
 - **Helm** v3.x or v4.x installed ([installation guide](https://helm.sh/docs/intro/install/))
 - **Kubernetes cluster** with appropriate access
 - **kubeconfig** configured to access your cluster
-- **cert-manager** installed in the cluster ([installation guide](https://cert-manager.io/docs/installation/))
 
-> **Note**: The webhook requires TLS certificates to operate. This chart uses cert-manager
+> [!WARNING]
+> The webhook requires TLS certificates to operate. This chart uses cert-manager
 > to automatically generate and manage these certificates.
+>
+> By default, cert-manager will be installed automatically (`certManager.install=true`).
+> If cert-manager is already installed in your cluster, set `--set certManager.install=false`.
+>
+> To disable cert-manager integration entirely and provide certificates manually,
+> set `--set certManager.enabled=false`.
 
 ## Quick Start
 
 ### Standalone Installation
 
-```bash
-# Install cert-manager if not already installed
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.3/cert-manager.yaml
+**With automatic cert-manager installation (default):**
 
-# Install the webhook chart
+```bash
 helm install peerpods-webhook ./chart \
+  -n confidential-containers-system \
+  --create-namespace
+```
+
+**If cert-manager is already installed:**
+
+```bash
+helm install peerpods-webhook ./chart \
+  --set certManager.install=false \
   -n confidential-containers-system \
   --create-namespace
 ```

--- a/src/webhook/chart/templates/certmanager.yaml
+++ b/src/webhook/chart/templates/certmanager.yaml
@@ -1,9 +1,15 @@
 {{- if .Values.certManager.enabled }}
+# Use post-install hooks to ensure cert-manager webhook is ready before creating CRs.
+# When cert-manager is installed as a dependency, its CRDs are created but the webhook
+# pods may not be running yet. These hooks run after --wait confirms all pods are ready.
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ .Values.namePrefix }}selfsigned-issuer
   namespace: {{ .Values.namespace }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "1"
 spec:
   selfSigned: {}
 ---
@@ -12,6 +18,9 @@ kind: Certificate
 metadata:
   name: {{ .Values.namePrefix }}serving-cert
   namespace: {{ .Values.namespace }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "2"
 spec:
   dnsNames:
   - {{ .Values.namePrefix }}webhook-service.{{ .Values.namespace }}.svc

--- a/src/webhook/chart/values.yaml
+++ b/src/webhook/chart/values.yaml
@@ -50,4 +50,11 @@ authProxy:
 # cert-manager automates certificate generation, rotation, and trust configuration
 # Without this, you would need to manually create and manage webhook certificates
 certManager:
+  # Use cert-manager to generate webhook TLS certificates
+  # Creates Certificate and Issuer custom resources
+  # Set to false only if you are providing certificates through another method
   enabled: true
+
+  # Install cert-manager as a chart dependency
+  # Set to false if cert-manager is already installed in your cluster
+  install: true


### PR DESCRIPTION
Webhook requires cert-manager and is enabled by default. But users can disable installation if have them already installed.