### PR TITLE
RFC (post 0.18): libvirt and azure helm provisioning support with cleaner API (conflicts with #2809)

### DIFF
--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -19,6 +19,11 @@ on:
       podvm-image-id:
         type: string
         description: prebuilt podvm image
+      install_method:
+        default: 'kustomize'
+        description: Installation method. Either kustomize or helm.
+        required: false
+        type: string
     secrets:
       AZURE_CLIENT_ID:
         required: true
@@ -32,6 +37,11 @@ on:
       podvm-image-id:
         type: string
         description: prebuilt podvm image
+      install_method:
+        default: 'kustomize'
+        description: Installation method. Either kustomize or helm.
+        required: false
+        type: string
 
 jobs:
   build-caa-container-image:
@@ -211,10 +221,23 @@ jobs:
         sudo apt-get install -y sipcalc
 
     - name: Install kustomize
+      if: ${{ inputs.install_method == 'kustomize' }}
       run: |
         command -v kustomize >/dev/null || \
         curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | \
           sudo bash -s /usr/local/bin
+
+    - name: Install Helm
+      if: ${{ inputs.install_method == 'helm' }}
+      run: |
+        HELM_VERSION="$(yq -e '.tools.helm.version' versions.yaml)"
+        HELM_CHECKSUM="$(yq -e '.tools.helm.sha256' versions.yaml)"
+        curl -fsSL -o helm.tar.gz "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz"
+        echo "${HELM_CHECKSUM}  helm.tar.gz" | sha256sum --check --strict
+        tar -xzf helm.tar.gz
+        sudo mv linux-amd64/helm /usr/local/bin/helm
+        rm -rf helm.tar.gz linux-amd64
+        helm version
 
     - name: Restore the configuration created before
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -246,6 +269,48 @@ jobs:
         AZURE_SUBNET_ID="$subnet_id"
         EOF
 
+        # Export for helm values step
+        echo "AZURE_SUBNET_ID=$subnet_id" >> "$GITHUB_ENV"
+
+    - name: Create helm values file
+      if: ${{ inputs.install_method == 'helm' }}
+      env:
+        CAA_IMAGE: "${{ needs.build-caa-container-image.outputs.caa-image }}"
+        AZURE_IMAGE_ID: "${{ inputs.podvm-image-id }}"
+        AZURE_INSTANCE_SIZE: "${{ matrix.parameters.machine_type }}"
+        AZURE_SUBSCRIPTION_ID: "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
+        AZURE_CLIENT_ID: "${{ secrets.AZURE_CLIENT_ID }}"
+      run: |
+        CAA_IMAGE_TAG="${CAA_IMAGE##*:}"
+        CAA_IMAGE_NAME="${CAA_IMAGE%:*}"
+
+        cat <<EOF > helm-values.yaml
+        image:
+          name: "${CAA_IMAGE_NAME}"
+          tag: "${CAA_IMAGE_TAG}"
+        providerConfigs:
+          azure:
+            AZURE_SUBSCRIPTION_ID: "${AZURE_SUBSCRIPTION_ID}"
+            AZURE_REGION: "${LOCATION}"
+            AZURE_RESOURCE_GROUP: "${RG_NAME}"
+            AZURE_IMAGE_ID: "${AZURE_IMAGE_ID}"
+            AZURE_INSTANCE_SIZE: "${AZURE_INSTANCE_SIZE}"
+            AZURE_SUBNET_ID: "${AZURE_SUBNET_ID}"
+        providerSecrets:
+          azure:
+            AZURE_CLIENT_ID: "${AZURE_CLIENT_ID}"
+        EOF
+
+        echo "HELM_VALUES_FILES=$PWD/install/charts/peerpods/providers/azure.yaml,$PWD/helm-values.yaml" >> "$GITHUB_ENV"
+
+        # For debugging (without secrets)
+        echo "::group::helm-values.yaml (structure only)"
+        echo "image.name: ${CAA_IMAGE_NAME}"
+        echo "image.tag: ${CAA_IMAGE_TAG}"
+        echo "providerConfigs.azure: (subscription, region, resource group, image, instance size, subnet)"
+        echo "providerSecrets.azure: (client id)"
+        echo "::endgroup::"
+
     - name: Checkout KBS Repository
       run: test/utils/checkout_kbs.sh
 
@@ -254,6 +319,7 @@ jobs:
       env:
         TEST_PROVISION: "no"
         DEPLOY_KBS: "yes"
+        INSTALL_METHOD: "${{ inputs.install_method }}"
         CUSTOM_PCCS_URL: "https://global.acccache.azure.net/sgx/certification/v4"
         CLUSTER_NAME: "${{ format(env.CLUSTER_NAME_TEMPLATE, matrix.parameters.id) }}"
       run: |

--- a/.github/workflows/e2e_aws.yaml
+++ b/.github/workflows/e2e_aws.yaml
@@ -191,6 +191,31 @@ jobs:
           cat aws.properties
           echo "::endgroup::"
 
+      - name: Create helm values file
+        if: ${{ inputs.install_method == 'helm' }}
+        run: |
+          CAA_IMAGE_TAG="${CAA_IMAGE##*:}"
+          CAA_IMAGE_NAME="${CAA_IMAGE%:*}"
+          cat <<EOF > helm-values.yaml
+          image:
+            name: "${CAA_IMAGE_NAME}"
+            tag: "${CAA_IMAGE_TAG}"
+          providerConfigs:
+            aws:
+              DISABLECVM: "true"
+              SSH_KP_NAME: "caa-e2e-test"
+              AWS_REGION: "us-east-1"
+              PODVM_INSTANCE_TYPE: "t2.medium"
+              USE_PUBLIC_IP: "true"
+          EOF
+
+          echo "HELM_VALUES_FILES=install/charts/peerpods/providers/aws.yaml,$PWD/helm-values.yaml" >> "$GITHUB_ENV"
+
+          # For debugging
+          echo "::group::helm-values.yaml"
+          cat helm-values.yaml
+          echo "::endgroup::"
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:

--- a/.github/workflows/e2e_docker.yaml
+++ b/.github/workflows/e2e_docker.yaml
@@ -144,16 +144,36 @@ jobs:
           DOCKER_API_VERSION="1.44"
           EOF
 
-          # If using helm, split CAA_IMAGE into CAA_IMAGE_NAME and CAA_IMAGE_TAG
-          if [ "${INSTALL_METHOD}" = "helm" ]; then
-            CAA_IMAGE_TAG="${CAA_IMAGE##*:}"
-            CAA_IMAGE_NAME="${CAA_IMAGE%:*}"
-            echo "CAA_IMAGE=\"${CAA_IMAGE_NAME}\"" >> docker.properties
-            echo "CAA_IMAGE_TAG=\"${CAA_IMAGE_TAG}\"" >> docker.properties
-          fi
+          # For debugging
+          echo "::group::docker.properties"
+          cat docker.properties
+          echo "::endgroup::"
+
+      - name: Create helm values file
+        if: ${{ inputs.install_method == 'helm' }}
+        env:
+          DOCKER_PODVM_IMAGE: ${{ inputs.podvm_image }}
+        run: |
+          CAA_IMAGE_TAG="${CAA_IMAGE##*:}"
+          CAA_IMAGE_NAME="${CAA_IMAGE%:*}"
+          cat <<EOF > helm-values.yaml
+          image:
+            name: "${CAA_IMAGE_NAME}"
+            tag: "${CAA_IMAGE_TAG}"
+          providerConfigs:
+            docker:
+              DOCKER_HOST: "unix:///var/run/docker.sock"
+              DOCKER_NETWORK_NAME: "kind"
+              DOCKER_API_VERSION: "1.44"
+              DOCKER_PODVM_IMAGE: "${DOCKER_PODVM_IMAGE}"
+          EOF
+
+          echo "HELM_VALUES_FILES=install/charts/peerpods/providers/docker.yaml,$PWD/helm-values.yaml" >> "$GITHUB_ENV"
 
           # For debugging
-          cat docker.properties
+          echo "::group::helm-values.yaml"
+          cat helm-values.yaml
+          echo "::endgroup::"
 
       - name: run tests
         id: runTests

--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -196,113 +196,38 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Provision cluster (helm only)
-        if: ${{ inputs.install_method == 'helm' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CLOUD_PROVIDER: libvirt
-          CONTAINER_RUNTIME: ${{ inputs.container_runtime }}
-          TEST_PROVISION_FILE: ${{ github.workspace }}/src/cloud-api-adaptor/libvirt.properties
-          TEST_PODVM_IMAGE: ${{ env.PODVM_QCOW2 }}
-          TEST_E2E_TIMEOUT: "30m"
-        run: make provision-cluster
-
-      - name: Deploy CAA using Helm chart
+      - name: Create helm values file
         if: ${{ inputs.install_method == 'helm' }}
         env:
           CAA_IMAGE: ${{ inputs.caa_image }}
         run: |
-          export KUBECONFIG="${HOME}/.kcli/clusters/peer-pods/auth/kubeconfig"
-
-          # Install cert-manager (required for webhook)
-          echo "Installing cert-manager..."
-          make -C ../webhook deploy-cert-manager
-
-          kubectl create namespace confidential-containers-system --dry-run=client -o yaml | kubectl apply -f -
-
-          # Extract image name and tag from caa_image (format: registry/image:tag)
-          IMAGE_FULL="${CAA_IMAGE}"
-          IMAGE_TAG="${IMAGE_FULL##*:}"
-          IMAGE_NAME="${IMAGE_FULL%:*}"
-
-          echo "Deploying with Helm:"
-          echo "  Image: ${IMAGE_NAME}"
-          echo "  Tag: ${IMAGE_TAG}"
-
-          # Build chart dependencies (downloads kata-deploy from OCI registry)
-          echo "Building Helm chart dependencies..."
-          helm dependency build ./install/charts/peerpods
-
-          # TODO: Temporary solution. Providers lack Helm Apply() in test framework.
-          #       Long term: implement HelmInstallOverlay.Apply() similar to other ProviderInstallOverlay implementations.
-          # Read libvirt config from properties file (created by config_libvirt.sh)
           source libvirt.properties
 
-          # Create SSH key secret for libvirt (keys created by config_libvirt.sh)
-          # TODO: This should use --set-file providerSecrets.libvirt.id_rsa once
-          #       providerSecrets.libvirt is defined in providers/libvirt.yaml
-          kubectl create secret generic ssh-key-secret \
-            --from-file=id_rsa="${HOME}/.ssh/id_rsa" \
-            --from-file=id_rsa.pub="${HOME}/.ssh/id_rsa.pub" \
-            -n confidential-containers-system
+          CAA_IMAGE_TAG="${CAA_IMAGE##*:}"
+          CAA_IMAGE_NAME="${CAA_IMAGE%:*}"
 
-          # Install chart with libvirt configuration
-          helm install peerpods ./install/charts/peerpods \
-            -f install/charts/peerpods/providers/libvirt.yaml \
-            --set "image.name=${IMAGE_NAME}" \
-            --set "image.tag=${IMAGE_TAG}" \
-            --set-string "providerConfigs.libvirt.LIBVIRT_URI=${libvirt_uri}" \
-            -n confidential-containers-system \
-            --wait --timeout=10m || {
-              echo "::error::Helm install failed. Collecting debug info..."
-              echo "::group::Pre-install job pods"
-              kubectl get pods -n confidential-containers-system -l app.kubernetes.io/component=installer -o wide
-              echo "::endgroup::"
-              echo "::group::Pre-install job pod describe (shows OOMKilled, exit code, etc)"
-              kubectl describe pods -n confidential-containers-system -l app.kubernetes.io/component=installer || true
-              echo "::endgroup::"
-              echo "::group::Pre-install job describe"
-              kubectl describe job -n confidential-containers-system -l app.kubernetes.io/component=installer || true
-              echo "::endgroup::"
-              echo "::group::Pre-install job logs (current)"
-              kubectl logs -n confidential-containers-system -l app.kubernetes.io/component=installer --tail=500 || true
-              echo "::endgroup::"
-              echo "::group::Pre-install job logs (previous - shows failed run)"
-              kubectl logs -n confidential-containers-system -l app.kubernetes.io/component=installer --previous --tail=500 || true
-              echo "::endgroup::"
-              echo "::group::Pre-install job events"
-              kubectl get events -n confidential-containers-system --sort-by='.lastTimestamp' | tail -50
-              echo "::endgroup::"
-              echo "::group::Webhook namespace check (peer-pods-webhook-system)"
-              kubectl get namespace peer-pods-webhook-system 2>&1 || echo "Namespace does not exist"
-              kubectl get events -n peer-pods-webhook-system --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
-              echo "::endgroup::"
-              exit 1
-            }
+          # Create base values file
+          cat <<EOF > helm-values.yaml
+          image:
+            name: "${CAA_IMAGE_NAME}"
+            tag: "${CAA_IMAGE_TAG}"
+          providerConfigs:
+            libvirt:
+              LIBVIRT_URI: "${libvirt_uri}"
+          EOF
 
-          echo "Waiting for CAA daemonset to be ready..."
-          kubectl rollout status daemonset/cloud-api-adaptor-daemonset -n confidential-containers-system --timeout=5m
+          # Append SSH keys using yq for proper YAML formatting
+          yq -i '.providerSecrets.libvirt.id_rsa = load_str("'"${HOME}"'/.ssh/id_rsa")' helm-values.yaml
+          yq -i '.providerSecrets.libvirt."id_rsa.pub" = load_str("'"${HOME}"'/.ssh/id_rsa.pub")' helm-values.yaml
 
-          echo "Waiting for kata-deploy daemonset to be ready..."
-          kubectl rollout status daemonset/kata-deploy -n confidential-containers-system --timeout=5m
+          echo "HELM_VALUES_FILES=install/charts/peerpods/providers/libvirt.yaml,$PWD/helm-values.yaml" >> "$GITHUB_ENV"
 
-          # kata-deploy labels nodes with katacontainers.io/kata-runtime=true after installing kata.
-          # The kata-remote RuntimeClass has a nodeSelector requiring this label.
-          # We must wait for at least one node to have this label before tests can run.
-          echo "Waiting for node to be labeled with katacontainers.io/kata-runtime=true..."
-          timeout 120 bash -c '
-            until kubectl get nodes -l katacontainers.io/kata-runtime=true --no-headers 2>/dev/null | grep -q .; do
-              echo "  Waiting for kata-runtime node label..."
-              sleep 5
-            done
-          '
-          echo "Node labeled successfully:"
-          kubectl get nodes -l katacontainers.io/kata-runtime=true
-
-          echo "::group::Helm deployment info"
-          helm list -n confidential-containers-system
-          kubectl get daemonset -n confidential-containers-system
-          kubectl get pods -n confidential-containers-system -l app=cloud-api-adaptor
+          # For debugging (without secrets)
+          echo "::group::helm-values.yaml (structure only)"
+          echo "image.name: ${CAA_IMAGE_NAME}"
+          echo "image.tag: ${CAA_IMAGE_TAG}"
+          echo "providerConfigs.libvirt.LIBVIRT_URI: ${libvirt_uri}"
+          echo "providerSecrets.libvirt: (ssh keys present)"
           echo "::endgroup::"
 
       - name: run tests
@@ -320,20 +245,11 @@ jobs:
           TEST_PODVM_IMAGE: ${{ env.PODVM_QCOW2 }}
           TEST_E2E_TIMEOUT: "75m"
         run: |
-          # Default: provision cluster and install CAA
           export TEST_PROVISION="yes"
           export TEST_TEARDOWN="no"
           export TEST_PROVISION_FILE="$PWD/libvirt.properties"
           export TEST_PODVM_IMAGE="${{ env.PODVM_QCOW2 }}"
           export TEST_E2E_TIMEOUT="75m"
-
-          # Skip provisioning and CAA installation if using helm (already done above)
-          # KBS is deployed here (not in provision step) so keys match
-          if [ "${INSTALL_METHOD}" = "helm" ]; then
-            export TEST_PROVISION="no"
-            export TEST_INSTALL_CAA="no"
-            export KUBECONFIG="${HOME}/.kcli/clusters/peer-pods/auth/kubeconfig"
-          fi
 
           make test-e2e
 

--- a/src/cloud-api-adaptor/go.mod
+++ b/src/cloud-api-adaptor/go.mod
@@ -73,6 +73,7 @@ require (
 	github.com/confidential-containers/cloud-api-adaptor/src/peerpod-ctrl v0.0.0-00010101000000-000000000000
 	github.com/distribution/reference v0.6.0
 	github.com/fenglyu/go-dmidecode v0.0.0-20220417074508-03f52eb45fe9
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -238,7 +239,6 @@ require (
 	gopkg.in/evanphx/json-patch.v5 v5.6.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.5.2 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect

--- a/src/cloud-api-adaptor/test/provisioner/aws/provision.go
+++ b/src/cloud-api-adaptor/test/provisioner/aws/provision.go
@@ -13,5 +13,4 @@ func init() {
 	// Add this implementation to the list of provisioners.
 	pv.NewProvisionerFunctions["aws"] = NewAWSProvisioner
 	pv.NewInstallOverlayFunctions["aws"] = NewAwsInstallOverlay
-	pv.NewInstallChartFunctions["aws"] = NewAwsInstallChart
 }

--- a/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
@@ -127,11 +127,6 @@ type AwsInstallOverlay struct {
 	Overlay *pv.KustomizeOverlay
 }
 
-// AwsInstallChart implements the InstallChart interface
-type AwsInstallChart struct {
-	Helm *pv.Helm
-}
-
 // NewAWSProvisioner instantiates the AWS provisioner
 func NewAWSProvisioner(properties map[string]string) (pv.CloudProvisioner, error) {
 	var cluster Cluster
@@ -317,6 +312,32 @@ func (a *AWSProvisioner) DeleteVPC(ctx context.Context, cfg *envconf.Config) err
 	}
 
 	return nil
+}
+
+func (a *AWSProvisioner) GetProvisionValues() map[string]interface{} {
+	credentials, _ := a.AwsConfig.Credentials.Retrieve(context.TODO())
+
+	// Dynamic values created during provisioning
+	providerConfigs := map[string]interface{}{
+		"PODVM_AMI_ID":  a.Image.ID,
+		"AWS_SG_IDS":    a.Vpc.SecurityGroupId,
+		"AWS_SUBNET_ID": a.Vpc.SubnetId,
+	}
+
+	providerSecrets := map[string]interface{}{
+		"AWS_ACCESS_KEY_ID":     credentials.AccessKeyID,
+		"AWS_SECRET_ACCESS_KEY": credentials.SecretAccessKey,
+		"AWS_SESSION_TOKEN":     credentials.SessionToken,
+	}
+
+	return map[string]interface{}{
+		"providerConfigs": map[string]interface{}{
+			"aws": providerConfigs,
+		},
+		"providerSecrets": map[string]interface{}{
+			"aws": providerSecrets,
+		},
+	}
 }
 
 func (a *AWSProvisioner) GetProperties(ctx context.Context, cfg *envconf.Config) map[string]string {
@@ -1206,93 +1227,6 @@ func (a *AwsInstallOverlay) Edit(ctx context.Context, cfg *envconf.Config, prope
 
 	if err = a.Overlay.YamlReload(); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func NewAwsInstallChart(installDir, provider string) (pv.InstallChart, error) {
-	chartPath := filepath.Join(installDir, "charts", "peerpods")
-	namespace := pv.GetCAANamespace()
-	releaseName := "peerpods"
-	debug := false
-
-	helm, err := pv.NewHelm(chartPath, namespace, releaseName, provider, debug)
-	if err != nil {
-		return nil, err
-	}
-
-	return &AwsInstallChart{
-		Helm: helm,
-	}, nil
-}
-
-func (a *AwsInstallChart) Install(ctx context.Context, cfg *envconf.Config) error {
-	return a.Helm.Install(ctx, cfg)
-}
-
-func (a *AwsInstallChart) Uninstall(ctx context.Context, cfg *envconf.Config) error {
-	return a.Helm.Uninstall(ctx, cfg)
-}
-
-func (a *AwsInstallChart) Configure(ctx context.Context, cfg *envconf.Config, properties map[string]string) error {
-	if properties["CAA_IMAGE"] != "" {
-		img := strings.Split(properties["CAA_IMAGE"], ":")
-		imageNameProp := "image.name"
-		log.Printf("Configuring helm: override value (%s=%s)", imageNameProp, img[0])
-		a.Helm.OverrideValues[imageNameProp] = img[0]
-		if len(img) == 2 {
-			imageTagProp := "image.tag"
-			//log.Printf("Configuring helm: override value (%s=%s)", imageTagProp, img[1])
-			a.Helm.OverrideValues[imageTagProp] = img[1]
-		}
-	}
-
-	if properties["CONTAINER_RUNTIME"] == "crio" {
-		prop := "kata-deploy.snapshotter.setup"
-		//log.Printf("Configuring helm: disable snapshotter setup(%s)", prop)
-		a.Helm.OverrideValues[prop] = ""
-	}
-
-	// Mapping the internal properties to Helm chart values.
-	mapProps := map[string]string{
-		"disablecvm":           "DISABLECVM",
-		"pause_image":          "PAUSE_IMAGE",
-		"podvm_launchtemplate": "PODVM_LAUNCHTEMPLATE_NAME",
-		"podvm_ami":            "PODVM_AMI_ID",
-		"podvm_instance_type":  "PODVM_INSTANCE_TYPE",
-		"sg_ids":               "AWS_SG_IDS",
-		"subnet_id":            "AWS_SUBNET_ID",
-		"ssh_kp_name":          "SSH_KP_NAME",
-		"region":               "AWS_REGION",
-		"tunnel_type":          "TUNNEL_TYPE",
-		"vxlan_port":           "VXLAN_PORT",
-		"use_public_ip":        "USE_PUBLIC_IP",
-	}
-
-	for k, v := range mapProps {
-		if properties[k] != "" {
-			//log.Printf("Configuring helm: override provider value (%s=%s)", v, properties[k])
-			a.Helm.OverrideProviderValues[v] = properties[k]
-		}
-	}
-
-	// Handle credentials
-	if properties["peerpods_secret_name"] == "" {
-		// If peerpods_secret_name is empty, use the direct approach (map to providerSecrets)
-		if properties["access_key_id"] != "" {
-			a.Helm.OverrideProviderSecrets["AWS_ACCESS_KEY_ID"] = properties["access_key_id"]
-		}
-		if properties["secret_access_key"] != "" {
-			a.Helm.OverrideProviderSecrets["AWS_SECRET_ACCESS_KEY"] = properties["secret_access_key"]
-		}
-		if properties["session_token"] != "" {
-			a.Helm.OverrideProviderSecrets["AWS_SESSION_TOKEN"] = properties["session_token"]
-		}
-	} else {
-		// Set OverrideValues for secret reference mode
-		a.Helm.OverrideValues["secrets.mode"] = "reference"
-		a.Helm.OverrideValues["secrets.existingSecretName"] = properties["peerpods_secret_name"]
 	}
 
 	return nil

--- a/src/cloud-api-adaptor/test/provisioner/azure/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/azure/provision_common.go
@@ -367,8 +367,18 @@ func getPropertiesImpl() map[string]string {
 }
 
 func (p *AzureCloudProvisioner) GetProvisionValues() map[string]interface{} {
-	// TODO: implement properly
-	return nil
+	// SubnetID is discovered from the AKS VNET during CreateCluster.
+	if AzureProps.SubnetID == "" {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"providerConfigs": map[string]interface{}{
+			"azure": map[string]interface{}{
+				"AZURE_SUBNET_ID": AzureProps.SubnetID,
+			},
+		},
+	}
 }
 
 func (p *AzureCloudProvisioner) GetProperties(ctx context.Context, cfg *envconf.Config) map[string]string {

--- a/src/cloud-api-adaptor/test/provisioner/azure/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/azure/provision_common.go
@@ -366,6 +366,11 @@ func getPropertiesImpl() map[string]string {
 	return props
 }
 
+func (p *AzureCloudProvisioner) GetProvisionValues() map[string]interface{} {
+	// TODO: implement properly
+	return nil
+}
+
 func (p *AzureCloudProvisioner) GetProperties(ctx context.Context, cfg *envconf.Config) map[string]string {
 	log.Trace("GetProperties()")
 	return getPropertiesImpl()

--- a/src/cloud-api-adaptor/test/provisioner/azure/provision_self_mgr.go
+++ b/src/cloud-api-adaptor/test/provisioner/azure/provision_self_mgr.go
@@ -34,8 +34,18 @@ func (p *AzureSelfManagedClusterProvisioner) UploadPodvm(imagePath string, ctx c
 }
 
 func (p *AzureSelfManagedClusterProvisioner) GetProvisionValues() map[string]interface{} {
-	// TODO: implement properly
-	return nil
+	// SubnetID is discovered from the AKS VNET during CreateCluster.
+	if AzureProps.SubnetID == "" {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"providerConfigs": map[string]interface{}{
+			"azure": map[string]interface{}{
+				"AZURE_SUBNET_ID": AzureProps.SubnetID,
+			},
+		},
+	}
 }
 
 func (p *AzureSelfManagedClusterProvisioner) GetProperties(ctx context.Context, cfg *envconf.Config) map[string]string {

--- a/src/cloud-api-adaptor/test/provisioner/azure/provision_self_mgr.go
+++ b/src/cloud-api-adaptor/test/provisioner/azure/provision_self_mgr.go
@@ -33,6 +33,11 @@ func (p *AzureSelfManagedClusterProvisioner) UploadPodvm(imagePath string, ctx c
 	return nil
 }
 
+func (p *AzureSelfManagedClusterProvisioner) GetProvisionValues() map[string]interface{} {
+	// TODO: implement properly
+	return nil
+}
+
 func (p *AzureSelfManagedClusterProvisioner) GetProperties(ctx context.Context, cfg *envconf.Config) map[string]string {
 	return getPropertiesImpl()
 }

--- a/src/cloud-api-adaptor/test/provisioner/byom/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/byom/provision_common.go
@@ -178,6 +178,11 @@ func (b *ByomProvisioner) DeletePodVMInstance(ctx context.Context, cfg *envconf.
 	return nil
 }
 
+func (b *ByomProvisioner) GetProvisionValues() map[string]interface{} {
+	// TODO: implement properly
+	return nil
+}
+
 func (b *ByomProvisioner) GetProperties(ctx context.Context, cfg *envconf.Config) map[string]string {
 	return map[string]string{
 		"VM_POOL_IPS":              ByomProps.VMPoolIPs,

--- a/src/cloud-api-adaptor/test/provisioner/docker/provision.go
+++ b/src/cloud-api-adaptor/test/provisioner/docker/provision.go
@@ -12,5 +12,4 @@ import (
 func init() {
 	pv.NewProvisionerFunctions["docker"] = NewDockerProvisioner
 	pv.NewInstallOverlayFunctions["docker"] = NewDockerInstallOverlay
-	pv.NewInstallChartFunctions["docker"] = NewDockerInstallChart
 }

--- a/src/cloud-api-adaptor/test/provisioner/docker/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/docker/provision_common.go
@@ -30,11 +30,6 @@ type DockerInstallOverlay struct {
 	Overlay *pv.KustomizeOverlay
 }
 
-// DockerInstallChart implements the InstallChart interface
-type DockerInstallChart struct {
-	Helm *pv.Helm
-}
-
 type DockerProperties struct {
 	DockerHost       string
 	ApiVer           string
@@ -134,6 +129,11 @@ func (l *DockerProvisioner) CreateVPC(ctx context.Context, cfg *envconf.Config) 
 func (l *DockerProvisioner) DeleteVPC(ctx context.Context, cfg *envconf.Config) error {
 	// TODO: delete the resources created on CreateVPC() that currently only checks
 	// the Docker's storage and network exist.
+	return nil
+}
+
+func (l *DockerProvisioner) GetProvisionValues() map[string]interface{} {
+	// Docker has no dynamic values created during provisioning
 	return nil
 }
 
@@ -281,57 +281,4 @@ func (lio *DockerInstallOverlay) Edit(ctx context.Context, cfg *envconf.Config, 
 
 	return nil
 
-}
-
-func NewDockerInstallChart(installDir, provider string) (pv.InstallChart, error) {
-	chartPath := filepath.Join(installDir, "charts", "peerpods")
-	namespace := pv.GetCAANamespace()
-	releaseName := "peerpods"
-	debug := false
-
-	helm, err := pv.NewHelm(chartPath, namespace, releaseName, provider, debug)
-	if err != nil {
-		return nil, err
-	}
-
-	return &DockerInstallChart{
-		Helm: helm,
-	}, nil
-}
-
-func (d *DockerInstallChart) Install(ctx context.Context, cfg *envconf.Config) error {
-	return d.Helm.Install(ctx, cfg)
-}
-
-func (d *DockerInstallChart) Uninstall(ctx context.Context, cfg *envconf.Config) error {
-	return d.Helm.Uninstall(ctx, cfg)
-}
-
-func (d *DockerInstallChart) Configure(ctx context.Context, cfg *envconf.Config, properties map[string]string) error {
-	// Handle CAA image - already split into CAA_IMAGE and CAA_IMAGE_TAG
-	if properties["CAA_IMAGE"] != "" {
-		d.Helm.OverrideValues["image.name"] = properties["CAA_IMAGE"]
-	}
-	if properties["CAA_IMAGE_TAG"] != "" {
-		d.Helm.OverrideValues["image.tag"] = properties["CAA_IMAGE_TAG"]
-	}
-
-	// Mapping the internal properties to Helm chart values.
-	mapProps := map[string]string{
-		"DOCKER_HOST":         "DOCKER_HOST",
-		"DOCKER_API_VERSION":  "DOCKER_API_VERSION",
-		"DOCKER_PODVM_IMAGE":  "DOCKER_PODVM_IMAGE",
-		"DOCKER_NETWORK_NAME": "DOCKER_NETWORK_NAME",
-		"TUNNEL_TYPE":         "TUNNEL_TYPE",
-		"VXLAN_PORT":          "VXLAN_PORT",
-		"INITDATA":            "INITDATA",
-	}
-
-	for k, v := range mapProps {
-		if properties[k] != "" {
-			d.Helm.OverrideProviderValues[v] = properties[k]
-		}
-	}
-
-	return nil
 }

--- a/src/cloud-api-adaptor/test/provisioner/gcp/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/gcp/provision_common.go
@@ -87,6 +87,11 @@ func (p *GCPProvisioner) DeleteVPC(ctx context.Context, cfg *envconf.Config) err
 	return p.GcpVPC.DeleteVPC(ctx, cfg)
 }
 
+func (p *GCPProvisioner) GetProvisionValues() map[string]interface{} {
+	// TODO: implement properly
+	return nil
+}
+
 func (p *GCPProvisioner) GetProperties(ctx context.Context, cfg *envconf.Config) map[string]string {
 	return map[string]string{
 		// GkeCluster properties

--- a/src/cloud-api-adaptor/test/provisioner/helm.go
+++ b/src/cloud-api-adaptor/test/provisioner/helm.go
@@ -11,23 +11,21 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
-// Helm represents a Helm chart installer
+// Helm represents a generic Helm chart installer
 type Helm struct {
-	ChartPath               string            // path to the chart directory
-	Namespace               string            // namespace where the chart will be installed
-	ReleaseName             string            // name of the Helm release
-	Provider                string            // cloud provider name
-	Debug                   bool              // enable debug mode for helm commands
-	OverrideValues          map[string]string // key-value map for overriding chart values
-	OverrideProviderValues  map[string]string // key-value map for overriding provider-specific chart values
-	OverrideProviderSecrets map[string]string // key-value map for overriding provider-specific chart secrets
+	ChartPath   string
+	Namespace   string
+	ReleaseName string
+	Debug       bool
+	Values      map[string]interface{} // Complete helm values structure
 }
 
 // NewHelm creates a new Helm instance and builds chart dependencies
-func NewHelm(chartPath, namespace, releaseName, provider string, debug bool) (*Helm, error) {
+func NewHelm(chartPath, namespace, releaseName string, debug bool) (*Helm, error) {
 	// Build chart dependencies
 	args := []string{"dependency", "build", chartPath}
 	cmd := exec.Command("helm", args...)
@@ -39,75 +37,136 @@ func NewHelm(chartPath, namespace, releaseName, provider string, debug bool) (*H
 	}
 
 	return &Helm{
-		ChartPath:               chartPath,
-		Namespace:               namespace,
-		ReleaseName:             releaseName,
-		Provider:                provider,
-		Debug:                   debug,
-		OverrideValues:          make(map[string]string),
-		OverrideProviderValues:  make(map[string]string),
-		OverrideProviderSecrets: make(map[string]string),
+		ChartPath:   chartPath,
+		Namespace:   namespace,
+		ReleaseName: releaseName,
+		Debug:       debug,
+		Values:      make(map[string]interface{}),
 	}, nil
 }
 
-// Install installs the Helm chart. Equivalent to the `helm install` command
+// LoadFromFile reads a YAML file and deep merges its content into the Values map
+func (h *Helm) LoadFromFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read values file %s: %w", path, err)
+	}
+
+	var fileValues map[string]interface{}
+	if err := yaml.Unmarshal(data, &fileValues); err != nil {
+		return fmt.Errorf("failed to parse YAML from %s: %w", path, err)
+	}
+
+	// Deep merge file values into existing Values map
+	h.Values = deepMerge(h.Values, fileValues)
+
+	log.Infof("Loaded helm values from: %s", path)
+	return nil
+}
+
+// deepMerge recursively merges src into dst. Values in src take precedence.
+func deepMerge(dst, src map[string]interface{}) map[string]interface{} {
+	if dst == nil {
+		dst = make(map[string]interface{})
+	}
+
+	for key, srcVal := range src {
+		dstVal, exists := dst[key]
+		if !exists {
+			dst[key] = srcVal
+			continue
+		}
+
+		// If both are maps, merge recursively
+		srcMap, srcIsMap := srcVal.(map[string]interface{})
+		dstMap, dstIsMap := dstVal.(map[string]interface{})
+		if srcIsMap && dstIsMap {
+			dst[key] = deepMerge(dstMap, srcMap)
+		} else {
+			// Otherwise, src wins
+			dst[key] = srcVal
+		}
+	}
+
+	return dst
+}
+
+// ErrDryRun is returned when dry-run mode completes successfully
+var ErrDryRun = fmt.Errorf("dry-run completed")
+
+// Install installs the Helm chart
 func (h *Helm) Install(ctx context.Context, cfg *envconf.Config) error {
-	providerValuesFile := fmt.Sprintf("%s/providers/%s.yaml", h.ChartPath, h.Provider)
+	// Create temporary values file
+	tmpFile, err := os.CreateTemp("", "helm-values-*.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to create temp values file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
 
-	args := []string{"install", h.ReleaseName, h.ChartPath,
-		"--namespace", h.Namespace,
-		"--create-namespace",
-		"--wait", "--timeout", "15m",
-		"--kubeconfig", cfg.KubeconfigFile(),
-		"-f", providerValuesFile}
+	// Write Values to temp file
+	data, err := yaml.Marshal(h.Values)
+	if err != nil {
+		return fmt.Errorf("failed to marshal values to YAML: %w", err)
+	}
 
-	// Add --debug flag if Debug is enabled
+	if _, err := tmpFile.Write(data); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("failed to write values to temp file: %w", err)
+	}
+	tmpFile.Close()
+
+	// Check for dry-run mode
+	dryRun := os.Getenv("HELM_DRY_RUN") == "true"
+
+	var args []string
+	if dryRun {
+		// Use helm template for dry-run
+		args = []string{
+			"template", h.ReleaseName, h.ChartPath,
+			"--namespace", h.Namespace,
+			"-f", tmpPath,
+		}
+	} else {
+		// Build helm install command
+		args = []string{
+			"install", h.ReleaseName, h.ChartPath,
+			"--namespace", h.Namespace,
+			"--create-namespace",
+			"--wait", "--timeout", "15m",
+			"--kubeconfig", cfg.KubeconfigFile(),
+			"-f", tmpPath,
+		}
+	}
+
 	if h.Debug {
 		args = append(args, "--debug")
 	}
 
-	// Add --set flags for OverrideValues if not empty (passed as-is)
-	if len(h.OverrideValues) > 0 {
-		for key, value := range h.OverrideValues {
-			setArg := fmt.Sprintf("%s=%s", key, value)
-			args = append(args, "--set", setArg)
-		}
-	}
-
-	// Add --set flags for OverrideProviderValues if not empty
-	if len(h.OverrideProviderValues) > 0 {
-		for key, value := range h.OverrideProviderValues {
-			setArg := fmt.Sprintf("providerConfigs.%s.%s=%s", h.Provider, key, value)
-			args = append(args, "--set", setArg)
-		}
-	}
-
-	// Add --set flags for OverrideProviderSecrets if not empty
-	if len(h.OverrideProviderSecrets) > 0 {
-		for key, value := range h.OverrideProviderSecrets {
-			setArg := fmt.Sprintf("providerSecrets.%s.%s=%s", h.Provider, key, value)
-			args = append(args, "--set", setArg)
-		}
-	}
-
 	cmd := exec.Command("helm", args...)
 	cmd.Env = os.Environ()
+	log.Infof("Executing helm command: helm %s", strings.Join(args, " "))
 	output, err := cmd.CombinedOutput()
-	log.Info("Helm install output:")
+	log.Info("Helm output:")
 	fmt.Printf("%s", output)
 	if err != nil {
-		return fmt.Errorf("failed to install helm chart: %w, output: %s", err, output)
+		return fmt.Errorf("failed to run helm: %w, output: %s", err, output)
+	}
+
+	if dryRun {
+		return ErrDryRun
 	}
 	return nil
 }
 
-// Uninstall uninstalls the Helm chart. Equivalent to the `helm uninstall` command
+// Uninstall uninstalls the Helm chart
 func (h *Helm) Uninstall(ctx context.Context, cfg *envconf.Config) error {
-	args := []string{"uninstall", h.ReleaseName,
+	args := []string{
+		"uninstall", h.ReleaseName,
 		"--namespace", h.Namespace,
-		"--kubeconfig", cfg.KubeconfigFile()}
+		"--kubeconfig", cfg.KubeconfigFile(),
+	}
 
-	// Add --debug flag if Debug is enabled
 	if h.Debug {
 		args = append(args, "--debug")
 	}

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_common.go
@@ -957,6 +957,11 @@ func getProfileList() string {
 	return profileList
 }
 
+func (p *IBMCloudProvisioner) GetProvisionValues() map[string]interface{} {
+	// TODO: implement properly
+	return nil
+}
+
 func (p *IBMCloudProvisioner) GetProperties(ctx context.Context, cfg *envconf.Config) map[string]string {
 	return map[string]string{
 		"CLOUD_PROVIDER":                       IBMCloudProps.IBMCloudProvider,

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_self_mgr.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_self_mgr.go
@@ -33,6 +33,11 @@ func (p *IBMSelfManagedClusterProvisioner) UploadPodvm(imagePath string, ctx con
 	return nil
 }
 
+func (p *IBMSelfManagedClusterProvisioner) GetProvisionValues() map[string]interface{} {
+	// TODO: implement properly
+	return nil
+}
+
 func (p *IBMSelfManagedClusterProvisioner) GetProperties(ctx context.Context, cfg *envconf.Config) map[string]string {
 	return make(map[string]string)
 }

--- a/src/cloud-api-adaptor/test/provisioner/libvirt/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/libvirt/provision_common.go
@@ -219,6 +219,11 @@ func (l *LibvirtProvisioner) DeleteVPC(ctx context.Context, cfg *envconf.Config)
 	return nil
 }
 
+func (l *LibvirtProvisioner) GetProvisionValues() map[string]interface{} {
+	// TODO: implement properly
+	return nil
+}
+
 func (l *LibvirtProvisioner) GetProperties(ctx context.Context, cfg *envconf.Config) map[string]string {
 	return map[string]string{
 		"CONTAINER_RUNTIME": l.containerRuntime,

--- a/src/cloud-api-adaptor/test/provisioner/libvirt/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/libvirt/provision_common.go
@@ -220,7 +220,8 @@ func (l *LibvirtProvisioner) DeleteVPC(ctx context.Context, cfg *envconf.Config)
 }
 
 func (l *LibvirtProvisioner) GetProvisionValues() map[string]interface{} {
-	// TODO: implement properly
+	// Libvirt has no dynamic values created during provisioning.
+	// Static config (URI, SSH keys) comes from workflow's helm values file.
 	return nil
 }
 


### PR DESCRIPTION
Hi folks, this seems big, but I hope its easy to review for those that are involved in the helm code at this point.

Before we implement the remaining providers, I'd like you to consider this approach if possible. This is groundwork for removing several map conversions in the code that can now be avoided with helm. Doing it now would avoid more rework later.

  1. This flow is helm-only; kustomize remains unchanged
  2. Eliminates boilerplate code and removes the need for each provider to implement certain APIs                                                                     
  3. Forces us to write helm values, which helps validate the chart
  4. Implemented for AWS, Docker, libvirt, and Azure, but testing so far has been basic (build and verifying templates generate correctly)

Risk looks low to me (though I might be colorblind to danger)... happy to postpone if needed.

If that makes sense, I can continue testing on that.

Note: I chose to replace helm.go with new code to make reviewing a bit easier, but most of the work there came from Wainer's interface.