### PR TITLE
dependabot: Add cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       # Check for updates to GitHub Actions every week on Saturday
       interval: "weekly"
       day: "saturday"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "gomod"
     directories:
       - "src/cloud-api-adaptor"
@@ -48,3 +50,5 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
It's good practice to get dependabot to wait after a release before bumping to avoid it bumping to a release done seconds before, which could have supply-chain security implications, so add a 7 day cooldown to help with this.

See https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns