### PR TITLE
test/provisioner: add GCP InstallChart implementation

### DIFF
--- a/src/cloud-api-adaptor/test/provisioner/gcp/provision.go
+++ b/src/cloud-api-adaptor/test/provisioner/gcp/provision.go
@@ -12,4 +12,5 @@ import (
 func init() {
 	pv.NewProvisionerFunctions["gcp"] = NewGCPProvisioner
 	pv.NewInstallOverlayFunctions["gcp"] = NewGCPInstallOverlay
+	pv.NewInstallChartFunctions["gcp"] = NewGCPInstallChart
 }


### PR DESCRIPTION
Implements NewGCPInstallChart, GCPInstallChart.Install, Uninstall, and Configure methods to support Helm-based cloud-api-adaptor deployment for GCP provider when INSTALL_METHOD=helm.

The implementation is added to provision_common.go (unlike IBMCloud which uses a separate file). It handles:
- CAA image parsing by splitting on ':' to extract image name and tag
- Property mapping from GetProperties to Helm chart providerConfigs
- GCP credentials: reads from file and sets as GCP_CREDENTIALS secret

Assisted-by: Cursor