### PR TITLE
GHA: Authenticate Helm with ghcr.io for s390x runners

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -196,6 +196,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Authenticate Helm with GitHub Container Registry
+        if: inputs.install_method == 'helm' && runner.environment == 'self-hosted'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+        run: |
+          echo "Authenticating Helm with GHCR..."
+          echo "${GITHUB_TOKEN}" | helm registry login ghcr.io \
+            --username "${GITHUB_ACTOR}" \
+            --password-stdin
+          echo "Helm authenticated with ghcr.io"
+
       - name: run tests
         id: runTests
         env:


### PR DESCRIPTION
The following error was observed during helm deployment on s390x runner::

```
GET "https://ghcr.io/token... response status code 403: denied: denied
```

Let's add an authentication step for ghcr.io beforehand.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>