### PR TITLE
workflows: Authenticate Helm with GHCR

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -196,6 +196,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Authenticate Helm with GitHub Container Registry
+        run: |
+          echo "Authenticating Helm with GHCR..."
+          echo "${GITHUB_TOKEN}" | helm registry login ghcr.io \
+            --username "${GITHUB_USER}" \
+            --password-stdin
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: run tests
         id: runTests
         env:


### PR DESCRIPTION
Ensure that we are logged into to ghcr with helm, so avoid any issues when installing the charts e.g.
```
F0205 07:12:59.572392 1222520 env.go:369] Setup failure: failed to build helm chart dependencies: exit status 1, output: Saving 3 charts
Downloading kata-deploy from repo oci://ghcr.io/kata-containers/kata-deploy-charts
Save error occurred:  could not download oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy: failed to perform "FetchReference" on source: GET "https://ghcr.io/v2/kata-containers/kata-deploy-charts/kata-deploy/manifests/3.25.0": GET "https://ghcr.io/token?scope=repository%3Akata-containers%2Fkata-deploy-charts%2Fkata-deploy%3Apull&service=ghcr.io": response status code 403: denied: denied
Error: could not download oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy: failed to perform "FetchReference" on source: GET "https://ghcr.io/v2/kata-containers/kata-deploy-charts/kata-deploy/manifests/3.25.0": GET "https://ghcr.io/token?scope=repository%3Akata-containers%2Fkata-deploy-charts%2Fkata-deploy%3Apull&service=ghcr.io": response status code 403: denied: denied
[12](https://github.com/confidential-containers/cloud-api-adaptor/actions/runs/21699323577/job/62584697971#step:20:12094)
```
we got on the s390x libvirt job: https://github.com/confidential-containers/cloud-api-adaptor/actions/runs/21699323577/job/62584697971 in the last nightly