### PR TITLE
workflows: drop kustomize install method from azure matrix

### DIFF
--- a/.github/workflows/azure-e2e-test.yml
+++ b/.github/workflows/azure-e2e-test.yml
@@ -19,11 +19,6 @@ on:
       podvm-image-id:
         type: string
         description: prebuilt podvm image
-      install_method:
-        default: 'kustomize'
-        description: Installation method. Either kustomize or helm.
-        required: false
-        type: string
     secrets:
       AZURE_CLIENT_ID:
         required: true
@@ -169,8 +164,6 @@ jobs:
 
   run-e2e-test:
     runs-on: ubuntu-24.04
-    # TODO: remove when helm installation gets implemented and stable.
-    continue-on-error: ${{ inputs.install_method == 'helm' }}
     defaults:
       run:
         working-directory: src/cloud-api-adaptor
@@ -230,7 +223,6 @@ jobs:
           sudo bash -s /usr/local/bin
 
     - name: Install Helm
-      if: ${{ inputs.install_method == 'helm' }}
       run: |
         curl -fsSL -o helm.tar.gz "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz"
         echo "${HELM_CHECKSUM}  helm.tar.gz" | sha256sum --check --strict
@@ -276,7 +268,7 @@ jobs:
       id: runTests
       env:
         TEST_PROVISION: "no"
-        INSTALL_METHOD: "${{ inputs.install_method }}"
+        INSTALL_METHOD: "helm"
         DEPLOY_KBS: "yes"
         CUSTOM_PCCS_URL: "https://global.acccache.azure.net/sgx/certification/v4"
         CLUSTER_NAME: "${{ format(env.CLUSTER_NAME_TEMPLATE, matrix.parameters.id) }}"

--- a/.github/workflows/azure-nightly-build.yml
+++ b/.github/workflows/azure-nightly-build.yml
@@ -51,13 +51,8 @@ jobs:
       id-token: write
     strategy:
       fail-fast: false
-      matrix:
-        install_method:
-          - kustomize
-          - helm
     with:
       podvm-image-id: ${{ needs.build-podvm-image.outputs.image-id }}
-      install_method: ${{ matrix.install_method }}
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
Currently the azure workflow is configured to run both helm and kustomize install methods, however, it's failing due to conflict on the AKS install step given that the jobs run on parallel. So instead of adapt/fix it, let's simply drop the support for kustomize right away as we will do it soon anyway.

---

Related with https://github.com/confidential-containers/cloud-api-adaptor/pull/2825#issuecomment-3877304016