### PR TITLE
install/helm: fix generation of empty providerConfigs

### DIFF
--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/docker.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/docker.yaml
@@ -10,7 +10,7 @@ image:
   tag: "latest"
 
 providerConfigs:
-  docker: {}
+  docker:
     # CA cert file
     # (default: "")
     # CACERT_FILE: ""

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/libvirt.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/libvirt.yaml
@@ -10,7 +10,7 @@ image:
   tag: "latest"
 
 providerConfigs:
-  libvirt: {}
+  libvirt:
     # CA cert file
     # (default: "")
     # CACERT_FILE: ""

--- a/src/cloud-providers/Makefile
+++ b/src/cloud-providers/Makefile
@@ -23,11 +23,7 @@ define gen-provider-values
 			empty \
 		end), \
 		"providerConfigs:", \
-		(if ([.flags[] | select(.env_var != "" and .required)] | length) > 0 then \
-			"  \(.provider):" \
-		else \
-			"  \(.provider): {}" \
-		end), \
+			"  \(.provider):", \
 		(.flags[] | select(.env_var != "") | \
 			if .required then \
 				"    # \(.description)", \


### PR DESCRIPTION
The providerConfigs for libvirt and docker has all the values commented and sync-chart-values generates `libvirt: {}` and `docker: {}` entries. This is not syntactically wrong, however, if user uncomment a value (e.g. `LIBVIRT_URI`) and forget to delete `{}` then it becomes an invalid yaml.

In reality the extract `{}` is not needed, so let's remove it.