### PR TITLE
refactor: remove deprecated auth-json-secret configuration

### DIFF
--- a/src/cloud-api-adaptor/install/overlays/alibabacloud/kustomization.yaml
+++ b/src/cloud-api-adaptor/install/overlays/alibabacloud/kustomization.yaml
@@ -46,10 +46,6 @@ configMapGenerator:
 ##TLS_SETTINGS
 
 secretGenerator:
-- name: auth-json-secret
-  namespace: confidential-containers-system
-  files:
-  #- auth.json # set - path to auth.json pull credentials file
 - name: peer-pods-secret
   namespace: confidential-containers-system
   envs:

--- a/src/cloud-api-adaptor/test/e2e/common.go
+++ b/src/cloud-api-adaptor/test/e2e/common.go
@@ -33,7 +33,6 @@ import (
 )
 
 const WAIT_DEPLOYMENT_AVAILABLE_TIMEOUT = time.Second * 180
-const DEFAULT_AUTH_SECRET = "auth-json-secret-default"
 const INITDATA_ANNOTATION = "io.katacontainers.config.hypervisor.cc_init_data"
 
 const POLICY = `package agent_policy


### PR DESCRIPTION
Remove unused auth-json-secret secretGenerator from alibabacloud kustomization and DEFAULT_AUTH_SECRET constant from e2e tests.