### PR TITLE
test/provisioner: fix Azure workload identity pod label

### DIFF
--- a/src/cloud-api-adaptor/test/provisioner/azure/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/azure/provision_common.go
@@ -532,10 +532,7 @@ func (a *AzureInstallChart) Configure(ctx context.Context, cfg *envconf.Config, 
 		log.Infof("Configuring helm: set secret (AZURE_CLIENT_ID)")
 		if properties["AZURE_CLIENT_SECRET"] == "" {
 			// Set pod label for workload identity
-			// The chart supports daemonset.podLabels which will add labels to the pod template
-			// Note: For nested keys with dots/slashes, we need to use the escaped format
-			// Helm will interpret this as a nested map: daemonset.podLabels["azure.workload.identity/use"] = "true"
-			a.Helm.OverrideValues["daemonset.podLabels.azure\\.workload\\.identity/use"] = "true"
+			a.Helm.OverrideValueMap["daemonset.podLabels"] = `{"azure.workload.identity/use":"true"}`
 			log.Infof("Configuring helm: set pod label for workload identity")
 		}
 	}

--- a/src/cloud-api-adaptor/test/provisioner/helm.go
+++ b/src/cloud-api-adaptor/test/provisioner/helm.go
@@ -22,6 +22,7 @@ type Helm struct {
 	Provider                string            // cloud provider name
 	Debug                   bool              // enable debug mode for helm commands
 	OverrideValues          map[string]string // key-value map for overriding chart values
+	OverrideValueMap        map[string]string // key-value map for overriding chart values where value=JSON string
 	OverrideProviderValues  map[string]string // key-value map for overriding provider-specific chart values
 	OverrideProviderSecrets map[string]string // key-value map for overriding provider-specific chart secrets
 }
@@ -45,6 +46,7 @@ func NewHelm(chartPath, namespace, releaseName, provider string, debug bool) (*H
 		Provider:                provider,
 		Debug:                   debug,
 		OverrideValues:          make(map[string]string),
+		OverrideValueMap:        make(map[string]string),
 		OverrideProviderValues:  make(map[string]string),
 		OverrideProviderSecrets: make(map[string]string),
 	}, nil
@@ -71,6 +73,14 @@ func (h *Helm) Install(ctx context.Context, cfg *envconf.Config) error {
 		for key, value := range h.OverrideValues {
 			setArg := fmt.Sprintf("%s=%s", key, value)
 			args = append(args, "--set-literal", setArg)
+		}
+	}
+
+	// Add --set-json flags for OverrideValueMap (for maps, arrays, or keys with dots/slashes)
+	if len(h.OverrideValueMap) > 0 {
+		for key, value := range h.OverrideValueMap {
+			setArg := fmt.Sprintf("%s=%s", key, value)
+			args = append(args, "--set-json", setArg)
 		}
 	}
 


### PR DESCRIPTION
Added OverrideValueMap to Helm provisioner for values that must be passed as JSON (e.g. daemonset.podLabels with keys containing slashes). Use it in Azure InstallChart to set azure.workload.identity/use=true when using workload identity.

Assisted-by: Cursor

---

Reported by @mkulke at https://github.com/confidential-containers/cloud-api-adaptor/pull/2825#issuecomment-3913873615

I tested with `helm template` and it seems to generate the right manifest now.
