### PR TITLE
test/provisioner/azure: fix Configure() and keep CLOUD_PROVIDER from chart

### DIFF
--- a/src/cloud-api-adaptor/test/provisioner/azure/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/azure/provision_common.go
@@ -539,13 +539,17 @@ func (a *AzureInstallChart) Configure(ctx context.Context, cfg *envconf.Config, 
 
 	for k, v := range properties {
 		if isAzureKustomizeConfigMapKey(k) {
+			// Do not override CLOUD_PROVIDER; use the chart default.
+			if k == "CLOUD_PROVIDER" {
+				continue
+			}
 			log.Infof("Configuring helm: override value (%s)", k)
-			a.Helm.OverrideProviderValues[k] = properties[v]
+			a.Helm.OverrideProviderValues[k] = v
 			continue
 		}
 		if k == "AZURE_CLIENT_SECRET" || k == "AZURE_TENANT_ID" {
 			log.Infof("Configuring helm: set secret (%s)", k)
-			a.Helm.OverrideProviderSecrets[k] = properties[v]
+			a.Helm.OverrideProviderSecrets[k] = v
 		}
 	}
 


### PR DESCRIPTION
- Use property value v instead of properties[v] when setting OverrideProviderValues and OverrideProviderSecrets so ConfigMap and Secret get the correct values (fixes empty CLOUD_PROVIDER in pod).
- Skip setting CLOUD_PROVIDER in overrides so the chart default from -f providers/azure.yaml is used and can be tested.

Assisted-by: Cursor

---

Fixes https://github.com/confidential-containers/cloud-api-adaptor/pull/2825#issuecomment-3927221070