### PR TITLE
helm: Move ext-network flags to FlagRegistrar

### DIFF
--- a/src/cloud-api-adaptor/cmd/cloud-api-adaptor/main.go
+++ b/src/cloud-api-adaptor/cmd/cloud-api-adaptor/main.go
@@ -112,13 +112,13 @@ func (cfg *daemonConfig) Setup() (cmd.Starter, error) {
 		reg.BoolWithEnv(&cfg.serverConfig.EnableCloudConfigVerify, "cloud-config-verify", false, "CLOUD_CONFIG_VERIFY", "Enable cloud config verify - should use it for production")
 		reg.IntWithEnv(&cfg.serverConfig.PeerPodsLimitPerNode, "peerpods-limit-per-node", 10, "PEERPODS_LIMIT_PER_NODE", "peer pods limit per node (default=10)")
 		reg.BoolWithEnv(&cfg.serverConfig.EnableScratchSpace, "enable-scratch-space", false, "ENABLE_SCRATCH_SPACE", "Enable encrypted scratch space for pod VMs")
+		reg.BoolWithEnv(&cfg.networkConfig.ExternalNetViaPodVM, "ext-network-via-podvm", false, "EXTERNAL_NETWORK_VIA_PODVM", "[EXPERIMENTAL] Enable external networking via pod VM")
+		reg.CustomTypeWithEnv(&cfg.networkConfig.PodSubnetCIDRs, "pod-subnet-cidrs", "", "POD_SUBNET_CIDRS", "[EXPERIMENTAL] Comma separated CIDRs for local pod subnets")
 
 		// Flags without environment variable support
 		flags.BoolVar(&disableTLS, "disable-tls", false, "Disable TLS encryption - use it only for testing")
 		flags.StringVar(&cfg.networkConfig.HostInterface, "host-interface", "", "Host Interface")
 		flags.IntVar(&cfg.networkConfig.VXLAN.MinID, "vxlan-min-id", vxlan.DefaultVXLANMinID, "Minimum VXLAN ID (VXLAN tunnel mode only")
-		flags.BoolVar(&cfg.networkConfig.ExternalNetViaPodVM, "ext-network-via-podvm", false, "[EXPERIMENTAL] Enable external networking via pod VM")
-		flags.Var(&cfg.networkConfig.PodSubnetCIDRs, "pod-subnet-cidrs", "[EXPERIMENTAL] Comma separated CIDRs for local pod subnets")
 
 		cloud.ParseCmd(flags)
 	})

--- a/src/cloud-api-adaptor/entrypoint.sh
+++ b/src/cloud-api-adaptor/entrypoint.sh
@@ -44,10 +44,6 @@ one_of() {
 aws() {
     test_vars AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
 
-    # Global flags without env var support - still need conversion
-    [[ "${EXTERNAL_NETWORK_VIA_PODVM}" ]] && optionals+="-ext-network-via-podvm  "
-    [[ "${POD_SUBNET_CIDRS}" ]] && optionals+="-pod-subnet-cidrs ${POD_SUBNET_CIDRS} "
-
     set -x
     exec cloud-api-adaptor aws ${optionals}
 
@@ -66,9 +62,6 @@ alibabacloud() {
     # TODO: Variable name mismatch - kustomization/entrypoint uses INSTANCE_TYPE
     # but manager.go expects PODVM_INSTANCE_TYPE. Consider standardizing in future.
     [[ "${INSTANCE_TYPE}" ]] && optionals+=" -instance-type ${INSTANCE_TYPE} "
-    # Global flag without env var support - still need conversion
-    [[ "${EXTERNAL_NETWORK_VIA_PODVM}" ]] && optionals+=" -ext-network-via-podvm"
-
     set -x
     exec cloud-api-adaptor alibabacloud ${optionals}
 }

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/alibabacloud.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/alibabacloud.yaml
@@ -30,6 +30,10 @@ providerConfigs:
     # (default: "false")
     # ENABLE_SCRATCH_SPACE: "false"
 
+    # [EXPERIMENTAL] Enable external networking via pod VM
+    # (default: "false")
+    # EXTERNAL_NETWORK_VIA_PODVM: "false"
+
     # port number of agent protocol forwarder
     # (default: "")
     # FORWARDER_PORT: ""
@@ -61,6 +65,10 @@ providerConfigs:
     # Pod VM instance type
     # (default: "ecs.g8i.xlarge")
     # PODVM_INSTANCE_TYPE: "ecs.g8i.xlarge"
+
+    # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
+    # (default: "")
+    # POD_SUBNET_CIDRS: ""
 
     # Maximum timeout in minutes for establishing agent proxy connection
     # (default: "")

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/aws.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/aws.yaml
@@ -42,6 +42,10 @@ providerConfigs:
     # (default: "false")
     # ENABLE_SCRATCH_SPACE: "false"
 
+    # [EXPERIMENTAL] Enable external networking via pod VM
+    # (default: "false")
+    # EXTERNAL_NETWORK_VIA_PODVM: "false"
+
     # port number of agent protocol forwarder
     # (default: "")
     # FORWARDER_PORT: ""
@@ -77,6 +81,10 @@ providerConfigs:
     # AWS Launch Template Name
     # (default: "kata")
     # PODVM_LAUNCHTEMPLATE_NAME: "kata"
+
+    # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
+    # (default: "")
+    # POD_SUBNET_CIDRS: ""
 
     # Maximum timeout in minutes for establishing agent proxy connection
     # (default: "")

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/azure.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/azure.yaml
@@ -66,6 +66,10 @@ providerConfigs:
     # (default: "false")
     # ENABLE_SECURE_BOOT: "false"
 
+    # [EXPERIMENTAL] Enable external networking via pod VM
+    # (default: "false")
+    # EXTERNAL_NETWORK_VIA_PODVM: "false"
+
     # port number of agent protocol forwarder
     # (default: "")
     # FORWARDER_PORT: ""
@@ -85,6 +89,10 @@ providerConfigs:
     # base directory for pod directories
     # (default: "")
     # PODS_DIR: ""
+
+    # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
+    # (default: "")
+    # POD_SUBNET_CIDRS: ""
 
     # Maximum timeout in minutes for establishing agent proxy connection
     # (default: "")

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/byom.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/byom.yaml
@@ -26,6 +26,10 @@ providerConfigs:
     # (default: "false")
     # ENABLE_SCRATCH_SPACE: "false"
 
+    # [EXPERIMENTAL] Enable external networking via pod VM
+    # (default: "false")
+    # EXTERNAL_NETWORK_VIA_PODVM: "false"
+
     # port number of agent protocol forwarder
     # (default: "")
     # FORWARDER_PORT: ""
@@ -49,6 +53,10 @@ providerConfigs:
     # base directory for pod directories
     # (default: "")
     # PODS_DIR: ""
+
+    # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
+    # (default: "")
+    # POD_SUBNET_CIDRS: ""
 
     # ConfigMap name for state storage
     # (default: "byom-ip-pool-state")

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/docker.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/docker.yaml
@@ -55,6 +55,10 @@ providerConfigs:
     # (default: "false")
     # ENABLE_SCRATCH_SPACE: "false"
 
+    # [EXPERIMENTAL] Enable external networking via pod VM
+    # (default: "false")
+    # EXTERNAL_NETWORK_VIA_PODVM: "false"
+
     # port number of agent protocol forwarder
     # (default: "")
     # FORWARDER_PORT: ""
@@ -74,6 +78,10 @@ providerConfigs:
     # base directory for pod directories
     # (default: "")
     # PODS_DIR: ""
+
+    # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
+    # (default: "")
+    # POD_SUBNET_CIDRS: ""
 
     # Maximum timeout in minutes for establishing agent proxy connection
     # (default: "")

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/gcp.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/gcp.yaml
@@ -30,6 +30,10 @@ providerConfigs:
     # (default: "false")
     # ENABLE_SCRATCH_SPACE: "false"
 
+    # [EXPERIMENTAL] Enable external networking via pod VM
+    # (default: "false")
+    # EXTERNAL_NETWORK_VIA_PODVM: "false"
+
     # port number of agent protocol forwarder
     # (default: "")
     # FORWARDER_PORT: ""
@@ -85,6 +89,10 @@ providerConfigs:
     # Pod VM image name
     # (default: "")
     # PODVM_IMAGE_NAME: ""
+
+    # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
+    # (default: "")
+    # POD_SUBNET_CIDRS: ""
 
     # Maximum timeout in minutes for establishing agent proxy connection
     # (default: "")

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/ibmcloud-powervs.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/ibmcloud-powervs.yaml
@@ -26,6 +26,10 @@ providerConfigs:
     # (default: "false")
     # ENABLE_SCRATCH_SPACE: "false"
 
+    # [EXPERIMENTAL] Enable external networking via pod VM
+    # (default: "false")
+    # EXTERNAL_NETWORK_VIA_PODVM: "false"
+
     # port number of agent protocol forwarder
     # (default: "")
     # FORWARDER_PORT: ""
@@ -45,6 +49,10 @@ providerConfigs:
     # base directory for pod directories
     # (default: "")
     # PODS_DIR: ""
+
+    # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
+    # (default: "")
+    # POD_SUBNET_CIDRS: ""
 
     # ID of the boot image
     # (required)

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/ibmcloud.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/ibmcloud.yaml
@@ -30,6 +30,10 @@ providerConfigs:
     # (default: "false")
     # ENABLE_SCRATCH_SPACE: "false"
 
+    # [EXPERIMENTAL] Enable external networking via pod VM
+    # (default: "false")
+    # EXTERNAL_NETWORK_VIA_PODVM: "false"
+
     # port number of agent protocol forwarder
     # (default: "")
     # FORWARDER_PORT: ""
@@ -105,6 +109,10 @@ providerConfigs:
     # base directory for pod directories
     # (default: "")
     # PODS_DIR: ""
+
+    # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
+    # (default: "")
+    # POD_SUBNET_CIDRS: ""
 
     # Maximum timeout in minutes for establishing agent proxy connection
     # (default: "")

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/libvirt.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/libvirt.yaml
@@ -35,6 +35,10 @@ providerConfigs:
     # (default: "false")
     # ENABLE_SCRATCH_SPACE: "false"
 
+    # [EXPERIMENTAL] Enable external networking via pod VM
+    # (default: "false")
+    # EXTERNAL_NETWORK_VIA_PODVM: "false"
+
     # port number of agent protocol forwarder
     # (default: "")
     # FORWARDER_PORT: ""
@@ -86,6 +90,10 @@ providerConfigs:
     # base directory for pod directories
     # (default: "")
     # PODS_DIR: ""
+
+    # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
+    # (default: "")
+    # POD_SUBNET_CIDRS: ""
 
     # Maximum timeout in minutes for establishing agent proxy connection
     # (default: "")


### PR DESCRIPTION
EXTERNAL_NETWORK_VIA_PODVM and POD_SUBNET_CIDRS were registered as raw flags without env var binding, relying on entrypoint.sh for conversion. Move them to FlagRegistrar so the config-extractor picks them up and they appear in generated helm values.

Thanks to @wainersm for finding this.