### PR TITLE
workflow: Update the permissions azure podvm build

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -62,6 +62,7 @@ jobs:
       contents: read
       packages: write
       attestations: write
+      artifact-metadata: write
     steps:
     - name: Clone cloud-api-adaptor repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Sorry, I missed that we also needed to set the permissions in the re-usable workflow being called.