### PR TITLE
ci: add artifact-metadata to az image build job

### DIFF
--- a/.github/workflows/azure-podvm-image-build.yml
+++ b/.github/workflows/azure-podvm-image-build.yml
@@ -61,6 +61,7 @@ jobs:
       id-token: write
       contents: read
       packages: write
+      artifact-metadata: write
       attestations: write
     steps:
     - name: Clone cloud-api-adaptor repository


### PR DESCRIPTION
it probably also need to be propagated to the individal job, not just on the call site.