### PR TITLE
ci: readd repo variables to Makefile.inc

### DIFF
--- a/src/cloud-api-adaptor/podvm/Makefile.inc
+++ b/src/cloud-api-adaptor/podvm/Makefile.inc
@@ -31,6 +31,8 @@ DEFAULT_AGENT_POLICY_FILE ?= allow-all.rego
 
 # Run github artifact provenance verifications
 VERIFY_PROVENANCE ?= no
+GUEST_COMPONENTS_REPO := confidential-containers/guest-components
+KATA_REPO := kata-containers/kata-containers
 
 # Verify that GUEST_COMPONENTS_REF is a sha-1 commit digest
 ifeq ($(shell echo $(GUEST_COMPONENTS_REF) | grep -E "^[0-9a-f]{40}$$"),)


### PR DESCRIPTION
They have been accidentally removed in a5f49248. We need the variables if we want to assert that an artifact originated in the upstream repos.

This breaks CI on azure podvm image builds, which is verifying provenance for the artifacts.