### PR TITLE
ibmcloud: Remove podvm_image_arch parameter

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -226,7 +226,6 @@ VPC_SERVICE_URL="https://jp-tok.iaas.cloud.ibm.com/v1"
 IKS_SERVICE_URL="https://containers.cloud.ibm.com/global"
 PODVM_IMAGE_ID="<podvm-image-uploaded-previously>"
 INSTANCE_PROFILE_NAME="bx2-2x8"
-PODVM_IMAGE_ARCH="s390x"
 IMAGE_PULL_API_KEY="<can-be-same-as-apikey>"
 CAA_IMAGE_TAG="<caa-image-tag>"
 EOF

--- a/src/cloud-api-adaptor/test/e2e/ibmcloud_common.go
+++ b/src/cloud-api-adaptor/test/e2e/ibmcloud_common.go
@@ -329,17 +329,6 @@ func (c IBMCloudAssert) GetInstanceType(t *testing.T, podName string) (string, e
 	return "", errors.New("Failed to Create PodVM Instance")
 }
 
-func GetIBMInstanceProfileType(prefix string, config string) string {
-	if strings.EqualFold("s390x", pv.IBMCloudProps.PodvmImageArch) {
-		if strings.Contains(pv.IBMCloudProps.InstanceProfile, "e-") {
-			return prefix + "z2e-" + config
-		} else {
-			return prefix + "z2-" + config
-		}
-	}
-	return prefix + "x2-" + config
-}
-
 type IBMRollingUpdateAssert struct {
 	VPC *vpcv1.VpcV1
 	// cache Pod VM instance IDs for rolling update test

--- a/src/cloud-api-adaptor/test/e2e/ibmcloud_test.go
+++ b/src/cloud-api-adaptor/test/e2e/ibmcloud_test.go
@@ -186,32 +186,32 @@ func TestDeletePod(t *testing.T) {
 	DoTestDeleteSimplePod(t, testEnv, assert)
 }
 
-func TestPodVMwithNoAnnotations(t *testing.T) {
+func TestPodVMWithNoAnnotations(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
-	DoTestPodVMwithNoAnnotations(t, testEnv, assert, GetIBMInstanceProfileType("b", "2x8"))
+	DoTestPodVMwithNoAnnotations(t, testEnv, assert, "bx2-2x8")
 }
 
-func TestPodVMwithAnnotationsInstanceType(t *testing.T) {
+func TestPodVMWithAnnotationsInstanceType(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
-	DoTestPodVMwithAnnotationsInstanceType(t, testEnv, assert, GetIBMInstanceProfileType("c", "2x4"))
+	DoTestPodVMwithAnnotationsInstanceType(t, testEnv, assert, "cx2-2x4")
 }
 
 func TestPodVMWithAnnotationsCPUMemory(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
-	DoTestPodVMWithAnnotationsCPUMemory(t, testEnv, assert, GetIBMInstanceProfileType("m", "2x16"))
+	DoTestPodVMWithAnnotationsCPUMemory(t, testEnv, assert, "mx2-2x16")
 }
 
-func TestPodVMwithAnnotationsInvalidInstanceType(t *testing.T) {
+func TestPodVMWithAnnotationsInvalidInstanceType(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
-	DoTestPodVMwithAnnotationsInvalidInstanceType(t, testEnv, assert, GetIBMInstanceProfileType("b", "2x4"))
+	DoTestPodVMwithAnnotationsInvalidInstanceType(t, testEnv, assert, "bx2-2x4")
 }
 func TestPodVMwithAnnotationsLargerMemory(t *testing.T) {
 	assert := IBMCloudAssert{

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_ibmcloud.properties
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_ibmcloud.properties
@@ -22,7 +22,6 @@ IS_SELF_MANAGED_CLUSTER="no"
 INSTANCE_PROFILE_NAME="bx2-2x8"
 # ibmcloud cs versions
 KUBE_VERSION="1.26.1"
-PODVM_IMAGE_ARCH="amd64"
 REGION="jp-tok"
 # Manage -> account -> resource groups
 RESOURCE_GROUP_ID="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_initializer.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_initializer.go
@@ -36,7 +36,6 @@ type IBMCloudProperties struct {
 	InstanceProfile       string
 	KubeVersion           string
 	PodvmImageID          string
-	PodvmImageArch        string
 	PublicGatewayName     string
 	PublicGatewayID       string
 	Region                string
@@ -91,7 +90,6 @@ func InitIBMCloudProperties(properties map[string]string) error {
 		InstanceProfile:       properties["INSTANCE_PROFILE_NAME"],
 		KubeVersion:           properties["KUBE_VERSION"],
 		PodvmImageID:          properties["PODVM_IMAGE_ID"],
-		PodvmImageArch:        properties["PODVM_IMAGE_ARCH"],
 		PublicGatewayName:     properties["PUBLIC_GATEWAY_NAME"],
 		Region:                properties["REGION"],
 		ResourceGroupID:       properties["RESOURCE_GROUP_ID"],


### PR DESCRIPTION
Now we only work with x86, we don't need to ask the tester for the PODVM_IMAGE_ARCH, or and of the code that drives.