### PR TITLE
workflow: Add option to run daily tests against non-main branch

### DIFF
--- a/.github/workflows/daily-e2e-tests.yaml
+++ b/.github/workflows/daily-e2e-tests.yaml
@@ -11,9 +11,15 @@ on:
   # will base on default branch `main`
     - cron: '15 4 * * *'
   workflow_dispatch:
+    inputs:
+      git_ref:
+        default: 'refs/heads/main'
+        description: Git ref to run the tests from/against. Defaults to refs/heads/main.
+        required: false
+        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.git_ref }}
   cancel-in-progress: true
 
 permissions: {}
@@ -23,7 +29,7 @@ jobs:
     uses: ./.github/workflows/e2e_run_all.yaml
     with:
       caa_image_tag: latest
-      git_ref: refs/heads/main
+      git_ref: "${{ inputs.git_ref }}"
       podvm_image_tag: latest
       registry: ghcr.io/${{ github.repository_owner }}
     permissions:


### PR DESCRIPTION
As we now need quite a few "secrets"/access to run our CI that forks won't have, it would be useful to be able to run the daily e2e tests against non-main code in order to test things before they are merged, so remove the hard-coding git_ref and allow it to be set on workflow_dispatch