### PR TITLE
ci: verify provenance in mkosi podvm builds

### DIFF
--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -143,6 +143,7 @@ jobs:
         run: make binaries
         env:
           ARCH: ${{ inputs.arch }}
+          VERIFY_PROVENANCE: yes
 
       - name: Build mkosi debug image
         if: ${{ inputs.debug == 'true' }}

--- a/.github/workflows/podvm_mkosi_ubuntu.yaml
+++ b/.github/workflows/podvm_mkosi_ubuntu.yaml
@@ -148,6 +148,7 @@ jobs:
         env:
           ARCH: ${{ inputs.arch }}
           PODVM_DISTRO: ubuntu
+          VERIFY_PROVENANCE: yes
 
       - name: Build mkosi debug image
         if: ${{ inputs.debug == 'true' }}


### PR DESCRIPTION
It's better that we exercise this path regularly, not just for release images. In general we should verify for all official podvm builds, since we cannot trust the oci image tags that we are using to reference artifacts (they are mutable and can be set to point on a malicious artifact by anyone who has write access to the container registry)