### PR TITLE
workflows: Use IBM Actions Z runners for s390x CI jobs

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,6 +6,5 @@
 self-hosted-runner:
   # Labels of self-hosted runner that linter should ignore
   labels:
-    - S390X
     - ubuntu-24.04-ppc64le
     - ubuntu-24.04-s390x

--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -201,7 +201,7 @@ jobs:
       dev_tags: ${{ inputs.caa_image_tag }}-s390x-dev
       release_tags: ${{ inputs.caa_image_tag }}-s390x
       git_ref: ${{ inputs.git_ref }}
-      runner: 's390x'
+      runner: 'ubuntu-24.04-s390x'
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -70,7 +70,7 @@ permissions: {}
 jobs:
   build-image:
     name: Build mkosi image for ${{ inputs.arch }}
-    runs-on: ${{ inputs.arch == 's390x' && 's390x' || inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.arch == 's390x' && 'ubuntu-24.04-s390x' || inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/podvm_mkosi_ubuntu.yaml
+++ b/.github/workflows/podvm_mkosi_ubuntu.yaml
@@ -74,7 +74,7 @@ permissions: {}
 jobs:
   build-image:
     name: Build mkosi Ubuntu image for ${{ inputs.arch }}
-    runs-on: ${{ inputs.arch == 's390x' && 's390x' || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.arch == 's390x' && 'ubuntu-24.04-s390x' || 'ubuntu-24.04' }}
     permissions:
       contents: read # Required if we want to run on a fork?
       packages: write # Required to publish the oras package to ghcr


### PR DESCRIPTION
As a follow-up to #2673, switch the remaining self-hosted runners labeled 's390x' to IBM Actions Z runners.

IBM Actions Z runners currently do not support nested virtualization, so keep the existing configuration for the runner labeled 's390x-large'.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>