### PR TITLE
webhook: update the kube-rbac image from gcr.io to registry.k8s.io

### DIFF
--- a/src/webhook/chart/values.yaml
+++ b/src/webhook/chart/values.yaml
@@ -41,7 +41,7 @@ webhook:
 # Set to false to expose metrics without authentication (not recommended for production)
 authProxy:
   enabled: true
-  image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
+  image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.14.0
   resources:
     limits:
       cpu: 500m

--- a/src/webhook/config/default/manager_auth_proxy_patch.yaml
+++ b/src/webhook/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.14.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
The image from gcr.io has been deprecated and unavailable, move to registry.k8s.io.

```
 Warning  Failed       11s (x3 over 55s)  kubelet            Failed to pull image "gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0": rpc error: code = NotFound desc = failed to pull and unpack image "gcr.io/kubebuilder
/kube-rbac-proxy:v0.14.0": failed to resolve image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0: not found
```