### PR TITLE
mkosi: Bump to Fedora 43

### DIFF
--- a/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.mkosi
+++ b/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.mkosi
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.5.0-labs
-FROM fedora:41 AS builder
+FROM fedora:43 AS builder
 
 ARG MKOSI_VERSION="v22"
 ARG PROFILE="debug"

--- a/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.podvm_docker_provider
+++ b/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.podvm_docker_provider
@@ -1,6 +1,6 @@
 # Adapted from https://github.com/kubernetes-sigs/kind/blob/main/images/base/Dockerfile
 
-ARG BASE_IMAGE=registry.fedoraproject.org/fedora:41
+ARG BASE_IMAGE=registry.fedoraproject.org/fedora:43
 
 FROM $BASE_IMAGE AS iptables
 

--- a/src/cloud-api-adaptor/podvm-mkosi/Makefile
+++ b/src/cloud-api-adaptor/podvm-mkosi/Makefile
@@ -40,8 +40,8 @@ DISTRO_IMAGE := ubuntu:24.04
 DISTRO_RELEASE := 24.04
 PKG_INSTALL := apt-get update && apt-get install -y
 else
-DISTRO_IMAGE := fedora:41
-DISTRO_RELEASE := 41
+DISTRO_IMAGE := fedora:43
+DISTRO_RELEASE := 43
 PKG_INSTALL := dnf install -y
 endif
 

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/initrd/mkosi.conf.d/fedora.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/initrd/mkosi.conf.d/fedora.conf
@@ -3,7 +3,7 @@ Distribution=fedora
 
 [Distribution]
 Distribution=fedora
-Release=41
+Release=43
 
 [Content]
 CleanPackageMetadata=true

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-s390x.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora-s390x.conf
@@ -4,7 +4,7 @@ Architecture=s390x
 
 [Distribution]
 Distribution=fedora
-Release=41
+Release=43
 
 [Content]
 Bootable=no

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora.conf
@@ -3,7 +3,7 @@ Distribution=fedora
 
 [Distribution]
 Distribution=fedora
-Release=41
+Release=43
 
 [Content]
 CleanPackageMetadata=true

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.finalize.chroot
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.finalize.chroot
@@ -5,7 +5,9 @@ set -euxo pipefail
 if [[ "${ARCHITECTURE}" == "s390x" ]]; then
 	# enable cloud-init services
         systemctl enable cloud-init-local.service
-        systemctl enable cloud-init.service
+	# Note: cloud-init.service was renamed to cloud-init-network.service in cloud-init 24.3
+	# https://github.com/canonical/cloud-init/blob/main/doc/rtd/reference/breaking_changes.rst#243
+        systemctl enable cloud-init-network.service
         systemctl enable cloud-config.service
         systemctl enable cloud-final.service
 


### PR DESCRIPTION
As Fedora 41 reached EOL in May 2025, it seems the GPG online bundle now only contains keys for Fedora 42 and above, not 41. 

Bump to Fedora 43.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>