### PR TITLE
helm: handle error if release is not found

### DIFF
--- a/src/cloud-api-adaptor/Makefile
+++ b/src/cloud-api-adaptor/Makefile
@@ -153,7 +153,12 @@ endif
 
 .PHONY: delete
 delete: ## Delete cloud-api-adaptor using Helm charts.
-	helm uninstall peerpods -n confidential-containers-system
+	@if helm status peerpods -n confidential-containers-system >/dev/null 2>&1; then \
+		echo "Uninstalling peerpods release..."; \
+		helm uninstall peerpods -n confidential-containers-system; \
+	else \
+		echo "Release 'peerpods' not found in namespace 'confidential-containers-system'(either not installed or already uninstalled)"; \
+	fi
 
 ### PODVM IMAGE BUILDING ###
 


### PR DESCRIPTION
Currently if the peerpods release does not exist or is already deleted, running `make delete` throws an error as expected.
```
helm uninstall peerpods -n confidential-containers-system
Error: uninstall: Release not loaded: peerpods: release: not found
make: *** [Makefile:156: delete] Error 1
```
Handle this case for better readability.