### PR TITLE
charts: update kube-rbac-proxy image

### DIFF
--- a/src/cloud-api-adaptor/install/charts/peerpods/Chart.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: peerpods
 description: Cloud API Adaptor (Peerpods) Helm Chart
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "v0.18.0"
 
 keywords:


### PR DESCRIPTION
The gcr.io registry is deprecated and no longer available. Same fix as #2906 applied to peerpod-ctrl.