### PR TITLE
peerpods: bump chart version to 0.1.2

### DIFF
--- a/src/cloud-api-adaptor/install/charts/peerpods/Chart.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: peerpods
 description: Cloud API Adaptor (Peerpods) Helm Chart
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "v0.18.0"
 
 keywords:


### PR DESCRIPTION
Picks up the kube-rbac-proxy registry fix for both webhook (#2906) and peerpod-ctrl. After merging, we need to trigger the "Release PeerPods Helm Chart" workflow to publish 0.1.2