### PR TITLE
ci: Add mkosi, ubuntu-based podvm image tests

### DIFF
--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -105,7 +105,6 @@ jobs:
 
   podvm_mkosi_s390x:
     uses: ./.github/workflows/podvm_mkosi.yaml
-
     with:
       registry: ${{ inputs.registry }}
       image_tag: ${{ inputs.podvm_image_tag }}
@@ -118,6 +117,40 @@ jobs:
       attestations: write
       id-token: write
       artifact-metadata: write  # Required by podvm_mkosi.yaml to write attestation metadata
+    secrets:
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+
+  podvm_ubuntu_amd64:
+    uses: ./.github/workflows/podvm_mkosi_ubuntu.yaml
+    with:
+      registry: ${{ inputs.registry }}
+      image_tag: ${{ inputs.podvm_image_tag }}
+      git_ref: ${{ inputs.git_ref }}
+      arch: amd64
+      debug: true
+    permissions:
+      contents: read # Required if we want to run on a fork?
+      packages: write # Required to publish the oras package to ghcr
+      id-token: write # Required to publish the attestation provenance to ghcr
+      attestations: write # Required to publish the attestation provenance to ghcr
+      artifact-metadata: write # Required by podvm_mkosi_ubuntu.yaml to write attestation metadata
+    secrets:
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+
+  podvm_ubuntu_s390x:
+    uses: ./.github/workflows/podvm_mkosi_ubuntu.yaml
+    with:
+      registry: ${{ inputs.registry }}
+      image_tag: ${{ inputs.podvm_image_tag }}
+      git_ref: ${{ inputs.git_ref }}
+      arch: s390x
+      debug: true
+    permissions:
+      contents: read # Required if we want to run on a fork?
+      packages: write # Required to publish the oras package to ghcr
+      id-token: write # Required to publish the attestation provenance to ghcr
+      attestations: write # Required to publish the attestation provenance to ghcr
+      artifact-metadata: write # Required by podvm_mkosi_ubuntu.yaml to write attestation metadata
     secrets:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 
@@ -232,6 +265,42 @@ jobs:
       runner: s390x-large
       caa_image: ${{ inputs.registry }}/cloud-api-adaptor:${{ inputs.caa_image_tag }}-dev-s390x
       podvm_image: ${{ needs.podvm_mkosi_s390x.outputs.qcow2_oras_image }}
+      git_ref: ${{ inputs.git_ref }}
+    secrets:
+      REGISTRY_CREDENTIAL_ENCODED: ${{ secrets.REGISTRY_CREDENTIAL_ENCODED }}
+
+  # Run libvirt amd64 e2e tests, based on the mkosi image, if pull request labeled 'test_e2e_libvirt'
+  libvirt_ubuntu_amd64:
+    name: E2E tests on libvirt, with the mkosi_ubuntu podvm image for the amd64 architecture
+    if: |
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'test_e2e_libvirt') ||
+      contains(github.event.pull_request.labels.*.name, 'test_e2e_libvirt_amd64')
+    needs: [podvm_ubuntu_amd64, libvirt_e2e_arch_prep, caa_image_amd64]
+    uses: ./.github/workflows/e2e_libvirt.yaml
+    with:
+      runner: ubuntu-24.04
+      caa_image: ${{ inputs.registry }}/cloud-api-adaptor:${{ inputs.caa_image_tag }}-amd64-dev
+      podvm_image: ${{ needs.podvm_ubuntu_amd64.outputs.qcow2_oras_image }}
+      git_ref: ${{ inputs.git_ref }}
+    secrets:
+      REGISTRY_CREDENTIAL_ENCODED: ${{ secrets.REGISTRY_CREDENTIAL_ENCODED }}
+
+  # Run libvirt s390x e2e tests, based on the mkosi image, if pull request labeled 'test_e2e_libvirt'
+  libvirt_ubuntu_s390x:
+    name: E2E tests on libvirt, with the mkosi_ubuntu podvm image for the s390x architecture
+    if: |
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'test_e2e_libvirt') ||
+      contains(github.event.pull_request.labels.*.name, 'test_e2e_libvirt_s390x')
+    needs: [podvm_ubuntu_s390x, libvirt_e2e_arch_prep, caa_image_s390x]
+    uses: ./.github/workflows/e2e_libvirt.yaml
+    with:
+      runner: s390x-large
+      caa_image: ${{ inputs.registry }}/cloud-api-adaptor:${{ inputs.caa_image_tag }}-s390x-dev
+      podvm_image: ${{ needs.podvm_ubuntu_s390x.outputs.qcow2_oras_image }}
       git_ref: ${{ inputs.git_ref }}
     secrets:
       REGISTRY_CREDENTIAL_ENCODED: ${{ secrets.REGISTRY_CREDENTIAL_ENCODED }}

--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -71,6 +71,7 @@ jobs:
   build-image:
     name: Build mkosi image for ${{ inputs.arch }}
     runs-on: ${{ inputs.arch == 's390x' && 's390x' || inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    continue-on-error: ${{ inputs.arch == 's390x' }}  # Remove once s390x image build is stable
     permissions:
       contents: read  # Required for checkout on forks
       packages: write  # Required to publish the oras package to ghcr

--- a/.github/workflows/podvm_mkosi_ubuntu.yaml
+++ b/.github/workflows/podvm_mkosi_ubuntu.yaml
@@ -62,7 +62,7 @@ on:
         value: ${{ jobs.build-image.outputs.docker_oci_image }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-mkosi-ubuntu-${{ inputs.arch }}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/podvm_publish.yaml
+++ b/.github/workflows/podvm_publish.yaml
@@ -64,3 +64,22 @@ jobs:
       debug: false
     secrets:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+
+  podvm-ubuntu-mkosi:
+    uses: ./.github/workflows/podvm_mkosi_ubuntu.yaml
+    permissions:
+      contents: read # Required if we want to run on a fork?
+      packages: write # Required to publish the oras package to ghcr
+      id-token: write # Required to publish the attestation provenance to ghcr
+      attestations: write # Required to publish the attestation provenance to ghcr
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, s390x, arm64]
+    with:
+      git_ref: ${{ github.sha }}
+      image_tag: ${{ github.sha }}
+      arch: ${{ matrix.arch}}
+      debug: false
+    secrets:
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
We want to switch for the fedora-based mkosi podvm image, to the ubuntu based one for stability and GPU support, so add e2e tests, so see how it's working.