### PR TITLE
workflows: align peerpods-chart concurrency group with parent workflow

### DIFF
--- a/.github/workflows/peerpods-chart_image.yaml
+++ b/.github/workflows/peerpods-chart_image.yaml
@@ -33,7 +33,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.chart_version || github.ref }}-peerpods-chart-image
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Update the concurrency group pattern in peerpods-chart_image.yaml to match the parent workflow (publish_images_on_push.yaml) to prevent deadlock errors when called via workflow_call.

Fix commit 40bb0a763cf1c1146adbcfc0d1421973d14dabc9
Assisted-by: Claude