### PR TITLE
charts: pin CAA image and kata-deploy for 0.1.2

### DIFF
--- a/src/cloud-api-adaptor/install/charts/peerpods/Chart.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/Chart.yaml
@@ -21,7 +21,7 @@ maintainers:
 
 dependencies:
   - name: kata-deploy
-    version: "0.0.0-dev"
+    version: "3.25.0"
     repository: "oci://ghcr.io/kata-containers/kata-deploy-charts"
     condition: kata-deploy.enabled
   - name: peerpodctrl

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/docker.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/docker.yaml
@@ -7,7 +7,7 @@ provider: docker
 # Dev image required for this provider (includes CGO bindings)
 # Update to dev-<commit> at release time
 image:
-  tag: "latest"
+  tag: "dev-a5f492482236b9fc4a77088efe6b4c2159ae6a03"
 
 providerConfigs:
   docker: {}

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/libvirt.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/libvirt.yaml
@@ -7,7 +7,7 @@ provider: libvirt
 # Dev image required for this provider (includes CGO bindings)
 # Update to dev-<commit> at release time
 image:
-  tag: "latest"
+  tag: "dev-a5f492482236b9fc4a77088efe6b4c2159ae6a03"
 
 providerConfigs:
   libvirt: {}

--- a/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
@@ -80,7 +80,7 @@ secrets:
 # Note: libvirt/docker provider files override this with the dev image.
 image:
   name: quay.io/confidential-containers/cloud-api-adaptor
-  tag: "latest"
+  tag: "a5f492482236b9fc4a77088efe6b4c2159ae6a03"
 
 # Cloud provider: libvirt, aws, azure, gcp, ibmcloud, vsphere
 provider: libvirt

--- a/src/cloud-providers/Makefile
+++ b/src/cloud-providers/Makefile
@@ -17,7 +17,7 @@ define gen-provider-values
 			"# Dev image required for this provider (includes CGO bindings)", \
 			"# Update to dev-<commit> at release time", \
 			"image:", \
-			"  tag: \"latest\"", \
+			"  tag: \"dev-a5f492482236b9fc4a77088efe6b4c2159ae6a03\"", \
 			"" \
 		else \
 			empty \


### PR DESCRIPTION
Revert image tags and kata-deploy version from dev defaults back to v0.18.0 release values for the chart-only z-bump. While there is a newer kata-deploy version available, the goal here is only to ship the kube-rbac-proxy registry migration (gcr.io to registry.k8s.io) in the webhook and peerpod-ctrl subcharts.