### PR TITLE
Revert "charts: pin CAA image and kata-deploy for 0.1.2"

### DIFF
--- a/src/cloud-api-adaptor/install/charts/peerpods/Chart.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/Chart.yaml
@@ -21,7 +21,7 @@ maintainers:
 
 dependencies:
   - name: kata-deploy
-    version: "3.25.0"
+    version: "0.0.0-dev"
     repository: "oci://ghcr.io/kata-containers/kata-deploy-charts"
     condition: kata-deploy.enabled
   - name: peerpodctrl

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/docker.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/docker.yaml
@@ -7,7 +7,7 @@ provider: docker
 # Dev image required for this provider (includes CGO bindings)
 # Update to dev-<commit> at release time
 image:
-  tag: "dev-a5f492482236b9fc4a77088efe6b4c2159ae6a03"
+  tag: "latest"
 
 providerConfigs:
   docker: {}

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/libvirt.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/libvirt.yaml
@@ -7,7 +7,7 @@ provider: libvirt
 # Dev image required for this provider (includes CGO bindings)
 # Update to dev-<commit> at release time
 image:
-  tag: "dev-a5f492482236b9fc4a77088efe6b4c2159ae6a03"
+  tag: "latest"
 
 providerConfigs:
   libvirt: {}

--- a/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
@@ -80,7 +80,7 @@ secrets:
 # Note: libvirt/docker provider files override this with the dev image.
 image:
   name: quay.io/confidential-containers/cloud-api-adaptor
-  tag: "a5f492482236b9fc4a77088efe6b4c2159ae6a03"
+  tag: "latest"
 
 # Cloud provider: libvirt, aws, azure, gcp, ibmcloud, vsphere
 provider: libvirt

--- a/src/cloud-providers/Makefile
+++ b/src/cloud-providers/Makefile
@@ -17,7 +17,7 @@ define gen-provider-values
 			"# Dev image required for this provider (includes CGO bindings)", \
 			"# Update to dev-<commit> at release time", \
 			"image:", \
-			"  tag: \"dev-a5f492482236b9fc4a77088efe6b4c2159ae6a03\"", \
+			"  tag: \"latest\"", \
 			"" \
 		else \
 			empty \


### PR DESCRIPTION
This reverts commit cd6c2b42aea3cf1ea94d644587e5e0957ea202a0.