### PR TITLE
ci: don't run smoke tests as part of the PR suite

### DIFF
--- a/.github/workflows/podvm_smoketest.yaml
+++ b/.github/workflows/podvm_smoketest.yaml
@@ -1,7 +1,7 @@
 name: smoke test
 
 on:
-  pull_request:
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
The smoke tests have been broken for a while and we need to investigate why. They are non-critical and merely give an early signal whether podvm logic is broken, but this is also covered by e2e tests.