### PR TITLE
ci: add artifact-metadata:write permission to attestation workflows

### DIFF
--- a/.github/workflows/peerpods-chart_image.yaml
+++ b/.github/workflows/peerpods-chart_image.yaml
@@ -45,6 +45,7 @@ jobs:
       packages: write      # Required for pushing to GitHub Container Registry
       id-token: write      # Required for attestation signing
       attestations: write  # Required for persisting attestations
+      artifact-metadata: write # Required by actions/attest to write attestation metadata
 
     defaults:
       run:

--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -72,10 +72,11 @@ jobs:
     name: Build mkosi image for ${{ inputs.arch }}
     runs-on: ${{ inputs.arch == 's390x' && 's390x' || inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      contents: read  # Required for checkout on forks
+      packages: write  # Required to publish the oras package to ghcr
+      id-token: write  # Required for attestation signing
+      attestations: write  # Required to create attestations
+      artifact-metadata: write  # Required by actions/attest to write attestation metadata
     outputs:
       qcow2_oras_image: ${{ steps.publish_oras_qcow2.outputs.image }}:${{ steps.publish_oras_qcow2.outputs.tag }}
       docker_oci_image: ${{ steps.build_docker_oci.outputs.image }}

--- a/.github/workflows/podvm_mkosi_ubuntu.yaml
+++ b/.github/workflows/podvm_mkosi_ubuntu.yaml
@@ -80,6 +80,7 @@ jobs:
       packages: write # Required to publish the oras package to ghcr
       id-token: write # Required to publish the attestation provenance to ghcr
       attestations: write # Required to publish the attestation provenance to ghcr
+      artifact-metadata: write # Required by actions/attest to write attestation metadata
     outputs:
       qcow2_oras_image: ${{ steps.publish_oras_qcow2.outputs.image }}:${{ steps.publish_oras_qcow2.outputs.tag }}
       docker_oci_image: ${{ steps.build_docker_oci.outputs.image }}


### PR DESCRIPTION
I spotted the `Please check that the 'artifact-metadata:write' permission has been included` warning in the recent charts publish and realised that we've missed some more permissions, so asked Bob to help find any places that this should be added and it found 3 workflows.

The actions/attest action requires the artifact-metadata:write permission to write attestation metadata to the registry when using push-to-registry: true.

Added the missing permission to three workflows that use actions/attest:
- peerpods-chart_image.yaml
- podvm_mkosi.yaml
- podvm_mkosi_ubuntu.yaml

Assisted-by: IBM Bob