### PR TITLE
ci: add artifact-metadata to e2e_run_all

### DIFF
--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -99,6 +99,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      artifact-metadata: write  # Required by podvm_mkosi.yaml to write attestation metadata
     secrets:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 
@@ -116,6 +117,7 @@ jobs:
       packages: write
       attestations: write
       id-token: write
+      artifact-metadata: write  # Required by podvm_mkosi.yaml to write attestation metadata
     secrets:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 

--- a/.github/workflows/podvm_publish.yaml
+++ b/.github/workflows/podvm_publish.yaml
@@ -52,6 +52,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      artifact-metadata: write  # Required by podvm_mkosi.yaml to write attestation metadata
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,6 +87,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      artifact-metadata: write  # Required by podvm_mkosi.yaml to write attestation metadata
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
the podvm_mkosi.yaml uses this to write attestation metadata and can only get them when we allow it when calling this.

Found by @BbolroC: https://github.com/confidential-containers/cloud-api-adaptor/pull/2973