### PR TITLE
ci: add artifact-metadata:write permission to e2e workflows

### DIFF
--- a/.github/workflows/daily-e2e-tests.yaml
+++ b/.github/workflows/daily-e2e-tests.yaml
@@ -37,6 +37,7 @@ jobs:
       contents: read
       packages: write
       attestations: write
+      artifact-metadata: write
     secrets:
       AWS_IAM_ROLE_ARN: ${{ secrets.AWS_IAM_ROLE_ARN }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/e2e_on_pull.yaml
+++ b/.github/workflows/e2e_on_pull.yaml
@@ -54,6 +54,7 @@ jobs:
       contents: read
       packages: write
       attestations: write
+      artifact-metadata: write
     secrets:
       AWS_IAM_ROLE_ARN: ${{ secrets.AWS_IAM_ROLE_ARN }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
Despite #2974, we still need to add `artifact-metadata: write` to all workflows in the calling chain of the nested workflows.

Error log: https://github.com/confidential-containers/cloud-api-adaptor/actions/runs/23903505288

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>