### PR TITLE
ci: add artifact-metadata:write to missing workflows

### DIFF
--- a/.github/workflows/publish_images_on_push.yaml
+++ b/.github/workflows/publish_images_on_push.yaml
@@ -72,3 +72,4 @@ jobs:
       packages: write      # Required for pushing to GitHub Container Registry
       id-token: write      # Required for attestation signing
       attestations: write  # Required for persisting attestations
+      artifact-metadata: write  # Required by actions/attest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,3 +120,4 @@ jobs:
       packages: write      # Required for pushing to GitHub Container Registry
       id-token: write      # Required for attestation signing
       attestations: write  # Required for persisting attestations
+      artifact-metadata: write  # Required by actions/attest


### PR DESCRIPTION
Requested at https://github.com/confidential-containers/cloud-api-adaptor/pull/2975#issuecomment-4178442316

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>