### PR TITLE
peerpod-ctrl: Add orphan VM garbage collector

### DIFF
--- a/src/cloud-api-adaptor/cmd/cloud-api-adaptor/main.go
+++ b/src/cloud-api-adaptor/cmd/cloud-api-adaptor/main.go
@@ -25,6 +25,10 @@ import (
 
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/podnetwork"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/probe"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 const (
@@ -99,6 +103,25 @@ func (cfg *daemonConfig) Setup() (cmd.Starter, error) {
 		printHelp(os.Stderr)
 		cmd.Exit(1)
 	}
+
+	// Resolve the cluster UID (kube-system namespace UID) so providers can
+	// tag VMs for orphan GC discovery. Each provider applies the tag in its
+	// own CreateInstance using provider.ClusterUID. Without this tag, the GC
+	// cannot discover VMs belonging to this cluster, so failure is fatal.
+	kubeConfig, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load in-cluster config for GC tagging: %w", err)
+	}
+	clientset, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client for GC tagging: %w", err)
+	}
+	ns, err := clientset.CoreV1().Namespaces().Get(context.Background(), "kube-system", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kube-system namespace UID for GC tagging: %w", err)
+	}
+	provider.ClusterUID = string(ns.UID)
+	fmt.Printf("%s: resolved cluster UID for GC tagging: %s\n", programName, ns.UID)
 
 	var (
 		disableTLS      bool

--- a/src/cloud-api-adaptor/install/charts/peerpods/templates/rbac.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/templates/rbac.yaml
@@ -24,6 +24,9 @@ rules:
 - apiGroups: [""]
   resources: ["serviceaccounts"]
   verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/src/cloud-providers/aws/list_instances_test.go
+++ b/src/cloud-providers/aws/list_instances_test.go
@@ -1,0 +1,208 @@
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	provider "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers"
+)
+
+type listInstancesMockEC2Client struct {
+	mockEC2Client
+	instances []types.Instance
+	lastInput *ec2.DescribeInstancesInput
+	callCount int
+}
+
+func (m *listInstancesMockEC2Client) DescribeInstances(ctx context.Context,
+	params *ec2.DescribeInstancesInput,
+	optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+
+	m.lastInput = params
+	m.callCount++
+	return &ec2.DescribeInstancesOutput{
+		Reservations: []types.Reservation{
+			{Instances: m.instances},
+		},
+	}, nil
+}
+
+func TestListInstances(t *testing.T) {
+	tests := []struct {
+		name       string
+		clusterUID string
+		instances  []types.Instance
+		wantCount  int
+		wantErr    bool
+	}{
+		{
+			name:       "empty cluster UID returns error",
+			clusterUID: "",
+			wantErr:    true,
+		},
+		{
+			name:       "no instances found",
+			clusterUID: "test-uid-123",
+			instances:  nil,
+			wantCount:  0,
+		},
+		{
+			name:       "returns matching instances",
+			clusterUID: "test-uid-123",
+			instances: []types.Instance{
+				{
+					InstanceId: aws.String("i-aaa"),
+					Tags: []types.Tag{
+						{Key: aws.String("Name"), Value: aws.String("vm-1")},
+						{Key: aws.String(provider.ClusterUIDTagKey), Value: aws.String("test-uid-123")},
+					},
+				},
+				{
+					InstanceId: aws.String("i-bbb"),
+					Tags: []types.Tag{
+						{Key: aws.String("Name"), Value: aws.String("vm-2")},
+						{Key: aws.String(provider.ClusterUIDTagKey), Value: aws.String("test-uid-123")},
+					},
+				},
+			},
+			wantCount: 2,
+		},
+		{
+			name:       "instance without Name tag",
+			clusterUID: "test-uid-123",
+			instances: []types.Instance{
+				{
+					InstanceId: aws.String("i-ccc"),
+					Tags: []types.Tag{
+						{Key: aws.String(provider.ClusterUIDTagKey), Value: aws.String("test-uid-123")},
+					},
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name:       "skips instance with nil InstanceId",
+			clusterUID: "test-uid-123",
+			instances: []types.Instance{
+				{InstanceId: nil},
+				{
+					InstanceId: aws.String("i-ddd"),
+					Tags: []types.Tag{
+						{Key: aws.String("Name"), Value: aws.String("vm-valid")},
+					},
+				},
+			},
+			wantCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &awsProvider{
+				ec2Client:     &listInstancesMockEC2Client{instances: tt.instances},
+				serviceConfig: &Config{},
+			}
+
+			got, err := p.ListInstances(context.Background(), provider.ListInstancesInput{ClusterUID: tt.clusterUID})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ListInstances() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(got) != tt.wantCount {
+				t.Errorf("ListInstances() returned %d instances, want %d", len(got), tt.wantCount)
+			}
+
+			for _, inst := range got {
+				if inst.ID == "" {
+					t.Error("ListInstances() returned instance with empty ID")
+				}
+			}
+		})
+	}
+}
+
+func TestListInstances_VerifyFilters(t *testing.T) {
+	mockClient := &listInstancesMockEC2Client{}
+	p := &awsProvider{
+		ec2Client:     mockClient,
+		serviceConfig: &Config{},
+	}
+
+	_, _ = p.ListInstances(context.Background(), provider.ListInstancesInput{ClusterUID: "uid-filter-test"})
+
+	if mockClient.lastInput == nil {
+		t.Fatal("DescribeInstances was not called")
+	}
+
+	filters := mockClient.lastInput.Filters
+	if len(filters) != 2 {
+		t.Fatalf("expected 2 filters, got %d", len(filters))
+	}
+
+	expectedTagFilter := "tag:" + provider.ClusterUIDTagKey
+	if aws.ToString(filters[0].Name) != expectedTagFilter {
+		t.Errorf("expected filter name %q, got %q", expectedTagFilter, aws.ToString(filters[0].Name))
+	}
+	if len(filters[0].Values) != 1 || filters[0].Values[0] != "uid-filter-test" {
+		t.Errorf("expected filter value [uid-filter-test], got %v", filters[0].Values)
+	}
+
+	if aws.ToString(filters[1].Name) != "instance-state-name" {
+		t.Errorf("expected filter name %q, got %q", "instance-state-name", aws.ToString(filters[1].Name))
+	}
+	expectedStates := map[string]bool{"pending": true, "running": true, "stopping": true, "stopped": true}
+	for _, v := range filters[1].Values {
+		if !expectedStates[v] {
+			t.Errorf("unexpected instance state filter value: %s", v)
+		}
+	}
+}
+
+func TestListInstances_VerifyIDAndName(t *testing.T) {
+	launchTime := time.Date(2026, 5, 19, 10, 0, 0, 0, time.UTC)
+	mockClient := &listInstancesMockEC2Client{
+		instances: []types.Instance{
+			{
+				InstanceId: aws.String("i-test123"),
+				LaunchTime: aws.Time(launchTime),
+				Tags: []types.Tag{
+					{Key: aws.String("Name"), Value: aws.String("my-pod-vm")},
+					{Key: aws.String(provider.ClusterUIDTagKey), Value: aws.String("uid-abc")},
+				},
+			},
+		},
+	}
+
+	p := &awsProvider{
+		ec2Client:     mockClient,
+		serviceConfig: &Config{},
+	}
+
+	instances, err := p.ListInstances(context.Background(), provider.ListInstancesInput{ClusterUID: "uid-abc"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(instances) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(instances))
+	}
+
+	if instances[0].ID != "i-test123" {
+		t.Errorf("expected ID i-test123, got %s", instances[0].ID)
+	}
+	if instances[0].Name != "my-pod-vm" {
+		t.Errorf("expected Name my-pod-vm, got %s", instances[0].Name)
+	}
+	if !instances[0].CreatedAt.Equal(launchTime) {
+		t.Errorf("expected CreatedAt %v, got %v", launchTime, instances[0].CreatedAt)
+	}
+}

--- a/src/cloud-providers/aws/provider.go
+++ b/src/cloud-providers/aws/provider.go
@@ -225,6 +225,13 @@ func (p *awsProvider) CreateInstance(ctx context.Context, podName, sandboxID str
 		})
 	}
 
+	if provider.ClusterUID != "" {
+		instanceTags = append(instanceTags, types.Tag{
+			Key:   aws.String(provider.ClusterUIDTagKey),
+			Value: aws.String(provider.ClusterUID),
+		})
+	}
+
 	// Create TagSpecifications for the instance
 	tagSpecifications := []types.TagSpecification{
 		{
@@ -888,4 +895,59 @@ func (p *awsProvider) getDeviceNameAndSize(imageID string) (string, int32, error
 	logger.Printf("image %s: device name=[%s], size=[%d]", imageID, *deviceName, *deviceSize)
 
 	return *deviceName, *deviceSize, nil
+}
+
+func (p *awsProvider) ListInstances(ctx context.Context, input provider.ListInstancesInput) ([]*provider.Instance, error) {
+	if input.ClusterUID == "" {
+		return nil, fmt.Errorf("cluster UID is required")
+	}
+
+	describeInput := &ec2.DescribeInstancesInput{
+		Filters: []types.Filter{
+			{
+				Name:   aws.String("tag:" + provider.ClusterUIDTagKey),
+				Values: []string{input.ClusterUID},
+			},
+			{
+				Name:   aws.String("instance-state-name"),
+				Values: []string{"pending", "running", "stopping", "stopped"},
+			},
+		},
+	}
+
+	var instances []*provider.Instance
+	for {
+		result, err := p.ec2Client.DescribeInstances(ctx, describeInput)
+		if err != nil {
+			return nil, fmt.Errorf("failed to describe instances: %w", err)
+		}
+
+		for _, reservation := range result.Reservations {
+			for _, inst := range reservation.Instances {
+				if inst.InstanceId == nil {
+					continue
+				}
+				name := ""
+				for _, tag := range inst.Tags {
+					if tag.Key != nil && *tag.Key == "Name" && tag.Value != nil {
+						name = *tag.Value
+						break
+					}
+				}
+				instances = append(instances, &provider.Instance{
+					ID:        *inst.InstanceId,
+					Name:      name,
+					CreatedAt: aws.ToTime(inst.LaunchTime),
+				})
+			}
+		}
+
+		if result.NextToken == nil {
+			break
+		}
+		describeInput.NextToken = result.NextToken
+	}
+
+	logger.Printf("ListInstances: found %d instances for cluster UID %s", len(instances), input.ClusterUID)
+	return instances, nil
 }

--- a/src/cloud-providers/cmd/config-extractor/main.go
+++ b/src/cloud-providers/cmd/config-extractor/main.go
@@ -127,15 +127,20 @@ func parseFile(path string) ([]FlagInfo, error) {
 func parsePackageConstants(dir string, fset *token.FileSet) map[string]string {
 	constants := make(map[string]string)
 
-	pkgs, err := parser.ParseDir(fset, dir, nil, parser.ParseComments)
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return constants
 	}
 
-	for _, pkg := range pkgs {
-		for _, file := range pkg.Files {
-			extractConstants(file, constants)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") {
+			continue
 		}
+		file, err := parser.ParseFile(fset, filepath.Join(dir, entry.Name()), nil, parser.ParseComments)
+		if err != nil {
+			continue
+		}
+		extractConstants(file, constants)
 	}
 
 	return constants

--- a/src/cloud-providers/types.go
+++ b/src/cloud-providers/types.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/netip"
 	"strings"
+	"time"
 
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers/util/cloudinit"
 )
@@ -18,6 +19,24 @@ type Provider interface {
 	DeleteInstance(ctx context.Context, instanceID string) error
 	Teardown() error
 	ConfigVerifier() error
+}
+
+const ClusterUIDTagKey = "caa-cluster-uid"
+
+// ClusterUID holds the kube-system namespace UID for this cluster.
+// Set once at startup by main.go; providers read it in CreateInstance
+// to tag VMs for orphan GC discovery.
+var ClusterUID string
+
+type ListInstancesInput struct {
+	ClusterUID string
+}
+
+// InstanceLister is an optional interface that providers can implement to
+// support orphan VM garbage collection. ListInstances returns all instances
+// tagged as belonging to this cluster.
+type InstanceLister interface {
+	ListInstances(ctx context.Context, input ListInstancesInput) ([]*Instance, error)
 }
 
 // keyValueFlag represents a flag of key-value pairs
@@ -58,6 +77,11 @@ type Instance struct {
 	ID   string
 	Name string
 	IPs  []netip.Addr
+	// CreatedAt is the instance creation timestamp from the cloud provider API
+	// (UTC). Available for informational logging; not used for grace period
+	// decisions (which use local discovery time instead to avoid cross-clock
+	// dependency in disconnected environments).
+	CreatedAt time.Time
 }
 
 type InstanceTypeSpec struct {

--- a/src/peerpod-ctrl/README.md
+++ b/src/peerpod-ctrl/README.md
@@ -12,10 +12,34 @@ The PeerPod CR is owned by the original Pod object. Upon Pod deletion [backgroun
 ### Deletion time:
 Normal case: When remote hypervisor will get the stopVM request (upon Pod deletion) it will delete the pod VM instance and if it succeeds it will remove the finalizer attached to the owned PeerPod object so it can then be cleaned by the GC.
 
-Failure case: If for any reason cloud-api-adaptor doesn’t honor the delete request or it fails to perform deletion, the finalizer is not removed. Hence, when PeerPod controller gets a delete event for the owned PeerPod object by the GC and it still has the finalizer, it will comprehend that it needs to perform the deletion of pod VM resource by itself, based on the PeerPod CR fields.
+Failure case: If for any reason cloud-api-adaptor doesn't honor the delete request or it fails to perform deletion, the finalizer is not removed. Hence, when PeerPod controller gets a delete event for the owned PeerPod object by the GC and it still has the finalizer, it will comprehend that it needs to perform the deletion of pod VM resource by itself, based on the PeerPod CR fields.
+
+### Orphan VM garbage collection
+If the cloud-api-adaptor crashes after creating a VM but before the corresponding PeerPod CR is written, the VM becomes an orphan with no Kubernetes object tracking it. The peerpod-ctrl includes a periodic garbage collector that detects and deletes these orphan VMs.
+
+**How it works:**
+1. At startup, the cloud-api-adaptor tags every VM it creates with a `caa-cluster-uid` tag containing the `kube-system` namespace UID, uniquely identifying the cluster.
+2. The garbage collector periodically calls `ListInstances` on the cloud provider to discover all VMs tagged with this cluster's UID.
+3. It compares the discovered VMs against existing PeerPod CRs. Any VM without a matching PeerPod CR is considered an orphan and deleted.
+
+**Grace period:** To avoid deleting VMs that were just created but whose PeerPod CR has not yet been written, the GC applies a 10-minute grace period. Instances are only deleted after the GC has observed them as orphan candidates for at least 10 minutes across consecutive cycles (using only the controller's local clock, avoiding any cross-clock dependency with the cloud provider). The 10-minute default provides a safety margin for large GPU instances that can take 5+ minutes to boot.
+
+**Timing:** An orphan is deleted on the first GC cycle after both (a) it has been discovered and (b) the grace period has elapsed since discovery. With defaults (`GC_INTERVAL=30m`, grace period 10m), deletion occurs on the cycle after first discovery (~30m), since 30m > 10m. Worst-case time from VM creation to deletion is approximately 2x `GC_INTERVAL` (one interval to discover, one to delete).
+
+**Configuration** via the `peer-pods-cm` ConfigMap:
+
+| Key | Default | Hot-reloadable | Description |
+|---|---|---|---|
+| `ENABLE_GC` | `true` | No (requires pod restart) | Set to `false` to disable orphan VM garbage collection |
+| `GC_INTERVAL` | `30m` | Yes | How often the GC runs (Go duration string, must be > 0) |
+| `GC_GRACE_PERIOD` | `10m` | Yes | How long an orphan candidate must be observed before deletion (Go duration string, must be > 0) |
+
+**Note:** Changing `GC_GRACE_PERIOD` at runtime resets the firstSeen tracking for all orphan candidates, so they must be re-observed for the new grace period before deletion.
+
+**Provider support:** The garbage collector requires the cloud provider to implement the `InstanceLister` interface. Currently supported: AWS. Providers that do not implement this interface are gracefully skipped.
 
 ## Getting Started
-You’ll need a Kubernetes cluster on a [supported provider](../../README.md#supported-providers) to run against (e.g. you can use [Libvirt for development](../cloud-api-adaptor/libvirt)).
+You'll need a Kubernetes cluster on a [supported provider](../../README.md#supported-providers) to run against (e.g. you can use [Libvirt for development](../cloud-api-adaptor/libvirt)).
 **Note:** Your controller will automatically use the current context in your kubeconfig file (i.e. whatever cluster `kubectl cluster-info` shows).
 
 ### Running on the cluster

--- a/src/peerpod-ctrl/chart/templates/rbac.yaml
+++ b/src/peerpod-ctrl/chart/templates/rbac.yaml
@@ -26,6 +26,12 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
   - confidentialcontainers.org
   resources:
   - peerpods

--- a/src/peerpod-ctrl/controllers/cloud_util.go
+++ b/src/peerpod-ctrl/controllers/cloud_util.go
@@ -1,0 +1,81 @@
+/*
+Copyright Confidential Containers Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	provider "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers"
+)
+
+const (
+	ppConfigMap = "peer-pods-cm"
+	ppSecret    = "peer-pods-secret"
+)
+
+func loadCloudConfigs(ctx context.Context, reader client.Reader, namespace string) error {
+	if namespace == "" {
+		return fmt.Errorf("PEERPODS_NAMESPACE is not set")
+	}
+
+	cm := corev1.ConfigMap{}
+	secret := corev1.Secret{}
+
+	var cmErr error
+	if cmErr = reader.Get(ctx, types.NamespacedName{Name: ppConfigMap, Namespace: namespace}, &cm); cmErr == nil {
+		for k, v := range cm.Data {
+			os.Setenv(k, v)
+		}
+	}
+
+	var secretErr error
+	if secretErr = reader.Get(ctx, types.NamespacedName{Name: ppSecret, Namespace: namespace}, &secret); secretErr == nil {
+		for k, v := range secret.Data {
+			os.Setenv(k, string(v))
+		}
+	}
+
+	if cm.Data == nil && secret.Data == nil {
+		return fmt.Errorf("ConfigMap Error: %v, Secret Error: %v", cmErr, secretErr)
+	}
+
+	return nil
+}
+
+// GetProvider loads a cloud provider by name. loadCloudConfigs must be called
+// first to populate environment variables that ParseCmd reads.
+func GetProvider(cloudName string) (provider.Provider, error) {
+	if cloud := provider.Get(cloudName); cloud != nil {
+		dummyFlags := flag.NewFlagSet(cloudName, flag.ContinueOnError)
+		cloud.ParseCmd(dummyFlags)
+
+		p, err := cloud.NewProvider()
+		if err != nil {
+			return nil, err
+		}
+		return p, nil
+	}
+
+	return nil, fmt.Errorf("%s cloud provider not supported", cloudName)
+}

--- a/src/peerpod-ctrl/controllers/gc.go
+++ b/src/peerpod-ctrl/controllers/gc.go
@@ -1,0 +1,251 @@
+/*
+Copyright Confidential Containers Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	provider "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers"
+	confidentialcontainersorgv1alpha1 "github.com/confidential-containers/cloud-api-adaptor/src/peerpod-ctrl/api/v1alpha1"
+)
+
+const defaultGCInterval = 30 * time.Minute
+const defaultGCGracePeriod = 10 * time.Minute
+
+var logger = ctrl.Log.WithName("gc")
+
+type GarbageCollector struct {
+	KubeClient client.Client
+	Namespace  string
+	firstSeen  map[string]time.Time
+}
+
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get
+
+func (gc *GarbageCollector) Start(ctx context.Context) error {
+	if !gc.isGCEnabled(ctx) {
+		logger.Info("GC is disabled via ENABLE_GC=false")
+		return nil
+	}
+
+	var (
+		cloudProvider string
+		clusterUID    string
+		p             provider.Provider
+		lister        provider.InstanceLister
+		initialized   bool
+	)
+
+	interval, prevGracePeriod := gc.readGCDynamicConfig(ctx)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Info("stopping garbage collector")
+			return nil
+		case <-ticker.C:
+			newInterval, gracePeriod := gc.readGCDynamicConfig(ctx)
+			if newInterval != interval {
+				logger.Info("GC interval changed", "old", interval, "new", newInterval)
+				interval = newInterval
+				ticker.Reset(interval)
+			}
+			if gracePeriod != prevGracePeriod {
+				logger.Info("GC grace period changed, resetting firstSeen tracking",
+					"old", prevGracePeriod, "new", gracePeriod)
+				gc.firstSeen = nil
+				prevGracePeriod = gracePeriod
+			}
+			if !initialized {
+				var err error
+				cloudProvider, p, lister, clusterUID, err = gc.initialize(ctx)
+				if err != nil {
+					logger.Error(err, "failed to initialize garbage collector, will retry next cycle")
+					continue
+				}
+				if lister == nil {
+					return nil
+				}
+				initialized = true
+				logger.Info("starting garbage collector", "provider", cloudProvider)
+			}
+			gc.collect(ctx, p, lister, cloudProvider, clusterUID, gracePeriod)
+		}
+	}
+}
+
+func (gc *GarbageCollector) initialize(ctx context.Context) (string, provider.Provider, provider.InstanceLister, string, error) {
+	if err := loadCloudConfigs(ctx, gc.KubeClient, gc.Namespace); err != nil {
+		return "", nil, nil, "", fmt.Errorf("failed to load cloud configs: %w", err)
+	}
+	logger.Info("cloud config loaded for GC")
+
+	uid, err := gc.getClusterUID(ctx)
+	if err != nil {
+		return "", nil, nil, "", fmt.Errorf("failed to get cluster UID: %w", err)
+	}
+
+	cloudProvider := os.Getenv("CLOUD_PROVIDER")
+	if cloudProvider == "" {
+		return "", nil, nil, "", fmt.Errorf("CLOUD_PROVIDER is not set in peer-pods-cm")
+	}
+
+	p, err := GetProvider(cloudProvider)
+	if err != nil {
+		return "", nil, nil, "", fmt.Errorf("failed to create provider %s: %w", cloudProvider, err)
+	}
+
+	lister, ok := p.(provider.InstanceLister)
+	if !ok {
+		logger.Info("provider does not implement InstanceLister, GC disabled", "provider", cloudProvider)
+		return cloudProvider, p, nil, uid, nil
+	}
+
+	return cloudProvider, p, lister, uid, nil
+}
+
+func (gc *GarbageCollector) getClusterUID(ctx context.Context) (string, error) {
+	ns := corev1.Namespace{}
+	if err := gc.KubeClient.Get(ctx, types.NamespacedName{Name: "kube-system"}, &ns); err != nil {
+		return "", fmt.Errorf("failed to get kube-system namespace: %w", err)
+	}
+	logger.Info("cluster UID resolved", "uid", string(ns.UID))
+	return string(ns.UID), nil
+}
+
+func parseDurationConfig(data map[string]string, key string, defaultVal time.Duration) time.Duration {
+	v, ok := data[key]
+	if !ok || v == "" {
+		return defaultVal
+	}
+	parsed, err := time.ParseDuration(v)
+	if err != nil {
+		logger.Error(err, "invalid duration config, using default", "key", key, "value", v)
+		return defaultVal
+	}
+	if parsed <= 0 {
+		logger.Info("WARNING: duration must be positive, falling back to default", "key", key, "value", v, "default", defaultVal)
+		return defaultVal
+	}
+	return parsed
+}
+
+func (gc *GarbageCollector) isGCEnabled(ctx context.Context) bool {
+	cm := corev1.ConfigMap{}
+	if err := gc.KubeClient.Get(ctx, types.NamespacedName{Name: ppConfigMap, Namespace: gc.Namespace}, &cm); err != nil {
+		logger.Error(err, "failed to read peer-pods-cm for ENABLE_GC, defaulting to enabled")
+		return true
+	}
+	if v, ok := cm.Data["ENABLE_GC"]; ok && v == "false" {
+		return false
+	}
+	return true
+}
+
+func (gc *GarbageCollector) readGCDynamicConfig(ctx context.Context) (interval, gracePeriod time.Duration) {
+	interval = defaultGCInterval
+	gracePeriod = defaultGCGracePeriod
+
+	cm := corev1.ConfigMap{}
+	if err := gc.KubeClient.Get(ctx, types.NamespacedName{Name: ppConfigMap, Namespace: gc.Namespace}, &cm); err != nil {
+		logger.Error(err, "failed to read peer-pods-cm for GC config, using defaults")
+		return
+	}
+
+	interval = parseDurationConfig(cm.Data, "GC_INTERVAL", defaultGCInterval)
+	gracePeriod = parseDurationConfig(cm.Data, "GC_GRACE_PERIOD", defaultGCGracePeriod)
+	return
+}
+
+func (gc *GarbageCollector) collect(ctx context.Context, p provider.Provider, lister provider.InstanceLister, cloudProvider, clusterUID string, gracePeriod time.Duration) {
+	cloudInstances, err := lister.ListInstances(ctx, provider.ListInstancesInput{ClusterUID: clusterUID})
+	if err != nil {
+		logger.Error(err, "failed to list cloud instances, skipping GC cycle")
+		return
+	}
+
+	if len(cloudInstances) == 0 {
+		gc.firstSeen = nil
+		return
+	}
+
+	ppList := confidentialcontainersorgv1alpha1.PeerPodList{}
+	if err := gc.KubeClient.List(ctx, &ppList); err != nil {
+		logger.Error(err, "failed to list PeerPod CRs, skipping GC cycle")
+		return
+	}
+
+	knownInstances := make(map[string]struct{})
+	for i := range ppList.Items {
+		pp := &ppList.Items[i]
+		if pp.Spec.CloudProvider == cloudProvider && pp.Spec.InstanceID != "" {
+			knownInstances[pp.Spec.InstanceID] = struct{}{}
+		}
+	}
+
+	deleted := 0
+	if gc.firstSeen == nil {
+		gc.firstSeen = make(map[string]time.Time)
+	}
+
+	cloudIDs := make(map[string]struct{}, len(cloudInstances))
+	for _, inst := range cloudInstances {
+		cloudIDs[inst.ID] = struct{}{}
+	}
+
+	for _, inst := range cloudInstances {
+		if _, ok := knownInstances[inst.ID]; ok {
+			delete(gc.firstSeen, inst.ID)
+			continue
+		}
+		if _, seen := gc.firstSeen[inst.ID]; !seen {
+			gc.firstSeen[inst.ID] = time.Now()
+		}
+		if time.Since(gc.firstSeen[inst.ID]) < gracePeriod {
+			logger.Info("skipping recently discovered orphan candidate",
+				"instanceID", inst.ID, "firstSeen", time.Since(gc.firstSeen[inst.ID]),
+				"createdAt", inst.CreatedAt.UTC().Format(time.RFC3339))
+			continue
+		}
+		logger.Info("deleting orphan instance", "instanceID", inst.ID, "instanceName", inst.Name,
+			"createdAt", inst.CreatedAt.UTC().Format(time.RFC3339))
+		if err := p.DeleteInstance(ctx, inst.ID); err != nil {
+			logger.Error(err, "failed to delete orphan instance", "instanceID", inst.ID)
+			continue
+		}
+		delete(gc.firstSeen, inst.ID)
+		deleted++
+	}
+
+	for id := range gc.firstSeen {
+		if _, exists := cloudIDs[id]; !exists {
+			delete(gc.firstSeen, id)
+		}
+	}
+
+	logger.Info("garbage collection cycle complete", "orphansDeleted", deleted, "totalCloudInstances", len(cloudInstances))
+}

--- a/src/peerpod-ctrl/controllers/gc_test.go
+++ b/src/peerpod-ctrl/controllers/gc_test.go
@@ -1,0 +1,394 @@
+/*
+Copyright Confidential Containers Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	provider "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers"
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers/util/cloudinit"
+	v1alpha1 "github.com/confidential-containers/cloud-api-adaptor/src/peerpod-ctrl/api/v1alpha1"
+)
+
+type mockProvider struct {
+	deletedIDs []string
+	deleteErr  error
+}
+
+func (m *mockProvider) CreateInstance(_ context.Context, _, _ string, _ cloudinit.CloudConfigGenerator, _ provider.InstanceTypeSpec) (*provider.Instance, error) {
+	return nil, nil
+}
+
+func (m *mockProvider) DeleteInstance(_ context.Context, instanceID string) error {
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	m.deletedIDs = append(m.deletedIDs, instanceID)
+	return nil
+}
+
+func (m *mockProvider) Teardown() error       { return nil }
+func (m *mockProvider) ConfigVerifier() error { return nil }
+
+type mockLister struct {
+	instances []*provider.Instance
+	err       error
+}
+
+func (m *mockLister) ListInstances(_ context.Context, _ provider.ListInstancesInput) ([]*provider.Instance, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.instances, nil
+}
+
+func newScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(s)
+	return s
+}
+
+func newPeerPod(name, cloudProvider, instanceID string) *v1alpha1.PeerPod {
+	return &v1alpha1.PeerPod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: v1alpha1.PeerPodSpec{
+			CloudProvider: cloudProvider,
+			InstanceID:    instanceID,
+		},
+	}
+}
+
+func TestCollect_InstanceWithMatchingPeerPod_NotDeleted(t *testing.T) {
+	scheme := newScheme()
+	pp := newPeerPod("pod-1", "aws", "i-aaa")
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pp).Build()
+
+	mp := &mockProvider{}
+	lister := &mockLister{
+		instances: []*provider.Instance{{ID: "i-aaa", Name: "vm-1"}},
+	}
+
+	gc := &GarbageCollector{KubeClient: k8sClient, Namespace: "test-ns"}
+	gc.collect(context.Background(), mp, lister, "aws", "uid-123", 10*time.Minute)
+
+	if len(mp.deletedIDs) != 0 {
+		t.Errorf("expected no deletions, got %v", mp.deletedIDs)
+	}
+}
+
+func TestCollect_OrphanWithinGracePeriod_NotDeleted(t *testing.T) {
+	scheme := newScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	mp := &mockProvider{}
+	lister := &mockLister{
+		instances: []*provider.Instance{{ID: "i-orphan", Name: "orphan-vm"}},
+	}
+
+	gc := &GarbageCollector{KubeClient: k8sClient, Namespace: "test-ns"}
+	gc.collect(context.Background(), mp, lister, "aws", "uid-123", 10*time.Minute)
+
+	if len(mp.deletedIDs) != 0 {
+		t.Errorf("expected no deletions during grace period, got %v", mp.deletedIDs)
+	}
+	if _, ok := gc.firstSeen["i-orphan"]; !ok {
+		t.Error("expected orphan to be tracked in firstSeen")
+	}
+}
+
+func TestCollect_OrphanPastGracePeriod_Deleted(t *testing.T) {
+	scheme := newScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	mp := &mockProvider{}
+	lister := &mockLister{
+		instances: []*provider.Instance{{ID: "i-orphan", Name: "orphan-vm"}},
+	}
+
+	gc := &GarbageCollector{
+		KubeClient: k8sClient,
+		Namespace:  "test-ns",
+		firstSeen:  map[string]time.Time{"i-orphan": time.Now().Add(-15 * time.Minute)},
+	}
+	gc.collect(context.Background(), mp, lister, "aws", "uid-123", 10*time.Minute)
+
+	if len(mp.deletedIDs) != 1 || mp.deletedIDs[0] != "i-orphan" {
+		t.Errorf("expected [i-orphan] to be deleted, got %v", mp.deletedIDs)
+	}
+	if _, ok := gc.firstSeen["i-orphan"]; ok {
+		t.Error("expected orphan to be removed from firstSeen after deletion")
+	}
+}
+
+func TestCollect_DisappearedInstance_RemovedFromFirstSeen(t *testing.T) {
+	scheme := newScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	mp := &mockProvider{}
+	lister := &mockLister{
+		instances: []*provider.Instance{},
+	}
+
+	gc := &GarbageCollector{
+		KubeClient: k8sClient,
+		Namespace:  "test-ns",
+		firstSeen:  map[string]time.Time{"i-gone": time.Now().Add(-20 * time.Minute)},
+	}
+	gc.collect(context.Background(), mp, lister, "aws", "uid-123", 10*time.Minute)
+
+	if gc.firstSeen != nil {
+		t.Errorf("expected firstSeen to be nil when no cloud instances exist, got %v", gc.firstSeen)
+	}
+}
+
+func TestCollect_StaleFirstSeenEntry_CleanedUp(t *testing.T) {
+	scheme := newScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	mp := &mockProvider{}
+	lister := &mockLister{
+		instances: []*provider.Instance{{ID: "i-current", Name: "current-vm"}},
+	}
+
+	gc := &GarbageCollector{
+		KubeClient: k8sClient,
+		Namespace:  "test-ns",
+		firstSeen: map[string]time.Time{
+			"i-gone":    time.Now().Add(-20 * time.Minute),
+			"i-current": time.Now(),
+		},
+	}
+	gc.collect(context.Background(), mp, lister, "aws", "uid-123", 10*time.Minute)
+
+	if _, ok := gc.firstSeen["i-gone"]; ok {
+		t.Error("expected stale firstSeen entry for i-gone to be cleaned up")
+	}
+	if _, ok := gc.firstSeen["i-current"]; !ok {
+		t.Error("expected firstSeen entry for i-current to be retained")
+	}
+}
+
+func TestCollect_ListInstancesError_SkipsCycle(t *testing.T) {
+	scheme := newScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	mp := &mockProvider{}
+	lister := &mockLister{err: fmt.Errorf("API error")}
+
+	gc := &GarbageCollector{KubeClient: k8sClient, Namespace: "test-ns"}
+	gc.collect(context.Background(), mp, lister, "aws", "uid-123", 10*time.Minute)
+
+	if len(mp.deletedIDs) != 0 {
+		t.Errorf("expected no deletions on ListInstances error, got %v", mp.deletedIDs)
+	}
+}
+
+func TestCollect_DeleteInstanceError_ContinuesProcessing(t *testing.T) {
+	scheme := newScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	failOnce := &mockProvider{deleteErr: fmt.Errorf("delete failed")}
+	lister := &mockLister{
+		instances: []*provider.Instance{
+			{ID: "i-fail", Name: "fail-vm"},
+			{ID: "i-ok", Name: "ok-vm"},
+		},
+	}
+
+	gc := &GarbageCollector{
+		KubeClient: k8sClient,
+		Namespace:  "test-ns",
+		firstSeen: map[string]time.Time{
+			"i-fail": time.Now().Add(-15 * time.Minute),
+			"i-ok":   time.Now().Add(-15 * time.Minute),
+		},
+	}
+	gc.collect(context.Background(), failOnce, lister, "aws", "uid-123", 10*time.Minute)
+
+	if _, ok := gc.firstSeen["i-fail"]; !ok {
+		t.Error("expected i-fail to remain in firstSeen after delete error")
+	}
+	if _, ok := gc.firstSeen["i-ok"]; !ok {
+		t.Error("expected i-ok to remain in firstSeen after delete error (deleteErr applies to all)")
+	}
+}
+
+func TestCollect_MatchedInstanceClearsFirstSeen(t *testing.T) {
+	scheme := newScheme()
+	pp := newPeerPod("pod-1", "aws", "i-matched")
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pp).Build()
+
+	mp := &mockProvider{}
+	lister := &mockLister{
+		instances: []*provider.Instance{{ID: "i-matched", Name: "matched-vm"}},
+	}
+
+	gc := &GarbageCollector{
+		KubeClient: k8sClient,
+		Namespace:  "test-ns",
+		firstSeen:  map[string]time.Time{"i-matched": time.Now().Add(-5 * time.Minute)},
+	}
+	gc.collect(context.Background(), mp, lister, "aws", "uid-123", 10*time.Minute)
+
+	if _, ok := gc.firstSeen["i-matched"]; ok {
+		t.Error("expected firstSeen to be cleared for matched instance")
+	}
+}
+
+func TestCollect_DifferentCloudProvider_NotMatched(t *testing.T) {
+	scheme := newScheme()
+	pp := newPeerPod("pod-1", "azure", "i-azure-vm")
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pp).Build()
+
+	mp := &mockProvider{}
+	lister := &mockLister{
+		instances: []*provider.Instance{{ID: "i-azure-vm", Name: "azure-vm"}},
+	}
+
+	gc := &GarbageCollector{
+		KubeClient: k8sClient,
+		Namespace:  "test-ns",
+		firstSeen:  map[string]time.Time{"i-azure-vm": time.Now().Add(-15 * time.Minute)},
+	}
+	gc.collect(context.Background(), mp, lister, "aws", "uid-123", 10*time.Minute)
+
+	if len(mp.deletedIDs) != 1 || mp.deletedIDs[0] != "i-azure-vm" {
+		t.Errorf("expected instance with different cloud provider PeerPod to be treated as orphan, got %v", mp.deletedIDs)
+	}
+}
+
+func TestCollect_MultipleOrphans_MixedGracePeriod(t *testing.T) {
+	scheme := newScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	mp := &mockProvider{}
+	lister := &mockLister{
+		instances: []*provider.Instance{
+			{ID: "i-old", Name: "old-orphan"},
+			{ID: "i-new", Name: "new-orphan"},
+		},
+	}
+
+	gc := &GarbageCollector{
+		KubeClient: k8sClient,
+		Namespace:  "test-ns",
+		firstSeen: map[string]time.Time{
+			"i-old": time.Now().Add(-15 * time.Minute),
+		},
+	}
+	gc.collect(context.Background(), mp, lister, "aws", "uid-123", 10*time.Minute)
+
+	if len(mp.deletedIDs) != 1 || mp.deletedIDs[0] != "i-old" {
+		t.Errorf("expected only i-old to be deleted, got %v", mp.deletedIDs)
+	}
+	if _, ok := gc.firstSeen["i-new"]; !ok {
+		t.Error("expected i-new to be tracked in firstSeen")
+	}
+}
+
+func TestCollect_ZeroGracePeriod_DeletesImmediately(t *testing.T) {
+	scheme := newScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	mp := &mockProvider{}
+	lister := &mockLister{
+		instances: []*provider.Instance{{ID: "i-instant", Name: "instant-orphan"}},
+	}
+
+	gc := &GarbageCollector{KubeClient: k8sClient, Namespace: "test-ns"}
+
+	// First call: firstSeen is recorded with time.Now(), so even 0 grace period
+	// will see time.Since(firstSeen) as ~0ns which is >= 0. The instance should
+	// be deleted because the check is `< gracePeriod` and gracePeriod is 0.
+	gc.collect(context.Background(), mp, lister, "aws", "uid-123", 0)
+
+	if len(mp.deletedIDs) != 1 || mp.deletedIDs[0] != "i-instant" {
+		t.Errorf("expected immediate deletion with zero grace period, got %v", mp.deletedIDs)
+	}
+}
+
+func TestParseDurationConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		data       map[string]string
+		key        string
+		defaultVal time.Duration
+		want       time.Duration
+	}{
+		{
+			name:       "missing key uses default",
+			data:       map[string]string{},
+			key:        "GC_INTERVAL",
+			defaultVal: 30 * time.Minute,
+			want:       30 * time.Minute,
+		},
+		{
+			name:       "empty value uses default",
+			data:       map[string]string{"GC_INTERVAL": ""},
+			key:        "GC_INTERVAL",
+			defaultVal: 30 * time.Minute,
+			want:       30 * time.Minute,
+		},
+		{
+			name:       "valid duration parsed",
+			data:       map[string]string{"GC_INTERVAL": "5m"},
+			key:        "GC_INTERVAL",
+			defaultVal: 30 * time.Minute,
+			want:       5 * time.Minute,
+		},
+		{
+			name:       "invalid duration uses default",
+			data:       map[string]string{"GC_INTERVAL": "notaduration"},
+			key:        "GC_INTERVAL",
+			defaultVal: 30 * time.Minute,
+			want:       30 * time.Minute,
+		},
+		{
+			name:       "negative duration uses default",
+			data:       map[string]string{"GC_INTERVAL": "-5m"},
+			key:        "GC_INTERVAL",
+			defaultVal: 30 * time.Minute,
+			want:       30 * time.Minute,
+		},
+		{
+			name:       "zero duration uses default",
+			data:       map[string]string{"GC_INTERVAL": "0s"},
+			key:        "GC_INTERVAL",
+			defaultVal: 30 * time.Minute,
+			want:       30 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseDurationConfig(tt.data, tt.key, tt.defaultVal)
+			if got != tt.want {
+				t.Errorf("parseDurationConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/src/peerpod-ctrl/controllers/peerpod_controller.go
+++ b/src/peerpod-ctrl/controllers/peerpod_controller.go
@@ -18,13 +18,9 @@ package controllers
 
 import (
 	"context"
-	"flag"
-	"fmt"
 	"os"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -42,11 +38,7 @@ type PeerPodReconciler struct {
 	Providers map[string]provider.Provider
 }
 
-const (
-	ppFinalizer = "peer.pod/finalizer"
-	ppConfigMap = "peer-pods-cm"
-	ppSecret    = "peer-pods-secret"
-)
+const ppFinalizer = "peer.pod/finalizer"
 
 //+kubebuilder:rbac:groups="",resourceNames=peer-pods-cm;peer-pods-secret,resources=configmaps;secrets,verbs=get
 
@@ -136,58 +128,7 @@ func (r *PeerPodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *PeerPodReconciler) cloudConfigsGetter() error {
-	peerpodscm := corev1.ConfigMap{}
-	peerpodssecret := corev1.Secret{}
-	ns := os.Getenv("PEERPODS_NAMESPACE")
-	if ns == "" {
-		return fmt.Errorf("PEERPODS_NAMESPACE is not set")
-	}
-
-	var cmErr error
-	if cmErr = r.Get(context.TODO(), types.NamespacedName{Name: ppConfigMap, Namespace: ns}, &peerpodscm); cmErr == nil {
-		// set all configs as env vars to make sure all the required vars for auth are set
-		for k, v := range peerpodscm.Data {
-			os.Setenv(k, v)
-		}
-	}
-
-	var secretErr error
-	if secretErr = r.Get(context.TODO(), types.NamespacedName{Name: ppSecret, Namespace: ns}, &peerpodssecret); secretErr == nil {
-		for k, v := range peerpodssecret.Data {
-			os.Setenv(k, string(v))
-		}
-	}
-
-	if peerpodscm.Data == nil && peerpodssecret.Data == nil {
-		return fmt.Errorf("ConfigMap Error: %v, Secret Error: %v", cmErr, secretErr)
-	}
-
-	return nil
-}
-
-func GetProvider(cloudName string) (provider.Provider, error) {
-	if cloud := provider.Get(cloudName); cloud != nil {
-		// Load cloud provider configuration from environment variables.
-		//
-		// cloudConfigsGetter() has already populated os.Environ() with values from
-		// the peer-pods-cm ConfigMap and peer-pods-secret Secret (e.g., AZURE_CLIENT_ID,
-		// AWS_ACCESS_KEY_ID, etc.).
-		//
-		// ParseCmd() reads these environment variables and populates the provider's
-		// configuration struct. We pass a dummy FlagSet because peerpod-ctrl doesn't
-		// use command-line flags - it only needs environment variable loading, which
-		// happens as a side effect of ParseCmd() during flag registration.
-		dummyFlags := flag.NewFlagSet(cloudName, flag.ContinueOnError)
-		cloud.ParseCmd(dummyFlags)
-
-		provider, err := cloud.NewProvider()
-		if err != nil {
-			return nil, err
-		}
-		return provider, nil
-	}
-
-	return nil, fmt.Errorf("%s cloud provider not supported", cloudName)
+	return loadCloudConfigs(context.TODO(), r.Client, os.Getenv("PEERPODS_NAMESPACE"))
 }
 
 func isOldPeerPod(pp, cur confidentialcontainersorgv1alpha1.PeerPod) bool {

--- a/src/peerpod-ctrl/main.go
+++ b/src/peerpod-ctrl/main.go
@@ -24,6 +24,9 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	// Register cloud providers so the GC can instantiate them.
+	_ "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers/aws"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -93,6 +96,7 @@ func main() {
 				DisableFor: []client.Object{
 					&corev1.Secret{},
 					&corev1.ConfigMap{},
+					&corev1.Namespace{},
 				},
 			},
 		},
@@ -111,6 +115,14 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "PeerPod")
 		os.Exit(1)
 	}
+	if err = mgr.Add(&controllers.GarbageCollector{
+		KubeClient: mgr.GetClient(),
+		Namespace:  os.Getenv("PEERPODS_NAMESPACE"),
+	}); err != nil {
+		setupLog.Error(err, "unable to add garbage collector")
+		os.Exit(1)
+	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {


### PR DESCRIPTION
## Problem

Orphan VM instances are created when the CAA crashes after `CreateInstance()` succeeds but before the corresponding PeerPod CR is created:

```go
instance, err := s.provider.CreateInstance(ctx, sandbox.podName, string(sid), sandbox.cloudConfig, sandbox.spec)
// ← crash here = orphan VM
if s.ppService != nil {
    if ownErr := s.ppService.OwnPeerPod(sandbox.podName, sandbox.podNamespace, instance.ID); ownErr != nil {
        logger.Printf("failed to create PeerPod: %v", ownErr)
    }
}
```

When this happens, no PeerPod object exists to track the VM, so the existing controller-based deletion never fires. The instance remains running indefinitely, consuming cloud resources.

## Solution

Add a periodic garbage collector to `peerpod-ctrl` that:

1. **Tags instances at creation** — the CAA injects the `kube-system` namespace UID as a `caa-cluster-uid` tag into `TAGS` at startup, so every VM is tagged with its cluster identity.
2. **Lists cloud instances** — via a new optional `InstanceLister` interface that providers can implement. Implemented for AWS using `DescribeInstances` filtered by the cluster UID tag. The cluster UID is passed explicitly via a `ListInstancesInput` struct rather than relying on environment variables.
3. **Compares against PeerPod CRs** — any cloud instance with no matching PeerPod CR is considered an orphan and deleted.
4. **Grace period** — instances are only deleted after the GC has observed them as orphan candidates for at least 10 minutes (configurable) across consecutive cycles, using only the controller's local clock (no cross-clock dependency with the cloud provider — safe for disconnected/air-gapped environments). The 10-minute default provides a safety margin for large GPU instances that can take 5+ minutes to boot.

The GC is **enabled by default** via `ENABLE_GC` (defaults to `true`) and `GC_INTERVAL` (default 30m) in the `peer-pods-cm` ConfigMap. All settings are hot-reloadable — no restart needed. Providers that do not implement `InstanceLister` are gracefully skipped — no impact to existing providers.

## Changes

- `cloud-providers/types.go` — Add `InstanceLister` interface, `ListInstancesInput` struct, `ClusterUIDTagKey` constant, and `CreatedAt` field on `Instance` (informational; not used for grace period decisions)
- `cloud-providers/aws/provider.go` — Implement `ListInstances` for AWS, accepting `ListInstancesInput` with explicit cluster UID; populate `CreatedAt` from EC2 `LaunchTime`
- `cloud-providers/aws/list_instances_test.go` — Unit tests for `ListInstances` including filter verification and `CreatedAt` assertion
- `cloud-api-adaptor/cmd/main.go` — Inject cluster UID tag at CAA startup with GC-contextualized log messages
- `cloud-api-adaptor/charts/peerpods/rbac.yaml` — RBAC for CAA to read namespaces
- `peerpod-ctrl/controllers/gc.go` — The garbage collector (package-level logger, lazy init with retry, clean cluster UID resolution, local-clock-only "first seen" grace period tracking, configurable grace period)
- `peerpod-ctrl/controllers/peerpod_controller.go` — Extract shared `loadCloudConfigs` helper to eliminate code duplication between GC and reconciler
- `peerpod-ctrl/main.go` — Register GC with the controller manager, disable cache for Namespace objects
- `peerpod-ctrl/chart/templates/rbac.yaml` — RBAC for peerpod-ctrl to read namespaces
- `peerpod-ctrl/README.md` — Documentation for orphan VM garbage collection

## Configuration

| ConfigMap key | Default | Description |
|---|---|---|
| `ENABLE_GC` | `true` | Set to `false` to disable orphan VM garbage collection |
| `GC_INTERVAL` | `30m` | How often the GC runs (Go duration string, must be > 0) |
| `GC_GRACE_PERIOD` | `10m` | How long an orphan candidate must be observed before deletion (Go duration string, must be > 0) |

**Timing:** An orphan is deleted on the first GC cycle after both (a) it has been discovered and (b) the grace period has elapsed since discovery. With defaults (`GC_INTERVAL=30m`, `GC_GRACE_PERIOD=10m`), deletion occurs on the cycle after first discovery (~30m), since 30m > 10m. Worst-case time from VM creation to deletion is approximately 2x `GC_INTERVAL` (one interval to discover, one to delete).

## Design decisions

- **Enabled by default** — GC runs automatically; operators can disable with `ENABLE_GC=false`
- **Provider opt-out** — Providers that don't implement `InstanceLister` are silently skipped
- **Cluster-scoped tagging** — Using `kube-system` namespace UID ensures multi-cluster environments don't interfere with each other
- **Explicit input** — `ListInstances` receives a `ListInstancesInput` struct with the cluster UID, keeping the interface clean and decoupled from environment variables
- **Clean UID resolution** — The GC resolves the cluster UID directly from the kube-system namespace without manipulating the TAGS env var (TAGS is only used by the CAA's CreateInstance path)
- **Dynamic config** — GC interval, grace period, and enabled state are re-read from the ConfigMap every cycle, no restart needed
- **Lazy initialization with retry** — Provider is only initialized when GC is enabled; transient failures (e.g., ConfigMap not ready) are retried on the next cycle instead of permanently disabling GC
- **Package-level logger** — Uses `ctrl.Log.WithName("gc")` at package level for consistent logging without parameter passing
- **Shared config loading** — `loadCloudConfigs` extracted as a shared helper used by both the PeerPod reconciler and the GC, eliminating code duplication
- **Local-clock grace period** — Uses a "first seen" tracker (local clock only) instead of comparing cloud provider timestamps against the controller clock. This avoids cross-clock dependency and works reliably in disconnected/air-gapped environments where NTP may not be available. Instances must be observed as orphan candidates for the configurable grace period (default 10m) before deletion

## Test plan

- [x] Unit tests for AWS `ListInstances` pass (including filter verification and `CreatedAt` population)
- [x] `go vet`, `golangci-lint`, `go mod tidy` clean
- [x] Deploy with `ENABLE_GC=true`, verify GC logs show periodic runs
- [x] Create orphan VM (tagged with cluster UID, no PeerPod CR), verify GC detects and deletes it after grace period
- [x] Verify GC **skips recently discovered orphan candidates** (< grace period) with `"skipping recently discovered orphan candidate"` log
- [x] Verify GC does **not** delete VMs with matching PeerPod CRs
- [x] Hot-reload `ENABLE_GC=false` -> GC tears down provider and stops
- [x] Hot-reload `ENABLE_GC=true` -> GC reinitializes and resumes
- [x] Hot-reload `GC_INTERVAL` change -> GC picks up new interval
- [x] Configurable `GC_GRACE_PERIOD` — set to `2m` via ConfigMap, verified orphan skipped for 2m then deleted
- [x] Shared `loadCloudConfigs` works for both reconciler and GC initialization

## Cluster test results (AWS EKS, us-east-2)

Tested on a live AWS EKS cluster with `GC_INTERVAL=30s` and `GC_GRACE_PERIOD=2m` for faster cycle iteration.

### Test 1 — Orphan VM deleted after configurable grace period

Created `i-0ca40918c22418615` (`gc-test-orphan-v2`) tagged with cluster UID but **no** PeerPod CR.
`GC_GRACE_PERIOD` set to `2m` via ConfigMap.

```
09:37:38  ListInstances: found 2 instances for cluster UID 35a596a9-...
09:37:38  gc  skipping recently discovered orphan candidate  instanceID=i-0ca40918c22418615  firstSeen=838ns
09:38:08  gc  skipping recently discovered orphan candidate  instanceID=i-0ca40918c22418615  firstSeen=29.9s
09:38:38  gc  skipping recently discovered orphan candidate  instanceID=i-0ca40918c22418615  firstSeen=59.9s
09:39:08  gc  skipping recently discovered orphan candidate  instanceID=i-0ca40918c22418615  firstSeen=1m29s
09:39:38  gc  skipping recently discovered orphan candidate  instanceID=i-0ca40918c22418615  firstSeen=1m59s
09:40:08  gc  deleting orphan instance  instanceID=i-0ca40918c22418615  instanceName=gc-test-orphan-v2
09:40:09  gc  garbage collection cycle complete  orphansDeleted=1  totalCloudInstances=2
```

AWS confirmed: `i-0ca40918c22418615` → **terminated**

### Test 2 — Non-orphan VM NOT deleted

Created `i-001efcfb1e4403967` (`gc-test-nonorphan-v2`) with a matching PeerPod CR (`spec.instanceID: i-001efcfb1e4403967`).

- Instance **never** appeared as an orphan candidate in any GC cycle
- AWS confirmed: `i-001efcfb1e4403967` → **running** (throughout all cycles)

### Test 3 — Configurable grace period (GC_GRACE_PERIOD=2m)

The orphan instance was tracked across consecutive 30s cycles using only the controller's local clock, with the grace period set to `2m` via ConfigMap:

| Cycle | firstSeen | Action |
|---|---|---|
| 09:37:38 | 838ns | skipped |
| 09:38:08 | 29.9s | skipped |
| 09:38:38 | 59.9s | skipped |
| 09:39:08 | 1m29s | skipped |
| 09:39:38 | 1m59s | skipped |
| 09:40:08 | >2m | **deleted** |

No dependency on cloud provider `CreatedAt` timestamps — uses `time.Now()` / `time.Since()` only.

### Test 4 — Hot-reload toggle

```
# Set ENABLE_GC=false in peer-pods-cm (no restart)
09:40:38  gc  GC disabled, tearing down provider

# Set ENABLE_GC=true in peer-pods-cm (no restart)
(GC reinitializes on next cycle)
```

GC tears down cleanly on disable and reinitializes on re-enable — no pod restart required.

### Summary

| Test | Instance | Expected | Actual |
|---|---|---|---|
| Orphan deleted after grace | `i-0ca40918c22418615` | terminated | ✅ terminated |
| Non-orphan not deleted | `i-001efcfb1e4403967` | running | ✅ running |
| Configurable grace (2m) | skip then delete | skip then delete | ✅ skip then delete |
| Hot-reload disable | GC stops | GC stops | ✅ tears down provider |
| Hot-reload re-enable | GC resumes | GC resumes | ✅ reinitializes |
