### PR TITLE
podvm-mkosi: fix CDH image pull failures due to missing DNS and TLS packages

### DIFF
--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.postinst
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.postinst
@@ -18,6 +18,11 @@ rm -f "${BUILDROOT}"/etc/systemd/system/{run-image,run-kata\x2dcontainers}.mount
 rm -f "${BUILDROOT}"/etc/systemd/system/multi-user.target.wants/{run-image,run-kata\x2dcontainers}.mount
 
 # mask unwanted sytemd units that measure a bunch of stuff into the vTPM
+# Set up /etc/resolv.conf symlink if not already present (Ubuntu only)
+if [ ! -e "${BUILDROOT}/etc/resolv.conf" ]; then
+    ln -s /run/systemd/resolve/stub-resolv.conf "${BUILDROOT}/etc/resolv.conf" || true
+fi
+
 ln -s /dev/null "${BUILDROOT}/etc/systemd/system/systemd-pcrmachine.service"
 ln -s /dev/null "${BUILDROOT}/etc/systemd/system/systemd-pcrfs-root.service"
 ln -s /dev/null "${BUILDROOT}/etc/systemd/system/systemd-pcrfs@.service"

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/ubuntu.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/ubuntu.conf
@@ -19,6 +19,8 @@ Packages=
     iptables
     e2fsprogs
     cryptsetup
+    ca-certificates
+    systemd-resolved
 
 RemoveFiles=/etc/issue
 RemoveFiles=/etc/issue.net


### PR DESCRIPTION
The Ubuntu podvm mkosi image was missing two packages required for the CDH (confidential-data-hub) to pull container images from OCI registries:

1. ca-certificates: Without this, the CDH's TLS library cannot verify server certificates, causing all HTTPS connections to registries to fail with "error sending request for url".

2. systemd-resolved: Without this DNS resolution is failing

Also add a defensive fix in mkosi.postinst to ensure /etc/resolv.conf -> /run/systemd/resolve/stub-resolv.conf symlink is always present, even if the systemd-resolved package postinst doesn't create it