### PR TITLE
version: Bump go to 1.25.9 cont.

### DIFF
--- a/src/cloud-api-adaptor/Dockerfile
+++ b/src/cloud-api-adaptor/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_TYPE=dev
-# quay.io/confidential-containers/golang-fedora:1.25.8-41
-ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora@sha256:ae334af8ec5e0832bfa71237f3b52fdb08077184c658962ecf91de95e952d7df
+# quay.io/confidential-containers/golang-fedora:1.25.9-41
+ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora@sha256:ee140c59abb205d6385ef89fb0dfc5352f480435b1b58a7fa9941492904dcc07
 # registry.fedoraproject.org/fedora:41
 ARG BASE=registry.fedoraproject.org/fedora@sha256:893f7eeffce8e3e2bb2bc62786ba5603fb1e0bd6ba07091acb892266b95bafdf
 

--- a/src/cloud-api-adaptor/docs/addnewprovider.md
+++ b/src/cloud-api-adaptor/docs/addnewprovider.md
@@ -219,7 +219,7 @@ go mod tidy
 
 ```bash
 cat > Dockerfile <<EOF
-ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.25.8-41
+ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.25.9-41
 FROM --platform="\$TARGETPLATFORM" \$BUILDER_BASE AS builder
 RUN dnf install -y libvirt-devel && dnf clean all
 WORKDIR /work

--- a/src/cloud-api-adaptor/go.mod
+++ b/src/cloud-api-adaptor/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0

--- a/src/cloud-providers/go.mod
+++ b/src/cloud-providers/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers
 
-go 1.25.8
+go 1.25.9
 
 require (
 	cloud.google.com/go/compute v1.54.0

--- a/src/csi-wrapper/Dockerfile.csi_wrappers
+++ b/src/csi-wrapper/Dockerfile.csi_wrappers
@@ -7,15 +7,15 @@
 ARG SOURCE_FROM=remote
 
 ##### Builder Dev Image #####
-# quay.io/confidential-containers/golang-fedora:1.25.8-41
-FROM --platform=${BUILDPLATFORM} quay.io/confidential-containers/golang-fedora@sha256:ae334af8ec5e0832bfa71237f3b52fdb08077184c658962ecf91de95e952d7df AS builder-local
+# quay.io/confidential-containers/golang-fedora:1.25.9-41
+FROM --platform=${BUILDPLATFORM} quay.io/confidential-containers/golang-fedora@sha256:ee140c59abb205d6385ef89fb0dfc5352f480435b1b58a7fa9941492904dcc07 AS builder-local
 WORKDIR /src
 COPY csi-wrapper ./cloud-api-adaptor/src/csi-wrapper/
 COPY cloud-api-adaptor ./cloud-api-adaptor/src/cloud-api-adaptor
 
 ##### Builder Release Image #####
-# quay.io/confidential-containers/golang-fedora:1.25.8-41
-FROM --platform=${BUILDPLATFORM} quay.io/confidential-containers/golang-fedora@sha256:ae334af8ec5e0832bfa71237f3b52fdb08077184c658962ecf91de95e952d7df AS builder-remote
+# quay.io/confidential-containers/golang-fedora:1.25.9-41
+FROM --platform=${BUILDPLATFORM} quay.io/confidential-containers/golang-fedora@sha256:ee140c59abb205d6385ef89fb0dfc5352f480435b1b58a7fa9941492904dcc07 AS builder-remote
 ARG BINARY
 ARG CAA_SRC="https://github.com/confidential-containers/cloud-api-adaptor"
 ARG CAA_SRC_REF="main"

--- a/src/csi-wrapper/go.mod
+++ b/src/csi-wrapper/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/csi-wrapper
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor v0.0.0-00010101000000-000000000000

--- a/src/peerpod-ctrl/Dockerfile
+++ b/src/peerpod-ctrl/Dockerfile
@@ -1,6 +1,6 @@
 # Build the manager binary
-# quay.io/confidential-containers/golang-fedora:1.25.8-41
-FROM --platform=$TARGETPLATFORM quay.io/confidential-containers/golang-fedora@sha256:ae334af8ec5e0832bfa71237f3b52fdb08077184c658962ecf91de95e952d7df AS builder
+# quay.io/confidential-containers/golang-fedora:1.25.9-41
+FROM --platform=$TARGETPLATFORM quay.io/confidential-containers/golang-fedora@sha256:ee140c59abb205d6385ef89fb0dfc5352f480435b1b58a7fa9941492904dcc07 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG CGO_ENABLED=1

--- a/src/peerpod-ctrl/go.mod
+++ b/src/peerpod-ctrl/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/peerpod-ctrl
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers v0.0.0-00010101000000-000000000000

--- a/src/webhook/Dockerfile
+++ b/src/webhook/Dockerfile
@@ -1,6 +1,6 @@
 # Build the manager binary
-# golang:1.25
-FROM --platform=$BUILDPLATFORM golang@sha256:f55a6ec7f24aedc1ed66e2641fdc52de01f2d24d6e49d1fa38582c07dd5f601d AS builder
+# golang:1.25.9
+FROM --platform=$BUILDPLATFORM golang@sha256:a95d3d115ec2643a014c9539962dcecba297fb4ed5e5cbfab84cf726327e8b8c AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/src/webhook/go.mod
+++ b/src/webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/webhook
 
-go 1.25.8
+go 1.25.9
 
 require (
 	k8s.io/api v0.35.2


### PR DESCRIPTION
Update the image to use the 1.25.9 builder and update the go.mod to use this as the toolchain