### PR TITLE
podvm: fix kata-agent startup race with CDH on Ubuntu

### DIFF
--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system-preset/30-coco.preset
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system-preset/30-coco.preset
@@ -1,4 +1,4 @@
-enable attestation-protocol-forwarder.service
+enable agent-protocol-forwarder.service
 enable attestation-agent.path
 enable api-server-rest.path
 enable confidential-data-hub.path

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system-preset/30-coco.preset
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.skeleton/usr/lib/systemd/system-preset/30-coco.preset
@@ -1,4 +1,4 @@
-enable agent-protocol-forwarder.service
+enable agent-protocol-forwarder.path
 enable attestation-agent.path
 enable api-server-rest.path
 enable confidential-data-hub.path
@@ -8,4 +8,4 @@ enable setup-nat-for-imds.service
 
 enable gen-issue.service
 enable image-env.service
-enable scratch-storage.service
+enable scratch-storage.path

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/agent-protocol-forwarder.path
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/agent-protocol-forwarder.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Wait for kata-agent socket before starting Agent Protocol Forwarder
+
+[Path]
+PathExists=/run/kata-containers/agent.sock
+Unit=agent-protocol-forwarder.service
+
+[Install]
+WantedBy=multi-user.target

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/agent-protocol-forwarder.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/agent-protocol-forwarder.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Agent Protocol Forwarder
-After=kata-agent.service
 DefaultDependencies=no
 
 [Service]

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/attestation-agent.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/attestation-agent.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Attestation Agent TTRPC API Server
-After=network.target cloud-init.service process-user-data.service
+After=network.target process-user-data.service
 
 [Service]
 Type=simple

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/confidential-data-hub.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/confidential-data-hub.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Confidential Data Hub TTRPC API Server
-After=network.target cloud-init.service process-user-data.service
+After=network.target process-user-data.service
 
 [Service]
 Type=simple

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/kata-agent.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/kata-agent.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Kata Agent
 BindsTo=netns@podns.service
-After=netns@podns.service process-user-data.service scratch-storage.service
+After=netns@podns.service scratch-storage.service
 Wants=scratch-storage.service
 
 [Service]

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/kata-agent.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/kata-agent.service
@@ -10,6 +10,3 @@ ExecStart=/usr/local/bin/kata-agent --config /etc/agent-config.toml
 ExecStartPre=-umount /sys/fs/cgroup/misc
 ExecStopPost=/usr/local/bin/kata-agent-clean --config /etc/agent-config.toml
 SyslogIdentifier=kata-agent
-
-[Install]
-WantedBy=multi-user.target

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/agent-protocol-forwarder.path
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/agent-protocol-forwarder.path
@@ -1,0 +1,1 @@
+../agent-protocol-forwarder.path

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/agent-protocol-forwarder.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/agent-protocol-forwarder.service
@@ -1,1 +1,0 @@
-../agent-protocol-forwarder.service

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/scratch-storage.path
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/scratch-storage.path
@@ -1,0 +1,1 @@
+../scratch-storage.path

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/scratch-storage.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/scratch-storage.service
@@ -1,1 +1,0 @@
-../scratch-storage.service

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/scratch-storage.path
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/scratch-storage.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Watch for scratch storage marker
+
+[Path]
+PathExists=/run/peerpod/scratch-space.marker
+Unit=scratch-storage.service
+
+[Install]
+WantedBy=multi-user.target

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/scratch-storage.service
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/scratch-storage.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Configurable Scratch Storage Setup for Kata Agent
-After=systemd-repart.service process-user-data.service
+After=systemd-repart.service
 # It must complete before the kata-agent starts
 Before=kata-agent.service
 DefaultDependencies=no


### PR DESCRIPTION
When a pod uses initdata (e.g. KBS tests with cc_kbc), both kata-agent and confidential-data-hub start after process-user-data completes. The startup order is:

  process-user-data -> AA -> AA socket -> CDH (via CDH.path) -> CDH socket
                                      |
                                       -> kata-agent (direct enable)

kata-agent.path already exists to gate kata-agent on CDH socket appearance (PathExists=/run/confidential-containers/cdh.sock). However, kata-agent.service also had WantedBy=multi-user.target in its [Install] section, causing systemd to activate it directly at boot without waiting for the path unit condition to be satisfied.

Fix: remove [Install]/WantedBy=multi-user.target from kata-agent.service so that systemd can only activate it via kata-agent.path.