### PR TITLE
Enhance test coverage in interceptor_test.go and forwarder_test.go

### DIFF
--- a/src/cloud-api-adaptor/pkg/forwarder/forwarder_test.go
+++ b/src/cloud-api-adaptor/pkg/forwarder/forwarder_test.go
@@ -9,6 +9,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/podnetwork/tunneler"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/agentproto"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/tlsutil"
 )
@@ -28,75 +32,577 @@ func dummyDialer(ctx context.Context) (net.Conn, error) {
 	return &mockConn{}, nil
 }
 
-func TestNew(t *testing.T) {
-
-	config := &Config{}
-	tlsConfig := tlsutil.TLSConfig{}
-
-	ret := NewDaemon(config, DefaultListenAddr, &tlsConfig, agentproto.NewRedirector(dummyDialer), &mockPodNode{})
-	if ret == nil {
-		t.Fatal("Expect non nil, got nil")
-	}
-	d, ok := ret.(*daemon)
-	if !ok {
-		t.Fatalf("Expect *daemon, got %T", d)
-	}
-	if d.interceptor == nil {
-		t.Fatal("Expect non nil, got nil")
-	}
-	if d.stopCh == nil {
-		t.Fatal("Expect non nil, got nil")
-	}
-	select {
-	case <-d.stopCh:
-		t.Fatal("channel is closed")
-	default:
-	}
+type mockPodNode struct {
+	setupCalled    bool
+	teardownCalled bool
+	setupError     error
+	teardownError  error
 }
-
-func TestStart(t *testing.T) {
-
-	d := &daemon{
-		interceptor: agentproto.NewRedirector(dummyDialer),
-		podNode:     &mockPodNode{},
-		readyCh:     make(chan struct{}),
-		stopCh:      make(chan struct{}),
-	}
-
-	errCh := make(chan error)
-	go func() {
-		defer close(errCh)
-
-		if err := d.Start(context.Background()); err != nil {
-			errCh <- err
-		}
-	}()
-
-	select {
-	case err := <-errCh:
-		t.Fatalf("Expect no error, got %q", err)
-	default:
-	}
-
-	if err := d.Shutdown(); err != nil {
-		t.Fatalf("Expect no error, got %q", err)
-	}
-
-	select {
-	case err := <-errCh:
-		if err != nil {
-			t.Fatalf("Expect no error, got %q", err)
-		}
-	default:
-	}
-}
-
-type mockPodNode struct{}
 
 func (n *mockPodNode) Setup() error {
-	return nil
+	n.setupCalled = true
+	return n.setupError
 }
 
 func (n *mockPodNode) Teardown() error {
-	return nil
+	n.teardownCalled = true
+	return n.teardownError
+}
+
+func TestNewDaemon(t *testing.T) {
+	t.Run("creates daemon with minimal config", func(t *testing.T) {
+		config := &Config{}
+		tlsConfig := &tlsutil.TLSConfig{}
+
+		ret := NewDaemon(config, DefaultListenAddr, tlsConfig, agentproto.NewRedirector(dummyDialer), &mockPodNode{})
+		require.NotNil(t, ret, "Expected non-nil daemon")
+
+		d, ok := ret.(*daemon)
+		require.True(t, ok, "Expected *daemon type, got %T", ret)
+		assert.NotNil(t, d.interceptor, "Expected non-nil interceptor")
+		assert.NotNil(t, d.stopCh, "Expected non-nil stopCh")
+		assert.NotNil(t, d.readyCh, "Expected non-nil readyCh")
+
+		// Verify stopCh is open
+		select {
+		case <-d.stopCh:
+			t.Fatal("Expected stopCh to be open")
+		default:
+		}
+	})
+
+	t.Run("creates daemon with TLS config", func(t *testing.T) {
+		config := &Config{
+			TLSServerCert: "cert-data",
+			TLSServerKey:  "key-data",
+			TLSClientCA:   "ca-data",
+		}
+		tlsConfig := &tlsutil.TLSConfig{}
+
+		ret := NewDaemon(config, DefaultListenAddr, tlsConfig, agentproto.NewRedirector(dummyDialer), &mockPodNode{})
+		require.NotNil(t, ret)
+
+		d, ok := ret.(*daemon)
+		require.True(t, ok)
+		assert.NotNil(t, d.tlsConfig)
+		assert.Equal(t, []byte("cert-data"), d.tlsConfig.CertData)
+		assert.Equal(t, []byte("key-data"), d.tlsConfig.KeyData)
+		assert.Equal(t, []byte("ca-data"), d.tlsConfig.CAData)
+	})
+
+	t.Run("creates daemon with custom listen address", func(t *testing.T) {
+		config := &Config{}
+		customAddr := "127.0.0.1:9999"
+
+		ret := NewDaemon(config, customAddr, nil, agentproto.NewRedirector(dummyDialer), &mockPodNode{})
+		require.NotNil(t, ret)
+
+		d, ok := ret.(*daemon)
+		require.True(t, ok)
+		assert.Equal(t, customAddr, d.listenAddr)
+	})
+
+	t.Run("creates daemon with nil TLS config", func(t *testing.T) {
+		config := &Config{}
+
+		ret := NewDaemon(config, DefaultListenAddr, nil, agentproto.NewRedirector(dummyDialer), &mockPodNode{})
+		require.NotNil(t, ret)
+
+		d, ok := ret.(*daemon)
+		require.True(t, ok)
+		assert.Nil(t, d.tlsConfig)
+	})
+
+	t.Run("creates daemon with pod network config", func(t *testing.T) {
+		config := &Config{
+			PodNetwork: &tunneler.Config{
+				ExternalNetViaPodVM: true,
+			},
+		}
+
+		ret := NewDaemon(config, DefaultListenAddr, nil, agentproto.NewRedirector(dummyDialer), &mockPodNode{})
+		require.NotNil(t, ret)
+
+		d, ok := ret.(*daemon)
+		require.True(t, ok)
+		assert.True(t, d.externalNetViaPodVM)
+	})
+
+	t.Run("handles TLS config with existing cert auth", func(t *testing.T) {
+		config := &Config{
+			TLSServerCert: "cert-data",
+			TLSServerKey:  "key-data",
+		}
+		tlsConfig := &tlsutil.TLSConfig{
+			CertFile: "/path/to/cert",
+			KeyFile:  "/path/to/key",
+		}
+
+		ret := NewDaemon(config, DefaultListenAddr, tlsConfig, agentproto.NewRedirector(dummyDialer), &mockPodNode{})
+		require.NotNil(t, ret)
+
+		d, ok := ret.(*daemon)
+		require.True(t, ok)
+		assert.NotNil(t, d.tlsConfig)
+		// Should not overwrite existing cert auth
+		assert.Empty(t, d.tlsConfig.CertData)
+	})
+
+	t.Run("handles TLS config with existing CA", func(t *testing.T) {
+		config := &Config{
+			TLSClientCA: "ca-data",
+		}
+		tlsConfig := &tlsutil.TLSConfig{
+			CAFile: "/path/to/ca",
+		}
+
+		ret := NewDaemon(config, DefaultListenAddr, tlsConfig, agentproto.NewRedirector(dummyDialer), &mockPodNode{})
+		require.NotNil(t, ret)
+
+		d, ok := ret.(*daemon)
+		require.True(t, ok)
+		assert.NotNil(t, d.tlsConfig)
+		// Should not overwrite existing CA
+		assert.Empty(t, d.tlsConfig.CAData)
+	})
+}
+
+func TestDaemonStart(t *testing.T) {
+	t.Run("starts and stops successfully", func(t *testing.T) {
+		podNode := &mockPodNode{}
+		d := &daemon{
+			interceptor: agentproto.NewRedirector(dummyDialer),
+			podNode:     podNode,
+			readyCh:     make(chan struct{}),
+			stopCh:      make(chan struct{}),
+			listenAddr:  "127.0.0.1:0", // Use port 0 for automatic assignment
+		}
+
+		errCh := make(chan error)
+		go func() {
+			defer close(errCh)
+
+			if err := d.Start(context.Background()); err != nil {
+				errCh <- err
+			}
+		}()
+
+		// Wait for daemon to be ready
+		select {
+		case <-d.readyCh:
+			// Daemon is ready
+		case err := <-errCh:
+			t.Fatalf("Expected daemon to start, got error: %v", err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("Timeout waiting for daemon to be ready")
+		}
+
+		// Verify pod node setup was called
+		assert.True(t, podNode.setupCalled, "Expected Setup to be called")
+
+		// Shutdown the daemon
+		err := d.Shutdown()
+		require.NoError(t, err, "Expected no error on shutdown")
+
+		// Wait for daemon to stop
+		select {
+		case err := <-errCh:
+			assert.NoError(t, err, "Expected no error from Start")
+		case <-time.After(5 * time.Second):
+			t.Fatal("Timeout waiting for daemon to stop")
+		}
+
+		// Verify pod node teardown was called
+		assert.True(t, podNode.teardownCalled, "Expected Teardown to be called")
+	})
+
+	t.Run("handles pod node setup error", func(t *testing.T) {
+		expectedErr := assert.AnError
+		podNode := &mockPodNode{
+			setupError: expectedErr,
+		}
+		d := &daemon{
+			interceptor: agentproto.NewRedirector(dummyDialer),
+			podNode:     podNode,
+			readyCh:     make(chan struct{}),
+			stopCh:      make(chan struct{}),
+			listenAddr:  "127.0.0.1:0",
+		}
+
+		err := d.Start(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to set up pod network")
+		assert.True(t, podNode.setupCalled)
+	})
+
+	t.Run("handles context cancellation", func(t *testing.T) {
+		podNode := &mockPodNode{}
+		d := &daemon{
+			interceptor: agentproto.NewRedirector(dummyDialer),
+			podNode:     podNode,
+			readyCh:     make(chan struct{}),
+			stopCh:      make(chan struct{}),
+			listenAddr:  "127.0.0.1:0",
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		errCh := make(chan error)
+		go func() {
+			defer close(errCh)
+			if err := d.Start(ctx); err != nil {
+				errCh <- err
+			}
+		}()
+
+		// Wait for daemon to be ready
+		select {
+		case <-d.readyCh:
+			// Daemon is ready
+		case err := <-errCh:
+			t.Fatalf("Expected daemon to start, got error: %v", err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("Timeout waiting for daemon to be ready")
+		}
+
+		// Cancel context
+		cancel()
+
+		// Wait for daemon to stop
+		select {
+		case err := <-errCh:
+			assert.NoError(t, err, "Expected no error from Start")
+		case <-time.After(5 * time.Second):
+			t.Fatal("Timeout waiting for daemon to stop")
+		}
+
+		assert.True(t, podNode.setupCalled)
+		assert.True(t, podNode.teardownCalled)
+	})
+
+	t.Run("handles invalid listen address", func(t *testing.T) {
+		podNode := &mockPodNode{}
+		d := &daemon{
+			interceptor: agentproto.NewRedirector(dummyDialer),
+			podNode:     podNode,
+			readyCh:     make(chan struct{}),
+			stopCh:      make(chan struct{}),
+			listenAddr:  "invalid:address:format",
+		}
+
+		err := d.Start(context.Background())
+		assert.Error(t, err)
+		assert.True(t, podNode.setupCalled)
+		assert.True(t, podNode.teardownCalled)
+	})
+}
+
+func TestDaemonShutdown(t *testing.T) {
+	t.Run("closes stop channel", func(t *testing.T) {
+		d := &daemon{
+			stopCh: make(chan struct{}),
+		}
+
+		err := d.Shutdown()
+		require.NoError(t, err)
+
+		// Verify stopCh is closed
+		select {
+		case <-d.stopCh:
+			// Channel is closed as expected
+		default:
+			t.Fatal("Expected stopCh to be closed")
+		}
+	})
+
+	t.Run("is idempotent", func(t *testing.T) {
+		d := &daemon{
+			stopCh: make(chan struct{}),
+		}
+
+		// First shutdown
+		err := d.Shutdown()
+		require.NoError(t, err)
+
+		// Second shutdown should not panic
+		err = d.Shutdown()
+		require.NoError(t, err)
+
+		// Verify stopCh is still closed
+		select {
+		case <-d.stopCh:
+			// Channel is closed as expected
+		default:
+			t.Fatal("Expected stopCh to be closed")
+		}
+	})
+
+	t.Run("can be called multiple times concurrently", func(t *testing.T) {
+		d := &daemon{
+			stopCh: make(chan struct{}),
+		}
+
+		done := make(chan struct{})
+		for i := 0; i < 10; i++ {
+			go func() {
+				defer func() { done <- struct{}{} }()
+				_ = d.Shutdown()
+			}()
+		}
+
+		// Wait for all goroutines to complete
+		for i := 0; i < 10; i++ {
+			<-done
+		}
+
+		// Verify stopCh is closed
+		select {
+		case <-d.stopCh:
+			// Channel is closed as expected
+		default:
+			t.Fatal("Expected stopCh to be closed")
+		}
+	})
+}
+
+func TestDaemonReady(t *testing.T) {
+	t.Run("returns ready channel", func(t *testing.T) {
+		readyCh := make(chan struct{})
+		d := &daemon{
+			readyCh: readyCh,
+		}
+
+		ch := d.Ready()
+		assert.Equal(t, readyCh, ch)
+	})
+
+	t.Run("ready channel is initially open", func(t *testing.T) {
+		d := &daemon{
+			readyCh: make(chan struct{}),
+		}
+
+		select {
+		case <-d.Ready():
+			t.Fatal("Expected ready channel to be open")
+		default:
+			// Channel is open as expected
+		}
+	})
+
+	t.Run("ready channel closes when daemon starts", func(t *testing.T) {
+		podNode := &mockPodNode{}
+		d := &daemon{
+			interceptor: agentproto.NewRedirector(dummyDialer),
+			podNode:     podNode,
+			readyCh:     make(chan struct{}),
+			stopCh:      make(chan struct{}),
+			listenAddr:  "127.0.0.1:0",
+		}
+
+		startErrCh := make(chan error, 1)
+		go func() {
+			startErrCh <- d.Start(context.Background())
+		}()
+
+		// Wait for ready channel to close
+		select {
+		case <-d.Ready():
+			// Channel closed as expected
+		case err := <-startErrCh:
+			require.NoError(t, err, "daemon failed to start before becoming ready")
+		case <-time.After(5 * time.Second):
+			t.Fatal("Timeout waiting for ready channel to close")
+		}
+
+		require.NoError(t, d.Shutdown())
+
+		// Wait for Start() to exit cleanly
+		select {
+		case err := <-startErrCh:
+			require.NoError(t, err, "daemon failed to stop cleanly")
+		case <-time.After(5 * time.Second):
+			t.Fatal("Timeout waiting for daemon Start() to exit after Shutdown()")
+		}
+	})
+}
+
+func TestDaemonAddr(t *testing.T) {
+	t.Run("returns listen address after ready", func(t *testing.T) {
+		podNode := &mockPodNode{}
+		d := &daemon{
+			interceptor: agentproto.NewRedirector(dummyDialer),
+			podNode:     podNode,
+			readyCh:     make(chan struct{}),
+			stopCh:      make(chan struct{}),
+			listenAddr:  "127.0.0.1:0",
+		}
+
+		startErrCh := make(chan error, 1)
+		go func() {
+			startErrCh <- d.Start(context.Background())
+		}()
+
+		// Wait for daemon to be ready with timeout
+		select {
+		case <-d.Ready():
+			// Daemon is ready as expected
+		case err := <-startErrCh:
+			require.NoError(t, err, "daemon failed to start before becoming ready")
+		case <-time.After(5 * time.Second):
+			t.Fatal("Timeout waiting for daemon to become ready")
+		}
+
+		// Now call Addr() with timeout protection
+		addrCh := make(chan string, 1)
+		go func() {
+			addrCh <- d.Addr()
+		}()
+
+		select {
+		case addr := <-addrCh:
+			assert.NotEmpty(t, addr)
+			assert.Contains(t, addr, "127.0.0.1:")
+		case <-time.After(1 * time.Second):
+			t.Fatal("Timeout waiting for Addr() to return")
+		}
+
+		require.NoError(t, d.Shutdown())
+
+		// Wait for Start() to exit cleanly
+		select {
+		case err := <-startErrCh:
+			require.NoError(t, err, "daemon failed to stop cleanly")
+		case <-time.After(5 * time.Second):
+			t.Fatal("Timeout waiting for daemon Start() to exit after Shutdown()")
+		}
+	})
+
+	t.Run("blocks until daemon is ready", func(t *testing.T) {
+		d := &daemon{
+			readyCh:    make(chan struct{}),
+			listenAddr: "127.0.0.1:8080",
+		}
+
+		addrCh := make(chan string)
+		go func() {
+			addrCh <- d.Addr()
+		}()
+
+		// Verify Addr() is blocking
+		select {
+		case <-addrCh:
+			t.Fatal("Expected Addr() to block until ready")
+		case <-time.After(100 * time.Millisecond):
+			// Addr() is blocking as expected
+		}
+
+		// Close ready channel
+		close(d.readyCh)
+
+		// Now Addr() should return
+		select {
+		case addr := <-addrCh:
+			assert.Equal(t, "127.0.0.1:8080", addr)
+		case <-time.After(1 * time.Second):
+			t.Fatal("Timeout waiting for Addr() to return")
+		}
+	})
+}
+
+func TestDaemonConstants(t *testing.T) {
+	t.Run("default constants are set correctly", func(t *testing.T) {
+		assert.Equal(t, "0.0.0.0", DefaultListenHost)
+		assert.Equal(t, "15150", DefaultListenPort)
+		assert.Equal(t, "0.0.0.0:15150", DefaultListenAddr)
+		assert.Equal(t, "/run/peerpod/apf.json", DefaultConfigPath)
+		assert.Equal(t, "/run/peerpod/podnetwork.json", DefaultPodNetworkSpecPath)
+		assert.Equal(t, "/run/kata-containers/agent.sock", DefaultKataAgentSocketPath)
+		assert.Equal(t, "/run/netns/podns", DefaultPodNamespace)
+		assert.Equal(t, "/agent", AgentURLPath)
+	})
+}
+
+func TestConfigStructure(t *testing.T) {
+	t.Run("config has expected fields", func(t *testing.T) {
+		config := &Config{
+			PodNamespace:  "test-namespace",
+			PodName:       "test-pod",
+			TLSServerKey:  "key",
+			TLSServerCert: "cert",
+			TLSClientCA:   "ca",
+			PpPrivateKey:  []byte("priv-key"),
+			WnPublicKey:   []byte("pub-key"),
+		}
+
+		assert.Equal(t, "test-namespace", config.PodNamespace)
+		assert.Equal(t, "test-pod", config.PodName)
+		assert.Equal(t, "key", config.TLSServerKey)
+		assert.Equal(t, "cert", config.TLSServerCert)
+		assert.Equal(t, "ca", config.TLSClientCA)
+		assert.Equal(t, []byte("priv-key"), config.PpPrivateKey)
+		assert.Equal(t, []byte("pub-key"), config.WnPublicKey)
+	})
+
+	t.Run("config can be empty", func(t *testing.T) {
+		config := &Config{}
+
+		assert.Empty(t, config.PodNamespace)
+		assert.Empty(t, config.PodName)
+		assert.Empty(t, config.TLSServerKey)
+		assert.Empty(t, config.TLSServerCert)
+		assert.Empty(t, config.TLSClientCA)
+		assert.Nil(t, config.PpPrivateKey)
+		assert.Nil(t, config.WnPublicKey)
+	})
+}
+
+func TestDaemonInterface(t *testing.T) {
+	t.Run("daemon implements Daemon interface", func(t *testing.T) {
+		config := &Config{}
+		d := NewDaemon(config, DefaultListenAddr, nil, agentproto.NewRedirector(dummyDialer), &mockPodNode{})
+
+		// Verify the concrete implementation satisfies the Daemon interface
+		var _ Daemon = (*daemon)(nil)
+
+		// Verify all interface methods are available
+		assert.NotNil(t, d.Ready())
+		assert.NotPanics(t, func() { _ = d.Shutdown() })
+
+		// Note: d.Addr() blocks until ready channel is closed, so we don't call it here
+		// It's tested separately in TestDaemonAddr
+	})
+}
+
+func TestDaemonWithTLSConfig(t *testing.T) {
+	t.Run("daemon with TLS config has proper initialization", func(t *testing.T) {
+		config := &Config{
+			TLSServerCert: "cert-data",
+			TLSServerKey:  "key-data",
+			TLSClientCA:   "ca-data",
+		}
+		tlsConfig := &tlsutil.TLSConfig{}
+
+		d := NewDaemon(config, DefaultListenAddr, tlsConfig, agentproto.NewRedirector(dummyDialer), &mockPodNode{})
+		require.NotNil(t, d)
+
+		daemonImpl, ok := d.(*daemon)
+		require.True(t, ok)
+
+		assert.NotNil(t, daemonImpl.tlsConfig)
+		assert.Equal(t, []byte("cert-data"), daemonImpl.tlsConfig.CertData)
+		assert.Equal(t, []byte("key-data"), daemonImpl.tlsConfig.KeyData)
+		assert.Equal(t, []byte("ca-data"), daemonImpl.tlsConfig.CAData)
+	})
+
+	t.Run("daemon without TLS config has nil tlsConfig", func(t *testing.T) {
+		config := &Config{}
+
+		d := NewDaemon(config, DefaultListenAddr, nil, agentproto.NewRedirector(dummyDialer), &mockPodNode{})
+		require.NotNil(t, d)
+
+		daemonImpl, ok := d.(*daemon)
+		require.True(t, ok)
+
+		assert.Nil(t, daemonImpl.tlsConfig)
+	})
 }

--- a/src/cloud-api-adaptor/pkg/forwarder/interceptor/interceptor_test.go
+++ b/src/cloud-api-adaptor/pkg/forwarder/interceptor/interceptor_test.go
@@ -4,26 +4,971 @@
 package interceptor
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
+	pb "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols/grpc"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/agentproto"
 )
 
+type mockRedirector struct {
+	agentproto.Redirector
+	createContainerCalled bool
+	startContainerCalled  bool
+	removeContainerCalled bool
+	createSandboxCalled   bool
+	destroySandboxCalled  bool
+	createContainerError  error
+	startContainerError   error
+	removeContainerError  error
+	createSandboxError    error
+	destroySandboxError   error
+}
+
+func (m *mockRedirector) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (*emptypb.Empty, error) {
+	m.createContainerCalled = true
+	return &emptypb.Empty{}, m.createContainerError
+}
+
+func (m *mockRedirector) StartContainer(ctx context.Context, req *pb.StartContainerRequest) (*emptypb.Empty, error) {
+	m.startContainerCalled = true
+	return &emptypb.Empty{}, m.startContainerError
+}
+
+func (m *mockRedirector) RemoveContainer(ctx context.Context, req *pb.RemoveContainerRequest) (*emptypb.Empty, error) {
+	m.removeContainerCalled = true
+	return &emptypb.Empty{}, m.removeContainerError
+}
+
+func (m *mockRedirector) CreateSandbox(ctx context.Context, req *pb.CreateSandboxRequest) (*emptypb.Empty, error) {
+	m.createSandboxCalled = true
+	return &emptypb.Empty{}, m.createSandboxError
+}
+
+func (m *mockRedirector) DestroySandbox(ctx context.Context, req *pb.DestroySandboxRequest) (*emptypb.Empty, error) {
+	m.destroySandboxCalled = true
+	return &emptypb.Empty{}, m.destroySandboxError
+}
+
+func (m *mockRedirector) Close() error {
+	return nil
+}
+
 func TestNewInterceptor(t *testing.T) {
+	t.Run("creates interceptor with valid socket name", func(t *testing.T) {
+		socketName := "dummy.sock"
 
-	socketName := "dummy.sock"
+		i := NewInterceptor(socketName, "")
+		require.NotNil(t, i, "Expected non-nil interceptor")
 
-	i := NewInterceptor(socketName, "")
-	if i == nil {
-		t.Fatal("Expect non nil, got nil")
-	}
+		// Verify the interceptor is properly initialized
+		assert.NotNil(t, i, "Expected interceptor to be non-nil")
+	})
+
+	t.Run("creates interceptor with namespace path", func(t *testing.T) {
+		socketName := "agent.sock"
+		nsPath := "/run/netns/test"
+
+		i := NewInterceptor(socketName, nsPath)
+		require.NotNil(t, i, "Expected non-nil interceptor")
+
+		// Verify the interceptor is properly initialized
+		interceptorImpl, ok := i.(*interceptor)
+		require.True(t, ok, "Expected *interceptor type")
+		assert.Equal(t, nsPath, interceptorImpl.nsPath)
+	})
+
+	t.Run("creates interceptor with empty namespace path", func(t *testing.T) {
+		socketName := "agent.sock"
+
+		i := NewInterceptor(socketName, "")
+		require.NotNil(t, i, "Expected non-nil interceptor")
+
+		interceptorImpl, ok := i.(*interceptor)
+		require.True(t, ok, "Expected *interceptor type")
+		assert.Empty(t, interceptorImpl.nsPath)
+	})
 }
 
 func TestIsTargetPath(t *testing.T) {
-	path := "/path/to/target"
+	t.Run("returns false when target path is empty", func(t *testing.T) {
+		path := "/path/to/target"
+		assert.False(t, isTargetPath(path, ""))
+	})
 
-	assert.False(t, isTargetPath(path, ""))
-	assert.False(t, isTargetPath("", ""))
-	assert.False(t, isTargetPath(path, "mock path"))
-	assert.True(t, isTargetPath(path, "/path/to/target"))
+	t.Run("returns false when both paths are empty", func(t *testing.T) {
+		assert.False(t, isTargetPath("", ""))
+	})
+
+	t.Run("returns false when paths do not match", func(t *testing.T) {
+		path := "/path/to/target"
+		assert.False(t, isTargetPath(path, "mock path"))
+		assert.False(t, isTargetPath(path, "/different/path"))
+	})
+
+	t.Run("returns true when paths match exactly", func(t *testing.T) {
+		path := "/path/to/target"
+		assert.True(t, isTargetPath(path, "/path/to/target"))
+	})
+
+	t.Run("returns false when path is empty but target is not", func(t *testing.T) {
+		assert.False(t, isTargetPath("", "/path/to/target"))
+	})
+
+	t.Run("handles paths with special characters", func(t *testing.T) {
+		path := "/path/to/target-with_special.chars"
+		assert.True(t, isTargetPath(path, path))
+		assert.False(t, isTargetPath(path, "/path/to/target"))
+	})
+}
+
+func TestInterceptorCreateContainer(t *testing.T) {
+	t.Run("adds network namespace to container spec", func(t *testing.T) {
+		nsPath := "/run/netns/podns"
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     nsPath,
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createContainerCalled)
+
+		// Verify network namespace was added
+		found := false
+		for _, ns := range req.OCI.Linux.Namespaces {
+			if ns.Type == string(specs.NetworkNamespace) && ns.Path == nsPath {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "Expected network namespace to be added")
+	})
+
+	t.Run("creates mount source directory if it doesn't exist", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		mountSource := filepath.Join(tmpDir, "nonexistent", "mount")
+
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "/run/netns/podns",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+				Mounts: []*pb.Mount{
+					{
+						Source: mountSource,
+						Type:   "bind",
+					},
+				},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createContainerCalled)
+
+		// Verify directory was created
+		_, err = os.Stat(mountSource)
+		assert.NoError(t, err, "Expected mount source directory to be created")
+	})
+
+	t.Run("handles existing mount source directory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		mountSource := filepath.Join(tmpDir, "existing")
+		require.NoError(t, os.MkdirAll(mountSource, 0o755))
+
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "/run/netns/podns",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+				Mounts: []*pb.Mount{
+					{
+						Source: mountSource,
+						Type:   "bind",
+					},
+				},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createContainerCalled)
+	})
+
+	t.Run("handles non-bind mount types", func(t *testing.T) {
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "/run/netns/podns",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+				Mounts: []*pb.Mount{
+					{
+						Source: "/nonexistent",
+						Type:   "tmpfs",
+					},
+				},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createContainerCalled)
+	})
+
+	t.Run("propagates redirector errors", func(t *testing.T) {
+		expectedErr := assert.AnError
+		mock := &mockRedirector{
+			createContainerError: expectedErr,
+		}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "/run/netns/podns",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+
+		assert.Error(t, err)
+		assert.Equal(t, expectedErr, err)
+		assert.True(t, mock.createContainerCalled)
+	})
+}
+
+func TestInterceptorStartContainer(t *testing.T) {
+	t.Run("successfully starts container", func(t *testing.T) {
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+		}
+
+		req := &pb.StartContainerRequest{
+			ContainerId: "test-container",
+		}
+
+		ctx := context.Background()
+		_, err := i.StartContainer(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.startContainerCalled)
+	})
+
+	t.Run("propagates redirector errors", func(t *testing.T) {
+		expectedErr := assert.AnError
+		mock := &mockRedirector{
+			startContainerError: expectedErr,
+		}
+		i := &interceptor{
+			Redirector: mock,
+		}
+
+		req := &pb.StartContainerRequest{
+			ContainerId: "test-container",
+		}
+
+		ctx := context.Background()
+		_, err := i.StartContainer(ctx, req)
+
+		assert.Error(t, err)
+		assert.Equal(t, expectedErr, err)
+		assert.True(t, mock.startContainerCalled)
+	})
+}
+
+func TestInterceptorRemoveContainer(t *testing.T) {
+	t.Run("successfully removes container", func(t *testing.T) {
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+		}
+
+		req := &pb.RemoveContainerRequest{
+			ContainerId: "test-container",
+		}
+
+		ctx := context.Background()
+		_, err := i.RemoveContainer(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.removeContainerCalled)
+	})
+
+	t.Run("propagates redirector errors", func(t *testing.T) {
+		expectedErr := assert.AnError
+		mock := &mockRedirector{
+			removeContainerError: expectedErr,
+		}
+		i := &interceptor{
+			Redirector: mock,
+		}
+
+		req := &pb.RemoveContainerRequest{
+			ContainerId: "test-container",
+		}
+
+		ctx := context.Background()
+		_, err := i.RemoveContainer(ctx, req)
+
+		assert.Error(t, err)
+		assert.Equal(t, expectedErr, err)
+		assert.True(t, mock.removeContainerCalled)
+	})
+}
+
+func TestInterceptorCreateSandbox(t *testing.T) {
+	t.Run("successfully creates sandbox", func(t *testing.T) {
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+		}
+
+		req := &pb.CreateSandboxRequest{
+			Hostname:  "test-host",
+			SandboxId: "test-sandbox",
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateSandbox(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createSandboxCalled)
+	})
+
+	t.Run("removes DNS settings from request", func(t *testing.T) {
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+		}
+
+		req := &pb.CreateSandboxRequest{
+			Hostname:  "test-host",
+			SandboxId: "test-sandbox",
+			Dns:       []string{"8.8.8.8", "8.8.4.4"},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateSandbox(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createSandboxCalled)
+		assert.Nil(t, req.Dns, "Expected DNS to be removed from request")
+	})
+
+	t.Run("handles empty DNS settings", func(t *testing.T) {
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+		}
+
+		req := &pb.CreateSandboxRequest{
+			Hostname:  "test-host",
+			SandboxId: "test-sandbox",
+			Dns:       []string{},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateSandbox(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createSandboxCalled)
+	})
+
+	t.Run("propagates redirector errors", func(t *testing.T) {
+		expectedErr := assert.AnError
+		mock := &mockRedirector{
+			createSandboxError: expectedErr,
+		}
+		i := &interceptor{
+			Redirector: mock,
+		}
+
+		req := &pb.CreateSandboxRequest{
+			Hostname:  "test-host",
+			SandboxId: "test-sandbox",
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateSandbox(ctx, req)
+
+		assert.Error(t, err)
+		assert.Equal(t, expectedErr, err)
+		assert.True(t, mock.createSandboxCalled)
+	})
+}
+
+func TestInterceptorDestroySandbox(t *testing.T) {
+	t.Run("successfully destroys sandbox", func(t *testing.T) {
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+		}
+
+		req := &pb.DestroySandboxRequest{}
+
+		ctx := context.Background()
+		_, err := i.DestroySandbox(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.destroySandboxCalled)
+	})
+
+	t.Run("propagates redirector errors", func(t *testing.T) {
+		expectedErr := assert.AnError
+		mock := &mockRedirector{
+			destroySandboxError: expectedErr,
+		}
+		i := &interceptor{
+			Redirector: mock,
+		}
+
+		req := &pb.DestroySandboxRequest{}
+
+		ctx := context.Background()
+		_, err := i.DestroySandbox(ctx, req)
+
+		assert.Error(t, err)
+		assert.Equal(t, expectedErr, err)
+		assert.True(t, mock.destroySandboxCalled)
+	})
+}
+
+func TestInterceptorWithAnnotations(t *testing.T) {
+	t.Run("handles volume target path annotation without matching mount", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		// Create annotation path but use different mount source to avoid device wait
+		annotationPath := filepath.Join(tmpDir, "annotation-volume")
+		mountSource := filepath.Join(tmpDir, "actual-mount")
+		require.NoError(t, os.MkdirAll(mountSource, 0o755))
+
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "/run/netns/podns",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+				Annotations: map[string]string{
+					volumeTargetPathKey: annotationPath,
+				},
+				Mounts: []*pb.Mount{
+					{
+						Source: mountSource,
+						Type:   "bind",
+					},
+				},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createContainerCalled)
+	})
+
+	t.Run("handles empty volume target path annotation", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		mountSource := filepath.Join(tmpDir, "volume")
+		require.NoError(t, os.MkdirAll(mountSource, 0o755))
+
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "/run/netns/podns",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+				Annotations: map[string]string{
+					volumeTargetPathKey: "",
+				},
+				Mounts: []*pb.Mount{
+					{
+						Source: mountSource,
+						Type:   "bind",
+					},
+				},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createContainerCalled)
+	})
+
+	t.Run("handles missing volume target path annotation", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		mountSource := filepath.Join(tmpDir, "volume")
+		require.NoError(t, os.MkdirAll(mountSource, 0o755))
+
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "/run/netns/podns",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+				Annotations: map[string]string{},
+				Mounts: []*pb.Mount{
+					{
+						Source: mountSource,
+						Type:   "bind",
+					},
+				},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createContainerCalled)
+	})
+}
+
+func TestInterceptorCreateContainerWithMountErrors(t *testing.T) {
+	t.Run("handles mount source creation error when MkdirAll fails", func(t *testing.T) {
+		// Create a temp directory with restricted permissions to trigger MkdirAll failure
+		tempDir := t.TempDir()
+		restrictedDir := filepath.Join(tempDir, "restricted")
+
+		// Create directory and make it non-writable
+		err := os.Mkdir(restrictedDir, 0755)
+		require.NoError(t, err)
+		err = os.Chmod(restrictedDir, 0444) // read-only
+		require.NoError(t, err)
+
+		// Restore permissions after test for cleanup
+		defer func() {
+			_ = os.Chmod(restrictedDir, 0755)
+		}()
+
+		// Try to create a subdirectory in the non-writable directory
+		mountSource := filepath.Join(restrictedDir, "subdir", "test-mount-should-fail")
+
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "/run/netns/podns",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+				Mounts: []*pb.Mount{
+					{
+						Source: mountSource,
+						Type:   "bind",
+					},
+				},
+			},
+		}
+
+		ctx := context.Background()
+		// Should not fail even if directory creation fails
+		_, err = i.CreateContainer(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createContainerCalled)
+	})
+
+	t.Run("handles multiple mounts with mixed types", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		bindMount := filepath.Join(tmpDir, "bind")
+		require.NoError(t, os.MkdirAll(bindMount, 0o755))
+
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "/run/netns/podns",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+				Mounts: []*pb.Mount{
+					{
+						Source: bindMount,
+						Type:   "bind",
+					},
+					{
+						Source: "tmpfs",
+						Type:   "tmpfs",
+					},
+					{
+						Source: "proc",
+						Type:   "proc",
+					},
+				},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createContainerCalled)
+	})
+
+	t.Run("handles container with no mounts", func(t *testing.T) {
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "/run/netns/podns",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+				Mounts: []*pb.Mount{},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createContainerCalled)
+	})
+
+	t.Run("handles container with nil mounts", func(t *testing.T) {
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "/run/netns/podns",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+				Mounts: nil,
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createContainerCalled)
+	})
+}
+
+func TestInterceptorCreateContainerWithNamespaces(t *testing.T) {
+	t.Run("adds network namespace to existing namespaces", func(t *testing.T) {
+		nsPath := "/run/netns/podns"
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     nsPath,
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{
+						{
+							Type: string(specs.PIDNamespace),
+							Path: "/proc/1/ns/pid",
+						},
+						{
+							Type: string(specs.UTSNamespace),
+							Path: "/proc/1/ns/uts",
+						},
+					},
+				},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createContainerCalled)
+
+		// Verify network namespace was added
+		assert.Len(t, req.OCI.Linux.Namespaces, 3)
+		found := false
+		for _, ns := range req.OCI.Linux.Namespaces {
+			if ns.Type == string(specs.NetworkNamespace) && ns.Path == nsPath {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "Expected network namespace to be added")
+	})
+
+	t.Run("handles empty namespace path", func(t *testing.T) {
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createContainerCalled)
+
+		// Verify network namespace was added even with empty path
+		found := false
+		for _, ns := range req.OCI.Linux.Namespaces {
+			if ns.Type == string(specs.NetworkNamespace) {
+				found = true
+				assert.Empty(t, ns.Path)
+				break
+			}
+		}
+		assert.True(t, found)
+	})
+}
+
+func TestInterceptorCreateSandboxWithDNS(t *testing.T) {
+	t.Run("handles single DNS server", func(t *testing.T) {
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+		}
+
+		req := &pb.CreateSandboxRequest{
+			Hostname:  "test-host",
+			SandboxId: "test-sandbox",
+			Dns:       []string{"8.8.8.8"},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateSandbox(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createSandboxCalled)
+		assert.Nil(t, req.Dns)
+	})
+
+	t.Run("handles many DNS servers", func(t *testing.T) {
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+		}
+
+		req := &pb.CreateSandboxRequest{
+			Hostname:  "test-host",
+			SandboxId: "test-sandbox",
+			Dns:       []string{"8.8.8.8", "8.8.4.4", "1.1.1.1", "1.0.0.1"},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateSandbox(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createSandboxCalled)
+		assert.Nil(t, req.Dns)
+	})
+
+	t.Run("handles nil DNS", func(t *testing.T) {
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+		}
+
+		req := &pb.CreateSandboxRequest{
+			Hostname:  "test-host",
+			SandboxId: "test-sandbox",
+			Dns:       nil,
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateSandbox(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createSandboxCalled)
+		assert.Nil(t, req.Dns)
+	})
+}
+
+func TestInterceptorWithComplexAnnotations(t *testing.T) {
+	t.Run("handles annotation with whitespace in paths", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		path1 := filepath.Join(tmpDir, "path1")
+		path2 := filepath.Join(tmpDir, "path2")
+		mountSource := filepath.Join(tmpDir, "mount")
+		require.NoError(t, os.MkdirAll(mountSource, 0o755))
+
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "/run/netns/podns",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+				Annotations: map[string]string{
+					volumeTargetPathKey: path1 + " , " + path2 + " ",
+				},
+				Mounts: []*pb.Mount{
+					{
+						Source: mountSource,
+						Type:   "bind",
+					},
+				},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createContainerCalled)
+	})
+
+	t.Run("handles annotation with single path and comma", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		annotationPath := filepath.Join(tmpDir, "annotation")
+		mountSource := filepath.Join(tmpDir, "mount")
+		require.NoError(t, os.MkdirAll(mountSource, 0o755))
+
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "/run/netns/podns",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+				Annotations: map[string]string{
+					volumeTargetPathKey: annotationPath + ",",
+				},
+				Mounts: []*pb.Mount{
+					{
+						Source: mountSource,
+						Type:   "bind",
+					},
+				},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+
+		require.NoError(t, err)
+		assert.True(t, mock.createContainerCalled)
+	})
+}
+
+func TestIsTargetPathEdgeCases(t *testing.T) {
+	t.Run("handles paths with trailing slashes", func(t *testing.T) {
+		assert.False(t, isTargetPath("/path/to/target/", "/path/to/target"))
+		assert.False(t, isTargetPath("/path/to/target", "/path/to/target/"))
+	})
+
+	t.Run("handles similar but different paths", func(t *testing.T) {
+		assert.False(t, isTargetPath("/path/to/target", "/path/to/target2"))
+		assert.False(t, isTargetPath("/path/to/target2", "/path/to/target"))
+	})
+
+	t.Run("handles paths with dots", func(t *testing.T) {
+		path := "/path/to/../target"
+		assert.True(t, isTargetPath(path, path))
+		assert.False(t, isTargetPath(path, "/path/target"))
+	})
 }


### PR DESCRIPTION
```
 interceptor]# go test -v -cover -tags "aws,ibmcloud,libvirt,azure"
=== RUN   TestNewInterceptor
=== RUN   TestNewInterceptor/creates_interceptor_with_valid_socket_name
=== RUN   TestNewInterceptor/creates_interceptor_with_namespace_path
=== RUN   TestNewInterceptor/creates_interceptor_with_empty_namespace_path
--- PASS: TestNewInterceptor (0.00s)
    --- PASS: TestNewInterceptor/creates_interceptor_with_valid_socket_name (0.00s)
    --- PASS: TestNewInterceptor/creates_interceptor_with_namespace_path (0.00s)
    --- PASS: TestNewInterceptor/creates_interceptor_with_empty_namespace_path (0.00s)
=== RUN   TestIsTargetPath
=== RUN   TestIsTargetPath/returns_false_when_target_path_is_empty
=== RUN   TestIsTargetPath/returns_false_when_both_paths_are_empty
=== RUN   TestIsTargetPath/returns_false_when_paths_do_not_match
=== RUN   TestIsTargetPath/returns_true_when_paths_match_exactly
=== RUN   TestIsTargetPath/returns_false_when_path_is_empty_but_target_is_not
=== RUN   TestIsTargetPath/handles_paths_with_special_characters
--- PASS: TestIsTargetPath (0.00s)
    --- PASS: TestIsTargetPath/returns_false_when_target_path_is_empty (0.00s)
    --- PASS: TestIsTargetPath/returns_false_when_both_paths_are_empty (0.00s)
    --- PASS: TestIsTargetPath/returns_false_when_paths_do_not_match (0.00s)
    --- PASS: TestIsTargetPath/returns_true_when_paths_match_exactly (0.00s)
    --- PASS: TestIsTargetPath/returns_false_when_path_is_empty_but_target_is_not (0.00s)
    --- PASS: TestIsTargetPath/handles_paths_with_special_characters (0.00s)
=== RUN   TestInterceptorCreateContainer
=== RUN   TestInterceptorCreateContainer/adds_network_namespace_to_container_spec
2026/04/16 09:35:42 [forwarder/interceptor] CreateContainer: containerID:test-container
2026/04/16 09:35:42 [forwarder/interceptor]     namespaces:
2026/04/16 09:35:42 [forwarder/interceptor]     network: "/run/netns/podns"
=== RUN   TestInterceptorCreateContainer/creates_mount_source_directory_if_it_doesn't_exist
2026/04/16 09:35:42 [forwarder/interceptor] CreateContainer: containerID:test-container
2026/04/16 09:35:42 [forwarder/interceptor]     namespaces:
2026/04/16 09:35:42 [forwarder/interceptor]     network: "/run/netns/podns"
2026/04/16 09:35:42 [forwarder/interceptor] mount source /tmp/TestInterceptorCreateContainercreates_mount_source_directory_if4242106494/001/nonexistent/mount doesn't exist, try to create
=== RUN   TestInterceptorCreateContainer/handles_existing_mount_source_directory
2026/04/16 09:35:42 [forwarder/interceptor] CreateContainer: containerID:test-container
2026/04/16 09:35:42 [forwarder/interceptor]     namespaces:
2026/04/16 09:35:42 [forwarder/interceptor]     network: "/run/netns/podns"
=== RUN   TestInterceptorCreateContainer/handles_non-bind_mount_types
2026/04/16 09:35:42 [forwarder/interceptor] CreateContainer: containerID:test-container
2026/04/16 09:35:42 [forwarder/interceptor]     namespaces:
2026/04/16 09:35:42 [forwarder/interceptor]     network: "/run/netns/podns"
=== RUN   TestInterceptorCreateContainer/propagates_redirector_errors
2026/04/16 09:35:42 [forwarder/interceptor] CreateContainer: containerID:test-container
2026/04/16 09:35:42 [forwarder/interceptor]     namespaces:
2026/04/16 09:35:42 [forwarder/interceptor]     network: "/run/netns/podns"
2026/04/16 09:35:42 [forwarder/interceptor] CreateContainer failed with error: assert.AnError general error for testing
--- PASS: TestInterceptorCreateContainer (0.00s)
    --- PASS: TestInterceptorCreateContainer/adds_network_namespace_to_container_spec (0.00s)
    --- PASS: TestInterceptorCreateContainer/creates_mount_source_directory_if_it_doesn't_exist (0.00s)
    --- PASS: TestInterceptorCreateContainer/handles_existing_mount_source_directory (0.00s)
    --- PASS: TestInterceptorCreateContainer/handles_non-bind_mount_types (0.00s)
    --- PASS: TestInterceptorCreateContainer/propagates_redirector_errors (0.00s)
=== RUN   TestInterceptorStartContainer
=== RUN   TestInterceptorStartContainer/successfully_starts_container
2026/04/16 09:35:42 [forwarder/interceptor] StartContainer: containerID:test-container
=== RUN   TestInterceptorStartContainer/propagates_redirector_errors
2026/04/16 09:35:42 [forwarder/interceptor] StartContainer: containerID:test-container
2026/04/16 09:35:42 [forwarder/interceptor] StartContainer failed with error: assert.AnError general error for testing
--- PASS: TestInterceptorStartContainer (0.00s)
    --- PASS: TestInterceptorStartContainer/successfully_starts_container (0.00s)
    --- PASS: TestInterceptorStartContainer/propagates_redirector_errors (0.00s)
=== RUN   TestInterceptorRemoveContainer
=== RUN   TestInterceptorRemoveContainer/successfully_removes_container
2026/04/16 09:35:42 [forwarder/interceptor] RemoveContainer: containerID:test-container
=== RUN   TestInterceptorRemoveContainer/propagates_redirector_errors
2026/04/16 09:35:42 [forwarder/interceptor] RemoveContainer: containerID:test-container
2026/04/16 09:35:42 [forwarder/interceptor] RemoveContainer failed with error: assert.AnError general error for testing
--- PASS: TestInterceptorRemoveContainer (0.00s)
    --- PASS: TestInterceptorRemoveContainer/successfully_removes_container (0.00s)
    --- PASS: TestInterceptorRemoveContainer/propagates_redirector_errors (0.00s)
=== RUN   TestInterceptorCreateSandbox
=== RUN   TestInterceptorCreateSandbox/successfully_creates_sandbox
2026/04/16 09:35:42 [forwarder/interceptor] CreateSandbox: hostname:test-host sandboxId:test-sandbox
=== RUN   TestInterceptorCreateSandbox/removes_DNS_settings_from_request
2026/04/16 09:35:42 [forwarder/interceptor] CreateSandbox: hostname:test-host sandboxId:test-sandbox
2026/04/16 09:35:42 [forwarder/interceptor]     dns:
2026/04/16 09:35:42 [forwarder/interceptor]         8.8.8.8
2026/04/16 09:35:42 [forwarder/interceptor]         8.8.4.4
2026/04/16 09:35:42 [forwarder/interceptor]       Eliminated the DNS setting above from CreateSandboxRequest to stop updating /etc/resolv.conf on the peer pod VM
2026/04/16 09:35:42 [forwarder/interceptor]       See https://github.com/confidential-containers/cloud-api-adaptor/issues/98 for the details.
2026/04/16 09:35:42 [forwarder/interceptor] 
=== RUN   TestInterceptorCreateSandbox/handles_empty_DNS_settings
2026/04/16 09:35:42 [forwarder/interceptor] CreateSandbox: hostname:test-host sandboxId:test-sandbox
=== RUN   TestInterceptorCreateSandbox/propagates_redirector_errors
2026/04/16 09:35:42 [forwarder/interceptor] CreateSandbox: hostname:test-host sandboxId:test-sandbox
2026/04/16 09:35:42 [forwarder/interceptor] CreateSandbox failed with error: assert.AnError general error for testing
--- PASS: TestInterceptorCreateSandbox (0.00s)
    --- PASS: TestInterceptorCreateSandbox/successfully_creates_sandbox (0.00s)
    --- PASS: TestInterceptorCreateSandbox/removes_DNS_settings_from_request (0.00s)
    --- PASS: TestInterceptorCreateSandbox/handles_empty_DNS_settings (0.00s)
    --- PASS: TestInterceptorCreateSandbox/propagates_redirector_errors (0.00s)
=== RUN   TestInterceptorDestroySandbox
=== RUN   TestInterceptorDestroySandbox/successfully_destroys_sandbox
2026/04/16 09:35:42 [forwarder/interceptor] DestroySandbox
=== RUN   TestInterceptorDestroySandbox/propagates_redirector_errors
2026/04/16 09:35:42 [forwarder/interceptor] DestroySandbox
2026/04/16 09:35:42 [forwarder/interceptor] DestroySandbox failed with error: assert.AnError general error for testing
--- PASS: TestInterceptorDestroySandbox (0.00s)
    --- PASS: TestInterceptorDestroySandbox/successfully_destroys_sandbox (0.00s)
    --- PASS: TestInterceptorDestroySandbox/propagates_redirector_errors (0.00s)
=== RUN   TestInterceptorWithAnnotations
=== RUN   TestInterceptorWithAnnotations/handles_volume_target_path_annotation_without_matching_mount
2026/04/16 09:35:42 [forwarder/interceptor] CreateContainer: containerID:test-container
2026/04/16 09:35:42 [forwarder/interceptor]     namespaces:
2026/04/16 09:35:42 [forwarder/interceptor]     network: "/run/netns/podns"
=== RUN   TestInterceptorWithAnnotations/handles_empty_volume_target_path_annotation
2026/04/16 09:35:42 [forwarder/interceptor] CreateContainer: containerID:test-container
2026/04/16 09:35:42 [forwarder/interceptor]     namespaces:
2026/04/16 09:35:42 [forwarder/interceptor]     network: "/run/netns/podns"
=== RUN   TestInterceptorWithAnnotations/handles_missing_volume_target_path_annotation
2026/04/16 09:35:42 [forwarder/interceptor] CreateContainer: containerID:test-container
2026/04/16 09:35:42 [forwarder/interceptor]     namespaces:
2026/04/16 09:35:42 [forwarder/interceptor]     network: "/run/netns/podns"
--- PASS: TestInterceptorWithAnnotations (0.00s)
    --- PASS: TestInterceptorWithAnnotations/handles_volume_target_path_annotation_without_matching_mount (0.00s)
    --- PASS: TestInterceptorWithAnnotations/handles_empty_volume_target_path_annotation (0.00s)
    --- PASS: TestInterceptorWithAnnotations/handles_missing_volume_target_path_annotation (0.00s)
=== RUN   TestInterceptorCreateContainerWithMountErrors
=== RUN   TestInterceptorCreateContainerWithMountErrors/handles_mount_source_creation_error_for_read-only_filesystem
2026/04/16 09:35:42 [forwarder/interceptor] CreateContainer: containerID:test-container
2026/04/16 09:35:42 [forwarder/interceptor]     namespaces:
2026/04/16 09:35:42 [forwarder/interceptor]     network: "/run/netns/podns"
2026/04/16 09:35:42 [forwarder/interceptor] mount source /proc/test-mount-should-fail doesn't exist, try to create
2026/04/16 09:35:42 [forwarder/interceptor] Failed to create dir: mkdir /proc/test-mount-should-fail: no such file or directory
=== RUN   TestInterceptorCreateContainerWithMountErrors/handles_multiple_mounts_with_mixed_types
2026/04/16 09:35:42 [forwarder/interceptor] CreateContainer: containerID:test-container
2026/04/16 09:35:42 [forwarder/interceptor]     namespaces:
2026/04/16 09:35:42 [forwarder/interceptor]     network: "/run/netns/podns"
=== RUN   TestInterceptorCreateContainerWithMountErrors/handles_container_with_no_mounts
2026/04/16 09:35:42 [forwarder/interceptor] CreateContainer: containerID:test-container
2026/04/16 09:35:42 [forwarder/interceptor]     namespaces:
2026/04/16 09:35:42 [forwarder/interceptor]     network: "/run/netns/podns"
=== RUN   TestInterceptorCreateContainerWithMountErrors/handles_container_with_nil_mounts
2026/04/16 09:35:42 [forwarder/interceptor] CreateContainer: containerID:test-container
2026/04/16 09:35:42 [forwarder/interceptor]     namespaces:
2026/04/16 09:35:42 [forwarder/interceptor]     network: "/run/netns/podns"
--- PASS: TestInterceptorCreateContainerWithMountErrors (0.00s)
    --- PASS: TestInterceptorCreateContainerWithMountErrors/handles_mount_source_creation_error_for_read-only_filesystem (0.00s)
    --- PASS: TestInterceptorCreateContainerWithMountErrors/handles_multiple_mounts_with_mixed_types (0.00s)
    --- PASS: TestInterceptorCreateContainerWithMountErrors/handles_container_with_no_mounts (0.00s)
    --- PASS: TestInterceptorCreateContainerWithMountErrors/handles_container_with_nil_mounts (0.00s)
=== RUN   TestInterceptorCreateContainerWithNamespaces
=== RUN   TestInterceptorCreateContainerWithNamespaces/adds_network_namespace_to_existing_namespaces
2026/04/16 09:35:42 [forwarder/interceptor] CreateContainer: containerID:test-container
2026/04/16 09:35:42 [forwarder/interceptor]     namespaces:
2026/04/16 09:35:42 [forwarder/interceptor]     pid: "/proc/1/ns/pid"
2026/04/16 09:35:42 [forwarder/interceptor]     uts: "/proc/1/ns/uts"
2026/04/16 09:35:42 [forwarder/interceptor]     network: "/run/netns/podns"
=== RUN   TestInterceptorCreateContainerWithNamespaces/handles_empty_namespace_path
2026/04/16 09:35:42 [forwarder/interceptor] CreateContainer: containerID:test-container
2026/04/16 09:35:42 [forwarder/interceptor]     namespaces:
2026/04/16 09:35:42 [forwarder/interceptor]     network: ""
--- PASS: TestInterceptorCreateContainerWithNamespaces (0.00s)
    --- PASS: TestInterceptorCreateContainerWithNamespaces/adds_network_namespace_to_existing_namespaces (0.00s)
    --- PASS: TestInterceptorCreateContainerWithNamespaces/handles_empty_namespace_path (0.00s)
=== RUN   TestInterceptorCreateSandboxWithDNS
=== RUN   TestInterceptorCreateSandboxWithDNS/handles_single_DNS_server
2026/04/16 09:35:42 [forwarder/interceptor] CreateSandbox: hostname:test-host sandboxId:test-sandbox
2026/04/16 09:35:42 [forwarder/interceptor]     dns:
2026/04/16 09:35:42 [forwarder/interceptor]         8.8.8.8
2026/04/16 09:35:42 [forwarder/interceptor]       Eliminated the DNS setting above from CreateSandboxRequest to stop updating /etc/resolv.conf on the peer pod VM
2026/04/16 09:35:42 [forwarder/interceptor]       See https://github.com/confidential-containers/cloud-api-adaptor/issues/98 for the details.
2026/04/16 09:35:42 [forwarder/interceptor] 
=== RUN   TestInterceptorCreateSandboxWithDNS/handles_many_DNS_servers
2026/04/16 09:35:42 [forwarder/interceptor] CreateSandbox: hostname:test-host sandboxId:test-sandbox
2026/04/16 09:35:42 [forwarder/interceptor]     dns:
2026/04/16 09:35:42 [forwarder/interceptor]         8.8.8.8
2026/04/16 09:35:42 [forwarder/interceptor]         8.8.4.4
2026/04/16 09:35:42 [forwarder/interceptor]         1.1.1.1
2026/04/16 09:35:42 [forwarder/interceptor]         1.0.0.1
2026/04/16 09:35:42 [forwarder/interceptor]       Eliminated the DNS setting above from CreateSandboxRequest to stop updating /etc/resolv.conf on the peer pod VM
2026/04/16 09:35:42 [forwarder/interceptor]       See https://github.com/confidential-containers/cloud-api-adaptor/issues/98 for the details.
2026/04/16 09:35:42 [forwarder/interceptor] 
=== RUN   TestInterceptorCreateSandboxWithDNS/handles_nil_DNS
2026/04/16 09:35:42 [forwarder/interceptor] CreateSandbox: hostname:test-host sandboxId:test-sandbox
--- PASS: TestInterceptorCreateSandboxWithDNS (0.00s)
    --- PASS: TestInterceptorCreateSandboxWithDNS/handles_single_DNS_server (0.00s)
    --- PASS: TestInterceptorCreateSandboxWithDNS/handles_many_DNS_servers (0.00s)
    --- PASS: TestInterceptorCreateSandboxWithDNS/handles_nil_DNS (0.00s)
=== RUN   TestInterceptorWithComplexAnnotations
=== RUN   TestInterceptorWithComplexAnnotations/handles_annotation_with_whitespace_in_paths
2026/04/16 09:35:42 [forwarder/interceptor] CreateContainer: containerID:test-container
2026/04/16 09:35:42 [forwarder/interceptor]     namespaces:
2026/04/16 09:35:42 [forwarder/interceptor]     network: "/run/netns/podns"
=== RUN   TestInterceptorWithComplexAnnotations/handles_annotation_with_single_path_and_comma
2026/04/16 09:35:42 [forwarder/interceptor] CreateContainer: containerID:test-container
2026/04/16 09:35:42 [forwarder/interceptor]     namespaces:
2026/04/16 09:35:42 [forwarder/interceptor]     network: "/run/netns/podns"
--- PASS: TestInterceptorWithComplexAnnotations (0.00s)
    --- PASS: TestInterceptorWithComplexAnnotations/handles_annotation_with_whitespace_in_paths (0.00s)
    --- PASS: TestInterceptorWithComplexAnnotations/handles_annotation_with_single_path_and_comma (0.00s)
=== RUN   TestIsTargetPathEdgeCases
=== RUN   TestIsTargetPathEdgeCases/handles_paths_with_trailing_slashes
=== RUN   TestIsTargetPathEdgeCases/handles_similar_but_different_paths
=== RUN   TestIsTargetPathEdgeCases/handles_paths_with_dots
--- PASS: TestIsTargetPathEdgeCases (0.00s)
    --- PASS: TestIsTargetPathEdgeCases/handles_paths_with_trailing_slashes (0.00s)
    --- PASS: TestIsTargetPathEdgeCases/handles_similar_but_different_paths (0.00s)
    --- PASS: TestIsTargetPathEdgeCases/handles_paths_with_dots (0.00s)
PASS
coverage: 58.0% of statements
ok  	github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/forwarder/interceptor	0.020s
```



```
forwarder]# go test -v -cover -tags "aws,ibmcloud,libvirt,azure"
=== RUN   TestNewDaemon
=== RUN   TestNewDaemon/creates_daemon_with_minimal_config
=== RUN   TestNewDaemon/creates_daemon_with_TLS_config
=== RUN   TestNewDaemon/creates_daemon_with_custom_listen_address
=== RUN   TestNewDaemon/creates_daemon_with_nil_TLS_config
=== RUN   TestNewDaemon/creates_daemon_with_pod_network_config
=== RUN   TestNewDaemon/handles_TLS_config_with_existing_cert_auth
=== RUN   TestNewDaemon/handles_TLS_config_with_existing_CA
--- PASS: TestNewDaemon (0.00s)
    --- PASS: TestNewDaemon/creates_daemon_with_minimal_config (0.00s)
    --- PASS: TestNewDaemon/creates_daemon_with_TLS_config (0.00s)
    --- PASS: TestNewDaemon/creates_daemon_with_custom_listen_address (0.00s)
    --- PASS: TestNewDaemon/creates_daemon_with_nil_TLS_config (0.00s)
    --- PASS: TestNewDaemon/creates_daemon_with_pod_network_config (0.00s)
    --- PASS: TestNewDaemon/handles_TLS_config_with_existing_cert_auth (0.00s)
    --- PASS: TestNewDaemon/handles_TLS_config_with_existing_CA (0.00s)
=== RUN   TestDaemonStart
=== RUN   TestDaemonStart/starts_and_stops_successfully
2026/04/16 09:35:37 [forwarder] Starting agent-protocol-forwarder listener on address 127.0.0.1:0
=== RUN   TestDaemonStart/handles_pod_node_setup_error
=== RUN   TestDaemonStart/handles_context_cancellation
2026/04/16 09:35:37 [forwarder] Starting agent-protocol-forwarder listener on address 127.0.0.1:0
=== RUN   TestDaemonStart/handles_invalid_listen_address
2026/04/16 09:35:37 [forwarder] Starting agent-protocol-forwarder listener on address invalid:address:format
2026/04/16 09:35:37 [forwarder] failed to create agent-protocol-forwarder listener: listen tcp: address invalid:address:format: too many colons in address
--- PASS: TestDaemonStart (0.00s)
    --- PASS: TestDaemonStart/starts_and_stops_successfully (0.00s)
    --- PASS: TestDaemonStart/handles_pod_node_setup_error (0.00s)
    --- PASS: TestDaemonStart/handles_context_cancellation (0.00s)
    --- PASS: TestDaemonStart/handles_invalid_listen_address (0.00s)
=== RUN   TestDaemonShutdown
=== RUN   TestDaemonShutdown/closes_stop_channel
=== RUN   TestDaemonShutdown/is_idempotent
=== RUN   TestDaemonShutdown/can_be_called_multiple_times_concurrently
--- PASS: TestDaemonShutdown (0.00s)
    --- PASS: TestDaemonShutdown/closes_stop_channel (0.00s)
    --- PASS: TestDaemonShutdown/is_idempotent (0.00s)
    --- PASS: TestDaemonShutdown/can_be_called_multiple_times_concurrently (0.00s)
=== RUN   TestDaemonReady
=== RUN   TestDaemonReady/returns_ready_channel
=== RUN   TestDaemonReady/ready_channel_is_initially_open
=== RUN   TestDaemonReady/ready_channel_closes_when_daemon_starts
2026/04/16 09:35:37 [forwarder] Starting agent-protocol-forwarder listener on address 127.0.0.1:0
--- PASS: TestDaemonReady (0.00s)
    --- PASS: TestDaemonReady/returns_ready_channel (0.00s)
    --- PASS: TestDaemonReady/ready_channel_is_initially_open (0.00s)
    --- PASS: TestDaemonReady/ready_channel_closes_when_daemon_starts (0.00s)
=== RUN   TestDaemonAddr
=== RUN   TestDaemonAddr/returns_listen_address_after_ready
2026/04/16 09:35:37 [forwarder] Starting agent-protocol-forwarder listener on address 127.0.0.1:0
=== RUN   TestDaemonAddr/blocks_until_daemon_is_ready
--- PASS: TestDaemonAddr (0.10s)
    --- PASS: TestDaemonAddr/returns_listen_address_after_ready (0.00s)
    --- PASS: TestDaemonAddr/blocks_until_daemon_is_ready (0.10s)
=== RUN   TestDaemonConstants
=== RUN   TestDaemonConstants/default_constants_are_set_correctly
--- PASS: TestDaemonConstants (0.00s)
    --- PASS: TestDaemonConstants/default_constants_are_set_correctly (0.00s)
=== RUN   TestConfigStructure
=== RUN   TestConfigStructure/config_has_expected_fields
=== RUN   TestConfigStructure/config_can_be_empty
--- PASS: TestConfigStructure (0.00s)
    --- PASS: TestConfigStructure/config_has_expected_fields (0.00s)
    --- PASS: TestConfigStructure/config_can_be_empty (0.00s)
=== RUN   TestDaemonInterface
=== RUN   TestDaemonInterface/daemon_implements_Daemon_interface
--- PASS: TestDaemonInterface (0.00s)
    --- PASS: TestDaemonInterface/daemon_implements_Daemon_interface (0.00s)
=== RUN   TestDaemonWithTLSConfig
=== RUN   TestDaemonWithTLSConfig/daemon_with_TLS_config_has_proper_initialization
=== RUN   TestDaemonWithTLSConfig/daemon_without_TLS_config_has_nil_tlsConfig
--- PASS: TestDaemonWithTLSConfig (0.00s)
    --- PASS: TestDaemonWithTLSConfig/daemon_with_TLS_config_has_proper_initialization (0.00s)
    --- PASS: TestDaemonWithTLSConfig/daemon_without_TLS_config_has_nil_tlsConfig (0.00s)
PASS
coverage: 75.4% of statements
ok  	github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/forwarder	0.115s
```