### PR TITLE
podvm: Run iptables-wrapper directly

### DIFF
--- a/src/cloud-api-adaptor/Dockerfile
+++ b/src/cloud-api-adaptor/Dockerfile
@@ -12,6 +12,7 @@ ARG BASE=registry.fedoraproject.org/fedora@sha256:893f7eeffce8e3e2bb2bc62786ba56
 FROM --platform=$BUILDPLATFORM $BUILDER_BASE AS builder-release
 ARG YQ_VERSION
 RUN go install github.com/mikefarah/yq/v4@$YQ_VERSION
+RUN dnf install -y git && dnf clean all
 
 # For `dev` builds due to CGO constraints we have to emulate the target platform
 # instead of using Go's cross-compilation
@@ -43,20 +44,21 @@ FROM builder-release AS iptables
 
 ARG TARGETARCH
 
-WORKDIR /iptables
-RUN --mount=type=bind,target=/versions.yaml,source=cloud-api-adaptor/versions.yaml,readonly \
-    version=$(yq -r .tools.iptables-wrapper /versions.yaml) && \
-    GOARCH=$TARGETARCH go install "github.com/kubernetes-sigs/iptables-wrappers@$version" && \
-    shopt -s globstar && \
-    cp /go/bin/**/iptables-wrappers ./iptables-wrapper && \
-    curl -L -o iptables-wrapper-installer.sh "https://raw.githubusercontent.com/kubernetes-sigs/iptables-wrappers/${version#v*-*-}/iptables-wrapper-installer.sh" && \
-    chmod 755 iptables-wrapper-installer.sh
+COPY cloud-api-adaptor/versions.yaml /versions.yaml
+
+RUN echo "Building iptables-wrapper... " \
+    && git clone https://github.com/kubernetes-sigs/iptables-wrappers.git /iptables \
+    && cd /iptables \
+    && version=$(grep 'iptables-wrapper:' /versions.yaml | awk '{print $2}') \
+    && git checkout $version \
+    && GOARCH=$TARGETARCH make BIN_DIR=. build
 
 FROM --platform=$TARGETPLATFORM $BASE AS base-release
 
 RUN dnf install -y iptables iptables-legacy iptables-nft nftables && dnf clean all
 RUN --mount=type=cache,target=/iptables,from=iptables,source=/iptables,readonly \
-    cd /iptables && ./iptables-wrapper-installer.sh --no-sanity-check --no-cleanup
+    cp /iptables/iptables-wrapper /usr/sbin \
+    && /usr/sbin/iptables-wrapper install
 
 FROM base-release AS base-dev
 RUN dnf install -y libvirt-libs /usr/bin/ssh && dnf clean all

--- a/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.podvm_docker_provider
+++ b/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.podvm_docker_provider
@@ -4,10 +4,14 @@ ARG BASE_IMAGE=registry.fedoraproject.org/fedora:43
 
 FROM $BASE_IMAGE AS iptables
 
+COPY ./versions.yaml /versions.yaml
+
 RUN echo "Building iptables-wrapper... " \
     && dnf install -y git golang \
     && git clone https://github.com/kubernetes-sigs/iptables-wrappers.git /iptables \
     && cd /iptables \
+    && version=$(grep 'iptables-wrapper:' /versions.yaml | awk '{print $2}') \
+    && git checkout $version \
     && make BIN_DIR=. build
 
 FROM $BASE_IMAGE AS base
@@ -32,18 +36,19 @@ RUN echo "Enabling / Disabling services ... " \
     && systemctl enable systemd-logind dbus.socket
 
 RUN --mount=type=cache,target=/iptables,from=iptables,source=/iptables,readonly \
-    cd /iptables && ./iptables-wrapper-installer.sh --no-sanity-check --no-cleanup
+    cp /iptables/iptables-wrapper /usr/sbin \
+    && /usr/sbin/iptables-wrapper install
 
 # Add podvm resources
-COPY ./resources/binaries-tree/etc/ /etc/
-COPY ./resources/binaries-tree/usr/ /usr/
-COPY ./resources/binaries-tree/pause_bundle/ /pause_bundle/
+COPY ./podvm-mkosi/resources/binaries-tree/etc/ /etc/
+COPY ./podvm-mkosi/resources/binaries-tree/usr/ /usr/
+COPY ./podvm-mkosi/resources/binaries-tree/pause_bundle/ /pause_bundle/
 
 RUN curl -LO https://raw.githubusercontent.com/confidential-containers/cloud-api-adaptor/main/src/cloud-api-adaptor/podvm/qcow2/misc-settings.sh
 
 RUN PODVM_DISTRO=ubuntu CLOUD_PROVIDER=generic bash ./misc-settings.sh
 
-COPY --chmod=0755 entrypoint.sh  /usr/local/bin/
+COPY --chmod=0755 ./podvm-mkosi/entrypoint.sh  /usr/local/bin/
 
 # https://systemd.io/CONTAINER_INTERFACE/
 ENV container=docker

--- a/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.podvm_docker_provider.ubuntu
+++ b/src/cloud-api-adaptor/podvm-mkosi/Dockerfile.podvm_docker_provider.ubuntu
@@ -6,11 +6,15 @@ FROM $BASE_IMAGE AS iptables
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+COPY ./versions.yaml /versions.yaml
+
 RUN echo "Building iptables-wrapper... " \
     && apt-get update \
     && apt-get install -y git golang build-essential \
     && git clone https://github.com/kubernetes-sigs/iptables-wrappers.git /iptables \
     && cd /iptables \
+    && version=$(grep 'iptables-wrapper:' /versions.yaml | awk '{print $2}') \
+    && git checkout $version \
     && make BIN_DIR=. build \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -42,18 +46,19 @@ RUN echo "Enabling / Disabling services ... " \
     && systemctl enable systemd-logind dbus.socket
 
 RUN --mount=type=cache,target=/iptables,from=iptables,source=/iptables,readonly \
-    cd /iptables && ./iptables-wrapper-installer.sh --no-sanity-check --no-cleanup
+    cp /iptables/iptables-wrapper /usr/sbin \
+    && /usr/sbin/iptables-wrapper install
 
 # Add podvm resources
-COPY ./resources/binaries-tree/etc/ /etc/
-COPY ./resources/binaries-tree/usr/ /usr/
-COPY ./resources/binaries-tree/pause_bundle/ /pause_bundle/
+COPY ./podvm-mkosi/resources/binaries-tree/etc/ /etc/
+COPY ./podvm-mkosi/resources/binaries-tree/usr/ /usr/
+COPY ./podvm-mkosi/resources/binaries-tree/pause_bundle/ /pause_bundle/
 
 RUN curl -LO https://raw.githubusercontent.com/confidential-containers/cloud-api-adaptor/main/src/cloud-api-adaptor/podvm/qcow2/misc-settings.sh
 
 RUN PODVM_DISTRO=ubuntu CLOUD_PROVIDER=generic bash ./misc-settings.sh
 
-COPY --chmod=0755 entrypoint.sh  /usr/local/bin/
+COPY --chmod=0755 ./podvm-mkosi/entrypoint.sh  /usr/local/bin/
 
 # https://systemd.io/CONTAINER_INTERFACE/
 ENV container=docker

--- a/src/cloud-api-adaptor/podvm-mkosi/Makefile
+++ b/src/cloud-api-adaptor/podvm-mkosi/Makefile
@@ -173,10 +173,10 @@ endif
 PHONY: image-container
 image-container:
 	@echo "Building podvm container image..."
-	docker buildx build \
+	cd .. && docker buildx build \
 		-t $(PODVM_CONTAINER_NAME):$(PODVM_TAG) \
 		-t $(PODVM_CONTAINER_NAME):latest \
-		-f Dockerfile.podvm_docker_provider$(if $(filter $(PODVM_DISTRO),ubuntu),.ubuntu,) .
+		-f podvm-mkosi/Dockerfile.podvm_docker_provider$(if $(filter $(PODVM_DISTRO),ubuntu),.ubuntu,) .
 
 PHONY: push-image
 push-image:

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -29,7 +29,7 @@ cloudimg:
 tools:
   cert-manager: v1.15.3
   bats: 1.10.0
-  iptables-wrapper: v0.0.0-20240819165702-06cad2ec6cb5
+  iptables-wrapper: bfef9e5087a198b50a4124bb9ce9d2c7c99025dd
   golang: 1.25.9
   kcli: 99.0.202507200957
   mkosi: v22


### PR DESCRIPTION
iptables-wrapper-installer.sh was removed in
https://github.com/kubernetes-sigs/iptables-wrappers/pull/14, so call the binary directly.

Assisted-by: IBM Bob
Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>