### PR TITLE
workflows: disregard e2e_aws status

### DIFF
--- a/.github/workflows/e2e_aws.yaml
+++ b/.github/workflows/e2e_aws.yaml
@@ -68,6 +68,8 @@ jobs:
     needs: aws-credentials
     if: needs.aws-credentials.outputs.has_secrets == 'true'
     runs-on: ubuntu-22.04
+    # TODO: AWS tests has failed for a while now, remove when we find a fix.
+    continue-on-error: true
     defaults:
       run:
         working-directory: src/cloud-api-adaptor


### PR DESCRIPTION
The CI job for AWS has failed for a while now and we still don't know the cause. Instead of disabling it completely, let's just ignore its status because it is still worth running it (e.g. catch build/setup/infra issues).