### PR TITLE
e2e-test: Improve test coverage for adaptor in CAA

### DIFF
--- a/src/cloud-api-adaptor/pkg/adaptor/proxy/mock_agent_test.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/proxy/mock_agent_test.go
@@ -1,0 +1,225 @@
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/containerd/ttrpc"
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols"
+	pb "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols/grpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// mockAgentService is a shared mock implementation of the agent service
+// for testing purposes. It implements both AgentServiceService and HealthService interfaces.
+type mockAgentService struct{}
+
+func (m *mockAgentService) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) StartContainer(ctx context.Context, req *pb.StartContainerRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) RemoveContainer(ctx context.Context, req *pb.RemoveContainerRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) ExecProcess(ctx context.Context, req *pb.ExecProcessRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) SignalProcess(ctx context.Context, req *pb.SignalProcessRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) WaitProcess(ctx context.Context, req *pb.WaitProcessRequest) (*pb.WaitProcessResponse, error) {
+	return &pb.WaitProcessResponse{}, nil
+}
+
+func (m *mockAgentService) UpdateContainer(ctx context.Context, req *pb.UpdateContainerRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) UpdateEphemeralMounts(ctx context.Context, req *pb.UpdateEphemeralMountsRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) StatsContainer(ctx context.Context, req *pb.StatsContainerRequest) (*pb.StatsContainerResponse, error) {
+	return &pb.StatsContainerResponse{}, nil
+}
+
+func (m *mockAgentService) PauseContainer(ctx context.Context, req *pb.PauseContainerRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) ResumeContainer(ctx context.Context, req *pb.ResumeContainerRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) WriteStdin(ctx context.Context, req *pb.WriteStreamRequest) (*pb.WriteStreamResponse, error) {
+	return &pb.WriteStreamResponse{}, nil
+}
+
+func (m *mockAgentService) ReadStdout(ctx context.Context, req *pb.ReadStreamRequest) (*pb.ReadStreamResponse, error) {
+	return &pb.ReadStreamResponse{}, nil
+}
+
+func (m *mockAgentService) ReadStderr(ctx context.Context, req *pb.ReadStreamRequest) (*pb.ReadStreamResponse, error) {
+	return &pb.ReadStreamResponse{}, nil
+}
+
+func (m *mockAgentService) CloseStdin(ctx context.Context, req *pb.CloseStdinRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) TtyWinResize(ctx context.Context, req *pb.TtyWinResizeRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) UpdateInterface(ctx context.Context, req *pb.UpdateInterfaceRequest) (*protocols.Interface, error) {
+	return &protocols.Interface{}, nil
+}
+
+func (m *mockAgentService) UpdateRoutes(ctx context.Context, req *pb.UpdateRoutesRequest) (*pb.Routes, error) {
+	return &pb.Routes{}, nil
+}
+
+func (m *mockAgentService) ListInterfaces(ctx context.Context, req *pb.ListInterfacesRequest) (*pb.Interfaces, error) {
+	return &pb.Interfaces{}, nil
+}
+
+func (m *mockAgentService) ListRoutes(ctx context.Context, req *pb.ListRoutesRequest) (*pb.Routes, error) {
+	return &pb.Routes{}, nil
+}
+
+func (m *mockAgentService) AddARPNeighbors(ctx context.Context, req *pb.AddARPNeighborsRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) GetIPTables(ctx context.Context, req *pb.GetIPTablesRequest) (*pb.GetIPTablesResponse, error) {
+	return &pb.GetIPTablesResponse{}, nil
+}
+
+func (m *mockAgentService) SetIPTables(ctx context.Context, req *pb.SetIPTablesRequest) (*pb.SetIPTablesResponse, error) {
+	return &pb.SetIPTablesResponse{}, nil
+}
+
+func (m *mockAgentService) GetMetrics(ctx context.Context, req *pb.GetMetricsRequest) (*pb.Metrics, error) {
+	return &pb.Metrics{}, nil
+}
+
+func (m *mockAgentService) CreateSandbox(ctx context.Context, req *pb.CreateSandboxRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) DestroySandbox(ctx context.Context, req *pb.DestroySandboxRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) OnlineCPUMem(ctx context.Context, req *pb.OnlineCPUMemRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) ReseedRandomDev(ctx context.Context, req *pb.ReseedRandomDevRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) GetGuestDetails(ctx context.Context, req *pb.GuestDetailsRequest) (*pb.GuestDetailsResponse, error) {
+	return &pb.GuestDetailsResponse{}, nil
+}
+
+func (m *mockAgentService) MemHotplugByProbe(ctx context.Context, req *pb.MemHotplugByProbeRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) SetGuestDateTime(ctx context.Context, req *pb.SetGuestDateTimeRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) CopyFile(ctx context.Context, req *pb.CopyFileRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) GetOOMEvent(ctx context.Context, req *pb.GetOOMEventRequest) (*pb.OOMEvent, error) {
+	return &pb.OOMEvent{}, nil
+}
+
+func (m *mockAgentService) AddSwap(ctx context.Context, req *pb.AddSwapRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) GetVolumeStats(ctx context.Context, req *pb.VolumeStatsRequest) (*pb.VolumeStatsResponse, error) {
+	return &pb.VolumeStatsResponse{}, nil
+}
+
+func (m *mockAgentService) ResizeVolume(ctx context.Context, req *pb.ResizeVolumeRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) RemoveStaleVirtiofsShareMounts(ctx context.Context, req *pb.RemoveStaleVirtiofsShareMountsRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) Check(ctx context.Context, req *pb.CheckRequest) (*pb.HealthCheckResponse, error) {
+	return &pb.HealthCheckResponse{}, nil
+}
+
+func (m *mockAgentService) Version(ctx context.Context, req *pb.CheckRequest) (*pb.VersionCheckResponse, error) {
+	return &pb.VersionCheckResponse{}, nil
+}
+
+func (m *mockAgentService) SetPolicy(ctx context.Context, req *pb.SetPolicyRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) AddSwapPath(ctx context.Context, req *pb.AddSwapPathRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) MemAgentMemcgSet(ctx context.Context, req *pb.MemAgentMemcgConfig) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) MemAgentCompactSet(ctx context.Context, req *pb.MemAgentCompactConfig) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockAgentService) GetDiagnosticData(ctx context.Context, req *pb.GetDiagnosticDataRequest) (*pb.GetDiagnosticDataResponse, error) {
+	return &pb.GetDiagnosticDataResponse{}, nil
+}
+
+// errorReturningMockAgent is a mock that returns errors for testing error handling
+type errorReturningMockAgent struct {
+	mockAgentService
+}
+
+func (m *errorReturningMockAgent) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (*emptypb.Empty, error) {
+	return nil, errors.New("mock agent error")
+}
+
+// setupMockAgent is a shared helper function to create and start a mock agent server
+// It returns the server and listener for use in tests
+func setupMockAgent(t *testing.T) (*ttrpc.Server, net.Listener) {
+	agentServer, err := ttrpc.NewServer()
+	require.NoError(t, err, "failed to create ttrpc server")
+
+	pb.RegisterAgentServiceService(agentServer, &mockAgentService{})
+	pb.RegisterHealthService(agentServer, &mockAgentService{})
+
+	agentListener, err := net.Listen("tcp", testListenAddressProxy)
+	require.NoError(t, err, "failed to create listener")
+
+	go func() {
+		_ = agentServer.Serve(context.Background(), agentListener)
+	}()
+
+	return agentServer, agentListener
+}

--- a/src/cloud-api-adaptor/pkg/adaptor/proxy/proxy_test.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/proxy/proxy_test.go
@@ -5,25 +5,64 @@ package proxy
 
 import (
 	"context"
-	"errors"
 	"net"
 	"net/url"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/tlsutil"
 	"github.com/containerd/ttrpc"
-	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols"
 	pb "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols/grpc"
-	"google.golang.org/protobuf/types/known/emptypb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test constants for proxy_test.go
+const (
+	// Socket and path constants
+	testSocketPathDummy   = "/run/dummy.sock"
+	testSocketPathTest    = "/run/test.sock"
+	testSocketPathInvalid = "/proc/invalid/test.sock"
+	testSocketFileName    = "test.sock"
+
+	// Server and network constants
+	testServerName         = "test-server"
+	testServerNamePodVM    = "podvm"
+	testListenAddressProxy = "127.0.0.1:0"
+	testInvalidAddress     = "0.0.0.0:0"
+	testUnreachableAddress = "127.0.0.1:1"
+	testUnreachablePort    = "127.0.0.1:9999"
+	testSchemeGRPC         = "grpc"
+	testNetworkUnix        = "unix"
+
+	// Container and annotation constants
+	testContainerIDProxy     = "123"
+	testAnnotationKeyProxy   = "aaa"
+	testAnnotationValueProxy = "111"
+
+	// Image constants
+	testPauseImageLatest = "pause:latest"
+
+	// Timeout constants
+	testTimeout1Second      = 1 * time.Second
+	testTimeout2Second      = 2 * time.Second
+	testTimeout5SecondProxy = 5 * time.Second
+	testTimeout250          = 250 * time.Millisecond
+
+	// TLS and certificate constants
+	testCAFilePath   = "/path/to/ca.pem"
+	testCertData     = "test-cert-data"
+	testMockRootCert = "mock-root-cert"
+	testMockCert     = "mock-cert"
+	testMockKey      = "mock-key"
 )
 
 func TestNewAgentProxy(t *testing.T) {
 
-	socketPath := "/run/dummy.sock"
+	socketPath := testSocketPathDummy
 
-	proxy := NewAgentProxy("podvm", socketPath, "", nil, nil, 0)
+	proxy := NewAgentProxy(testServerNamePodVM, socketPath, "", nil, nil, 0)
 	p, ok := proxy.(*agentProxy)
 	if !ok {
 		t.Fatalf("expect %T, got %T", &agentProxy{}, proxy)
@@ -34,52 +73,20 @@ func TestNewAgentProxy(t *testing.T) {
 }
 
 func TestStartStop(t *testing.T) {
-
 	dir := t.TempDir()
+	socketPath := filepath.Join(dir, testSocketFileName)
 
-	socketPath := filepath.Join(dir, "test.sock")
-
-	agentServer, err := ttrpc.NewServer()
-	if err != nil {
-		t.Fatalf("expect no error, got %q", err)
-	}
-	pb.RegisterAgentServiceService(agentServer, &agentMock{})
-	pb.RegisterHealthService(agentServer, &agentMock{})
-
-	agentListener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("expect no error, got %q", err)
-	}
-	defer func() {
-		err := agentListener.Close()
-		if e, a := net.ErrClosed, err; !errors.Is(a, e) {
-			t.Fatalf("expect %q, got %q", e, a)
-		}
-	}()
-
-	agentServerErrCh := make(chan error)
-	go func() {
-		defer close(agentServerErrCh)
-
-		err := agentServer.Serve(context.Background(), agentListener)
-		if err != nil {
-			agentServerErrCh <- err
-			return
-		}
-	}()
-	defer func() {
-		err := agentServer.Shutdown(context.Background())
-		if err != nil {
-			t.Fatalf("expect no error, got %q", err)
-		}
-	}()
+	// Setup mock agent server using shared helper
+	agentServer, agentListener := setupMockAgent(t)
+	defer func() { _ = agentServer.Shutdown(context.Background()) }()
+	defer agentListener.Close()
 
 	serverURL := &url.URL{
-		Scheme: "grpc",
+		Scheme: testSchemeGRPC,
 		Host:   agentListener.Addr().String(),
 	}
 
-	proxy := NewAgentProxy("podvm", socketPath, "", nil, nil, 5*time.Second)
+	proxy := NewAgentProxy(testServerNamePodVM, socketPath, "", nil, nil, testTimeout5SecondProxy)
 	p, ok := proxy.(*agentProxy)
 	if !ok {
 		t.Fatalf("expect %T, got %T", &agentProxy{}, proxy)
@@ -88,27 +95,22 @@ func TestStartStop(t *testing.T) {
 	proxyErrCh := make(chan error)
 	go func() {
 		defer close(proxyErrCh)
-
 		if err := proxy.Start(context.Background(), serverURL); err != nil {
 			proxyErrCh <- err
 		}
 	}()
 	defer func() {
-		if err := p.Shutdown(); err != nil {
-			t.Fatalf("expect no error, got %q", err)
-		}
+		require.NoError(t, p.Shutdown(), "expect no error during shutdown")
 	}()
 
 	select {
 	case err := <-proxyErrCh:
-		t.Fatalf("expect no error, got %q", err)
+		require.NoError(t, err, "expect no error from proxy")
 	case <-proxy.Ready():
 	}
 
-	conn, err := net.Dial("unix", socketPath)
-	if err != nil {
-		t.Fatalf("expect no error, got %q", err)
-	}
+	conn, err := net.Dial(testNetworkUnix, socketPath)
+	require.NoError(t, err, "expect no error dialing unix socket")
 
 	ttrpcClient := ttrpc.NewClient(conn)
 
@@ -121,50 +123,40 @@ func TestStartStop(t *testing.T) {
 	}
 
 	{
-		res, err := client.CreateContainer(context.Background(), &pb.CreateContainerRequest{ContainerId: "123", OCI: &pb.Spec{Annotations: map[string]string{"aaa": "111"}}})
-		if err != nil {
-			t.Fatalf("expect no error, got %q", err)
-		}
-		if res == nil {
-			t.Fatal("expect non nil, got nil")
-		}
+		res, err := client.CreateContainer(context.Background(), &pb.CreateContainerRequest{ContainerId: testContainerIDProxy, OCI: &pb.Spec{Annotations: map[string]string{testAnnotationKeyProxy: testAnnotationValueProxy}}})
+		assert.NoError(t, err, "expect no error creating container")
+		assert.NotNil(t, res, "expect non nil response")
 	}
 
 	select {
-	case err := <-agentServerErrCh:
-		t.Fatalf("expect no error, got %q", err)
 	case err := <-proxyErrCh:
-		t.Fatalf("expect no error, got %q", err)
+		assert.NoError(t, err, "expect no error from proxy channel")
 	default:
 	}
 }
 
 func TestDialerSuccess(t *testing.T) {
 	p := &agentProxy{
-		proxyTimeout: 5 * time.Second,
+		proxyTimeout: testTimeout5SecondProxy,
 	}
 
 	for {
-		listener, err := net.Listen("tcp", "127.0.0.1:0")
-		if err != nil {
-			t.Fatalf("expect no error, got %q", err)
-		}
+		listener, err := net.Listen(testNetworkTCP, testListenAddressProxy)
+		require.NoError(t, err, "expect no error creating listener")
 
 		address := listener.Addr().String()
 
-		if err := listener.Close(); err != nil {
-			t.Fatalf("expect no error, got %q", err)
-		}
+		require.NoError(t, listener.Close(), "expect no error closing listener")
 
 		listenerErrCh := make(chan error)
 		go func() {
 			defer close(listenerErrCh)
 
-			time.Sleep(250 * time.Millisecond)
+			time.Sleep(testTimeout250)
 
 			var err error
 			// Open the same port
-			listener, err = net.Listen("tcp", address)
+			listener, err = net.Listen(testNetworkTCP, address)
 			if err != nil {
 				listenerErrCh <- err
 			}
@@ -184,161 +176,157 @@ func TestDialerSuccess(t *testing.T) {
 		}
 
 		listener.Close()
-		if err != nil {
-			t.Fatalf("expect no error, got %q", err)
-		}
+		assert.NoError(t, err, "expect no error dialing")
 		break
 	}
 }
 
 func TestDialerFailure(t *testing.T) {
 	p := &agentProxy{
-		proxyTimeout: 5 * time.Second,
+		proxyTimeout: testTimeout5SecondProxy,
 	}
 
-	address := "0.0.0.0:0"
+	address := testInvalidAddress
 	conn, err := p.dial(context.Background(), address)
+	assert.ErrorContains(t, err, "failed to establish agent proxy connection")
 	if err == nil {
 		conn.Close()
-		t.Fatal("expect error, got nil")
-	}
-
-	if e, a := "failed to establish agent proxy connection", err.Error(); !strings.Contains(a, e) {
-		t.Fatalf("expect %q, got %q", e, a)
 	}
 }
 
-type agentMock struct{}
+// Test CAService method
+func TestCAService(t *testing.T) {
+	t.Run("CAService returns nil when not set", func(t *testing.T) {
+		proxy := NewAgentProxy(testServerNamePodVM, testSocketPathTest, "", nil, nil, 0)
+		p := proxy.(*agentProxy)
+		assert.Nil(t, p.CAService())
+	})
 
-func (m *agentMock) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
+	t.Run("CAService returns service when set", func(t *testing.T) {
+		mockCAService := &mockCAService{}
+		proxy := NewAgentProxy(testServerNamePodVM, testSocketPathTest, "", nil, mockCAService, 0)
+		p := proxy.(*agentProxy)
+		assert.Equal(t, mockCAService, p.CAService())
+	})
 }
-func (m *agentMock) StartContainer(ctx context.Context, req *pb.StartContainerRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
+
+// Test ClientCA method
+func TestClientCA(t *testing.T) {
+	t.Run("ClientCA returns nil when tlsConfig is nil", func(t *testing.T) {
+		proxy := NewAgentProxy(testServerNamePodVM, testSocketPathTest, "", nil, nil, 0)
+		p := proxy.(*agentProxy)
+		assert.Nil(t, p.ClientCA())
+	})
+
+	t.Run("ClientCA returns nil when CAFile is set", func(t *testing.T) {
+		tlsConfig := &tlsutil.TLSConfig{
+			CAFile: testCAFilePath,
+		}
+		proxy := NewAgentProxy(testServerNamePodVM, testSocketPathTest, "", tlsConfig, nil, 0)
+		p := proxy.(*agentProxy)
+		assert.Nil(t, p.ClientCA())
+	})
+
+	t.Run("ClientCA returns CertData when CAFile is empty", func(t *testing.T) {
+		certData := []byte(testCertData)
+		tlsConfig := &tlsutil.TLSConfig{
+			CertData: certData,
+		}
+		proxy := NewAgentProxy(testServerNamePodVM, testSocketPathTest, "", tlsConfig, nil, 0)
+		p := proxy.(*agentProxy)
+		result := p.ClientCA()
+		assert.Equal(t, string(certData), string(result))
+	})
 }
-func (m *agentMock) RemoveContainer(ctx context.Context, req *pb.RemoveContainerRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
+
+// Test Ready channel
+func TestReady(t *testing.T) {
+	proxy := NewAgentProxy(testServerNamePodVM, testSocketPathTest, "", nil, nil, 0)
+	readyCh := proxy.Ready()
+	assert.NotNil(t, readyCh)
 }
-func (m *agentMock) ExecProcess(ctx context.Context, req *pb.ExecProcessRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
+
+// Test multiple Shutdown calls
+func TestMultipleShutdown(t *testing.T) {
+	proxy := NewAgentProxy(testServerNamePodVM, testSocketPathTest, "", nil, nil, 0)
+	p := proxy.(*agentProxy)
+
+	// First shutdown
+	assert.NoError(t, p.Shutdown())
+
+	// Second shutdown should also succeed (stopOnce ensures it's safe)
+	assert.NoError(t, p.Shutdown())
 }
-func (m *agentMock) SignalProcess(ctx context.Context, req *pb.SignalProcessRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
+
+// Test Start with invalid socket path
+func TestStartInvalidSocketPath(t *testing.T) {
+	// Use a path that cannot be created
+	socketPath := testSocketPathInvalid
+	proxy := NewAgentProxy(testServerNamePodVM, socketPath, "", nil, nil, testTimeout5SecondProxy)
+
+	serverURL := &url.URL{
+		Scheme: testSchemeGRPC,
+		Host:   testUnreachablePort,
+	}
+
+	err := proxy.Start(context.Background(), serverURL)
+	assert.ErrorContains(t, err, "failed to create parent directories")
 }
-func (m *agentMock) WaitProcess(ctx context.Context, req *pb.WaitProcessRequest) (*pb.WaitProcessResponse, error) {
-	return &pb.WaitProcessResponse{}, nil
+
+// Test Start with connection failure
+func TestStartConnectionFailure(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, testSocketFileName)
+
+	proxy := NewAgentProxy(testServerNamePodVM, socketPath, "", nil, nil, testTimeout1Second)
+
+	// Use an address that will fail to connect
+	serverURL := &url.URL{
+		Scheme: testSchemeGRPC,
+		Host:   testUnreachableAddress, // Port 1 is typically not accessible
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout2Second)
+	defer cancel()
+
+	err := proxy.Start(ctx, serverURL)
+	assert.Error(t, err)
 }
-func (m *agentMock) UpdateContainer(ctx context.Context, req *pb.UpdateContainerRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
+
+// Test NewFactory
+func TestNewFactory(t *testing.T) {
+	t.Run("NewFactory with nil TLS config", func(t *testing.T) {
+		proxyFactory := NewFactory(testPauseImageLatest, nil, testTimeout5SecondProxy)
+		assert.NotNil(t, proxyFactory)
+
+		// Just verify it's not nil and can create proxies
+		proxy := proxyFactory.New(testServerName, testSocketPathTest)
+		assert.NotNil(t, proxy)
+	})
+
+	t.Run("Factory.New creates AgentProxy", func(t *testing.T) {
+		proxyFactory := NewFactory(testPauseImageLatest, nil, testTimeout5SecondProxy)
+		proxy := proxyFactory.New(testServerName, testSocketPathTest)
+
+		assert.NotNil(t, proxy)
+
+		p, ok := proxy.(*agentProxy)
+		assert.True(t, ok, "expected *agentProxy, got %T", proxy)
+
+		assert.Equal(t, testServerName, p.serverName)
+		assert.Equal(t, testSocketPathTest, p.socketPath)
+		assert.Equal(t, testPauseImageLatest, p.pauseImage)
+		assert.Equal(t, testTimeout5SecondProxy, p.proxyTimeout)
+	})
 }
-func (m *agentMock) UpdateEphemeralMounts(ctx context.Context, req *pb.UpdateEphemeralMountsRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
+
+// Mock types for testing
+type mockCAService struct{}
+
+func (m *mockCAService) RootCertificate() []byte {
+	return []byte(testMockRootCert)
 }
-func (m *agentMock) StatsContainer(ctx context.Context, req *pb.StatsContainerRequest) (*pb.StatsContainerResponse, error) {
-	return &pb.StatsContainerResponse{}, nil
-}
-func (m *agentMock) PauseContainer(ctx context.Context, req *pb.PauseContainerRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-func (m *agentMock) ResumeContainer(ctx context.Context, req *pb.ResumeContainerRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-func (m *agentMock) WriteStdin(ctx context.Context, req *pb.WriteStreamRequest) (*pb.WriteStreamResponse, error) {
-	return &pb.WriteStreamResponse{}, nil
-}
-func (m *agentMock) ReadStdout(ctx context.Context, req *pb.ReadStreamRequest) (*pb.ReadStreamResponse, error) {
-	return &pb.ReadStreamResponse{}, nil
-}
-func (m *agentMock) ReadStderr(ctx context.Context, req *pb.ReadStreamRequest) (*pb.ReadStreamResponse, error) {
-	return &pb.ReadStreamResponse{}, nil
-}
-func (m *agentMock) CloseStdin(ctx context.Context, req *pb.CloseStdinRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-func (m *agentMock) TtyWinResize(ctx context.Context, req *pb.TtyWinResizeRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-func (m *agentMock) UpdateInterface(ctx context.Context, req *pb.UpdateInterfaceRequest) (*protocols.Interface, error) {
-	return &protocols.Interface{}, nil
-}
-func (m *agentMock) UpdateRoutes(ctx context.Context, req *pb.UpdateRoutesRequest) (*pb.Routes, error) {
-	return &pb.Routes{}, nil
-}
-func (m *agentMock) ListInterfaces(ctx context.Context, req *pb.ListInterfacesRequest) (*pb.Interfaces, error) {
-	return &pb.Interfaces{}, nil
-}
-func (m *agentMock) ListRoutes(ctx context.Context, req *pb.ListRoutesRequest) (*pb.Routes, error) {
-	return &pb.Routes{}, nil
-}
-func (m *agentMock) AddARPNeighbors(ctx context.Context, req *pb.AddARPNeighborsRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-func (m *agentMock) GetIPTables(ctx context.Context, req *pb.GetIPTablesRequest) (*pb.GetIPTablesResponse, error) {
-	return &pb.GetIPTablesResponse{}, nil
-}
-func (m *agentMock) SetIPTables(ctx context.Context, req *pb.SetIPTablesRequest) (*pb.SetIPTablesResponse, error) {
-	return &pb.SetIPTablesResponse{}, nil
-}
-func (m *agentMock) GetMetrics(ctx context.Context, req *pb.GetMetricsRequest) (*pb.Metrics, error) {
-	return &pb.Metrics{}, nil
-}
-func (m *agentMock) CreateSandbox(ctx context.Context, req *pb.CreateSandboxRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-func (m *agentMock) DestroySandbox(ctx context.Context, req *pb.DestroySandboxRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-func (m *agentMock) OnlineCPUMem(ctx context.Context, req *pb.OnlineCPUMemRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-func (m *agentMock) ReseedRandomDev(ctx context.Context, req *pb.ReseedRandomDevRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-func (m *agentMock) GetGuestDetails(ctx context.Context, req *pb.GuestDetailsRequest) (*pb.GuestDetailsResponse, error) {
-	return &pb.GuestDetailsResponse{}, nil
-}
-func (m *agentMock) MemHotplugByProbe(ctx context.Context, req *pb.MemHotplugByProbeRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-func (m *agentMock) SetGuestDateTime(ctx context.Context, req *pb.SetGuestDateTimeRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-func (m *agentMock) CopyFile(ctx context.Context, req *pb.CopyFileRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-func (m *agentMock) GetOOMEvent(ctx context.Context, req *pb.GetOOMEventRequest) (*pb.OOMEvent, error) {
-	return &pb.OOMEvent{}, nil
-}
-func (m *agentMock) AddSwap(ctx context.Context, req *pb.AddSwapRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-func (m *agentMock) GetVolumeStats(ctx context.Context, req *pb.VolumeStatsRequest) (*pb.VolumeStatsResponse, error) {
-	return &pb.VolumeStatsResponse{}, nil
-}
-func (m *agentMock) ResizeVolume(ctx context.Context, req *pb.ResizeVolumeRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-func (m *agentMock) RemoveStaleVirtiofsShareMounts(ctx context.Context, req *pb.RemoveStaleVirtiofsShareMountsRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-func (m *agentMock) GetDiagnosticData(ctx context.Context, req *pb.GetDiagnosticDataRequest) (*pb.GetDiagnosticDataResponse, error) {
-	return &pb.GetDiagnosticDataResponse{}, nil
-}
-func (m *agentMock) Check(ctx context.Context, req *pb.CheckRequest) (*pb.HealthCheckResponse, error) {
-	return &pb.HealthCheckResponse{}, nil
-}
-func (m *agentMock) Version(ctx context.Context, req *pb.CheckRequest) (*pb.VersionCheckResponse, error) {
-	return &pb.VersionCheckResponse{}, nil
-}
-func (m *agentMock) SetPolicy(ctx context.Context, req *pb.SetPolicyRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-func (m *agentMock) AddSwapPath(ctx context.Context, req *pb.AddSwapPathRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-func (m *agentMock) MemAgentMemcgSet(ctx context.Context, req *pb.MemAgentMemcgConfig) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-func (m *agentMock) MemAgentCompactSet(ctx context.Context, req *pb.MemAgentCompactConfig) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
+
+func (m *mockCAService) Issue(name string) (certPEM, keyPEM []byte, err error) {
+	return []byte(testMockCert), []byte(testMockKey), nil
 }

--- a/src/cloud-api-adaptor/pkg/adaptor/proxy/service_test.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/proxy/service_test.go
@@ -4,18 +4,78 @@
 package proxy
 
 import (
+	"context"
 	b64 "encoding/base64"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/containerd/ttrpc"
+	pb "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols/grpc"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test constants
+const (
+	// Volume and path constants
+	testVolumePathCSI        = "/var/lib/kubelet/pods/abc/volumes/kubernetes.io~csi/pvc123/mount"
+	testVolumePathKubelet    = "/var/lib/kubelet"
+	testVolumePathInvalidCSI = "/var/lib/kubelet/kubernetes.io~csi/12345/mount"
+	testMountDestination     = "/data"
+	testMountType            = "bind"
+	testMountPointData       = "/mnt/data"
+	testMountPointImage      = "/mnt/image"
+	testMountPointShared     = "/mnt/shared"
+	testDeviceContainerPath  = "/dev/test"
+	testDeviceVMPath         = "/dev/vda"
+	testDeviceVMPathVdb      = "/dev/vdb"
+	testDeviceType           = "b"
+
+	// Container ID constants
+	testContainerID123    = "test-123"
+	testContainerID456    = "test-456"
+	testContainerID789    = "test-789"
+	testContainerIDDevice = "test-device"
+	testContainerIDGPU    = "test-gpu"
+	testContainerIDCSI    = "test-csi"
+	testContainerIDError  = "test-error"
+	testContainerIDCancel = "test-cancel"
+
+	// Sandbox ID constants
+	testSandboxID123 = "sandbox-123"
+	testSandboxID456 = "sandbox-456"
+
+	// Annotation constants
+	testAnnotationKey1     = "key1"
+	testAnnotationValue1   = "value1"
+	testAnnotationGPUKey   = "io.katacontainers.config.hypervisor.default_gpus"
+	testAnnotationGPUValue = "1"
+	testAnnotationCDIKey   = "cdi.k8s.io/peer-pods"
+	testAnnotationCDIValue = "nvidia.com/gpu=all"
+
+	// Storage and filesystem constants
+	testFstypeExt4              = "ext4"
+	testDriverBlk               = "blk"
+	testDriverImageGuestPull    = "image_guest_pull"
+	testStorageSourceImageLayer = "image-layer"
+
+	// Network and service constants
+	testListenAddr = "127.0.0.1:0"
+	testNetworkTCP = "tcp"
+	testPauseImage = "pause:3.9"
+	testHostname   = "test-host"
+	testPolicyData = "test-policy-data"
+
+	// File permission constant
+	testDirPermission = 0700
 )
 
 func TestIsNodePublishVolumeTargetPath(t *testing.T) {
-	volumePath := "/var/lib/kubelet/pods/abc/volumes/kubernetes.io~csi/pvc123/mount"
+	volumePath := testVolumePathCSI
 	directVolumesDir := t.TempDir()
 
 	t.Run("Empty direct-volumes dir", func(t *testing.T) {
@@ -24,31 +84,25 @@ func TestIsNodePublishVolumeTargetPath(t *testing.T) {
 
 	t.Run("Good path", func(t *testing.T) {
 		err := prepareVolumeDir(directVolumesDir, volumePath)
-		if err != nil {
-			t.Errorf("Failed to add volume dir: %v", err)
-		}
+		require.NoError(t, err, "Failed to add volume dir")
 
 		assert.True(t, isNodePublishVolumeTargetPath(volumePath, directVolumesDir))
 	})
 
 	t.Run("Not CSI path", func(t *testing.T) {
-		volumePath = "/var/lib/kubelet"
+		volumePath = testVolumePathKubelet
 
 		err := prepareVolumeDir(directVolumesDir, volumePath)
-		if err != nil {
-			t.Errorf("Failed to add volume dir: %v", err)
-		}
+		require.NoError(t, err, "Failed to add volume dir")
 
 		assert.False(t, isNodePublishVolumeTargetPath(volumePath, directVolumesDir))
 	})
 
 	t.Run("Not much volumes/kubernetes.io~csi", func(t *testing.T) {
-		volumePath = "/var/lib/kubelet/kubernetes.io~csi/12345/mount"
+		volumePath = testVolumePathInvalidCSI
 
 		err := prepareVolumeDir(directVolumesDir, volumePath)
-		if err != nil {
-			t.Errorf("Failed to add volume dir: %v", err)
-		}
+		require.NoError(t, err, "Failed to add volume dir")
 
 		assert.False(t, isNodePublishVolumeTargetPath(volumePath, directVolumesDir))
 	})
@@ -61,7 +115,7 @@ func prepareVolumeDir(directVolumesDir, volumePath string) error {
 		if !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
-		if err := os.MkdirAll(volumeDir, 0700); err != nil {
+		if err := os.MkdirAll(volumeDir, testDirPermission); err != nil {
 			return err
 		}
 	}
@@ -70,4 +124,354 @@ func prepareVolumeDir(directVolumesDir, volumePath string) error {
 	}
 
 	return nil
+}
+
+// Test newProxyService
+func TestNewProxyService(t *testing.T) {
+	dialer := func(ctx context.Context) (net.Conn, error) {
+		return nil, nil
+	}
+
+	service := newProxyService(dialer, testPauseImage)
+	assert.NotNil(t, service, "expected non-nil service")
+	assert.Equal(t, testPauseImage, service.pauseImage, "expected pause:3.9")
+}
+
+// createContainerRequestBuilder helps build CreateContainerRequest with fluent API
+type createContainerRequestBuilder struct {
+	req *pb.CreateContainerRequest
+}
+
+func newCreateContainerRequest(containerID string) *createContainerRequestBuilder {
+	return &createContainerRequestBuilder{
+		req: &pb.CreateContainerRequest{
+			ContainerId: containerID,
+			OCI: &pb.Spec{
+				Annotations: make(map[string]string),
+			},
+		},
+	}
+}
+
+func (b *createContainerRequestBuilder) withAnnotations(annotations map[string]string) *createContainerRequestBuilder {
+	for k, v := range annotations {
+		b.req.OCI.Annotations[k] = v
+	}
+	return b
+}
+
+func (b *createContainerRequestBuilder) withMounts(mounts ...*pb.Mount) *createContainerRequestBuilder {
+	b.req.OCI.Mounts = append(b.req.OCI.Mounts, mounts...)
+	return b
+}
+
+func (b *createContainerRequestBuilder) withStorages(storages ...*pb.Storage) *createContainerRequestBuilder {
+	b.req.Storages = append(b.req.Storages, storages...)
+	return b
+}
+
+func (b *createContainerRequestBuilder) withDevices(devices ...*pb.Device) *createContainerRequestBuilder {
+	b.req.Devices = append(b.req.Devices, devices...)
+	return b
+}
+
+func (b *createContainerRequestBuilder) build() *pb.CreateContainerRequest {
+	return b.req
+}
+
+// Test CreateContainer with various scenarios
+func TestProxyServiceCreateContainer(t *testing.T) {
+	dir := t.TempDir()
+
+	service, cleanup := setupMockAgentAndService(t)
+	defer cleanup()
+
+	tests := []struct {
+		name           string
+		setupFn        func(t *testing.T) (*proxyService, func())
+		buildRequest   func() *pb.CreateContainerRequest
+		getContext     func() context.Context
+		expectError    bool
+		validateResult func(t *testing.T, req *pb.CreateContainerRequest, err error)
+	}{
+		{
+			name: "CreateContainer with mounts and annotations",
+			buildRequest: func() *pb.CreateContainerRequest {
+				return newCreateContainerRequest(testContainerID123).
+					withAnnotations(map[string]string{testAnnotationKey1: testAnnotationValue1}).
+					withMounts(&pb.Mount{
+						Destination: testMountDestination,
+						Source:      testVolumePathCSI,
+						Type:        testMountType,
+					}).
+					build()
+			},
+			expectError: false,
+		},
+		{
+			name: "CreateContainer with storages",
+			buildRequest: func() *pb.CreateContainerRequest {
+				return newCreateContainerRequest(testContainerID456).
+					withStorages(&pb.Storage{
+						MountPoint: testMountPointData,
+						Source:     testDeviceVMPath,
+						Fstype:     testFstypeExt4,
+						Driver:     testDriverBlk,
+					}).
+					build()
+			},
+			expectError: false,
+		},
+		{
+			name: "CreateContainer with image_guest_pull driver",
+			buildRequest: func() *pb.CreateContainerRequest {
+				return newCreateContainerRequest(testContainerID789).
+					withStorages(&pb.Storage{
+						MountPoint: testMountPointImage,
+						Source:     testStorageSourceImageLayer,
+						Driver:     testDriverImageGuestPull,
+					}).
+					build()
+			},
+			expectError: false,
+		},
+		{
+			name: "CreateContainer with devices",
+			buildRequest: func() *pb.CreateContainerRequest {
+				return newCreateContainerRequest(testContainerIDDevice).
+					withDevices(&pb.Device{
+						ContainerPath: testDeviceContainerPath,
+						VmPath:        testDeviceVMPath,
+						Type:          testDeviceType,
+					}).
+					build()
+			},
+			expectError: false,
+		},
+		{
+			name: "CreateContainer with GPU annotation",
+			buildRequest: func() *pb.CreateContainerRequest {
+				return newCreateContainerRequest(testContainerIDGPU).
+					withAnnotations(map[string]string{testAnnotationGPUKey: testAnnotationGPUValue}).
+					build()
+			},
+			expectError: false,
+			validateResult: func(t *testing.T, req *pb.CreateContainerRequest, err error) {
+				// Verify CDI annotation was added
+				assert.Equal(t, testAnnotationCDIValue, req.OCI.Annotations[testAnnotationCDIKey], "expected CDI annotation to be set")
+			},
+		},
+		{
+			name: "CreateContainer with CSI volume mount",
+			buildRequest: func() *pb.CreateContainerRequest {
+				// Prepare volume directory
+				volumePath := testVolumePathCSI
+				err := prepareVolumeDir(dir, volumePath)
+				require.NoError(t, err, "failed to prepare volume dir")
+
+				return newCreateContainerRequest(testContainerIDCSI).
+					withMounts(&pb.Mount{
+						Destination: testMountDestination,
+						Source:      volumePath,
+						Type:        testMountType,
+					}).
+					build()
+			},
+			expectError: false,
+		},
+		{
+			name: "CreateContainer with agent error",
+			setupFn: func(t *testing.T) (*proxyService, func()) {
+				// Setup a separate mock agent that returns errors
+				errorAgentServer, err := ttrpc.NewServer()
+				require.NoError(t, err, "failed to create ttrpc server")
+
+				pb.RegisterAgentServiceService(errorAgentServer, &errorReturningMockAgent{})
+				pb.RegisterHealthService(errorAgentServer, &errorReturningMockAgent{})
+
+				errorAgentListener, err := net.Listen(testNetworkTCP, testListenAddr)
+				require.NoError(t, err, "failed to create listener")
+
+				go func() {
+					_ = errorAgentServer.Serve(context.Background(), errorAgentListener)
+				}()
+
+				errorDialer := func(ctx context.Context) (net.Conn, error) {
+					return net.Dial(testNetworkTCP, errorAgentListener.Addr().String())
+				}
+
+				errorService := newProxyService(errorDialer, "")
+				err = errorService.Connect(context.Background())
+				require.NoError(t, err, "failed to connect")
+
+				cleanup := func() {
+					errorService.Close()
+					_ = errorAgentServer.Shutdown(context.Background())
+					errorAgentListener.Close()
+				}
+
+				return errorService, cleanup
+			},
+			buildRequest: func() *pb.CreateContainerRequest {
+				return newCreateContainerRequest(testContainerIDError).build()
+			},
+			expectError: true,
+		},
+		{
+			name: "CreateContainer with context cancellation",
+			buildRequest: func() *pb.CreateContainerRequest {
+				return newCreateContainerRequest(testContainerIDCancel).build()
+			},
+			getContext: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel() // Cancel immediately
+				return ctx
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Use custom service setup if provided, otherwise use the shared service
+			testService := service
+			var testCleanup func()
+			if tt.setupFn != nil {
+				testService, testCleanup = tt.setupFn(t)
+				defer testCleanup()
+			}
+
+			// Build the request
+			req := tt.buildRequest()
+
+			// Get the context
+			ctx := context.Background()
+			if tt.getContext != nil {
+				ctx = tt.getContext()
+			}
+
+			// Execute the test
+			_, err := testService.CreateContainer(ctx, req)
+
+			// Validate the result
+			if tt.expectError {
+				assert.Error(t, err, "expected error")
+			} else {
+				assert.NoError(t, err, "CreateContainer failed")
+			}
+
+			// Run custom validation if provided
+			if tt.validateResult != nil {
+				tt.validateResult(t, req, err)
+			}
+		})
+	}
+}
+
+// Test simple proxy service methods with table-driven approach
+func TestProxyServiceSimpleMethods(t *testing.T) {
+	service, cleanup := setupMockAgentAndService(t)
+	defer cleanup()
+
+	tests := []struct {
+		name string
+		fn   func() error
+	}{
+		{
+			name: "SetPolicy",
+			fn: func() error {
+				req := &pb.SetPolicyRequest{
+					Policy: testPolicyData,
+				}
+				_, err := service.SetPolicy(context.Background(), req)
+				return err
+			},
+		},
+		{
+			name: "StartContainer",
+			fn: func() error {
+				req := &pb.StartContainerRequest{
+					ContainerId: testContainerID123,
+				}
+				_, err := service.StartContainer(context.Background(), req)
+				return err
+			},
+		},
+		{
+			name: "RemoveContainer",
+			fn: func() error {
+				req := &pb.RemoveContainerRequest{
+					ContainerId: testContainerID123,
+				}
+				_, err := service.RemoveContainer(context.Background(), req)
+				return err
+			},
+		},
+		{
+			name: "CreateSandbox basic",
+			fn: func() error {
+				req := &pb.CreateSandboxRequest{
+					Hostname:  testHostname,
+					SandboxId: testSandboxID123,
+				}
+				_, err := service.CreateSandbox(context.Background(), req)
+				return err
+			},
+		},
+		{
+			name: "CreateSandbox with storages",
+			fn: func() error {
+				req := &pb.CreateSandboxRequest{
+					Hostname:  testHostname,
+					SandboxId: testSandboxID456,
+					Storages: []*pb.Storage{
+						{
+							MountPoint: testMountPointShared,
+							Source:     testDeviceVMPathVdb,
+							Fstype:     testFstypeExt4,
+							Driver:     testDriverBlk,
+						},
+					},
+				}
+				_, err := service.CreateSandbox(context.Background(), req)
+				return err
+			},
+		},
+		{
+			name: "DestroySandbox",
+			fn: func() error {
+				req := &pb.DestroySandboxRequest{}
+				_, err := service.DestroySandbox(context.Background(), req)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NoError(t, tt.fn())
+		})
+	}
+}
+
+// setupMockAgentAndService is a helper that sets up a mock agent server and returns
+// a connected proxy service along with cleanup functions
+func setupMockAgentAndService(t *testing.T) (*proxyService, func()) {
+	agentServer, agentListener := setupMockAgent(t)
+
+	dialer := func(ctx context.Context) (net.Conn, error) {
+		return net.Dial(testNetworkTCP, agentListener.Addr().String())
+	}
+
+	service := newProxyService(dialer, "")
+	err := service.Connect(context.Background())
+	require.NoError(t, err)
+
+	cleanup := func() {
+		service.Close()
+		_ = agentServer.Shutdown(context.Background())
+		agentListener.Close()
+	}
+
+	return service, cleanup
 }


### PR DESCRIPTION
  Add comprehensive tests for proxy lifecycle, factory pattern,
  and service methods (CreateContainer, SetPolicy, StartContainer,
  RemoveContainer, CreateSandbox, DestroySandbox).
  Testcase coverage has been improved to 78%
  
New Test Coverage Report:
  
  ```
go test -v -cover -tags "aws,ibmcloud,libvirt,azure"
=== RUN   TestNewAgentProxy
--- PASS: TestNewAgentProxy (0.00s)
=== RUN   TestStartStop
2026/04/23 00:08:37 [adaptor/proxy] Listening on /tmp/TestStartStop2367205623/001/test.sock
2026/04/23 00:08:37 [adaptor/proxy] Trying to establish agent proxy connection to 127.0.0.1:37495
2026/04/23 00:08:37 [adaptor/proxy] established agent proxy connection to 127.0.0.1:37495
2026/04/23 00:08:37 [adaptor/proxy] CreateContainer: containerID:123
2026/04/23 00:08:37 [adaptor/proxy]     annotations:
2026/04/23 00:08:37 [adaptor/proxy]         aaa: 111
2026/04/23 00:08:37 [adaptor/proxy] Pulling image separately not support on main. It is required to use the nydus-snapshotter, which isn't configured properly here.
2026/04/23 00:08:37 [adaptor/proxy] shutting down socket forwarder
--- PASS: TestStartStop (0.01s)
=== RUN   TestDialerSuccess
2026/04/23 00:08:37 [adaptor/proxy] Trying to establish agent proxy connection to 127.0.0.1:34735
2026/04/23 00:08:37 [adaptor/proxy] Retrying failed agent proxy connection: dial tcp 127.0.0.1:34735: connect: connection refused
2026/04/23 00:08:37 [adaptor/proxy] Retrying failed agent proxy connection: dial tcp 127.0.0.1:34735: connect: connection refused
2026/04/23 00:08:37 [adaptor/proxy] established agent proxy connection to 127.0.0.1:34735
--- PASS: TestDialerSuccess (0.73s)
=== RUN   TestDialerFailure
2026/04/23 00:08:37 [adaptor/proxy] Trying to establish agent proxy connection to 0.0.0.0:0
2026/04/23 00:08:37 [adaptor/proxy] Retrying failed agent proxy connection: dial tcp 0.0.0.0:0: connect: connection refused
2026/04/23 00:08:38 [adaptor/proxy] Retrying failed agent proxy connection: dial tcp 0.0.0.0:0: connect: connection refused
2026/04/23 00:08:38 [adaptor/proxy] Retrying failed agent proxy connection: dial tcp 0.0.0.0:0: connect: connection refused
2026/04/23 00:08:39 [adaptor/proxy] Retrying failed agent proxy connection: dial tcp 0.0.0.0:0: connect: connection refused
2026/04/23 00:08:41 [adaptor/proxy] Retrying failed agent proxy connection: dial tcp 0.0.0.0:0: connect: connection refused
2026/04/23 00:08:42 [adaptor/proxy] failed to establish agent proxy connection to 0.0.0.0:0: context deadline exceeded
--- PASS: TestDialerFailure (5.00s)
=== RUN   TestCAService
=== RUN   TestCAService/CAService_returns_nil_when_not_set
=== RUN   TestCAService/CAService_returns_service_when_set
--- PASS: TestCAService (0.00s)
    --- PASS: TestCAService/CAService_returns_nil_when_not_set (0.00s)
    --- PASS: TestCAService/CAService_returns_service_when_set (0.00s)
=== RUN   TestClientCA
=== RUN   TestClientCA/ClientCA_returns_nil_when_tlsConfig_is_nil
=== RUN   TestClientCA/ClientCA_returns_nil_when_CAFile_is_set
=== RUN   TestClientCA/ClientCA_returns_CertData_when_CAFile_is_empty
--- PASS: TestClientCA (0.00s)
    --- PASS: TestClientCA/ClientCA_returns_nil_when_tlsConfig_is_nil (0.00s)
    --- PASS: TestClientCA/ClientCA_returns_nil_when_CAFile_is_set (0.00s)
    --- PASS: TestClientCA/ClientCA_returns_CertData_when_CAFile_is_empty (0.00s)
=== RUN   TestReady
--- PASS: TestReady (0.00s)
=== RUN   TestMultipleShutdown
2026/04/23 00:08:42 [adaptor/proxy] shutting down socket forwarder
2026/04/23 00:08:42 [adaptor/proxy] shutting down socket forwarder
--- PASS: TestMultipleShutdown (0.00s)
=== RUN   TestStartInvalidSocketPath
--- PASS: TestStartInvalidSocketPath (0.00s)
=== RUN   TestStartConnectionFailure
2026/04/23 00:08:42 [adaptor/proxy] Listening on /tmp/TestStartConnectionFailure2146745850/001/test.sock
2026/04/23 00:08:42 [adaptor/proxy] Trying to establish agent proxy connection to 127.0.0.1:1
2026/04/23 00:08:42 [adaptor/proxy] Retrying failed agent proxy connection: dial tcp 127.0.0.1:1: connect: connection refused
2026/04/23 00:08:43 [adaptor/proxy] Retrying failed agent proxy connection: dial tcp 127.0.0.1:1: connect: connection refused
2026/04/23 00:08:43 [adaptor/proxy] Retrying failed agent proxy connection: dial tcp 127.0.0.1:1: connect: connection refused
2026/04/23 00:08:43 [adaptor/proxy] failed to establish agent proxy connection to 127.0.0.1:1: context deadline exceeded
--- PASS: TestStartConnectionFailure (1.00s)
=== RUN   TestNewFactory
=== RUN   TestNewFactory/NewFactory_with_nil_TLS_config
=== RUN   TestNewFactory/Factory.New_creates_AgentProxy
--- PASS: TestNewFactory (0.00s)
    --- PASS: TestNewFactory/NewFactory_with_nil_TLS_config (0.00s)
    --- PASS: TestNewFactory/Factory.New_creates_AgentProxy (0.00s)
=== RUN   TestIsNodePublishVolumeTargetPath
=== RUN   TestIsNodePublishVolumeTargetPath/Empty_direct-volumes_dir
=== RUN   TestIsNodePublishVolumeTargetPath/Good_path
=== RUN   TestIsNodePublishVolumeTargetPath/Not_CSI_path
=== RUN   TestIsNodePublishVolumeTargetPath/Not_much_volumes/kubernetes.io~csi
--- PASS: TestIsNodePublishVolumeTargetPath (0.00s)
    --- PASS: TestIsNodePublishVolumeTargetPath/Empty_direct-volumes_dir (0.00s)
    --- PASS: TestIsNodePublishVolumeTargetPath/Good_path (0.00s)
    --- PASS: TestIsNodePublishVolumeTargetPath/Not_CSI_path (0.00s)
    --- PASS: TestIsNodePublishVolumeTargetPath/Not_much_volumes/kubernetes.io~csi (0.00s)
=== RUN   TestNewProxyService
--- PASS: TestNewProxyService (0.00s)
=== RUN   TestProxyServiceCreateContainer
=== RUN   TestProxyServiceCreateContainer/CreateContainer_with_mounts_and_annotations
2026/04/23 00:08:43 [adaptor/proxy] CreateContainer: containerID:test-123
2026/04/23 00:08:43 [adaptor/proxy]     mounts:
2026/04/23 00:08:43 [adaptor/proxy]         destination:/data source:/var/lib/kubelet/pods/abc/volumes/kubernetes.io~csi/pvc123/mount type:bind
2026/04/23 00:08:43 [adaptor/proxy]     annotations:
2026/04/23 00:08:43 [adaptor/proxy]         key1: value1
2026/04/23 00:08:43 [adaptor/proxy] Pulling image separately not support on main. It is required to use the nydus-snapshotter, which isn't configured properly here.
=== RUN   TestProxyServiceCreateContainer/CreateContainer_with_storages
2026/04/23 00:08:43 [adaptor/proxy] CreateContainer: containerID:test-456
2026/04/23 00:08:43 [adaptor/proxy]     storages:
2026/04/23 00:08:43 [adaptor/proxy]         mount_point:/mnt/data source:/dev/vda fstype:ext4 driver:blk
2026/04/23 00:08:43 [adaptor/proxy] Pulling image separately not support on main. It is required to use the nydus-snapshotter, which isn't configured properly here.
=== RUN   TestProxyServiceCreateContainer/CreateContainer_with_image_guest_pull_driver
2026/04/23 00:08:43 [adaptor/proxy] CreateContainer: containerID:test-789
2026/04/23 00:08:43 [adaptor/proxy]     storages:
2026/04/23 00:08:43 [adaptor/proxy]         mount_point:/mnt/image source:image-layer fstype: driver:image_guest_pull
=== RUN   TestProxyServiceCreateContainer/CreateContainer_with_devices
2026/04/23 00:08:43 [adaptor/proxy] CreateContainer: containerID:test-device
2026/04/23 00:08:43 [adaptor/proxy]     devices:
2026/04/23 00:08:43 [adaptor/proxy]         container_path:/dev/test vm_path:/dev/vda type:b
2026/04/23 00:08:43 [adaptor/proxy] Pulling image separately not support on main. It is required to use the nydus-snapshotter, which isn't configured properly here.
=== RUN   TestProxyServiceCreateContainer/CreateContainer_with_GPU_annotation
2026/04/23 00:08:43 [adaptor/proxy] CreateContainer: containerID:test-gpu
2026/04/23 00:08:43 [adaptor/proxy]     annotations:
2026/04/23 00:08:43 [adaptor/proxy]         io.katacontainers.config.hypervisor.default_gpus: 1
2026/04/23 00:08:43 [adaptor/proxy] adding CDI annotation cdi.k8s.io/peer-pods: nvidia.com/gpu=all
2026/04/23 00:08:43 [adaptor/proxy] Pulling image separately not support on main. It is required to use the nydus-snapshotter, which isn't configured properly here.
=== RUN   TestProxyServiceCreateContainer/CreateContainer_with_CSI_volume_mount
2026/04/23 00:08:43 [adaptor/proxy] CreateContainer: containerID:test-csi
2026/04/23 00:08:43 [adaptor/proxy]     mounts:
2026/04/23 00:08:43 [adaptor/proxy]         destination:/data source:/var/lib/kubelet/pods/abc/volumes/kubernetes.io~csi/pvc123/mount type:bind
2026/04/23 00:08:43 [adaptor/proxy] Pulling image separately not support on main. It is required to use the nydus-snapshotter, which isn't configured properly here.
--- PASS: TestProxyServiceCreateContainer (0.01s)
    --- PASS: TestProxyServiceCreateContainer/CreateContainer_with_mounts_and_annotations (0.00s)
    --- PASS: TestProxyServiceCreateContainer/CreateContainer_with_storages (0.00s)
    --- PASS: TestProxyServiceCreateContainer/CreateContainer_with_image_guest_pull_driver (0.00s)
    --- PASS: TestProxyServiceCreateContainer/CreateContainer_with_devices (0.00s)
    --- PASS: TestProxyServiceCreateContainer/CreateContainer_with_GPU_annotation (0.00s)
    --- PASS: TestProxyServiceCreateContainer/CreateContainer_with_CSI_volume_mount (0.00s)
=== RUN   TestProxyServiceSetPolicy
2026/04/23 00:08:43 [adaptor/proxy] SetPolicy: policy:test-policy-data
--- PASS: TestProxyServiceSetPolicy (0.00s)
=== RUN   TestProxyServiceStartContainer
2026/04/23 00:08:43 [adaptor/proxy] StartContainer: containerID:test-123
--- PASS: TestProxyServiceStartContainer (0.00s)
=== RUN   TestProxyServiceRemoveContainer
2026/04/23 00:08:43 [adaptor/proxy] RemoveContainer: containerID:test-123
--- PASS: TestProxyServiceRemoveContainer (0.00s)
=== RUN   TestProxyServiceCreateSandbox
=== RUN   TestProxyServiceCreateSandbox/CreateSandbox_basic
2026/04/23 00:08:43 [adaptor/proxy] CreateSandbox: hostname:test-host sandboxId:sandbox-123
=== RUN   TestProxyServiceCreateSandbox/CreateSandbox_with_storages
2026/04/23 00:08:43 [adaptor/proxy] CreateSandbox: hostname:test-host sandboxId:sandbox-456
2026/04/23 00:08:43 [adaptor/proxy]     storages:
2026/04/23 00:08:43 [adaptor/proxy]         mountpoint:/mnt/shared source:/dev/vdb fstype:ext4 driver:blk
--- PASS: TestProxyServiceCreateSandbox (0.00s)
    --- PASS: TestProxyServiceCreateSandbox/CreateSandbox_basic (0.00s)
    --- PASS: TestProxyServiceCreateSandbox/CreateSandbox_with_storages (0.00s)
=== RUN   TestProxyServiceDestroySandbox
2026/04/23 00:08:43 [adaptor/proxy] DestroySandbox
--- PASS: TestProxyServiceDestroySandbox (0.00s)
PASS
coverage: 78.0% of statements
ok  	github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/adaptor/proxy	6.781s
```