### PR TITLE
podvm: fix IMDS timeout counter

### DIFF
--- a/src/cloud-api-adaptor/podvm/files/usr/local/bin/setup-nat-for-imds.sh
+++ b/src/cloud-api-adaptor/podvm/files/usr/local/bin/setup-nat-for-imds.sh
@@ -56,7 +56,7 @@ while :; do
 		exit 1
 	fi
 	sleep 1
-	((counter++))
+	((++counter))
 done
 
 # Execute functions


### PR DESCRIPTION
The script runs with `set -e`, which causes the script to exit on first error. The line `((counter++))` causes Bash to evaluate the expression, which on first iteration returns `0`, which is regarded as an error, causing the script to exit with `1` prematurely.

Use the prefix `++` operator instead.

**Note:** The failing [lint / govulncheck (pull_request)](https://github.com/confidential-containers/cloud-api-adaptor/actions/runs/24968315133/job/73125344842?pr=3020) check is a red herring, at least as far as the change in this PR goes.

---

I've observed the following behavior on my Azure PodVMs with the Fedora (debug) image on CoCo v0.19.0:

<img width="1494" height="518" alt="image" src="https://github.com/user-attachments/assets/b91e42a3-9bfd-4abe-9ab5-e0d14c5ed929" />

Notice how the script exits one second after starting, indicating that it did not wait.

I did also try this:

```bash
#!/bin/bash
set -euo pipefail
counter=0
((counter++))
```

```
❯ ./test.sh

❯ echo $?
1
```

Whereas:

```bash
#!/bin/bash
set -euo pipefail
counter=0
((++counter))
```

```
❯ ./test.sh

❯ echo $?
0
```

So I figure this change should do the trick.

## Update

A coworker created a new image, and the script works well now:

<img width="2140" height="940" alt="image" src="https://github.com/user-attachments/assets/a6290ed7-be2d-4ab7-8935-adc30ace8716" />