### PR TITLE
peerpods/chart: expose podLabels and serviceAccount.annotations for both controllers

### DIFF
--- a/src/cloud-api-adaptor/install/charts/peerpods/templates/rbac.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/templates/rbac.yaml
@@ -5,6 +5,10 @@ kind: ServiceAccount
 metadata:
   name: cloud-api-adaptor
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.daemonset.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
@@ -112,6 +112,14 @@ daemonset:
   # - When setting via CLI, prefer --set-json or a values file (plain --set will interpret dots as map nesting)
   podLabels: {}
 
+  # ServiceAccount customization for the cloud-api-adaptor daemonset.
+  # For example, attach a cloud workload-identity binding via
+  # serviceAccount.annotations.azure\.workload\.identity/client-id (Azure
+  # Workload Identity), or the equivalent GCP / AWS annotation, so the
+  # daemonset can authenticate to the cloud provider.
+  serviceAccount:
+    annotations: {}
+
 # peerpod-ctrl subchart configuration
 # Manages lifecycle of peer pod cloud resources and cleans up dangling VMs
 # Configuration options documented in ../../../peerpod-ctrl/chart/values.yaml

--- a/src/peerpod-ctrl/chart/templates/deployment.yaml
+++ b/src/peerpod-ctrl/chart/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       affinity:
         nodeAffinity:

--- a/src/peerpod-ctrl/chart/templates/permissions.yaml
+++ b/src/peerpod-ctrl/chart/templates/permissions.yaml
@@ -7,6 +7,10 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: peerpodctrl
     app.kubernetes.io/part-of: peerpodctrl
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ .Values.namePrefix }}controller-manager
   namespace: {{ .Release.Namespace }}
 ---

--- a/src/peerpod-ctrl/chart/values.yaml
+++ b/src/peerpod-ctrl/chart/values.yaml
@@ -13,3 +13,17 @@ image:
 authProxy:
   enabled: true
   image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.14.0
+
+# Additional labels merged into the peerpod-ctrl controller-manager pod template.
+# For example, opt into webhook injection via
+# azure.workload.identity/use: "true" (Azure Workload Identity), or the
+# equivalent label for other clouds' workload-identity webhooks.
+podLabels: {}
+
+# ServiceAccount customization for the peerpod-ctrl controller-manager.
+# For example, attach a cloud workload-identity binding via
+# annotations.azure\.workload\.identity/client-id (Azure Workload Identity),
+# or the equivalent GCP / AWS annotation, so the controller can authenticate
+# to the cloud provider.
+serviceAccount:
+  annotations: {}


### PR DESCRIPTION
## Summary

Expose `podLabels` and `serviceAccount.annotations` (or daemonset equivalents) as configurable values for **both** controllers in the `peerpods` chart — the `peerpod-ctrl` subchart's deployment and the `cloud-api-adaptor` daemonset. This lets operators wire cloud workload-identity bindings (Azure WI, GCP WI, AWS IRSA, EKS Pod Identity, etc.) at install time without patching chart templates or running post-install `kubectl annotate` on either SA.

Per the discussion in #3021, where the maintainers OK'd the approach.

Fixes #3021

## Background

The chart's workload-identity story was previously asymmetric and incomplete:

- `daemonset.podLabels` was already exposed (with an Azure WI example in the values.yaml comment block) — daemonset *pod label* could be set.
- The `cloud-api-adaptor` daemonset SA had no `serviceAccountAnnotations` knob — the *SA annotation* half was not exposed.
- The `peerpod-ctrl` subchart exposed neither — *both halves* were unreachable.

So the chart could be partially wired for WI on the daemonset (with operators workarounding the SA half via `kubectl annotate` post-install), and not at all on `peerpod-ctrl`. Webhook injection for `peerpod-ctrl` therefore never happened, and reconciles failed every cycle with `no client ID specified`.

## Concrete impact

On Azure AKS, peer-pod cleanup needs both controllers authenticated:

- `cloud-api-adaptor` daemonset — primary VM-delete path. Today operators `kubectl annotate` the SA post-install to make WI work; this PR makes that step expressible through the helm install command instead.
- `peerpod-ctrl` deployment — backup path that reconciles stuck PeerPod CRs the daemonset missed. Could not be wired through the chart at all; this PR closes that gap.

In our cluster the half-broken state surfaced as 17 stuck PeerPod CRs across 5 namespaces (oldest from 2025-11-14), each holding the `peer.pod/finalizer` and corresponding to an Azure VM that consumed quota until manually cleaned up. After applying the diff this PR proposes (locally, as a chart patch) plus the matching federated credential on the managed identity, peerpod-ctrl auth'd successfully and the backlog drained to 0.

## Backwards compatibility

All four new value paths default to `{}`; existing installs see zero behavior change. Only operators who explicitly set `daemonset.serviceAccountAnnotations`, `resourceCtrl.serviceAccount.annotations`, or `resourceCtrl.podLabels` see the new templating render.

## Validation

`helm template` against the patched chart confirms: with overrides set, both SAs get the requested annotations and both pod templates get the requested labels; with no overrides, all four sites render cleanly (no empty `annotations:` block on either SA, no extra labels on either pod template).

End-to-end on a real AKS cluster: with the patched chart values set + matching federated credentials trusting both SAs on the managed identity, both controllers authenticate successfully and the existing backlog of stuck CRs drains without further intervention.

## Why this benefits more than just Azure

The same pattern is needed for every cloud's workload-identity mechanism:

| Cloud | SA annotation key | Pod label |
|---|---|---|
| Azure WI | `azure.workload.identity/client-id` | `azure.workload.identity/use: "true"` |
| GCP WI (GKE) | `iam.gke.io/gcp-service-account` | (uses different opt-in path) |
| AWS IRSA / EKS Pod Identity | `eks.amazonaws.com/role-arn` | (none required) |

Exposing generic `serviceAccountAnnotations` and `podLabels` on both controllers lets operators wire any of these without forking the chart.