### PR TITLE
Revert "workflows: disregard e2e_aws status"

### DIFF
--- a/.github/workflows/e2e_aws.yaml
+++ b/.github/workflows/e2e_aws.yaml
@@ -68,8 +68,6 @@ jobs:
     needs: aws-credentials
     if: needs.aws-credentials.outputs.has_secrets == 'true'
     runs-on: ubuntu-22.04
-    # TODO: AWS tests has failed for a while now, remove when we find a fix.
-    continue-on-error: true
     defaults:
       run:
         working-directory: src/cloud-api-adaptor


### PR DESCRIPTION
This reverts commit e12e726056db0aa18d4ed727fafd89c763c574b6.

CI is working again.

----

It was caused by a misconfiguration on the AWS account.