### PR TITLE
ci: refactor release.yaml to call podvm_publish.yaml

### DIFF
--- a/.github/workflows/podvm_publish.yaml
+++ b/.github/workflows/podvm_publish.yaml
@@ -12,6 +12,26 @@ on:
         required: false
         type: string
         default: ''
+  workflow_call:
+    inputs:
+      git_ref:
+        description: 'Git ref to build from'
+        required: false
+        type: string
+        default: ''
+      image_tag:
+        description: 'Image tag to use'
+        required: false
+        type: string
+        default: ''
+      registry:
+        description: 'Container registry to push images to (e.g., quay.io/your-username)'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      QUAY_PASSWORD:
+        required: true
 
 permissions: {}
 
@@ -19,8 +39,8 @@ jobs:
   podvm_builder:
     uses: ./.github/workflows/podvm_builder.yaml
     with:
-      git_ref: ${{ github.sha }}
-      image_tag: ${{ github.sha }}
+      git_ref: ${{ inputs.git_ref || github.sha }}
+      image_tag: ${{ inputs.image_tag || github.sha }}
       registry: ${{ inputs.registry != '' && inputs.registry || (github.repository == 'confidential-containers/cloud-api-adaptor' && 'quay.io/confidential-containers' || format('ghcr.io/{0}', github.repository_owner)) }}
     permissions:
       contents: read
@@ -32,8 +52,8 @@ jobs:
     needs: [podvm_builder]
     uses: ./.github/workflows/podvm_binaries.yaml
     with:
-      git_ref: ${{ github.sha }}
-      image_tag: ${{ github.sha }}
+      git_ref: ${{ inputs.git_ref || github.sha }}
+      image_tag: ${{ inputs.image_tag || github.sha }}
       registry: ${{ inputs.registry != '' && inputs.registry || (github.repository == 'confidential-containers/cloud-api-adaptor' && 'quay.io/confidential-containers' || format('ghcr.io/{0}', github.repository_owner)) }}
 
     permissions:
@@ -45,8 +65,8 @@ jobs:
     needs: [podvm_binaries]
     uses: ./.github/workflows/podvm.yaml
     with:
-      git_ref: ${{ github.sha }}
-      image_tag: ${{ github.sha }}
+      git_ref: ${{ inputs.git_ref || github.sha }}
+      image_tag: ${{ inputs.image_tag || github.sha }}
       registry: ${{ inputs.registry != '' && inputs.registry || (github.repository == 'confidential-containers/cloud-api-adaptor' && 'quay.io/confidential-containers' || format('ghcr.io/{0}', github.repository_owner)) }}
     permissions:
       contents: read
@@ -67,8 +87,8 @@ jobs:
       matrix:
         arch: [amd64, s390x, arm64]
     with:
-      git_ref: ${{ github.sha }}
-      image_tag: ${{ github.sha }}
+      git_ref: ${{ inputs.git_ref || github.sha }}
+      image_tag: ${{ inputs.image_tag || github.sha }}
       arch: ${{ matrix.arch}}
       debug: false
       registry: ${{ inputs.registry != '' && inputs.registry || (github.repository == 'confidential-containers/cloud-api-adaptor' && 'quay.io/confidential-containers' || format('ghcr.io/{0}', github.repository_owner)) }}
@@ -87,8 +107,8 @@ jobs:
       matrix:
         arch: [amd64, s390x, arm64]
     with:
-      git_ref: ${{ github.sha }}
-      image_tag: ${{ github.sha }}
+      git_ref: ${{ inputs.git_ref || github.sha }}
+      image_tag: ${{ inputs.image_tag || github.sha }}
       arch: ${{ matrix.arch}}
       debug: false
       registry: ${{ inputs.registry != '' && inputs.registry || (github.repository == 'confidential-containers/cloud-api-adaptor' && 'quay.io/confidential-containers' || format('ghcr.io/{0}', github.repository_owner)) }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,58 +45,17 @@ jobs:
     secrets:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 
-  podvm_builder:
-    uses: ./.github/workflows/podvm_builder.yaml
+  podvm-images:
+    uses: ./.github/workflows/podvm_publish.yaml
     with:
-      image_tag: ${{ github.event.release.tag_name }}
       git_ref: ${{ github.ref }}
-    permissions:
-      contents: read
-      packages: write
-    secrets:
-      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-
-  podvm_binaries:
-    needs: [podvm_builder]
-    uses: ./.github/workflows/podvm_binaries.yaml
-    with:
       image_tag: ${{ github.event.release.tag_name }}
-      git_ref: ${{ github.ref }}
     permissions:
-      contents: read
-      packages: write
-    secrets:
-      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-
-  podvm:
-    needs: [podvm_binaries]
-    uses: ./.github/workflows/podvm.yaml
-    with:
-      image_tag: ${{ github.event.release.tag_name }}
-      git_ref: ${{ github.ref }}
-    permissions:
-      contents: read
-      packages: write
-    secrets:
-      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-
-  podvm-mkosi:
-    uses: ./.github/workflows/podvm_mkosi.yaml
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-      artifact-metadata: write  # Required by podvm_mkosi.yaml to write attestation metadata
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [amd64, s390x, arm64]
-    with:
-      image_tag: ${{ github.event.release.tag_name }}
-      git_ref: ${{ github.ref }}
-      arch: ${{ matrix.arch}}
-      debug: false
+      contents: read           # Required for checkout
+      packages: write          # Required for pushing to GitHub Container Registry
+      id-token: write          # Required for attestation signing
+      attestations: write      # Required for persisting attestations
+      artifact-metadata: write # Required by podvm_mkosi.yaml to write attestation metadata
     secrets:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 


### PR DESCRIPTION
Eliminate duplication between release.yaml and podvm_publish.yaml by making podvm_publish.yaml reusable and calling it from release.yaml.

Changes:
- Add workflow_call trigger to podvm_publish.yaml with git_ref and image_tag inputs
- Update podvm_publish.yaml to use inputs with fallback to github.sha
- Replace 4 duplicate jobs in release.yaml (54 lines) with single call to podvm_publish.yaml (13 lines)
- Add comprehensive permission comments explaining each permission's purpose

Assisted-by: IBM Bob