### PR TITLE
ci: fix duplicated arch suffix in CAA image tags

### DIFF
--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -160,8 +160,8 @@ jobs:
       registry: ${{ inputs.registry }}
       dev_arches: 'linux/amd64'
       release_arches: 'linux/amd64'
-      dev_tags: ${{ inputs.caa_image_tag }}-dev-amd64
-      release_tags: ${{ inputs.caa_image_tag }}-amd64
+      dev_tags: ${{ inputs.caa_image_tag }}-dev
+      release_tags: ${{ inputs.caa_image_tag }}
       git_ref: ${{ inputs.git_ref }}
     permissions:
       contents: read
@@ -175,8 +175,8 @@ jobs:
       registry: ${{ inputs.registry }}
       dev_arches: 'linux/s390x'
       release_arches: 'linux/s390x'
-      dev_tags: ${{ inputs.caa_image_tag }}-dev-s390x
-      release_tags: ${{ inputs.caa_image_tag }}-s390x
+      dev_tags: ${{ inputs.caa_image_tag }}-dev
+      release_tags: ${{ inputs.caa_image_tag }}
       git_ref: ${{ inputs.git_ref }}
       runner: 'ubuntu-24.04-s390x'
     permissions:


### PR DESCRIPTION
The arch suffix (e.g. -amd64) was being appended twice: once explicitly in e2e_run_all.yaml tags and again by build.sh's get_tag_string() for single-arch builds. Remove the manual suffix and let build.sh handle it, consistent with caa_build_and_push_all_arches.yaml.

Assisted-by: Claude

----

If you have a look at latest nightly you gonna see caa images being publish with `-amd64-amd64` and `-s390x-s390x`. For example, in https://github.com/confidential-containers/cloud-api-adaptor/actions/runs/25035579037/job/73326396339 :

```
#28 exporting to image
  #28 exporting manifest sha256:37704149381c0bb0b0409ac6dccedf5eccaf3e3011739bc5336929d9b7f797be done
  #28 exporting config sha256:444d6622283ccb9a8c19409a5ad7076cb05e3bbe35cc27e2019286c954b7f8a7 done
  #28 pushing layers
  #28 pushing layers 1.9s done
  #28 pushing manifest for ghcr.io/confidential-containers/cloud-api-adaptor:latest-dev-amd64-amd64@sha256:37704149381c0bb0b0409ac6dccedf5eccaf3e3011739bc5336929d9b7f797be
  #28 pushing manifest for ghcr.io/confidential-containers/cloud-api-adaptor:latest-dev-amd64-amd64@sha256:37704149381c0bb0b0409ac6dccedf5eccaf3e3011739bc5336929d9b7f797be 0.5s done

```