### PR TITLE
PodVM: fix awk not found when running setup-nat-for-imds.sh

### DIFF
--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.presets/system/mkosi.conf.d/fedora.conf
@@ -25,6 +25,7 @@ Packages=
     fastfetch
     e2fsprogs
     cryptsetup
+    gawk
 
 RemoveFiles=/etc/issue
 RemoveFiles=/etc/issue.net


### PR DESCRIPTION
Hey guys, we've built Fedora images for CoCo v0.19.0 and found two issues
- One is with the script itself which was fixed #3020 
- The other one: `awk` can not be found

```
/usr/local/bin/setup-nat-for-imds.sh: line 18: awk: command not found
```

With both changes, the new image works well on Azure.
<img width="2140" height="940" alt="image" src="https://github.com/user-attachments/assets/3e12a419-56e4-43e7-9d4b-22244efe83db" />

