### PR TITLE
ci: add versions cli

### DIFF
--- a/.github/workflows/podvm_smoketest_ubuntu.yaml
+++ b/.github/workflows/podvm_smoketest_ubuntu.yaml
@@ -33,16 +33,15 @@ jobs:
           sudo apt-get install -y \
             genisoimage \
             qemu-utils
-          sudo snap install yq
 
       - name: Read properties from versions.yaml
         working-directory: src/cloud-api-adaptor
         run: |
           {
-            echo "MKOSI_VERSION=$(yq -e '.tools.mkosi' versions.yaml)";
-            echo "ORAS_VERSION=$(yq -e '.tools.oras' versions.yaml)";
-            echo "KATA_REF=$(yq -e '.oci.kata-containers.reference' versions.yaml)";
-            echo "KATA_REG=$(yq -e '.oci.kata-containers.registry' versions.yaml)";
+            echo "MKOSI_VERSION=$(./hack/versions.py -q tools.mkosi)";
+            echo "ORAS_VERSION=$(./hack/versions.py -q tools.oras)";
+            echo "KATA_REF=$(./hack/versions.py -q oci.kata-containers.reference)";
+            echo "KATA_REG=$(./hack/versions.py -q oci.kata-containers.registry)";
           } >> "$GITHUB_ENV"
 
       - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
@@ -101,19 +100,23 @@ jobs:
             qemu-utils\
             socat \
             virt-manager
-          sudo snap install yq
 
       - name: Read properties from versions.yaml
         working-directory: src/cloud-api-adaptor
         run: |
           {
-            echo "KATA_REF=$(yq -e '.oci.kata-agent-ctl.reference' versions.yaml)";
-            echo "KATA_REG=$(yq -e '.oci.kata-agent-ctl.registry' versions.yaml)";
+            echo "ORAS_VERSION=$(./hack/versions.py -q tools.oras)";
+            echo "KATA_AGENT_CTL_REF=$(./hack/versions.py -q oci.kata-agent-ctl.reference)";
+            echo "KATA_AGENT_CTL_REG=$(./hack/versions.py -q oci.kata-agent-ctl.registry)";
           } >> "$GITHUB_ENV"
+
+      - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+        with:
+          version: ${{ env.ORAS_VERSION }}
 
       - name: Install kata-agent-ctl
         run: |
-          oras pull "${KATA_REG}/agent-ctl:${KATA_REF}-x86_64"
+          oras pull "${KATA_AGENT_CTL_REG}/agent-ctl:${KATA_AGENT_CTL_REF}-x86_64"
           tar --zstd -xf kata-static-agent-ctl.tar.zst
           cp opt/kata/bin/kata-agent-ctl /usr/local/bin
 

--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -1,0 +1,47 @@
+# (C) Copyright Confidential Containers Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Validate src/cloud-api-adaptor/versions.yaml against the JSON schema
+# embedded in the `versions` CLI tool. Runs on PRs and main pushes that
+# touch the file, the schema, or the tool's source.
+---
+name: versions
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'src/cloud-api-adaptor/versions.yaml'
+      - 'src/cloud-api-adaptor/cmd/versions/**'
+      - 'src/cloud-api-adaptor/pkg/versions/**'
+      - '.github/workflows/versions.yaml'
+  pull_request:
+    paths:
+      - 'src/cloud-api-adaptor/versions.yaml'
+      - 'src/cloud-api-adaptor/cmd/versions/**'
+      - 'src/cloud-api-adaptor/pkg/versions/**'
+      - '.github/workflows/versions.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  validate:
+    name: validate versions.yaml
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout the pull request code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Validate versions.yaml against the embedded schema
+        working-directory: src/cloud-api-adaptor
+        run: make versions-check

--- a/src/cloud-api-adaptor/Makefile
+++ b/src/cloud-api-adaptor/Makefile
@@ -90,6 +90,10 @@ test: ## Run tests.
 	# parse build errors.
 	go test -v $(GOFLAGS) -cover $(PACKAGES) 2>&1
 
+.PHONY: versions-check
+versions-check: ## Validate versions.yaml against the JSON schema
+	./hack/versions.py -c versions.schema.json
+
 .PHONY: test-e2e
 test-e2e: ## Run end-to-end tests for single provider.
 ifneq ($(CLOUD_PROVIDER),)

--- a/src/cloud-api-adaptor/hack/versions.py
+++ b/src/cloud-api-adaptor/hack/versions.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Query and validate versions.yaml."""
+
+import argparse
+import json
+import sys
+
+import yaml
+
+
+def lookup(data, path):
+    cur = data
+    for key in path.split("."):
+        if not isinstance(cur, dict) or key not in cur:
+            sys.exit(f"error: '{path}' not found")
+        cur = cur[key]
+    if isinstance(cur, dict):
+        sys.exit(f"error: '{path}' is an object, not a scalar")
+    return cur
+
+
+def validate(data, schema_path):
+    import jsonschema
+
+    with open(schema_path) as f:
+        schema = json.load(f)
+    errors = list(jsonschema.Draft7Validator(schema).iter_errors(data))
+    if errors:
+        for e in errors:
+            print(f"  - {e.message}", file=sys.stderr)
+        sys.exit(1)
+    print("ok")
+
+
+def main():
+    p = argparse.ArgumentParser(description="Query and validate versions.yaml")
+    p.add_argument("-f", "--file", default="versions.yaml")
+    p.add_argument("-q", "--query", help="Dot path, e.g. tools.golang, oci.pause.tag")
+    p.add_argument(
+        "-c", "--check", metavar="SCHEMA", help="Validate against JSON schema"
+    )
+    args = p.parse_args()
+
+    with open(args.file) as f:
+        data = yaml.safe_load(f)
+
+    if args.check:
+        validate(data, args.check)
+    elif args.query:
+        print(lookup(data, args.query))
+    else:
+        p.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cloud-api-adaptor/versions.schema.json
+++ b/src/cloud-api-adaptor/versions.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "cloud-api-adaptor versions.yaml",
+  "description": "Schema for src/cloud-api-adaptor/versions.yaml",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["tools", "git", "oci"],
+  "properties": {
+    "cloudimg": {
+      "type": "object",
+      "description": "Sources for base cloud OS images, keyed by distribution then release.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/imageSource"
+          }
+        }
+      }
+    },
+    "tools": {
+      "type": "object",
+      "description": "External tool versions used by build and CI. Each entry is either a plain version string or an object with a version and a sha256 checksum.",
+      "additionalProperties": false,
+      "required": [
+        "cert-manager",
+        "bats",
+        "iptables-wrapper",
+        "golang",
+        "kcli",
+        "mkosi",
+        "protoc",
+        "packer",
+        "oras",
+        "helm"
+      ],
+      "properties": {
+        "cert-manager":     { "$ref": "#/$defs/tool" },
+        "bats":             { "$ref": "#/$defs/tool" },
+        "iptables-wrapper": { "$ref": "#/$defs/tool" },
+        "golang":           { "$ref": "#/$defs/tool" },
+        "kcli":             { "$ref": "#/$defs/tool" },
+        "mkosi":            { "$ref": "#/$defs/tool" },
+        "protoc":           { "$ref": "#/$defs/tool" },
+        "packer":           { "$ref": "#/$defs/tool" },
+        "oras":             { "$ref": "#/$defs/tool" },
+        "helm":             { "$ref": "#/$defs/tool" }
+      }
+    },
+    "git": {
+      "type": "object",
+      "description": "Git repositories referenced at build/run time.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["url", "reference"],
+        "properties": {
+          "url":       { "type": "string", "format": "uri" },
+          "reference": { "$ref": "#/$defs/nonEmptyString" }
+        }
+      }
+    },
+    "oci": {
+      "type": "object",
+      "description": "OCI artefacts pulled by tag or by reference.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["registry"],
+        "properties": {
+          "registry":  { "$ref": "#/$defs/nonEmptyString" },
+          "tag":       { "$ref": "#/$defs/nonEmptyString" },
+          "reference": { "$ref": "#/$defs/nonEmptyString" }
+        },
+        "oneOf": [
+          { "required": ["tag"] },
+          { "required": ["reference"] }
+        ]
+      }
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sha256Hex": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "tool": {
+      "oneOf": [
+        { "$ref": "#/$defs/nonEmptyString" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["version", "sha256"],
+          "properties": {
+            "version": { "$ref": "#/$defs/nonEmptyString" },
+            "sha256":  { "$ref": "#/$defs/sha256Hex" }
+          }
+        }
+      ]
+    },
+    "imageSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["url", "checksum"],
+      "properties": {
+        "url":      { "type": "string", "format": "uri" },
+        "checksum": {
+          "type": "string",
+          "description": "Algorithm-prefixed digest, e.g. sha256:<64 hex> or sha512:<128 hex>.",
+          "pattern": "^(sha256:[0-9a-f]{64}|sha512:[0-9a-f]{128})$"
+        }
+      }
+    }
+  }
+}

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -11,7 +11,7 @@ cloudimg:
         checksum: "sha256:367eef35e239ebd123bd00a1fb66cd048604b70bca362eccad1f95b0021d7458"
       arm64:
         url: https://cloud-images.ubuntu.com/releases/noble/release-20250115/ubuntu-24.04-server-cloudimg-arm64.img
-        checksum: "f11282a728ad42f8bfe0b646a6807674d79a019bfc229d80032345dd3228a2db"
+        checksum: "sha256:f11282a728ad42f8bfe0b646a6807674d79a019bfc229d80032345dd3228a2db"
   rhel:
     9: # dummy links, get trial image from: https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux/server/trial
       amd64:
@@ -56,7 +56,7 @@ git:
 oci:
   pause:
     registry: registry.k8s.io/pause
-    tag: 3.9
+    tag: "3.9"
   kata-containers:
     registry: ghcr.io/kata-containers/cached-artefacts
     reference: 8dccf4cf37aeea4b6c2caacf3e61510d6eef2f71 # v3.29.0


### PR DESCRIPTION
yq has been a constant source of problems in this repo, either because
we end up confusing v3 and v4 on runners, which do not share the same
syntax, or we have problems installing it via snap source.

the introduction of a project-local versions cli tool addresses this
issue, but also tightens and enforces a schema on the values that we put
into versions.yaml, currently we miss e.g. sha256 prefixes and use
floating point numbers as version strings.

```bash
$ ./versions -c
versions.yaml: ok
```

will check the schema, we can use this as part of CI. values can be
queried like this:

```
$ ./versions -o kata-containers -R
8dccf4cf37aeea4b6c2caacf3e61510d6eef2f71
$ ./versions --help
Query and validate versions.yaml

Usage:
  versions [flags]

Flags:
  -c, --check          Validate versions.yaml against the embedded JSON schema
  -f, --file string    Path to versions.yaml (default "versions.yaml")
  -h, --help           help for versions
  -o, --oci string     Select an oci.<name> entry (use with -r or -R)
  -R, --reference      With -o, print oci.<name>.reference
  -r, --registry       With -o, print oci.<name>.registry
  -t, --tool string    Select a tools.<name> entry (use -v/-d for object entries)
  -d, --tool-digest    With -t, print the tool's sha256 digest
  -v, --tool-version   With -t, print the tool's version
      --version        Print the version
```

The PR also adds a workflow to verify versions.yaml changes