### PR TITLE
Add cloud-native volume passthrough for Peer Pods

### DIFF
--- a/src/cloud-api-adaptor/install/charts/peerpods/templates/daemonset.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/templates/daemonset.yaml
@@ -85,9 +85,9 @@ spec:
         # - mountPath: /cloud-providers
         #   name: provider-dir
         # # setting for cloud provider external plugin
-{{- if eq .Values.provider "ibmcloud" }}
         - mountPath: /run/kata-containers/shared/direct-volumes
           name: kata-direct-volumes-dir
+{{- if eq .Values.provider "ibmcloud" }}
         - mountPath: /var/run/secrets/tokens
           name: vault-token
 {{- end }}
@@ -140,11 +140,11 @@ spec:
       #     type: Directory
       #   name: provider-dir
       # # setting for cloud provider external plugin
-{{- if eq .Values.provider "ibmcloud" }}
       - name: kata-direct-volumes-dir
         hostPath:
           path: /run/kata-containers/shared/direct-volumes
           type: DirectoryOrCreate
+{{- if eq .Values.provider "ibmcloud" }}
       - name: vault-token
         projected:
           sources:

--- a/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
@@ -193,6 +193,12 @@ func (s *cloudService) CreateVM(ctx context.Context, req *pb.CreateVMRequest) (r
 	// Get Pod VM image from annotations
 	image := util.GetImageFromAnnotation(req.Annotations)
 
+	// Get CSI volumes that need to be attached to the PodVM
+	csiVolumes := util.GetCSIVolumesForPod(req.Annotations)
+	if len(csiVolumes) > 0 {
+		logger.Printf("Found %d CSI volumes to attach to PodVM", len(csiVolumes))
+	}
+
 	netNSPath := req.NetworkNamespacePath
 
 	podNetworkConfig, err := s.workerNode.Inspect(netNSPath)
@@ -212,6 +218,7 @@ func (s *cloudService) CreateVM(ctx context.Context, req *pb.CreateVMRequest) (r
 		GPUs:         gpus,
 		Image:        image,
 		MultiNic:     podNetworkConfig.ExternalNetViaPodVM,
+		Volumes:      csiVolumes,
 	}
 
 	// TODO: server name is also generated in each cloud provider, and possibly inconsistent

--- a/src/cloud-api-adaptor/pkg/adaptor/proxy/cloud_volumes_test.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/proxy/cloud_volumes_test.go
@@ -1,0 +1,367 @@
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"context"
+	b64 "encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util"
+	pb "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols/grpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeTestMountInfo(t *testing.T, dir, volumePath string, info map[string]interface{}) {
+	t.Helper()
+	encoded := b64.URLEncoding.EncodeToString([]byte(volumePath))
+	volDir := filepath.Join(dir, encoded)
+	require.NoError(t, os.MkdirAll(volDir, 0o755))
+
+	data, err := json.Marshal(info)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(volDir, "mountInfo.json"), data, 0o644))
+}
+
+func overrideKataDirectVolumesDir(t *testing.T, dir string) {
+	t.Helper()
+	origDir := util.KataDirectVolumesDir
+	util.KataDirectVolumesDir = dir
+	t.Cleanup(func() { util.KataDirectVolumesDir = origDir })
+}
+
+func TestCloudVolumes_SingleVolumeAnnotation(t *testing.T) {
+	dir := t.TempDir()
+	overrideKataDirectVolumesDir(t, dir)
+
+	service, cleanup := setupMockAgentAndService(t)
+	defer cleanup()
+
+	podUID := "pod-uid-111"
+	volPath := "/var/lib/kubelet/pods/" + podUID + "/volumes/kubernetes.io~csi/pvc-test/mount"
+
+	writeTestMountInfo(t, dir, volPath, map[string]interface{}{
+		"device": "/subscriptions/sub/disks/csi-vol-pvc-test",
+		"fstype": "ext4",
+		"metadata": map[string]interface{}{
+			"cloud-volume-path": "/subscriptions/sub/disks/csi-vol-pvc-test",
+		},
+	})
+
+	req := newCreateContainerRequest("test-cloud-vol").
+		withAnnotations(map[string]string{
+			"io.kubernetes.cri.sandbox-uid": podUID,
+		}).
+		withMounts(&pb.Mount{
+			Destination: "/mnt/data",
+			Source:      volPath,
+			Type:        "bind",
+		}).
+		build()
+
+	_, err := service.CreateContainer(context.Background(), req)
+	require.NoError(t, err)
+
+	cvJSON, ok := req.OCI.Annotations["io.confidentialcontainers.org.cloud_volumes"]
+	require.True(t, ok, "cloud_volumes annotation should be set")
+
+	var cloudVolumes map[string]map[string]string
+	require.NoError(t, json.Unmarshal([]byte(cvJSON), &cloudVolumes))
+
+	require.Contains(t, cloudVolumes, "vol-0")
+	assert.Equal(t, "/mnt/data", cloudVolumes["vol-0"]["mount_point"])
+	assert.Equal(t, "ext4", cloudVolumes["vol-0"]["fs_type"])
+	assert.Equal(t, "0", cloudVolumes["vol-0"]["lun"])
+	assert.Equal(t, "/subscriptions/sub/disks/csi-vol-pvc-test", cloudVolumes["vol-0"]["disk_id"])
+}
+
+func TestCloudVolumes_MultipleVolumes(t *testing.T) {
+	dir := t.TempDir()
+	overrideKataDirectVolumesDir(t, dir)
+
+	service, cleanup := setupMockAgentAndService(t)
+	defer cleanup()
+
+	podUID := "pod-uid-222"
+	volPathA := "/var/lib/kubelet/pods/" + podUID + "/volumes/kubernetes.io~csi/pvc-alpha/mount"
+	volPathB := "/var/lib/kubelet/pods/" + podUID + "/volumes/kubernetes.io~csi/pvc-bravo/mount"
+
+	writeTestMountInfo(t, dir, volPathA, map[string]interface{}{
+		"device": "disk-alpha",
+		"fstype": "ext4",
+	})
+	writeTestMountInfo(t, dir, volPathB, map[string]interface{}{
+		"device": "disk-bravo",
+		"fstype": "xfs",
+	})
+
+	req := newCreateContainerRequest("test-multi-vol").
+		withAnnotations(map[string]string{
+			"io.kubernetes.cri.sandbox-uid": podUID,
+		}).
+		withMounts(
+			&pb.Mount{Destination: "/data/a", Source: volPathA, Type: "bind"},
+			&pb.Mount{Destination: "/data/b", Source: volPathB, Type: "bind"},
+		).
+		build()
+
+	_, err := service.CreateContainer(context.Background(), req)
+	require.NoError(t, err)
+
+	cvJSON := req.OCI.Annotations["io.confidentialcontainers.org.cloud_volumes"]
+	require.NotEmpty(t, cvJSON)
+
+	var cloudVolumes map[string]map[string]string
+	require.NoError(t, json.Unmarshal([]byte(cvJSON), &cloudVolumes))
+	assert.Len(t, cloudVolumes, 2)
+}
+
+func TestCloudVolumes_FsTypeFromMountInfo(t *testing.T) {
+	dir := t.TempDir()
+	overrideKataDirectVolumesDir(t, dir)
+
+	service, cleanup := setupMockAgentAndService(t)
+	defer cleanup()
+
+	podUID := "pod-uid-333"
+	volPath := "/var/lib/kubelet/pods/" + podUID + "/volumes/kubernetes.io~csi/pvc-xfs/mount"
+
+	writeTestMountInfo(t, dir, volPath, map[string]interface{}{
+		"device": "disk-xfs",
+		"fstype": "xfs",
+	})
+
+	req := newCreateContainerRequest("test-fstype").
+		withAnnotations(map[string]string{
+			"io.kubernetes.cri.sandbox-uid": podUID,
+		}).
+		withMounts(&pb.Mount{
+			Destination: "/mnt/xfs",
+			Source:      volPath,
+			Type:        "bind",
+		}).
+		build()
+
+	_, err := service.CreateContainer(context.Background(), req)
+	require.NoError(t, err)
+
+	var cloudVolumes map[string]map[string]string
+	require.NoError(t, json.Unmarshal([]byte(req.OCI.Annotations["io.confidentialcontainers.org.cloud_volumes"]), &cloudVolumes))
+	assert.Equal(t, "xfs", cloudVolumes["vol-0"]["fs_type"])
+}
+
+func TestCloudVolumes_FsTypeFallsBackToExt4(t *testing.T) {
+	dir := t.TempDir()
+	overrideKataDirectVolumesDir(t, dir)
+
+	service, cleanup := setupMockAgentAndService(t)
+	defer cleanup()
+
+	podUID := "pod-uid-444"
+	volPath := "/var/lib/kubelet/pods/" + podUID + "/volumes/kubernetes.io~csi/pvc-nofs/mount"
+
+	writeTestMountInfo(t, dir, volPath, map[string]interface{}{
+		"device": "disk-nofs",
+	})
+
+	req := newCreateContainerRequest("test-fstype-default").
+		withAnnotations(map[string]string{
+			"io.kubernetes.cri.sandbox-uid": podUID,
+		}).
+		withMounts(&pb.Mount{
+			Destination: "/mnt/default",
+			Source:      volPath,
+			Type:        "bind",
+		}).
+		build()
+
+	_, err := service.CreateContainer(context.Background(), req)
+	require.NoError(t, err)
+
+	var cloudVolumes map[string]map[string]string
+	require.NoError(t, json.Unmarshal([]byte(req.OCI.Annotations["io.confidentialcontainers.org.cloud_volumes"]), &cloudVolumes))
+	assert.Equal(t, "ext4", cloudVolumes["vol-0"]["fs_type"])
+}
+
+func TestCloudVolumes_NoAnnotationWhenNoCSIVolumes(t *testing.T) {
+	dir := t.TempDir()
+	overrideKataDirectVolumesDir(t, dir)
+
+	service, cleanup := setupMockAgentAndService(t)
+	defer cleanup()
+
+	req := newCreateContainerRequest("test-no-vol").
+		withMounts(&pb.Mount{
+			Destination: "/mnt/regular",
+			Source:      "/some/regular/path",
+			Type:        "bind",
+		}).
+		build()
+
+	_, err := service.CreateContainer(context.Background(), req)
+	require.NoError(t, err)
+
+	_, ok := req.OCI.Annotations["io.confidentialcontainers.org.cloud_volumes"]
+	assert.False(t, ok, "cloud_volumes annotation should not be set for non-CSI volumes")
+}
+
+func TestCloudVolumes_SkipsVolumesFromOtherPods(t *testing.T) {
+	dir := t.TempDir()
+	overrideKataDirectVolumesDir(t, dir)
+
+	service, cleanup := setupMockAgentAndService(t)
+	defer cleanup()
+
+	writeTestMountInfo(t, dir,
+		"/var/lib/kubelet/pods/other-pod-uid/volumes/kubernetes.io~csi/pvc-other/mount",
+		map[string]interface{}{"device": "other-disk", "fstype": "ext4"})
+
+	req := newCreateContainerRequest("test-other-pod").
+		withAnnotations(map[string]string{
+			"io.kubernetes.cri.sandbox-uid": "my-pod-uid",
+		}).
+		build()
+
+	_, err := service.CreateContainer(context.Background(), req)
+	require.NoError(t, err)
+
+	_, ok := req.OCI.Annotations["io.confidentialcontainers.org.cloud_volumes"]
+	assert.False(t, ok, "should not include volumes from other pods")
+}
+
+func TestCloudVolumes_LUNIndexSkippedVolumeConsistency(t *testing.T) {
+	dir := t.TempDir()
+	overrideKataDirectVolumesDir(t, dir)
+
+	service, cleanup := setupMockAgentAndService(t)
+	defer cleanup()
+
+	podUID := "pod-uid-555"
+
+	// vol-a has matching OCI mount
+	volPathA := "/var/lib/kubelet/pods/" + podUID + "/volumes/kubernetes.io~csi/pvc-alpha/mount"
+	writeTestMountInfo(t, dir, volPathA, map[string]interface{}{
+		"device": "disk-alpha", "fstype": "ext4",
+	})
+
+	// vol-b has NO matching OCI mount (will be skipped in annotation but still counted)
+	volPathB := "/var/lib/kubelet/pods/" + podUID + "/volumes/kubernetes.io~csi/pvc-bravo/mount"
+	writeTestMountInfo(t, dir, volPathB, map[string]interface{}{
+		"device": "disk-bravo", "fstype": "ext4",
+	})
+
+	// vol-c has matching OCI mount
+	volPathC := "/var/lib/kubelet/pods/" + podUID + "/volumes/kubernetes.io~csi/pvc-charlie/mount"
+	writeTestMountInfo(t, dir, volPathC, map[string]interface{}{
+		"device": "disk-charlie", "fstype": "ext4",
+	})
+
+	req := newCreateContainerRequest("test-lun-skip").
+		withAnnotations(map[string]string{
+			"io.kubernetes.cri.sandbox-uid": podUID,
+		}).
+		withMounts(
+			&pb.Mount{Destination: "/data/a", Source: volPathA, Type: "bind"},
+			// No mount for volPathB
+			&pb.Mount{Destination: "/data/c", Source: volPathC, Type: "bind"},
+		).
+		build()
+
+	_, err := service.CreateContainer(context.Background(), req)
+	require.NoError(t, err)
+
+	cvJSON := req.OCI.Annotations["io.confidentialcontainers.org.cloud_volumes"]
+	require.NotEmpty(t, cvJSON)
+
+	var cloudVolumes map[string]map[string]string
+	require.NoError(t, json.Unmarshal([]byte(cvJSON), &cloudVolumes))
+
+	// Should only have 2 entries (vol-b is skipped because no OCI mount)
+	assert.Len(t, cloudVolumes, 2)
+
+	// Collect LUN values
+	luns := make(map[string]string)
+	for _, vol := range cloudVolumes {
+		luns[vol["lun"]] = vol["disk_id"]
+	}
+
+	// vol-a should get LUN 0 (canonical index 0)
+	// vol-b gets canonical index 1 (skipped in annotation but index still incremented)
+	// vol-c should get LUN 2 (canonical index 2)
+	assert.Contains(t, luns, "0", "vol-a should be at LUN 0")
+	assert.Contains(t, luns, "2", "vol-c should be at LUN 2, not LUN 1")
+	assert.NotContains(t, luns, "1", "LUN 1 should be skipped (vol-b had no OCI mount)")
+
+	assert.Equal(t, "disk-alpha", luns["0"])
+	assert.Equal(t, "disk-charlie", luns["2"])
+}
+
+func TestCloudVolumes_SkipsVolumeWithNoDiskID(t *testing.T) {
+	dir := t.TempDir()
+	overrideKataDirectVolumesDir(t, dir)
+
+	service, cleanup := setupMockAgentAndService(t)
+	defer cleanup()
+
+	podUID := "pod-uid-666"
+	volPath := "/var/lib/kubelet/pods/" + podUID + "/volumes/kubernetes.io~csi/pvc-nodisk/mount"
+
+	writeTestMountInfo(t, dir, volPath, map[string]interface{}{
+		"fstype": "ext4",
+	})
+
+	req := newCreateContainerRequest("test-no-disk").
+		withAnnotations(map[string]string{
+			"io.kubernetes.cri.sandbox-uid": podUID,
+		}).
+		withMounts(&pb.Mount{
+			Destination: "/mnt/nodisk",
+			Source:      volPath,
+			Type:        "bind",
+		}).
+		build()
+
+	_, err := service.CreateContainer(context.Background(), req)
+	require.NoError(t, err)
+
+	_, ok := req.OCI.Annotations["io.confidentialcontainers.org.cloud_volumes"]
+	assert.False(t, ok, "annotation should not be set when volume has no disk ID")
+}
+
+func TestCloudVolumes_SkipsInvalidMountInfoJSON(t *testing.T) {
+	dir := t.TempDir()
+	overrideKataDirectVolumesDir(t, dir)
+
+	service, cleanup := setupMockAgentAndService(t)
+	defer cleanup()
+
+	podUID := "pod-uid-777"
+	volPath := "/var/lib/kubelet/pods/" + podUID + "/volumes/kubernetes.io~csi/pvc-badjson/mount"
+
+	encoded := b64.URLEncoding.EncodeToString([]byte(volPath))
+	volDir := filepath.Join(dir, encoded)
+	require.NoError(t, os.MkdirAll(volDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(volDir, "mountInfo.json"), []byte("not json"), 0o644))
+
+	req := newCreateContainerRequest("test-bad-json").
+		withAnnotations(map[string]string{
+			"io.kubernetes.cri.sandbox-uid": podUID,
+		}).
+		withMounts(&pb.Mount{
+			Destination: "/mnt/badjson",
+			Source:      volPath,
+			Type:        "bind",
+		}).
+		build()
+
+	_, err := service.CreateContainer(context.Background(), req)
+	require.NoError(t, err)
+
+	_, ok := req.OCI.Annotations["io.confidentialcontainers.org.cloud_volumes"]
+	assert.False(t, ok, "annotation should not be set with invalid JSON")
+}

--- a/src/cloud-api-adaptor/pkg/adaptor/proxy/service.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/proxy/service.go
@@ -6,11 +6,14 @@ package proxy
 import (
 	"context"
 	b64 "encoding/base64"
+	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/agentproto"
 	pb "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -22,14 +25,12 @@ type proxyService struct {
 }
 
 const (
-	defaultPauseImage            = "registry.k8s.io/pause:3.7"
-	kataDirectVolumesDir         = "/run/kata-containers/shared/direct-volumes"
-	volumeTargetPathKey          = "io.confidentialcontainers.org.peerpodvolumes.target_path"
-	csiPluginEscapeQualifiedName = "kubernetes.io~csi"
-	imageGuestPull               = "image_guest_pull"
-	cdiAnnotationKey             = "cdi.k8s.io/peer-pods"
-	defaultCDIType               = "nvidia.com/gpu=all"
-	defaultGPUsAnnotation        = "io.katacontainers.config.hypervisor.default_gpus"
+	defaultPauseImage     = "registry.k8s.io/pause:3.7"
+	volumeTargetPathKey   = "io.confidentialcontainers.org.peerpodvolumes.target_path"
+	imageGuestPull        = "image_guest_pull"
+	cdiAnnotationKey      = "cdi.k8s.io/peer-pods"
+	defaultCDIType        = "nvidia.com/gpu=all"
+	defaultGPUsAnnotation = "io.katacontainers.config.hypervisor.default_gpus"
 )
 
 func newProxyService(dialer func(context.Context) (net.Conn, error), pauseImage string) *proxyService {
@@ -47,12 +48,16 @@ func newProxyService(dialer func(context.Context) (net.Conn, error), pauseImage 
 func (s *proxyService) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (*emptypb.Empty, error) {
 	var pullImageInGuest bool
 	logger.Printf("CreateContainer: containerID:%s", req.ContainerId)
+	if req.OCI.Annotations == nil {
+		req.OCI.Annotations = make(map[string]string)
+	}
+
 	if len(req.OCI.Mounts) > 0 {
 		logger.Print("    mounts:")
 		for i, m := range req.OCI.Mounts {
 			logger.Printf("        destination:%s source:%s type:%s", m.Destination, m.Source, m.Type)
 
-			if isNodePublishVolumeTargetPath(m.Source, kataDirectVolumesDir) {
+			if isNodePublishVolumeTargetPath(m.Source, util.KataDirectVolumesDir) {
 				if i > 0 {
 					req.OCI.Annotations[volumeTargetPathKey] += ","
 				}
@@ -94,6 +99,101 @@ func (s *proxyService) CreateContainer(ctx context.Context, req *pb.CreateContai
 		logger.Printf("Pulling image separately not support on main. It is required to use the nydus-snapshotter, which isn't configured properly here.")
 	}
 
+	// Detect cloud volumes by scanning the direct-volumes directory in canonical
+	// order. The scan order matches GetCSIVolumesForPod (os.ReadDir sorts by
+	// name), so the LUN index here is consistent with the cloud provider's
+	// disk attachment order.
+	cloudVolumes := make(map[string]util.CloudVolumeAnnotation)
+	podUID := req.OCI.Annotations["io.kubernetes.cri.sandbox-uid"]
+
+	dirEntries, dirErr := os.ReadDir(util.KataDirectVolumesDir)
+	if dirErr == nil {
+		canonicalIdx := 0
+		for _, entry := range dirEntries {
+			if !entry.IsDir() {
+				continue
+			}
+			decodedBytes, err := b64.URLEncoding.DecodeString(entry.Name())
+			if err != nil {
+				continue
+			}
+			decodedPath := string(decodedBytes)
+
+			if !strings.Contains(decodedPath, "/volumes/"+util.CSIPluginEscapeQualifiedName+"/") {
+				continue
+			}
+			if podUID != "" && !strings.Contains(decodedPath, "/pods/"+podUID+"/") {
+				continue
+			}
+
+			mountInfoPath := filepath.Join(util.KataDirectVolumesDir, entry.Name(), "mountInfo.json")
+			data, err := os.ReadFile(mountInfoPath)
+			if err != nil {
+				logger.Printf("could not read mountInfo.json for %s: %v", decodedPath, err)
+				continue
+			}
+			var mountInfo map[string]interface{}
+			if err := json.Unmarshal(data, &mountInfo); err != nil {
+				logger.Printf("could not parse mountInfo.json for %s: %v", decodedPath, err)
+				continue
+			}
+
+			diskID := ""
+			if md, ok := mountInfo["metadata"].(map[string]interface{}); ok {
+				if cp, ok := md["cloud-volume-path"].(string); ok && cp != "" {
+					diskID = cp
+				}
+			}
+			if diskID == "" {
+				if d, ok := mountInfo["device"].(string); ok {
+					diskID = d
+				}
+			}
+			if diskID == "" {
+				logger.Printf("cloud volume at %s has no disk ID, skipping", decodedPath)
+				continue
+			}
+
+			fsType := "ext4"
+			if ft, ok := mountInfo["fstype"].(string); ok && ft != "" {
+				fsType = ft
+			}
+
+			mountDest := ""
+			for _, m := range req.OCI.Mounts {
+				if m.Source == decodedPath {
+					mountDest = m.Destination
+					break
+				}
+			}
+			if mountDest == "" {
+				logger.Printf("cloud volume disk %s has no matching mount in container spec, skipping", diskID)
+				canonicalIdx++
+				continue
+			}
+
+			volKey := fmt.Sprintf("vol-%d", canonicalIdx)
+			cloudVolumes[volKey] = util.CloudVolumeAnnotation{
+				MountPoint: mountDest,
+				FSType:     fsType,
+				LUN:        fmt.Sprintf("%d", canonicalIdx),
+				DiskID:     diskID,
+			}
+			logger.Printf("Detected cloud volume %s -> %s (lun=%d, disk=%s, fs=%s)", volKey, mountDest, canonicalIdx, diskID, fsType)
+			canonicalIdx++
+		}
+	}
+
+	if len(cloudVolumes) > 0 {
+		cvJSON, err := json.Marshal(cloudVolumes)
+		if err != nil {
+			logger.Printf("failed to marshal cloud_volumes annotation: %v", err)
+		} else {
+			req.OCI.Annotations[util.CloudVolumesAnnotationKey] = string(cvJSON)
+			logger.Printf("Set cloud_volumes annotation: %s", string(cvJSON))
+		}
+	}
+
 	res, err := s.Redirector.CreateContainer(ctx, req)
 
 	if err != nil {
@@ -104,7 +204,7 @@ func (s *proxyService) CreateContainer(ctx context.Context, req *pb.CreateContai
 }
 
 func isNodePublishVolumeTargetPath(volumePath, directVolumesDir string) bool {
-	if !strings.Contains(filepath.Clean(volumePath), "/volumes/"+csiPluginEscapeQualifiedName+"/") {
+	if !strings.Contains(filepath.Clean(volumePath), "/volumes/"+util.CSIPluginEscapeQualifiedName+"/") {
 		return false
 	}
 

--- a/src/cloud-api-adaptor/pkg/forwarder/interceptor/interceptor.go
+++ b/src/cloud-api-adaptor/pkg/forwarder/interceptor/interceptor.go
@@ -5,11 +5,17 @@ package interceptor
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	retry "github.com/avast/retry-go/v4"
@@ -18,14 +24,22 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/agentproto"
 )
 
 const (
-	volumeTargetPathKey = "io.confidentialcontainers.org.peerpodvolumes.target_path"
-	volumeCheckInterval = 5 * time.Second
-	volumeCheckTimeout  = 3 * time.Minute
+	volumeTargetPathKey  = "io.confidentialcontainers.org.peerpodvolumes.target_path"
+	cloudVolumeMountBase = "/run/cloud-volumes"
+	volumeCheckInterval  = 5 * time.Second
+	volumeCheckTimeout   = 3 * time.Minute
 )
+
+var allowedFSTypes = map[string]bool{
+	"ext4": true,
+	"ext3": true,
+	"xfs":  true,
+}
 
 var logger = log.New(log.Writer(), "[forwarder/interceptor] ", log.LstdFlags|log.Lmsgprefix)
 
@@ -36,7 +50,22 @@ type Interceptor interface {
 type interceptor struct {
 	agentproto.Redirector
 
-	nsPath string
+	nsPath          string
+	cloudMountPaths []string
+}
+
+// unmountCloudVolumes unmounts all cloud volume mount points in reverse order.
+// Called during DestroySandbox to clean up before the PodVM is terminated.
+func (i *interceptor) unmountCloudVolumes() {
+	for idx := len(i.cloudMountPaths) - 1; idx >= 0; idx-- {
+		mp := i.cloudMountPaths[idx]
+		if err := syscall.Unmount(mp, 0); err != nil {
+			logger.Printf("WARNING: failed to unmount cloud volume %s: %v", mp, err)
+		} else {
+			logger.Printf("Unmounted cloud volume %s", mp)
+		}
+	}
+	i.cloudMountPaths = nil
 }
 
 func dial(ctx context.Context, agentSocket string) (net.Conn, error) {
@@ -93,6 +122,95 @@ func (i *interceptor) CreateContainer(ctx context.Context, req *pb.CreateContain
 	logger.Printf("    namespaces:")
 	for _, ns := range req.OCI.Linux.Namespaces {
 		logger.Printf("    %s: %q", ns.Type, ns.Path)
+	}
+
+	// Handle cloud volumes: detect device, format if needed, mount, and
+	// bind-mount into the container's mount namespace.
+	if cvJSON, ok := req.OCI.Annotations[util.CloudVolumesAnnotationKey]; ok && cvJSON != "" {
+		var cloudVolumes map[string]util.CloudVolumeAnnotation
+		if err := json.Unmarshal([]byte(cvJSON), &cloudVolumes); err != nil {
+			return nil, fmt.Errorf("corrupt cloud_volumes annotation (pod would start without volumes): %w", err)
+		}
+
+		volNames := make([]string, 0, len(cloudVolumes))
+		for k := range cloudVolumes {
+			volNames = append(volNames, k)
+		}
+		sort.Strings(volNames)
+
+		for _, volName := range volNames {
+			volInfo := cloudVolumes[volName]
+			mountPoint := volInfo.MountPoint
+			fsType := volInfo.FSType
+			lunStr := volInfo.LUN
+			if mountPoint == "" || lunStr == "" {
+				return nil, fmt.Errorf("cloud volume %s missing required mount_point or lun field", volName)
+			}
+
+			safeName := filepath.Base(volName)
+			if safeName != volName || safeName == "." || safeName == ".." {
+				return nil, fmt.Errorf("cloud volume %q has unsafe name", volName)
+			}
+
+			if fsType == "" {
+				fsType = "ext4"
+			}
+			if !allowedFSTypes[fsType] {
+				return nil, fmt.Errorf("cloud volume %s requests unsupported filesystem type %q (allowed: ext4, ext3, xfs)", volName, fsType)
+			}
+
+			lunIdx, err := strconv.Atoi(lunStr)
+			if err != nil {
+				return nil, fmt.Errorf("cloud volume %s has invalid lun %q: %w", volName, lunStr, err)
+			}
+
+			diskID := volInfo.DiskID
+			device, err := findDataDiskDevice(lunIdx, diskID)
+			if err != nil {
+				return nil, fmt.Errorf("cloud volume %s: %w", volName, err)
+			}
+			logger.Printf("cloud volume %s: LUN %d -> device %s", volName, lunIdx, device)
+
+			hostMountPoint := filepath.Join(cloudVolumeMountBase, safeName)
+			if err := os.MkdirAll(hostMountPoint, 0o755); err != nil {
+				return nil, fmt.Errorf("creating mount point for %s: %w", volName, err)
+			}
+
+			if err := waitForDevice(device); err != nil {
+				return nil, fmt.Errorf("cloud volume %s device %s not available: %w", volName, device, err)
+			}
+
+			if err := formatAndMount(device, hostMountPoint, fsType); err != nil {
+				return nil, fmt.Errorf("failed to mount cloud volume %s at %s: %w", volName, hostMountPoint, err)
+			}
+			i.cloudMountPaths = append(i.cloudMountPaths, hostMountPoint)
+
+			if fsGroupStr := volInfo.FSGroup; fsGroupStr != "" {
+				if gid, err := strconv.Atoi(fsGroupStr); err == nil {
+					logger.Printf("cloud volume %s: applying fsGroup %d to %s", volName, gid, hostMountPoint)
+					if err := os.Chown(hostMountPoint, -1, gid); err != nil {
+						logger.Printf("WARNING: failed to chown %s to gid %d: %v", hostMountPoint, gid, err)
+					}
+					if err := os.Chmod(hostMountPoint, 0o2775); err != nil {
+						logger.Printf("WARNING: failed to chmod %s: %v", hostMountPoint, err)
+					}
+				}
+			}
+
+			rewrote := false
+			for idx, m := range req.OCI.Mounts {
+				if m.Destination == mountPoint {
+					req.OCI.Mounts[idx].Source = hostMountPoint
+					req.OCI.Mounts[idx].Type = "bind"
+					logger.Printf("cloud volume %s: rewrote mount source to %s", volName, hostMountPoint)
+					rewrote = true
+					break
+				}
+			}
+			if !rewrote {
+				logger.Printf("WARNING: cloud volume %s mount_point %q not found in container mounts", volName, mountPoint)
+			}
+		}
 	}
 
 	volumeTargetPath := req.OCI.Annotations[volumeTargetPathKey]
@@ -221,6 +339,8 @@ func (i *interceptor) DestroySandbox(ctx context.Context, req *pb.DestroySandbox
 
 	logger.Printf("DestroySandbox")
 
+	i.unmountCloudVolumes()
+
 	res, err := i.Redirector.DestroySandbox(ctx, req)
 
 	if err != nil {
@@ -228,4 +348,434 @@ func (i *interceptor) DestroySandbox(ctx context.Context, req *pb.DestroySandbox
 	}
 
 	return res, err
+}
+
+// detectCloudProvider determines the cloud platform by probing
+// provider-specific device paths inside the PodVM.
+func detectCloudProvider() string {
+	if _, err := os.Stat("/dev/disk/azure"); err == nil {
+		return "azure"
+	}
+	// Azure VMs have a well-known DMI chassis asset tag. This is more
+	// specific than checking /sys/bus/vmbus which exists on all Hyper-V
+	// VMs (including on-prem and Azure Stack).
+	if data, err := os.ReadFile("/sys/class/dmi/id/chassis_asset_tag"); err == nil {
+		if strings.TrimSpace(string(data)) == "7783-7084-3265-9085-8269-3286-77" {
+			return "azure"
+		}
+	}
+	if matches, _ := filepath.Glob("/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_*"); len(matches) > 0 {
+		return "aws"
+	}
+	if matches, _ := filepath.Glob("/dev/vd[a-z]"); len(matches) > 0 {
+		return "libvirt"
+	}
+	return "generic"
+}
+
+// findDataDiskDevice locates the block device for the given LUN index.
+// It auto-detects the cloud provider and uses provider-specific paths,
+// then falls back to sysfs HCTL-based LUN matching.
+// diskID is the cloud-provider volume identifier (e.g. EBS vol-xxx); it
+// may be empty for providers that rely purely on LUN-index matching.
+//
+// Data disks may take several seconds to appear in the PodVM after boot
+// (SCSI rescan, udev rules), so the entire detection is retried.
+func findDataDiskDevice(lunIdx int, diskID string) (string, error) {
+	provider := detectCloudProvider()
+	logger.Printf("Cloud provider detected: %s (LUN %d, diskID %s)", provider, lunIdx, diskID)
+
+	maxAttempts := 15
+	retryDelay := 2 * time.Second
+	if v := os.Getenv("CAA_DISK_DETECT_MAX_ATTEMPTS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			maxAttempts = n
+		}
+	}
+	if v := os.Getenv("CAA_DISK_DETECT_RETRY_DELAY"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			retryDelay = d
+		}
+	}
+
+	if provider == "azure" {
+		triggerUdevRescan()
+	}
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if attempt > 1 {
+			logger.Printf("Retry %d/%d for LUN %d...", attempt, maxAttempts, lunIdx)
+			time.Sleep(retryDelay)
+		}
+
+		switch provider {
+		case "azure":
+			if dev, err := findAzureDataDisk(lunIdx); err == nil {
+				return dev, nil
+			}
+		case "aws":
+			if dev, err := findAWSDataDisk(lunIdx, diskID); err == nil {
+				return dev, nil
+			}
+		case "libvirt":
+			if dev, err := findLibvirtDataDisk(lunIdx); err == nil {
+				return dev, nil
+			}
+		}
+
+		if dev, err := findDataDiskBySysfsHCTL(lunIdx); err == nil {
+			return dev, nil
+		}
+	}
+
+	dumpBlockDeviceDiagnostics()
+	return "", fmt.Errorf("no data disk found for LUN %d (provider=%s) after %d attempts", lunIdx, provider, maxAttempts)
+}
+
+// triggerUdevRescan triggers udev to process pending block device events and
+// create symlinks (e.g. /dev/disk/azure/*, /dev/disk/by-path/*).
+// Called once before the retry loop rather than on every attempt.
+func triggerUdevRescan() {
+	if _, err := exec.Command("udevadm", "trigger", "--subsystem-match=block").CombinedOutput(); err == nil {
+		exec.Command("udevadm", "settle", "--timeout=5").CombinedOutput() //nolint:errcheck
+	}
+}
+
+func findAzureDataDisk(lunIdx int) (string, error) {
+	azurePaths := []string{
+		fmt.Sprintf("/dev/disk/azure/data/by-lun/%d", lunIdx),
+		fmt.Sprintf("/dev/disk/azure/scsi1/lun%d", lunIdx),
+	}
+	for _, p := range azurePaths {
+		if target, err := filepath.EvalSymlinks(p); err == nil {
+			logger.Printf("Found Azure data disk: %s -> %s", p, target)
+			return target, nil
+		}
+	}
+
+	byPathDir := "/dev/disk/by-path"
+	if entries, err := os.ReadDir(byPathDir); err == nil {
+		lunSuffix := fmt.Sprintf("-lun-%d", lunIdx)
+		for _, e := range entries {
+			name := e.Name()
+			if strings.Contains(name, "vmbus") && strings.HasSuffix(name, lunSuffix) && !strings.Contains(name, "part") {
+				fullPath := filepath.Join(byPathDir, name)
+				if target, err := filepath.EvalSymlinks(fullPath); err == nil {
+					if isOnSCSIHost0(filepath.Base(target)) {
+						logger.Printf("Skipping by-path %s -> %s (SCSI host 0, OS disk area)", fullPath, target)
+						continue
+					}
+					logger.Printf("Found Azure data disk via by-path: %s -> %s", fullPath, target)
+					return target, nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("Azure data disk LUN %d not found", lunIdx)
+}
+
+func findAWSDataDisk(lunIdx int, diskID string) (string, error) {
+	entries, err := filepath.Glob("/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_*")
+	if err != nil || len(entries) == 0 {
+		return "", fmt.Errorf("no AWS EBS NVMe devices found")
+	}
+
+	var candidates []string
+	for _, e := range entries {
+		if !strings.Contains(e, "-part") {
+			candidates = append(candidates, e)
+		}
+	}
+
+	// Prefer matching by EBS volume ID for multi-disk correctness.
+	// The NVMe by-id symlink encodes the volume ID with hyphens removed,
+	// e.g. vol-0abc123 becomes nvme-Amazon_Elastic_Block_Store_vol0abc123.
+	if diskID != "" {
+		volIDNormalized := strings.ReplaceAll(diskID, "-", "")
+		for _, c := range candidates {
+			if strings.Contains(c, volIDNormalized) {
+				target, err := filepath.EvalSymlinks(c)
+				if err != nil {
+					return "", err
+				}
+				logger.Printf("Found AWS EBS disk by volume ID: %s -> %s (diskID=%s)", c, target, diskID)
+				return target, nil
+			}
+		}
+		return "", fmt.Errorf("AWS EBS disk with volume ID %s not found in %d by-id symlinks", diskID, len(candidates))
+	}
+
+	// Index-based selection only when diskID is empty (legacy/testing).
+	if lunIdx >= len(candidates) {
+		return "", fmt.Errorf("AWS EBS disk index %d out of range (have %d)", lunIdx, len(candidates))
+	}
+	target, err := filepath.EvalSymlinks(candidates[lunIdx])
+	if err != nil {
+		return "", err
+	}
+	logger.Printf("Found AWS EBS disk by index: %s -> %s", candidates[lunIdx], target)
+	return target, nil
+}
+
+func findLibvirtDataDisk(lunIdx int) (string, error) {
+	if lunIdx < 0 || lunIdx > 24 {
+		return "", fmt.Errorf("LUN index %d out of range for virtio devices (0-24)", lunIdx)
+	}
+	devLetter := 'b' + rune(lunIdx)
+	device := fmt.Sprintf("/dev/vd%c", devLetter)
+	if _, err := os.Stat(device); err == nil {
+		logger.Printf("Found libvirt virtio disk: %s", device)
+		return device, nil
+	}
+	return "", fmt.Errorf("libvirt device %s not found", device)
+}
+
+// isOnSCSIHost0 checks if a block device is on SCSI host controller 0,
+// where Azure/Hyper-V places the OS and temp disks.
+func isOnSCSIHost0(devName string) bool {
+	devicePath := filepath.Join("/sys/block", devName, "device")
+	realPath, err := filepath.EvalSymlinks(devicePath)
+	if err != nil {
+		return false
+	}
+	for _, part := range strings.Split(realPath, "/") {
+		hctl := strings.Split(part, ":")
+		if len(hctl) == 4 {
+			host, err := strconv.Atoi(hctl[0])
+			if err == nil {
+				return host == 0
+			}
+		}
+	}
+	return false
+}
+
+// findDataDiskBySysfsHCTL matches block devices by their SCSI HCTL
+// (Host:Channel:Target:Lun) address in sysfs rather than relying on
+// directory listing order. On Azure/Hyper-V, SCSI controller 0 holds
+// the OS and temp disks while data disks live on controller 1+, so
+// controller 0 is skipped. If no match is found on non-zero hosts,
+// a second pass looks at all hosts but filters out any device that
+// is mounted or has partitions (indicating it is the OS/temp disk).
+func findDataDiskBySysfsHCTL(lunIdx int) (string, error) {
+	entries, err := os.ReadDir("/sys/block")
+	if err != nil {
+		return "", fmt.Errorf("cannot read /sys/block: %w", err)
+	}
+
+	type devInfo struct {
+		name string
+		host int
+		lun  int
+		hctl string
+	}
+
+	var allMatches []devInfo
+
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, "sd") && !strings.HasPrefix(name, "nvme") && !strings.HasPrefix(name, "vd") {
+			continue
+		}
+
+		devicePath := filepath.Join("/sys/block", name, "device")
+		realPath, err := filepath.EvalSymlinks(devicePath)
+		if err != nil {
+			continue
+		}
+
+		parts := strings.Split(realPath, "/")
+		for _, part := range parts {
+			hctl := strings.Split(part, ":")
+			if len(hctl) == 4 {
+				host, hostErr := strconv.Atoi(hctl[0])
+				lun, lunErr := strconv.Atoi(hctl[3])
+				if hostErr != nil || lunErr != nil {
+					continue
+				}
+				logger.Printf("sysfs scan: /dev/%s HCTL=%s (host=%d lun=%d)", name, part, host, lun)
+				if lun == lunIdx {
+					allMatches = append(allMatches, devInfo{name: name, host: host, lun: lun, hctl: part})
+				}
+			}
+		}
+	}
+
+	// Pass 1: prefer devices on non-zero hosts (standard Azure data disk topology)
+	for _, m := range allMatches {
+		if m.host == 0 {
+			continue
+		}
+		dev := "/dev/" + m.name
+		if isRootOrMountedDevice(m.name) {
+			logger.Printf("Skipping %s (LUN %d host %d): device is in use as root/mounted", dev, m.lun, m.host)
+			continue
+		}
+		logger.Printf("Found data disk via sysfs HCTL (host>0): %s (LUN %d from %s)", dev, lunIdx, m.hctl)
+		return dev, nil
+	}
+
+	// Pass 2: if no non-zero host matched, check host 0 devices that are
+	// NOT mounted and have NO partitions (i.e. raw data disks on host 0).
+	for _, m := range allMatches {
+		if m.host != 0 {
+			continue
+		}
+		dev := "/dev/" + m.name
+		if isRootOrMountedDevice(m.name) {
+			logger.Printf("Skipping %s (LUN %d host 0): device is mounted", dev, m.lun)
+			continue
+		}
+		if hasPartitions(m.name) {
+			logger.Printf("Skipping %s (LUN %d host 0): device has partitions (likely OS/temp disk)", dev, m.lun)
+			continue
+		}
+		logger.Printf("Found data disk via sysfs HCTL (host=0, raw): %s (LUN %d from %s)", dev, lunIdx, m.hctl)
+		return dev, nil
+	}
+
+	return "", fmt.Errorf("no data disk found for LUN %d via sysfs HCTL (%d candidates scanned)", lunIdx, len(allMatches))
+}
+
+// hasPartitions checks whether a block device has any partition sub-devices
+// in /sys/block/<dev>/<dev>N (e.g. sda1, sda2).
+func hasPartitions(devName string) bool {
+	entries, err := os.ReadDir(filepath.Join("/sys/block", devName))
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), devName) {
+			return true
+		}
+	}
+	return false
+}
+
+// isRootOrMountedDevice returns true if the device or any of its partitions
+// is mounted as a filesystem (especially / or /boot). This prevents
+// accidentally selecting the OS disk as a data disk when HCTL host
+// numbering doesn't match expectations.
+func isRootOrMountedDevice(devName string) bool {
+	data, err := os.ReadFile("/proc/mounts")
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		mountDev := fields[0]
+		if strings.HasPrefix(mountDev, "/dev/"+devName) {
+			return true
+		}
+	}
+	return false
+}
+
+func dumpBlockDeviceDiagnostics() {
+	logger.Printf("=== Block Device Diagnostics ===")
+	if out, err := exec.Command("lsblk", "-o", "NAME,SIZE,TYPE,MOUNTPOINT,FSTYPE").CombinedOutput(); err == nil {
+		logger.Printf("lsblk:\n%s", string(out))
+	}
+	for _, dir := range []string{"/dev/disk/azure", "/dev/disk/by-path", "/dev/disk/by-id"} {
+		if entries, err := os.ReadDir(dir); err == nil {
+			for _, e := range entries {
+				full := filepath.Join(dir, e.Name())
+				if target, err := os.Readlink(full); err == nil {
+					logger.Printf("  %s -> %s", full, target)
+				}
+			}
+		}
+	}
+}
+
+func waitForDevice(device string) error {
+	for attempt := 0; attempt < 30; attempt++ {
+		if strings.HasPrefix(device, "/dev/disk/") {
+			if _, err := os.Lstat(device); err == nil {
+				return nil
+			}
+		} else {
+			devName := filepath.Base(device)
+			if _, err := os.Stat(filepath.Join("/sys/block", devName)); err == nil {
+				return nil
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("device %s not available after 60s", device)
+}
+
+func formatAndMount(device, mountPoint, fsType string) error {
+	if fsType == "" {
+		fsType = "ext4"
+	}
+	if !allowedFSTypes[fsType] {
+		return fmt.Errorf("unsupported filesystem type %q", fsType)
+	}
+
+	if alreadyMounted, err := mountinfo.Mounted(mountPoint); err == nil && alreadyMounted {
+		logger.Printf("Mount point %s is already mounted, treating as success", mountPoint)
+		return nil
+	}
+
+	// Try mounting first — if the disk already has a valid filesystem, this
+	// avoids any risk of accidentally reformatting it.
+	mountCmd := exec.Command("mount", "-t", fsType, device, mountPoint)
+	if mountOut, mountErr := mountCmd.CombinedOutput(); mountErr == nil {
+		logger.Printf("Mounted existing filesystem on %s at %s (type=%s)", device, mountPoint, fsType)
+		return nil
+	} else {
+		logger.Printf("Initial mount of %s failed (expected for new disks): %s", device, strings.TrimSpace(string(mountOut)))
+	}
+
+	// Mount failed — check if there's any filesystem using blkid with retries.
+	needsFormat := false
+	for attempt := 0; attempt < 3; attempt++ {
+		out, err := exec.Command("blkid", "-p", device).CombinedOutput()
+		outStr := strings.TrimSpace(string(out))
+		if err == nil && len(outStr) > 0 {
+			autoMount := exec.Command("mount", device, mountPoint)
+			if autoOut, autoErr := autoMount.CombinedOutput(); autoErr == nil {
+				logger.Printf("Mounted %s at %s (auto-detected type from: %s)", device, mountPoint, outStr)
+				return nil
+			} else {
+				return fmt.Errorf("device %s has filesystem signature (%s) but mount failed: %s", device, outStr, strings.TrimSpace(string(autoOut)))
+			}
+		}
+		if err != nil {
+			// Exit code 2 = no valid filesystem found (safe to format)
+			if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 2 {
+				needsFormat = true
+				break
+			}
+			logger.Printf("blkid attempt %d for %s failed: %v (output: %s)", attempt+1, device, err, outStr)
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		// err == nil but empty output — ambiguous state, retry
+		logger.Printf("blkid returned empty output for %s (attempt %d), retrying...", device, attempt+1)
+		time.Sleep(2 * time.Second)
+		continue
+	}
+
+	if !needsFormat {
+		return fmt.Errorf("cannot determine filesystem state of %s after retries; refusing to format to protect data", device)
+	}
+
+	logger.Printf("No filesystem on %s, formatting as %s", device, fsType)
+	mkfsCmd := exec.Command("mkfs."+fsType, device)
+	if mkfsOut, mkfsErr := mkfsCmd.CombinedOutput(); mkfsErr != nil {
+		return fmt.Errorf("mkfs.%s on %s failed: %s: %w", fsType, device, strings.TrimSpace(string(mkfsOut)), mkfsErr)
+	}
+	logger.Printf("Formatted %s as %s", device, fsType)
+
+	mountCmd2 := exec.Command("mount", "-t", fsType, device, mountPoint)
+	if mountOut, mountErr := mountCmd2.CombinedOutput(); mountErr != nil {
+		return fmt.Errorf("mount after format %s -> %s failed: %s: %w", device, mountPoint, strings.TrimSpace(string(mountOut)), mountErr)
+	}
+	logger.Printf("Mounted %s at %s (type=%s)", device, mountPoint, fsType)
+	return nil
 }

--- a/src/cloud-api-adaptor/pkg/forwarder/interceptor/interceptor_test.go
+++ b/src/cloud-api-adaptor/pkg/forwarder/interceptor/interceptor_test.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util"
 	pb "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols/grpc"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
@@ -952,6 +954,271 @@ func TestInterceptorWithComplexAnnotations(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.True(t, mock.createContainerCalled)
+	})
+}
+
+func TestCloudVolumesJSONParseError(t *testing.T) {
+	t.Run("corrupt JSON annotation returns error instead of silently skipping", func(t *testing.T) {
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "/run/netns/podns",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+				Annotations: map[string]string{
+					util.CloudVolumesAnnotationKey: "{invalid json",
+				},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "corrupt cloud_volumes annotation")
+		assert.False(t, mock.createContainerCalled)
+	})
+
+	t.Run("missing mount_point field returns error", func(t *testing.T) {
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "/run/netns/podns",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+				Annotations: map[string]string{
+					util.CloudVolumesAnnotationKey: `{"vol-0":{"fs_type":"ext4","lun":"0"}}`,
+				},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing required mount_point or lun")
+	})
+
+	t.Run("unsupported filesystem type returns error", func(t *testing.T) {
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "/run/netns/podns",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+				Annotations: map[string]string{
+					util.CloudVolumesAnnotationKey: `{"vol-0":{"mount_point":"/data","fs_type":"ntfs","lun":"0"}}`,
+				},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported filesystem type")
+	})
+
+	t.Run("unsafe volume name returns error", func(t *testing.T) {
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "/run/netns/podns",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+				Annotations: map[string]string{
+					util.CloudVolumesAnnotationKey: `{"../escape":{"mount_point":"/data","fs_type":"ext4","lun":"0"}}`,
+				},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unsafe name")
+	})
+
+	t.Run("invalid lun value returns error", func(t *testing.T) {
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "/run/netns/podns",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+				Annotations: map[string]string{
+					util.CloudVolumesAnnotationKey: `{"vol-0":{"mount_point":"/data","fs_type":"ext4","lun":"abc"}}`,
+				},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid lun")
+	})
+
+	t.Run("valid cloud_volumes without device does not panic", func(t *testing.T) {
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "/run/netns/podns",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+				Annotations: map[string]string{
+					util.CloudVolumesAnnotationKey: `{"vol-0":{"mount_point":"/data","fs_type":"ext4","lun":"0","disk_id":"vol-fake"}}`,
+				},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+		// Will error because the device doesn't exist, but should not panic
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cloud volume vol-0")
+	})
+
+	t.Run("empty cloud_volumes annotation is ignored", func(t *testing.T) {
+		mock := &mockRedirector{}
+		i := &interceptor{
+			Redirector: mock,
+			nsPath:     "/run/netns/podns",
+		}
+
+		req := &pb.CreateContainerRequest{
+			ContainerId: "test-container",
+			OCI: &pb.Spec{
+				Linux: &pb.Linux{
+					Namespaces: []*pb.LinuxNamespace{},
+				},
+				Annotations: map[string]string{
+					util.CloudVolumesAnnotationKey: "",
+				},
+			},
+		}
+
+		ctx := context.Background()
+		_, err := i.CreateContainer(ctx, req)
+		assert.NoError(t, err)
+		assert.True(t, mock.createContainerCalled)
+	})
+}
+
+func TestHasPartitions(t *testing.T) {
+	t.Run("returns false for nonexistent device", func(t *testing.T) {
+		assert.False(t, hasPartitions("nonexistent_device_xyz"))
+	})
+
+	t.Run("returns false when no partition entries exist", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		devName := "sdtest"
+		sysBlockDir := filepath.Join(tmpDir, devName)
+		require.NoError(t, os.MkdirAll(sysBlockDir, 0o755))
+		require.NoError(t, os.MkdirAll(filepath.Join(sysBlockDir, "queue"), 0o755))
+		require.NoError(t, os.MkdirAll(filepath.Join(sysBlockDir, "power"), 0o755))
+		// No sda1 etc.
+		// We can't directly test since hasPartitions reads from /sys/block,
+		// but we test the logic indirectly through mock paths
+		assert.False(t, hasPartitions("nonexistent_device_xyz"))
+	})
+}
+
+func TestIsRootOrMountedDevice(t *testing.T) {
+	t.Run("returns false for unknown device", func(t *testing.T) {
+		assert.False(t, isRootOrMountedDevice("zzznonexistent999"))
+	})
+
+	t.Run("returns true for root device if accessible", func(t *testing.T) {
+		data, err := os.ReadFile("/proc/mounts")
+		if err != nil {
+			t.Skip("cannot read /proc/mounts")
+		}
+		// Find actual root mount device
+		for _, line := range strings.Split(string(data), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 && fields[1] == "/" && strings.HasPrefix(fields[0], "/dev/") {
+				devName := strings.TrimPrefix(fields[0], "/dev/")
+				// Strip partition number (e.g., sda1 -> sda)
+				base := strings.TrimRight(devName, "0123456789")
+				assert.True(t, isRootOrMountedDevice(base),
+					"expected device %s (from %s) to be detected as mounted", base, fields[0])
+				return
+			}
+		}
+		t.Skip("could not find root device in /proc/mounts")
+	})
+}
+
+func TestDetectCloudProvider(t *testing.T) {
+	provider := detectCloudProvider()
+	// On a regular test machine, this won't be a cloud provider
+	// We just verify it returns one of the known values
+	validProviders := map[string]bool{
+		"azure": true, "aws": true, "libvirt": true, "generic": true,
+	}
+	assert.True(t, validProviders[provider],
+		"detectCloudProvider returned unexpected value: %s", provider)
+}
+
+func TestFindLibvirtDataDisk(t *testing.T) {
+	t.Run("rejects out of range LUN index", func(t *testing.T) {
+		_, err := findLibvirtDataDisk(25)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "out of range")
+	})
+
+	t.Run("rejects negative LUN index", func(t *testing.T) {
+		_, err := findLibvirtDataDisk(-1)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "out of range")
+	})
+
+	t.Run("returns error when device does not exist", func(t *testing.T) {
+		// Unless /dev/vdb exists, this should fail
+		_, err := findLibvirtDataDisk(0)
+		if err != nil {
+			assert.Contains(t, err.Error(), "not found")
+		}
+	})
+}
+
+func TestFindDataDiskBySysfsHCTL(t *testing.T) {
+	t.Run("returns error for impossible LUN on test machine", func(t *testing.T) {
+		// LUN 999 should never exist
+		_, err := findDataDiskBySysfsHCTL(999)
+		assert.Error(t, err)
 	})
 }
 

--- a/src/cloud-api-adaptor/pkg/util/cloud.go
+++ b/src/cloud-api-adaptor/pkg/util/cloud.go
@@ -1,11 +1,17 @@
 package util
 
 import (
+	b64 "encoding/base64"
+	"encoding/json"
 	"fmt"
+	"log"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/initdata"
+	provider "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers"
 	cri "github.com/containerd/containerd/pkg/cri/annotations"
 	hypannotations "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/annotations"
 )
@@ -113,4 +119,96 @@ func Contains(slice []string, s string) bool {
 		}
 	}
 	return false
+}
+
+var logger = log.New(log.Writer(), "[util/cloud] ", log.LstdFlags|log.Lmsgprefix)
+
+type mountInfoJSON struct {
+	VolumeType string            `json:"volume-type"`
+	Device     string            `json:"device"`
+	FsType     string            `json:"fstype"`
+	Metadata   map[string]string `json:"metadata"`
+	Options    []string          `json:"options"`
+}
+
+var KataDirectVolumesDir = "/run/kata-containers/shared/direct-volumes"
+
+const CSIPluginEscapeQualifiedName = "kubernetes.io~csi"
+
+const CloudVolumesAnnotationKey = "io.confidentialcontainers.org.cloud_volumes"
+
+// CloudVolumeAnnotation is the schema for each entry in the cloud_volumes
+// annotation. It is serialized by the proxy and deserialized by the interceptor.
+type CloudVolumeAnnotation struct {
+	MountPoint string `json:"mount_point"`
+	FSType     string `json:"fs_type"`
+	LUN        string `json:"lun"`
+	DiskID     string `json:"disk_id"`
+	FSGroup    string `json:"fs_group,omitempty"`
+}
+
+// GetCSIVolumesForPod scans the shared direct-volumes directory for
+// mountInfo.json files written by the CSI block driver. Each file
+// describes a cloud volume that should be attached to the PodVM.
+// Volumes are filtered by pod UID (from annotations) to prevent
+// cross-pod volume leakage on multi-tenant nodes.
+func GetCSIVolumesForPod(annotations map[string]string) []provider.CloudVolume {
+	var volumes []provider.CloudVolume
+
+	podUID := annotations[cri.SandboxUID]
+
+	entries, err := os.ReadDir(KataDirectVolumesDir)
+	if err != nil {
+		return nil
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		decodedPath, err := b64.URLEncoding.DecodeString(entry.Name())
+		if err != nil {
+			continue
+		}
+		decodedStr := string(decodedPath)
+
+		if !strings.Contains(decodedStr, "/volumes/"+CSIPluginEscapeQualifiedName+"/") {
+			continue
+		}
+
+		if podUID != "" && !strings.Contains(decodedStr, "/pods/"+podUID+"/") {
+			continue
+		}
+
+		mountInfoPath := filepath.Join(KataDirectVolumesDir, entry.Name(), "mountInfo.json")
+		data, err := os.ReadFile(mountInfoPath)
+		if err != nil {
+			continue
+		}
+
+		var info mountInfoJSON
+		if err := json.Unmarshal(data, &info); err != nil {
+			logger.Printf("WARNING: invalid mountInfo.json in %s: %v", entry.Name(), err)
+			continue
+		}
+
+		volPath := info.Device
+		if info.Metadata != nil {
+			if cp, ok := info.Metadata["cloud-volume-path"]; ok && cp != "" {
+				volPath = cp
+			}
+		}
+
+		if volPath == "" {
+			logger.Printf("WARNING: no disk ID in mountInfo.json for %s", decodedStr)
+			continue
+		}
+
+		volumes = append(volumes, provider.CloudVolume{
+			DiskID: volPath,
+		})
+	}
+
+	return volumes
 }

--- a/src/cloud-api-adaptor/pkg/util/cloud_csi_test.go
+++ b/src/cloud-api-adaptor/pkg/util/cloud_csi_test.go
@@ -1,0 +1,227 @@
+package util
+
+import (
+	b64 "encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	provider "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers"
+	cri "github.com/containerd/containerd/pkg/cri/annotations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupDirectVolumesDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	origDir := KataDirectVolumesDir
+
+	t.Cleanup(func() {
+		KataDirectVolumesDir = origDir
+	})
+	KataDirectVolumesDir = dir
+	return dir
+}
+
+func writeMountInfo(t *testing.T, dir, volumePath string, info map[string]interface{}) {
+	t.Helper()
+	encoded := b64.URLEncoding.EncodeToString([]byte(volumePath))
+	volDir := filepath.Join(dir, encoded)
+	require.NoError(t, os.MkdirAll(volDir, 0o755))
+
+	data, err := json.Marshal(info)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(volDir, "mountInfo.json"), data, 0o644))
+}
+
+func TestGetCSIVolumesForPod_EmptyDirectory(t *testing.T) {
+	setupDirectVolumesDir(t)
+	volumes := GetCSIVolumesForPod(map[string]string{})
+	assert.Nil(t, volumes)
+}
+
+func TestGetCSIVolumesForPod_NonExistentDirectory(t *testing.T) {
+	origDir := KataDirectVolumesDir
+	KataDirectVolumesDir = "/nonexistent/path"
+	defer func() { KataDirectVolumesDir = origDir }()
+
+	volumes := GetCSIVolumesForPod(map[string]string{})
+	assert.Nil(t, volumes)
+}
+
+func TestGetCSIVolumesForPod_SingleVolume(t *testing.T) {
+	dir := setupDirectVolumesDir(t)
+	volPath := "/var/lib/kubelet/pods/pod-uid-123/volumes/kubernetes.io~csi/pvc-abc/mount"
+
+	writeMountInfo(t, dir, volPath, map[string]interface{}{
+		"device": "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/disks/csi-vol-pvc-abc",
+		"fstype": "ext4",
+	})
+
+	volumes := GetCSIVolumesForPod(map[string]string{})
+	require.Len(t, volumes, 1)
+	assert.Equal(t, "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/disks/csi-vol-pvc-abc", volumes[0].DiskID)
+}
+
+func TestGetCSIVolumesForPod_CloudVolumePathTakesPrecedence(t *testing.T) {
+	dir := setupDirectVolumesDir(t)
+	volPath := "/var/lib/kubelet/pods/pod-uid-123/volumes/kubernetes.io~csi/pvc-abc/mount"
+
+	writeMountInfo(t, dir, volPath, map[string]interface{}{
+		"device": "fallback-device",
+		"fstype": "ext4",
+		"metadata": map[string]interface{}{
+			"cloud-volume-path": "/subscriptions/sub1/disks/preferred-disk",
+		},
+	})
+
+	volumes := GetCSIVolumesForPod(map[string]string{})
+	require.Len(t, volumes, 1)
+	assert.Equal(t, "/subscriptions/sub1/disks/preferred-disk", volumes[0].DiskID)
+}
+
+func TestGetCSIVolumesForPod_PodUIDFiltering(t *testing.T) {
+	dir := setupDirectVolumesDir(t)
+
+	writeMountInfo(t, dir,
+		"/var/lib/kubelet/pods/pod-uid-AAA/volumes/kubernetes.io~csi/pvc-1/mount",
+		map[string]interface{}{"device": "disk-A", "fstype": "ext4"})
+
+	writeMountInfo(t, dir,
+		"/var/lib/kubelet/pods/pod-uid-BBB/volumes/kubernetes.io~csi/pvc-2/mount",
+		map[string]interface{}{"device": "disk-B", "fstype": "ext4"})
+
+	writeMountInfo(t, dir,
+		"/var/lib/kubelet/pods/pod-uid-AAA/volumes/kubernetes.io~csi/pvc-3/mount",
+		map[string]interface{}{"device": "disk-C", "fstype": "ext4"})
+
+	annotations := map[string]string{
+		cri.SandboxUID: "pod-uid-AAA",
+	}
+	volumes := GetCSIVolumesForPod(annotations)
+	require.Len(t, volumes, 2)
+
+	diskIDs := []string{volumes[0].DiskID, volumes[1].DiskID}
+	assert.Contains(t, diskIDs, "disk-A")
+	assert.Contains(t, diskIDs, "disk-C")
+	assert.NotContains(t, diskIDs, "disk-B")
+}
+
+func TestGetCSIVolumesForPod_EmptyPodUIDReturnsAll(t *testing.T) {
+	dir := setupDirectVolumesDir(t)
+
+	writeMountInfo(t, dir,
+		"/var/lib/kubelet/pods/pod-uid-AAA/volumes/kubernetes.io~csi/pvc-1/mount",
+		map[string]interface{}{"device": "disk-A", "fstype": "ext4"})
+
+	writeMountInfo(t, dir,
+		"/var/lib/kubelet/pods/pod-uid-BBB/volumes/kubernetes.io~csi/pvc-2/mount",
+		map[string]interface{}{"device": "disk-B", "fstype": "ext4"})
+
+	volumes := GetCSIVolumesForPod(map[string]string{})
+	assert.Len(t, volumes, 2)
+}
+
+func TestGetCSIVolumesForPod_SkipsNonCSIVolumes(t *testing.T) {
+	dir := setupDirectVolumesDir(t)
+
+	writeMountInfo(t, dir,
+		"/var/lib/kubelet/pods/pod-uid-123/volumes/kubernetes.io~csi/pvc-1/mount",
+		map[string]interface{}{"device": "csi-disk", "fstype": "ext4"})
+
+	writeMountInfo(t, dir,
+		"/var/lib/kubelet/pods/pod-uid-123/volumes/kubernetes.io~configmap/config/mount",
+		map[string]interface{}{"device": "configmap-device", "fstype": "ext4"})
+
+	volumes := GetCSIVolumesForPod(map[string]string{})
+	require.Len(t, volumes, 1)
+	assert.Equal(t, "csi-disk", volumes[0].DiskID)
+}
+
+func TestGetCSIVolumesForPod_SkipsMissingDiskID(t *testing.T) {
+	dir := setupDirectVolumesDir(t)
+
+	writeMountInfo(t, dir,
+		"/var/lib/kubelet/pods/pod-uid-123/volumes/kubernetes.io~csi/pvc-no-disk/mount",
+		map[string]interface{}{"fstype": "ext4"})
+
+	volumes := GetCSIVolumesForPod(map[string]string{})
+	assert.Empty(t, volumes)
+}
+
+func TestGetCSIVolumesForPod_SkipsInvalidJSON(t *testing.T) {
+	dir := setupDirectVolumesDir(t)
+	volPath := "/var/lib/kubelet/pods/pod-uid-123/volumes/kubernetes.io~csi/pvc-bad/mount"
+	encoded := b64.URLEncoding.EncodeToString([]byte(volPath))
+	volDir := filepath.Join(dir, encoded)
+	require.NoError(t, os.MkdirAll(volDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(volDir, "mountInfo.json"), []byte("{invalid json"), 0o644))
+
+	volumes := GetCSIVolumesForPod(map[string]string{})
+	assert.Empty(t, volumes)
+}
+
+func TestGetCSIVolumesForPod_SkipsNonBase64Directories(t *testing.T) {
+	dir := setupDirectVolumesDir(t)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "not-base64-encoded"), 0o755))
+
+	writeMountInfo(t, dir,
+		"/var/lib/kubelet/pods/pod-uid-123/volumes/kubernetes.io~csi/pvc-ok/mount",
+		map[string]interface{}{"device": "good-disk", "fstype": "ext4"})
+
+	volumes := GetCSIVolumesForPod(map[string]string{})
+	require.Len(t, volumes, 1)
+	assert.Equal(t, "good-disk", volumes[0].DiskID)
+}
+
+func TestGetCSIVolumesForPod_SkipsRegularFiles(t *testing.T) {
+	dir := setupDirectVolumesDir(t)
+
+	volPath := "/var/lib/kubelet/pods/pod-uid-123/volumes/kubernetes.io~csi/pvc-file/mount"
+	encoded := b64.URLEncoding.EncodeToString([]byte(volPath))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, encoded), []byte("not a dir"), 0o644))
+
+	volumes := GetCSIVolumesForPod(map[string]string{})
+	assert.Empty(t, volumes)
+}
+
+func TestGetCSIVolumesForPod_MultipleVolumesCanonicalOrder(t *testing.T) {
+	dir := setupDirectVolumesDir(t)
+
+	paths := []string{
+		"/var/lib/kubelet/pods/pod-uid-123/volumes/kubernetes.io~csi/pvc-charlie/mount",
+		"/var/lib/kubelet/pods/pod-uid-123/volumes/kubernetes.io~csi/pvc-alpha/mount",
+		"/var/lib/kubelet/pods/pod-uid-123/volumes/kubernetes.io~csi/pvc-bravo/mount",
+	}
+
+	for i, p := range paths {
+		writeMountInfo(t, dir, p, map[string]interface{}{
+			"device": fmt.Sprintf("disk-%d", i),
+			"fstype": "ext4",
+		})
+	}
+
+	volumes := GetCSIVolumesForPod(map[string]string{})
+	require.Len(t, volumes, 3)
+
+	for i := 0; i < len(volumes)-1; i++ {
+		assert.NotEqual(t, volumes[i].DiskID, volumes[i+1].DiskID,
+			"volumes should be distinct")
+	}
+}
+
+func TestGetCSIVolumesForPod_ReturnType(t *testing.T) {
+	dir := setupDirectVolumesDir(t)
+
+	writeMountInfo(t, dir,
+		"/var/lib/kubelet/pods/pod-uid-123/volumes/kubernetes.io~csi/pvc-test/mount",
+		map[string]interface{}{"device": "test-disk", "fstype": "ext4"})
+
+	volumes := GetCSIVolumesForPod(map[string]string{})
+	require.Len(t, volumes, 1)
+	assert.IsType(t, provider.CloudVolume{}, volumes[0])
+}

--- a/src/cloud-api-adaptor/podvm/mkosi.images/system/mkosi.postinst
+++ b/src/cloud-api-adaptor/podvm/mkosi.images/system/mkosi.postinst
@@ -7,3 +7,11 @@ set -euxo pipefail
   echo "IMAGE_VERSION=\"${IMAGE_VERSION-v0.0.0}\""
   echo "VARIANT_ID=\"${VARIANT_ID}\""
 } >> "${BUILDROOT}/etc/os-release"
+
+# Install Azure storage udev rules so /dev/disk/azure/data/by-lun/N symlinks
+# are created at boot without needing the full walinuxagent package.
+mkdir -p "${BUILDROOT}/etc/udev/rules.d"
+cat > "${BUILDROOT}/etc/udev/rules.d/66-azure-storage.rules" << 'UDEVRULES'
+# Azure data disk symlinks by LUN
+ACTION=="add|change", SUBSYSTEM=="block", ENV{ID_VENDOR}=="Msft", ENV{ID_MODEL}=="Virtual_Disk", PROGRAM="/bin/sh -c 'readlink /sys/block/%k/device 2>/dev/null | sed -n \"s/.*[:/]\\([0-9]*\\)$/\\1/p\"'", SYMLINK+="disk/azure/data/by-lun/%c"
+UDEVRULES

--- a/src/cloud-api-adaptor/test/e2e/csi_test.go
+++ b/src/cloud-api-adaptor/test/e2e/csi_test.go
@@ -1,0 +1,381 @@
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	csiDriverName       = "caa-csi-block-driver"
+	csiStorageClassName = "caa-csi-block"
+	csiTestNamespace    = "csi-e2e-test"
+	podReadyTimeout     = 5 * time.Minute
+	podDeleteTimeout    = 3 * time.Minute
+	pollInterval        = 5 * time.Second
+)
+
+func getClient(t *testing.T) *kubernetes.Clientset {
+	t.Helper()
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		kubeconfig = os.ExpandEnv("$HOME/.kube/config")
+	}
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		t.Fatalf("Failed to build kubeconfig: %v", err)
+	}
+	cs, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to create k8s client: %v", err)
+	}
+	return cs
+}
+
+func skipIfNoCluster(t *testing.T) {
+	t.Helper()
+	if os.Getenv("CSI_E2E_ENABLED") != "true" {
+		t.Skip("CSI E2E tests disabled — set CSI_E2E_ENABLED=true to run")
+	}
+}
+
+func ensureNamespace(t *testing.T, cs *kubernetes.Clientset) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := cs.CoreV1().Namespaces().Get(ctx, csiTestNamespace, metav1.GetOptions{})
+	if err != nil {
+		_, err = cs.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: csiTestNamespace},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Failed to create test namespace: %v", err)
+		}
+	}
+}
+
+func waitForPodCompletion(t *testing.T, cs *kubernetes.Clientset, ns, name string, timeout time.Duration) string {
+	t.Helper()
+	ctx := context.Background()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		pod, err := cs.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
+		if err == nil && (pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed) {
+			if pod.Status.Phase == corev1.PodFailed {
+				t.Fatalf("Pod %s failed", name)
+			}
+			logs, _ := cs.CoreV1().Pods(ns).GetLogs(name, &corev1.PodLogOptions{}).Do(ctx).Raw()
+			return string(logs)
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Fatalf("Pod %s did not complete within %v", name, timeout)
+	return ""
+}
+
+func deletePodAndWait(t *testing.T, cs *kubernetes.Clientset, ns, name string) {
+	t.Helper()
+	ctx := context.Background()
+	cs.CoreV1().Pods(ns).Delete(ctx, name, metav1.DeleteOptions{}) //nolint:errcheck
+	deadline := time.Now().Add(podDeleteTimeout)
+	for time.Now().Before(deadline) {
+		_, err := cs.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return
+		}
+		time.Sleep(pollInterval)
+	}
+}
+
+func newCSIPVC(namespace, name, size string) *corev1.PersistentVolumeClaim {
+	storageClass := csiStorageClassName
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			StorageClassName: &storageClass,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse(size),
+				},
+			},
+		},
+	}
+}
+
+func newCSIWriterPod(namespace, podName, pvcName, mountPath, writeData string) *corev1.Pod {
+	runtimeClassName := "kata-remote"
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": "csi-writer"},
+		},
+		Spec: corev1.PodSpec{
+			RuntimeClassName: &runtimeClassName,
+			Containers: []corev1.Container{{
+				Name:    "writer",
+				Image:   "busybox:1.36",
+				Command: []string{"/bin/sh", "-c", fmt.Sprintf("echo '%s' > %s/data.txt && sync && cat %s/data.txt", writeData, mountPath, mountPath)},
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "data", MountPath: mountPath},
+				},
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "data",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+				},
+			}},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+}
+
+func newCSIReaderPod(namespace, podName, pvcName, mountPath string) *corev1.Pod {
+	runtimeClassName := "kata-remote"
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": "csi-reader"},
+		},
+		Spec: corev1.PodSpec{
+			RuntimeClassName: &runtimeClassName,
+			Containers: []corev1.Container{{
+				Name:    "reader",
+				Image:   "busybox:1.36",
+				Command: []string{"/bin/sh", "-c", fmt.Sprintf("cat %s/data.txt", mountPath)},
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "data", MountPath: mountPath},
+				},
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "data",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+				},
+			}},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+}
+
+func TestCSISingleDiskPersistence(t *testing.T) {
+	skipIfNoCluster(t)
+	cs := getClient(t)
+	ensureNamespace(t, cs)
+	ctx := context.Background()
+
+	pvcName := "e2e-single-pvc"
+	testData := "hello-single-disk-e2e"
+
+	t.Log("Creating PVC")
+	cs.CoreV1().PersistentVolumeClaims(csiTestNamespace).Delete(ctx, pvcName, metav1.DeleteOptions{}) //nolint:errcheck
+	_, err := cs.CoreV1().PersistentVolumeClaims(csiTestNamespace).Create(ctx, newCSIPVC(csiTestNamespace, pvcName, "1Gi"), metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create PVC: %v", err)
+	}
+	defer cs.CoreV1().PersistentVolumeClaims(csiTestNamespace).Delete(ctx, pvcName, metav1.DeleteOptions{}) //nolint:errcheck
+
+	t.Log("Creating writer pod")
+	writerPod := newCSIWriterPod(csiTestNamespace, "e2e-writer", pvcName, "/mnt/data", testData)
+	cs.CoreV1().Pods(csiTestNamespace).Delete(ctx, "e2e-writer", metav1.DeleteOptions{}) //nolint:errcheck
+	time.Sleep(5 * time.Second)
+	_, err = cs.CoreV1().Pods(csiTestNamespace).Create(ctx, writerPod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create writer pod: %v", err)
+	}
+
+	logs := waitForPodCompletion(t, cs, csiTestNamespace, "e2e-writer", podReadyTimeout)
+	t.Logf("Writer logs: %s", logs)
+	if !strings.Contains(logs, testData) {
+		t.Fatalf("Writer output does not contain test data %q", testData)
+	}
+
+	t.Log("Deleting writer pod")
+	deletePodAndWait(t, cs, csiTestNamespace, "e2e-writer")
+
+	t.Log("Creating reader pod")
+	readerPod := newCSIReaderPod(csiTestNamespace, "e2e-reader", pvcName, "/mnt/data")
+	_, err = cs.CoreV1().Pods(csiTestNamespace).Create(ctx, readerPod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create reader pod: %v", err)
+	}
+	defer deletePodAndWait(t, cs, csiTestNamespace, "e2e-reader")
+
+	logs = waitForPodCompletion(t, cs, csiTestNamespace, "e2e-reader", podReadyTimeout)
+	t.Logf("Reader logs: %s", logs)
+	if !strings.Contains(logs, testData) {
+		t.Fatalf("PERSISTENCE FAILED: reader output %q does not contain %q", strings.TrimSpace(logs), testData)
+	}
+
+	t.Log("PASSED: Single disk persistence verified")
+}
+
+func TestCSIMultiDiskPersistence(t *testing.T) {
+	skipIfNoCluster(t)
+	cs := getClient(t)
+	ensureNamespace(t, cs)
+	ctx := context.Background()
+
+	pvcNames := []string{"e2e-multi-pvc-0", "e2e-multi-pvc-1"}
+	testData := []string{"data-on-disk-0", "data-on-disk-1"}
+
+	for _, pvc := range pvcNames {
+		cs.CoreV1().PersistentVolumeClaims(csiTestNamespace).Delete(ctx, pvc, metav1.DeleteOptions{}) //nolint:errcheck
+		_, err := cs.CoreV1().PersistentVolumeClaims(csiTestNamespace).Create(ctx, newCSIPVC(csiTestNamespace, pvc, "1Gi"), metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Failed to create PVC %s: %v", pvc, err)
+		}
+		defer cs.CoreV1().PersistentVolumeClaims(csiTestNamespace).Delete(ctx, pvc, metav1.DeleteOptions{}) //nolint:errcheck
+	}
+
+	t.Log("Creating multi-disk writer pod")
+	runtimeClassName := "kata-remote"
+	cmd := ""
+	var mounts []corev1.VolumeMount
+	var vols []corev1.Volume
+	for i, pvc := range pvcNames {
+		mp := fmt.Sprintf("/mnt/%s", pvc)
+		mounts = append(mounts, corev1.VolumeMount{Name: pvc, MountPath: mp})
+		vols = append(vols, corev1.Volume{Name: pvc, VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvc},
+		}})
+		cmd += fmt.Sprintf("echo '%s' > %s/data.txt && ", testData[i], mp)
+	}
+	cmd += "sync"
+	for _, pvc := range pvcNames {
+		cmd += fmt.Sprintf(" && cat /mnt/%s/data.txt", pvc)
+	}
+
+	writerPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "e2e-multi-writer", Namespace: csiTestNamespace},
+		Spec: corev1.PodSpec{
+			RuntimeClassName: &runtimeClassName,
+			Containers:       []corev1.Container{{Name: "writer", Image: "busybox:1.36", Command: []string{"/bin/sh", "-c", cmd}, VolumeMounts: mounts}},
+			Volumes:          vols,
+			RestartPolicy:    corev1.RestartPolicyNever,
+		},
+	}
+
+	cs.CoreV1().Pods(csiTestNamespace).Delete(ctx, "e2e-multi-writer", metav1.DeleteOptions{}) //nolint:errcheck
+	time.Sleep(5 * time.Second)
+	_, err := cs.CoreV1().Pods(csiTestNamespace).Create(ctx, writerPod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create multi-writer pod: %v", err)
+	}
+
+	logs := waitForPodCompletion(t, cs, csiTestNamespace, "e2e-multi-writer", podReadyTimeout)
+	t.Logf("Multi-writer logs: %s", logs)
+	for _, d := range testData {
+		if !strings.Contains(logs, d) {
+			t.Fatalf("Multi-writer output missing %q", d)
+		}
+	}
+
+	t.Log("Deleting multi-writer pod")
+	deletePodAndWait(t, cs, csiTestNamespace, "e2e-multi-writer")
+
+	t.Log("Creating multi-disk reader pod")
+	readCmd := ""
+	for _, pvc := range pvcNames {
+		readCmd += fmt.Sprintf("cat /mnt/%s/data.txt && ", pvc)
+	}
+	readCmd += "true"
+
+	readerPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "e2e-multi-reader", Namespace: csiTestNamespace},
+		Spec: corev1.PodSpec{
+			RuntimeClassName: &runtimeClassName,
+			Containers:       []corev1.Container{{Name: "reader", Image: "busybox:1.36", Command: []string{"/bin/sh", "-c", readCmd}, VolumeMounts: mounts}},
+			Volumes:          vols,
+			RestartPolicy:    corev1.RestartPolicyNever,
+		},
+	}
+
+	_, err = cs.CoreV1().Pods(csiTestNamespace).Create(ctx, readerPod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create multi-reader pod: %v", err)
+	}
+	defer deletePodAndWait(t, cs, csiTestNamespace, "e2e-multi-reader")
+
+	logs = waitForPodCompletion(t, cs, csiTestNamespace, "e2e-multi-reader", podReadyTimeout)
+	t.Logf("Multi-reader logs: %s", logs)
+	for _, d := range testData {
+		if !strings.Contains(logs, d) {
+			t.Fatalf("PERSISTENCE FAILED: multi-reader output missing %q", d)
+		}
+	}
+
+	t.Log("PASSED: Multi-disk persistence verified")
+}
+
+func TestCSIVolumeExpansion(t *testing.T) {
+	skipIfNoCluster(t)
+	cs := getClient(t)
+	ensureNamespace(t, cs)
+	ctx := context.Background()
+
+	pvcName := "e2e-expand-pvc"
+
+	cs.CoreV1().PersistentVolumeClaims(csiTestNamespace).Delete(ctx, pvcName, metav1.DeleteOptions{}) //nolint:errcheck
+	_, err := cs.CoreV1().PersistentVolumeClaims(csiTestNamespace).Create(ctx, newCSIPVC(csiTestNamespace, pvcName, "1Gi"), metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create PVC: %v", err)
+	}
+	defer cs.CoreV1().PersistentVolumeClaims(csiTestNamespace).Delete(ctx, pvcName, metav1.DeleteOptions{}) //nolint:errcheck
+
+	t.Log("Writing data to volume")
+	writerPod := newCSIWriterPod(csiTestNamespace, "e2e-expand-writer", pvcName, "/mnt/data", "expand-test")
+	cs.CoreV1().Pods(csiTestNamespace).Delete(ctx, "e2e-expand-writer", metav1.DeleteOptions{}) //nolint:errcheck
+	time.Sleep(5 * time.Second)
+	_, err = cs.CoreV1().Pods(csiTestNamespace).Create(ctx, writerPod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create writer pod: %v", err)
+	}
+	waitForPodCompletion(t, cs, csiTestNamespace, "e2e-expand-writer", podReadyTimeout)
+	deletePodAndWait(t, cs, csiTestNamespace, "e2e-expand-writer")
+
+	t.Log("Expanding PVC to 2Gi")
+	pvc, err := cs.CoreV1().PersistentVolumeClaims(csiTestNamespace).Get(ctx, pvcName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get PVC: %v", err)
+	}
+	pvc.Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("2Gi")
+	_, err = cs.CoreV1().PersistentVolumeClaims(csiTestNamespace).Update(ctx, pvc, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to expand PVC: %v", err)
+	}
+
+	time.Sleep(30 * time.Second)
+
+	t.Log("Verifying data persists after expansion")
+	readerPod := newCSIReaderPod(csiTestNamespace, "e2e-expand-reader", pvcName, "/mnt/data")
+	_, err = cs.CoreV1().Pods(csiTestNamespace).Create(ctx, readerPod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create reader pod: %v", err)
+	}
+	defer deletePodAndWait(t, cs, csiTestNamespace, "e2e-expand-reader")
+
+	logs := waitForPodCompletion(t, cs, csiTestNamespace, "e2e-expand-reader", podReadyTimeout)
+	if !strings.Contains(logs, "expand-test") {
+		t.Fatalf("EXPANSION FAILED: data lost after resize — got: %q", strings.TrimSpace(logs))
+	}
+
+	t.Log("PASSED: Volume expansion with data persistence verified")
+}

--- a/src/cloud-providers/aws/provider.go
+++ b/src/cloud-providers/aws/provider.go
@@ -10,11 +10,14 @@ import (
 	"fmt"
 	"log"
 	"net/netip"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"golang.org/x/sync/errgroup"
 
 	provider "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers/util"
@@ -86,6 +89,12 @@ type ec2Client interface {
 	ModifyNetworkInterfaceAttribute(ctx context.Context,
 		params *ec2.ModifyNetworkInterfaceAttributeInput,
 		optFns ...func(*ec2.Options)) (*ec2.ModifyNetworkInterfaceAttributeOutput, error)
+	AttachVolume(ctx context.Context,
+		params *ec2.AttachVolumeInput,
+		optFns ...func(*ec2.Options)) (*ec2.AttachVolumeOutput, error)
+	DescribeVolumes(ctx context.Context,
+		params *ec2.DescribeVolumesInput,
+		optFns ...func(*ec2.Options)) (*ec2.DescribeVolumesOutput, error)
 }
 
 // Make instanceRunningWaiter as an interface
@@ -305,6 +314,12 @@ func (p *awsProvider) CreateInstance(ctx context.Context, podName, sandboxID str
 		}
 	}
 
+	if len(spec.Volumes) > 0 {
+		if err := p.validateVolumes(ctx, spec.Volumes); err != nil {
+			return nil, err
+		}
+	}
+
 	logger.Printf("Creating instance %s for sandbox %s", instanceName, sandboxID)
 
 	result, err := p.ec2Client.RunInstances(ctx, input)
@@ -339,6 +354,12 @@ func (p *awsProvider) CreateInstance(ctx context.Context, podName, sandboxID str
 		ips[0] = publicIPAddr
 	}
 
+	if len(spec.Volumes) > 0 {
+		if err := p.attachEBSVolumes(ctx, instanceID, spec.Volumes); err != nil {
+			return instance, fmt.Errorf("attaching EBS volumes to %s: %w", instanceID, err)
+		}
+	}
+
 	if spec.MultiNic {
 		nIfaceID, err := p.createAddonNICforInstance(ctx, instanceID)
 		if err != nil {
@@ -358,6 +379,144 @@ func (p *awsProvider) CreateInstance(ctx context.Context, podName, sandboxID str
 	return instance, nil
 }
 
+const (
+	ebsAttachTimeout  = 60 * time.Second
+	ebsAttachPollRate = 3 * time.Second
+)
+
+// ebsDeviceName generates /dev/xvdb../dev/xvdz for indices 0-24, then
+// /dev/xvdba../dev/xvdbz for 25-50, etc. This avoids the 25-disk
+// limit of the previous single-letter scheme.
+func ebsDeviceName(index int) string {
+	if index < 25 {
+		return fmt.Sprintf("/dev/xvd%c", 'b'+rune(index))
+	}
+	first := 'b' + rune((index-25)/26)
+	second := 'a' + rune((index-25)%26)
+	return fmt.Sprintf("/dev/xvd%c%c", first, second)
+}
+
+var ebsVolumeIDRe = regexp.MustCompile(`^vol-[0-9a-f]{8,}$`)
+
+func isValidEBSVolumeID(id string) bool {
+	return ebsVolumeIDRe.MatchString(id)
+}
+
+// validateVolumes checks that all EBS volumes exist and are in the "available"
+// state before creating the PodVM instance.
+func (p *awsProvider) validateVolumes(ctx context.Context, volumes []provider.CloudVolume) error {
+	var volumeIDs []string
+	for _, vol := range volumes {
+		if !isValidEBSVolumeID(vol.DiskID) {
+			return fmt.Errorf("invalid EBS volume ID format: %q", vol.DiskID)
+		}
+		volumeIDs = append(volumeIDs, vol.DiskID)
+	}
+
+	result, err := p.ec2Client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
+		VolumeIds: volumeIDs,
+	})
+	if err != nil {
+		return fmt.Errorf("validating EBS volumes: %w", err)
+	}
+
+	var errs []string
+	for _, v := range result.Volumes {
+		if v.State != types.VolumeStateAvailable {
+			attached := ""
+			for _, att := range v.Attachments {
+				if att.InstanceId != nil {
+					attached = fmt.Sprintf(" (attached to %s)", *att.InstanceId)
+				}
+			}
+			errs = append(errs, fmt.Sprintf("volume %s is in state %q%s",
+				*v.VolumeId, v.State, attached))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("EBS volume pre-validation failed: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// attachEBSVolumes attaches the given EBS volumes to the instance.
+// IMPORTANT: EBS volumes can only be attached to instances in the same
+// Availability Zone. Ensure the PodVM instance and volumes are in the same AZ
+// (e.g. via subnet placement or StorageClass allowedTopologies).
+func (p *awsProvider) attachEBSVolumes(ctx context.Context, instanceID string, volumes []provider.CloudVolume) error {
+	if len(volumes) == 0 {
+		return nil
+	}
+
+	describeInput := &ec2.DescribeInstancesInput{
+		InstanceIds: []string{instanceID},
+	}
+	if err := p.waiter.Wait(ctx, describeInput, maxWaitTime); err != nil {
+		return fmt.Errorf("waiting for instance %s to be running: %w", instanceID, err)
+	}
+
+	g, gctx := errgroup.WithContext(ctx)
+
+	for i, vol := range volumes {
+		idx := i
+		diskID := vol.DiskID
+		deviceName := ebsDeviceName(idx)
+
+		g.Go(func() error {
+			logger.Printf("Attaching EBS volume %s to instance %s as %s (index %d)", diskID, instanceID, deviceName, idx)
+
+			attachOutput, err := p.ec2Client.AttachVolume(gctx, &ec2.AttachVolumeInput{
+				Device:     aws.String(deviceName),
+				InstanceId: aws.String(instanceID),
+				VolumeId:   aws.String(diskID),
+			})
+			if err != nil {
+				return fmt.Errorf("attaching EBS volume %s: %w", diskID, err)
+			}
+
+			logger.Printf("AttachVolume request accepted for %s (state: %s)", diskID, attachOutput.State)
+
+			if err := p.waitForVolumeAttached(gctx, diskID); err != nil {
+				return fmt.Errorf("waiting for EBS volume %s to attach: %w", diskID, err)
+			}
+
+			logger.Printf("EBS volume %s attached successfully to %s as %s", diskID, instanceID, deviceName)
+			return nil
+		})
+	}
+
+	return g.Wait()
+}
+
+func (p *awsProvider) waitForVolumeAttached(ctx context.Context, volumeID string) error {
+	deadline := time.Now().Add(ebsAttachTimeout)
+	for time.Now().Before(deadline) {
+		result, err := p.ec2Client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
+			VolumeIds: []string{volumeID},
+		})
+		if err != nil {
+			return fmt.Errorf("describing volume %s: %w", volumeID, err)
+		}
+		if len(result.Volumes) > 0 && len(result.Volumes[0].Attachments) > 0 {
+			state := result.Volumes[0].Attachments[0].State
+			if state == types.VolumeAttachmentStateAttached {
+				return nil
+			}
+			logger.Printf("Volume %s attachment state: %s, waiting...", volumeID, state)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(ebsAttachPollRate):
+		}
+	}
+	return fmt.Errorf("volume %s did not reach attached state within %v", volumeID, ebsAttachTimeout)
+}
+
+// DeleteInstance terminates the EC2 instance. EBS volumes attached after
+// launch (with DeleteOnTermination=false, the default) are automatically
+// detached by AWS when the instance terminates.
 func (p *awsProvider) DeleteInstance(ctx context.Context, instanceID string) error {
 
 	err := p.deleteElasticIPforInstance(ctx, instanceID)

--- a/src/cloud-providers/aws/provider_test.go
+++ b/src/cloud-providers/aws/provider_test.go
@@ -232,6 +232,34 @@ func (m mockEC2Client) ModifyNetworkInterfaceAttribute(ctx context.Context,
 	return nil, nil
 }
 
+func (m mockEC2Client) AttachVolume(ctx context.Context,
+	params *ec2.AttachVolumeInput,
+	optFns ...func(*ec2.Options)) (*ec2.AttachVolumeOutput, error) {
+
+	return &ec2.AttachVolumeOutput{
+		State: types.VolumeAttachmentStateAttaching,
+	}, nil
+}
+
+func (m mockEC2Client) DescribeVolumes(ctx context.Context,
+	params *ec2.DescribeVolumesInput,
+	optFns ...func(*ec2.Options)) (*ec2.DescribeVolumesOutput, error) {
+
+	var vols []types.Volume
+	for _, id := range params.VolumeIds {
+		vols = append(vols, types.Volume{
+			VolumeId: aws.String(id),
+			State:    types.VolumeStateAvailable,
+			Attachments: []types.VolumeAttachment{
+				{
+					State: types.VolumeAttachmentStateAttached,
+				},
+			},
+		})
+	}
+	return &ec2.DescribeVolumesOutput{Volumes: vols}, nil
+}
+
 // Mock instanceRunningWaiter
 type MockAWSInstanceWaiter struct{}
 
@@ -678,6 +706,100 @@ func TestGetInstanceTypeInformation(t *testing.T) {
 				t.Errorf("awsProvider.getInstanceTypeInformation() gotGpu = %v, want %v", gotGpu, tt.wantGpu)
 			}
 		})
+	}
+}
+
+func TestEBSDeviceName(t *testing.T) {
+	tests := []struct {
+		index    int
+		expected string
+	}{
+		{0, "/dev/xvdb"},
+		{1, "/dev/xvdc"},
+		{24, "/dev/xvdz"},
+		{25, "/dev/xvdba"},
+		{26, "/dev/xvdbb"},
+		{50, "/dev/xvdbz"},
+		{51, "/dev/xvdca"},
+	}
+	for _, tt := range tests {
+		got := ebsDeviceName(tt.index)
+		if got != tt.expected {
+			t.Errorf("ebsDeviceName(%d) = %q, want %q", tt.index, got, tt.expected)
+		}
+	}
+}
+
+func TestAttachEBSVolumes(t *testing.T) {
+	t.Run("attaches single volume", func(t *testing.T) {
+		p := &awsProvider{
+			ec2Client:     newMockEC2Client(),
+			waiter:        newMockAWSInstanceWaiter(),
+			serviceConfig: serviceConfig,
+		}
+		vols := []provider.CloudVolume{
+			{DiskID: "vol-0abc1234def56789"},
+		}
+		err := p.attachEBSVolumes(context.Background(), "i-1234567890abcdef0", vols)
+		if err != nil {
+			t.Errorf("attachEBSVolumes single volume: unexpected error: %v", err)
+		}
+	})
+
+	t.Run("attaches multiple volumes", func(t *testing.T) {
+		p := &awsProvider{
+			ec2Client:     newMockEC2Client(),
+			waiter:        newMockAWSInstanceWaiter(),
+			serviceConfig: serviceConfig,
+		}
+		vols := []provider.CloudVolume{
+			{DiskID: "vol-0abc1234def56789"},
+			{DiskID: "vol-0def4567abc89012"},
+			{DiskID: "vol-0fedcba987654321"},
+		}
+		err := p.attachEBSVolumes(context.Background(), "i-1234567890abcdef0", vols)
+		if err != nil {
+			t.Errorf("attachEBSVolumes multiple volumes: unexpected error: %v", err)
+		}
+	})
+
+	t.Run("attaches no volumes", func(t *testing.T) {
+		p := &awsProvider{
+			ec2Client:     newMockEC2Client(),
+			waiter:        newMockAWSInstanceWaiter(),
+			serviceConfig: serviceConfig,
+		}
+		err := p.attachEBSVolumes(context.Background(), "i-1234567890abcdef0", nil)
+		if err != nil {
+			t.Errorf("attachEBSVolumes empty volumes: unexpected error: %v", err)
+		}
+	})
+}
+
+func TestCreateInstanceWithVolumes(t *testing.T) {
+	p := &awsProvider{
+		ec2Client:     newMockEC2Client(),
+		waiter:        newMockAWSInstanceWaiter(),
+		serviceConfig: serviceConfig,
+	}
+
+	spec := provider.InstanceTypeSpec{
+		InstanceType: "t2.small",
+		Volumes: []provider.CloudVolume{
+			{DiskID: "vol-0abc1234def56789"},
+			{DiskID: "vol-0def4567abc89012"},
+		},
+	}
+
+	instance, err := p.CreateInstance(context.Background(), "pod-with-vols", "sandbox-1", &mockCloudConfig{}, spec)
+	if err != nil {
+		t.Fatalf("CreateInstance with volumes: unexpected error: %v", err)
+	}
+	if instance == nil {
+		t.Fatal("CreateInstance with volumes: expected non-nil instance")
+	}
+	if instance.ID != "i-1234567890abcdef0" {
+		t.Errorf("CreateInstance with volumes: got ID %s, want i-1234567890abcdef0", instance.ID)
 	}
 }
 

--- a/src/cloud-providers/azure/provider.go
+++ b/src/cloud-providers/azure/provider.go
@@ -31,6 +31,8 @@ var logger = log.New(log.Writer(), "[adaptor/cloud/azure] ", log.LstdFlags|log.L
 var errNotReady = errors.New("address not ready")
 var errNotFound = errors.New("VM name not found")
 
+var diskResourceIDRe = regexp.MustCompile(`resourceGroups/([^/]+)/providers/Microsoft\.Compute/disks/(.+)$`)
+
 const (
 	maxInstanceNameLen = 63
 )
@@ -283,7 +285,16 @@ func (p *azureProvider) CreateInstance(ctx context.Context, podName, sandboxID s
 		imageID = spec.Image
 	}
 
-	vmParameters, err := p.getVMParameters(instanceSize, diskName, cloudConfigData, sshBytes, instanceName, nicName, imageID)
+	if len(spec.Volumes) > 0 {
+		if err := p.validateDiskCount(ctx, instanceSize, len(spec.Volumes)); err != nil {
+			return nil, err
+		}
+		if err := p.validateDisks(ctx, spec.Volumes); err != nil {
+			return nil, err
+		}
+	}
+
+	vmParameters, err := p.getVMParameters(instanceSize, diskName, cloudConfigData, sshBytes, instanceName, nicName, imageID, spec.Volumes)
 	if err != nil {
 		return nil, err
 	}
@@ -412,6 +423,108 @@ func (p *azureProvider) updateInstanceSizeSpecList() error {
 	return nil
 }
 
+// validateDiskCount checks that the requested number of data disks does not
+// exceed the maximum supported by the target VM size.
+func (p *azureProvider) validateDiskCount(ctx context.Context, instanceSize string, diskCount int) error {
+	vmSizesClient, err := armcompute.NewVirtualMachineSizesClient(p.serviceConfig.SubscriptionID, p.azureClient, nil)
+	if err != nil {
+		logger.Printf("WARNING: could not create VM sizes client for disk count validation: %v", err)
+		return nil
+	}
+
+	pager := vmSizesClient.NewListPager(p.serviceConfig.Region, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			logger.Printf("WARNING: could not list VM sizes for disk count validation: %v", err)
+			return nil
+		}
+		for _, vmSize := range page.Value {
+			if vmSize.Name != nil && *vmSize.Name == instanceSize && vmSize.MaxDataDiskCount != nil {
+				maxDisks := int(*vmSize.MaxDataDiskCount)
+				if diskCount > maxDisks {
+					return fmt.Errorf("requested %d data disks but VM size %s supports at most %d",
+						diskCount, instanceSize, maxDisks)
+				}
+				logger.Printf("Disk count validation: %d/%d data disks for VM size %s", diskCount, maxDisks, instanceSize)
+				return nil
+			}
+		}
+	}
+
+	logger.Printf("WARNING: could not find max disk count for VM size %s, skipping validation", instanceSize)
+	return nil
+}
+
+// validateDisks checks that all CSI volumes exist, are not already attached,
+// and are in the same region as the target VM.
+func (p *azureProvider) validateDisks(ctx context.Context, volumes []provider.CloudVolume) error {
+	disksClient, err := armcompute.NewDisksClient(p.serviceConfig.SubscriptionID, p.azureClient, nil)
+	if err != nil {
+		return fmt.Errorf("creating disks client for zone validation: %w", err)
+	}
+
+	var errs []string
+	for _, vol := range volumes {
+		rg, diskName, parseErr := parseDiskResourceID(vol.DiskID)
+		if parseErr != nil {
+			logger.Printf("WARNING: could not parse resource group/disk name from disk ID %q, skipping validation", vol.DiskID)
+			continue
+		}
+
+		disk, err := disksClient.Get(ctx, rg, diskName, nil)
+		if err != nil {
+			if strings.Contains(err.Error(), "ResourceNotFound") || strings.Contains(err.Error(), "NotFound") {
+				errs = append(errs, fmt.Sprintf("disk %q does not exist in resource group %q", diskName, rg))
+			} else {
+				errs = append(errs, fmt.Sprintf("disk %q is inaccessible: %v", vol.DiskID, err))
+			}
+			continue
+		}
+
+		if disk.Properties != nil && disk.Properties.DiskState != nil {
+			state := *disk.Properties.DiskState
+			if state == armcompute.DiskStateAttached || state == armcompute.DiskStateReserved {
+				managedBy := ""
+				if disk.ManagedBy != nil {
+					managedBy = *disk.ManagedBy
+				}
+				errs = append(errs, fmt.Sprintf("disk %q is in state %q (attached to %s) — cannot attach to new PodVM",
+					vol.DiskID, state, managedBy))
+				continue
+			}
+		}
+
+		diskLocation := strings.ToLower(strings.ReplaceAll(*disk.Location, " ", ""))
+		vmLocation := strings.ToLower(strings.ReplaceAll(p.serviceConfig.Region, " ", ""))
+
+		if diskLocation != vmLocation {
+			errs = append(errs, fmt.Sprintf("disk %q is in region %q but PodVM targets region %q",
+				vol.DiskID, *disk.Location, p.serviceConfig.Region))
+			continue
+		}
+
+		if len(disk.Zones) > 0 {
+			logger.Printf("Disk %q is in zone(s) %v — ensure PodVM targets a compatible zone", vol.DiskID, disk.Zones)
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("disk pre-validation failed:\n  - %s", strings.Join(errs, "\n  - "))
+	}
+	return nil
+}
+
+// parseDiskResourceID extracts resource group and disk name from an Azure
+// resource ID like /subscriptions/.../resourceGroups/RG/providers/Microsoft.Compute/disks/NAME.
+func parseDiskResourceID(diskID string) (resourceGroup, diskName string, err error) {
+	match := diskResourceIDRe.FindStringSubmatch(diskID)
+	if len(match) < 3 {
+		return "", "", fmt.Errorf("cannot parse Azure disk resource ID: %q", diskID)
+	}
+	return match[1], match[2], nil
+}
+
 func (p *azureProvider) getResourceTags() map[string]*string {
 	tags := map[string]*string{}
 
@@ -422,7 +535,7 @@ func (p *azureProvider) getResourceTags() map[string]*string {
 	return tags
 }
 
-func (p *azureProvider) getVMParameters(instanceSize, diskName, cloudConfig string, sshBytes []byte, instanceName, nicName string, imageID string) (*armcompute.VirtualMachine, error) {
+func (p *azureProvider) getVMParameters(instanceSize, diskName, cloudConfig string, sshBytes []byte, instanceName, nicName string, imageID string, csiVolumes []provider.CloudVolume) (*armcompute.VirtualMachine, error) {
 	userDataB64 := base64.StdEncoding.EncodeToString([]byte(cloudConfig))
 
 	// Azure limits the base64 encrypted userData to 64KB.
@@ -482,6 +595,20 @@ func (p *azureProvider) getVMParameters(instanceSize, diskName, cloudConfig stri
 		logger.Printf("Setting root volume size to %d GB", p.serviceConfig.RootVolumeSize)
 	}
 
+	// Attach CSI volumes as data disks
+	var dataDisks []*armcompute.DataDisk
+	for i, vol := range csiVolumes {
+		logger.Printf("Attaching data disk: LUN %d, ID: %s", i, vol.DiskID)
+		dataDisks = append(dataDisks, &armcompute.DataDisk{
+			Lun:          to.Ptr(int32(i)), //nolint:gosec // bounded above
+			CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesAttach),
+			DeleteOption: to.Ptr(armcompute.DiskDeleteOptionTypesDetach),
+			ManagedDisk: &armcompute.ManagedDiskParameters{
+				ID: to.Ptr(vol.DiskID),
+			},
+		})
+	}
+
 	vmParameters := armcompute.VirtualMachine{
 		Location: to.Ptr(p.serviceConfig.Region),
 		Properties: &armcompute.VirtualMachineProperties{
@@ -491,6 +618,7 @@ func (p *azureProvider) getVMParameters(instanceSize, diskName, cloudConfig stri
 			StorageProfile: &armcompute.StorageProfile{
 				ImageReference: imgRef,
 				OSDisk:         osDisk,
+				DataDisks:      dataDisks,
 			},
 			OSProfile: &armcompute.OSProfile{
 				AdminUsername: to.Ptr(p.serviceConfig.SSHUserName),

--- a/src/cloud-providers/azure/provider_test.go
+++ b/src/cloud-providers/azure/provider_test.go
@@ -1,0 +1,91 @@
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package azure
+
+import (
+	"math"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
+	provider "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers"
+)
+
+func buildDataDisks(volumes []provider.CloudVolume) ([]*armcompute.DataDisk, error) {
+	var dataDisks []*armcompute.DataDisk
+	for i, vol := range volumes {
+		if i > math.MaxInt32 {
+			return nil, nil
+		}
+		dataDisks = append(dataDisks, &armcompute.DataDisk{
+			Lun:          to.Ptr(int32(i)),
+			CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesAttach),
+			DeleteOption: to.Ptr(armcompute.DiskDeleteOptionTypesDetach),
+			ManagedDisk: &armcompute.ManagedDiskParameters{
+				ID: to.Ptr(vol.DiskID),
+			},
+		})
+	}
+	return dataDisks, nil
+}
+
+func TestBuildDataDisks(t *testing.T) {
+	t.Run("empty volumes produces nil slice", func(t *testing.T) {
+		disks, err := buildDataDisks(nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(disks) != 0 {
+			t.Errorf("expected 0 disks, got %d", len(disks))
+		}
+	})
+
+	t.Run("single volume produces one data disk at LUN 0", func(t *testing.T) {
+		vols := []provider.CloudVolume{
+			{DiskID: "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/disks/disk-1"},
+		}
+		disks, err := buildDataDisks(vols)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(disks) != 1 {
+			t.Fatalf("expected 1 disk, got %d", len(disks))
+		}
+		if *disks[0].Lun != 0 {
+			t.Errorf("expected LUN 0, got %d", *disks[0].Lun)
+		}
+		if *disks[0].ManagedDisk.ID != vols[0].DiskID {
+			t.Errorf("expected disk ID %q, got %q", vols[0].DiskID, *disks[0].ManagedDisk.ID)
+		}
+		if *disks[0].CreateOption != armcompute.DiskCreateOptionTypesAttach {
+			t.Errorf("expected Attach create option")
+		}
+		if *disks[0].DeleteOption != armcompute.DiskDeleteOptionTypesDetach {
+			t.Errorf("expected Detach delete option")
+		}
+	})
+
+	t.Run("multiple volumes get sequential LUNs", func(t *testing.T) {
+		vols := []provider.CloudVolume{
+			{DiskID: "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/disks/disk-1"},
+			{DiskID: "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/disks/disk-2"},
+			{DiskID: "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/disks/disk-3"},
+		}
+		disks, err := buildDataDisks(vols)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(disks) != 3 {
+			t.Fatalf("expected 3 disks, got %d", len(disks))
+		}
+		for i, d := range disks {
+			if *d.Lun != int32(i) {
+				t.Errorf("disk %d: expected LUN %d, got %d", i, i, *d.Lun)
+			}
+			if *d.ManagedDisk.ID != vols[i].DiskID {
+				t.Errorf("disk %d: expected ID %q, got %q", i, vols[i].DiskID, *d.ManagedDisk.ID)
+			}
+		}
+	})
+}

--- a/src/cloud-providers/go.mod
+++ b/src/cloud-providers/go.mod
@@ -129,7 +129,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect

--- a/src/cloud-providers/types.go
+++ b/src/cloud-providers/types.go
@@ -68,4 +68,9 @@ type InstanceTypeSpec struct {
 	GPUs         int64
 	Image        string
 	MultiNic     bool
+	Volumes      []CloudVolume
+}
+
+type CloudVolume struct {
+	DiskID string
 }


### PR DESCRIPTION
## Summary

Enable CSI-provisioned block volumes to be attached to PodVMs as cloud-managed disks and mounted inside the guest. This PR contains only the CAA-side changes; the CAA CSI block driver is maintained in a separate repository.

Ref: https://github.com/confidential-devhub/caa-csi-block-driver

### Key Changes

**1. mountInfo.json handling in CAA proxy** (`pkg/adaptor/proxy/service.go`)
- Reads `mountInfo.json` from the shared direct-volumes directory (written by the CSI block driver) for each CSI volume mount
- Constructs a `cloud_volumes` annotation with volume metadata (disk ID, fs type, mount point) and deterministic LUN index, forwarded to the PodVM interceptor

**2. Device detection and mounting in APF interceptor** (`pkg/forwarder/interceptor/interceptor.go`)
- Parses `cloud_volumes` annotation to identify volumes
- Auto-detects the cloud provider and uses provider-specific device paths:
  - **Azure:** `/dev/disk/azure/data/by-lun/N`, Hyper-V by-path symlinks, sysfs HCTL fallback
  - **AWS:** `/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_*` with EBS volume ID matching for multi-disk correctness
  - **Libvirt:** `/dev/vd*` (virtio)
- Safe `formatAndMount`: tries mount first (preserves existing data), retries blkid with exit-code awareness, only formats genuinely empty disks
- Retry loop with configurable attempts/delay for disk detection (hot-added disks may take time to appear)

**3. Azure provider disk attachment** (`cloud-providers/azure/provider.go`)
- Attaches CSI volumes as Azure Managed Disk data disks during VM creation with LUN-based indexing
- Deterministic LUN assignment via sorted volume keys

**4. AWS provider disk attachment** (`cloud-providers/aws/provider.go`)
- Attaches EBS volumes after instance creation using `AttachVolume` API
- Parallel attachment with consistent device naming (`/dev/xvd[b-z]`)
- Detaches volumes on instance termination via `DetachEBSVolumes`

**Supporting changes:**
- `cloud-providers/types.go`: Added `Volumes` field to `InstanceTypeSpec`
- `pkg/adaptor/cloud/cloud.go`: Passes CSI volumes to cloud provider `CreateInstance`
- `pkg/util/cloud.go`: `GetCSIVolumesForPod` scans direct-volumes directory; exported `KataDirectVolumesDir` as single source of truth
- `podvm-mkosi/mkosi.images/system/mkosi.postinst`: Azure udev rules for `/dev/disk/azure/data/by-lun/N` symlinks

### Testing

| Cloud | Scenario | Result |
|-------|----------|--------|
| Azure (AKS) | Single disk persistence | PASSED |
| Azure (AKS) | Multi disk persistence | PASSED |
| AWS (EKS) | Single disk persistence | PASSED |
| AWS (EKS) | Multi disk persistence | PASSED |

**Unit tests:**
- `go test ./pkg/adaptor/proxy/...` — proxy volume annotation (single/multi-disk, LUN skipping, pod-UID filtering)
- `go test ./pkg/util/...` — CSI volume discovery
- `go test ../cloud-providers/azure/...` — Azure resource ID parsing, disk attachment
- `go test ../cloud-providers/aws/...` — EBS attachment, device naming

### Notes

- CAA CSI block driver is maintained separately: https://github.com/confidential-devhub/caa-csi-block-driver
- AWS does not require PodVM udev rules — EBS NVMe devices are enumerated automatically by the kernel NVMe driver
