### PR TITLE
libvirt: validate required provider configuration earlier

### DIFF
--- a/src/cloud-providers/libvirt/libvirt_test.go
+++ b/src/cloud-providers/libvirt/libvirt_test.go
@@ -207,3 +207,99 @@ func TestGetDeletableDiskPaths(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigVerifier(t *testing.T) {
+	newConfig := func(overrides func(*Config)) *Config {
+		cfg := &Config{
+			URI:         "qemu:///system",
+			PoolName:    "default",
+			NetworkName: "default",
+			VolName:     "podvm-base.qcow2",
+			CPU:         1,
+			Memory:      512,
+		}
+		if overrides != nil {
+			overrides(cfg)
+		}
+		return cfg
+	}
+
+	tests := []struct {
+		name          string
+		provider      *libvirtProvider
+		expectedError string
+	}{
+		{
+			name: "empty URI fails",
+			provider: &libvirtProvider{
+				serviceConfig: newConfig(func(c *Config) {
+					c.URI = ""
+				}),
+			},
+			expectedError: "URI is empty",
+		},
+		{
+			name: "empty pool name fails",
+			provider: &libvirtProvider{
+				serviceConfig: newConfig(func(c *Config) {
+					c.PoolName = ""
+				}),
+			},
+			expectedError: "PoolName is empty",
+		},
+		{
+			name: "empty network name fails",
+			provider: &libvirtProvider{
+				serviceConfig: newConfig(func(c *Config) {
+					c.NetworkName = ""
+				}),
+			},
+			expectedError: "NetworkName is empty",
+		},
+		{
+			name: "empty volume name fails",
+			provider: &libvirtProvider{
+				serviceConfig: newConfig(func(c *Config) {
+					c.VolName = ""
+				}),
+			},
+			expectedError: "VolName is empty",
+		},
+		{
+			name: "zero CPU fails",
+			provider: &libvirtProvider{
+				serviceConfig: newConfig(func(c *Config) {
+					c.CPU = 0
+				}),
+			},
+			expectedError: "CPU must be greater than zero",
+		},
+		{
+			name: "zero memory fails",
+			provider: &libvirtProvider{
+				serviceConfig: newConfig(func(c *Config) {
+					c.Memory = 0
+				}),
+			},
+			expectedError: "Memory must be greater than zero",
+		},
+		{
+			name: "valid config passes",
+			provider: &libvirtProvider{
+				serviceConfig: newConfig(nil),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.provider.ConfigVerifier()
+			if tc.expectedError == "" {
+				assert.NoError(t, err)
+				return
+			}
+
+			assert.EqualError(t, err, tc.expectedError)
+		})
+	}
+}

--- a/src/cloud-providers/libvirt/provider.go
+++ b/src/cloud-providers/libvirt/provider.go
@@ -158,9 +158,31 @@ func (p *libvirtProvider) Teardown() error {
 }
 
 func (p *libvirtProvider) ConfigVerifier() error {
-	VolName := p.serviceConfig.VolName
-	if len(VolName) == 0 {
+	config := p.serviceConfig
+
+	if config.URI == "" {
+		return fmt.Errorf("URI is empty")
+	}
+
+	if config.PoolName == "" {
+		return fmt.Errorf("PoolName is empty")
+	}
+
+	if config.NetworkName == "" {
+		return fmt.Errorf("NetworkName is empty")
+	}
+
+	if config.VolName == "" {
 		return fmt.Errorf("VolName is empty")
 	}
+
+	if config.CPU == 0 {
+		return fmt.Errorf("CPU must be greater than zero")
+	}
+
+	if config.Memory == 0 {
+		return fmt.Errorf("Memory must be greater than zero")
+	}
+
 	return nil
 }


### PR DESCRIPTION
Extend ConfigVerifier() to fail fast on missing required libvirt settings and invalid default CPU or memory values.

Add focused unit tests for the new validation paths.

Fixes: #3024