### PR TITLE
e2e-test: Add test coverage for redirector.go

### DIFF
--- a/src/cloud-api-adaptor/pkg/adaptor/proxy/mock_agent_test.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/proxy/mock_agent_test.go
@@ -10,195 +10,28 @@ import (
 	"testing"
 
 	"github.com/containerd/ttrpc"
-	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols"
 	pb "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols/grpc"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/agentproto/testutil"
 )
 
-// mockAgentService is a shared mock implementation of the agent service
-// for testing purposes. It implements both AgentServiceService and HealthService interfaces.
-type mockAgentService struct{}
-
-func (m *mockAgentService) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
+type mockAgentService struct {
+	*testutil.MockAgentServiceClient
+	*testutil.MockHealthServiceClient
 }
 
-func (m *mockAgentService) StartContainer(ctx context.Context, req *pb.StartContainerRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) RemoveContainer(ctx context.Context, req *pb.RemoveContainerRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) ExecProcess(ctx context.Context, req *pb.ExecProcessRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) SignalProcess(ctx context.Context, req *pb.SignalProcessRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) WaitProcess(ctx context.Context, req *pb.WaitProcessRequest) (*pb.WaitProcessResponse, error) {
-	return &pb.WaitProcessResponse{}, nil
-}
-
-func (m *mockAgentService) UpdateContainer(ctx context.Context, req *pb.UpdateContainerRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) UpdateEphemeralMounts(ctx context.Context, req *pb.UpdateEphemeralMountsRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) StatsContainer(ctx context.Context, req *pb.StatsContainerRequest) (*pb.StatsContainerResponse, error) {
-	return &pb.StatsContainerResponse{}, nil
-}
-
-func (m *mockAgentService) PauseContainer(ctx context.Context, req *pb.PauseContainerRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) ResumeContainer(ctx context.Context, req *pb.ResumeContainerRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) WriteStdin(ctx context.Context, req *pb.WriteStreamRequest) (*pb.WriteStreamResponse, error) {
-	return &pb.WriteStreamResponse{}, nil
-}
-
-func (m *mockAgentService) ReadStdout(ctx context.Context, req *pb.ReadStreamRequest) (*pb.ReadStreamResponse, error) {
-	return &pb.ReadStreamResponse{}, nil
-}
-
-func (m *mockAgentService) ReadStderr(ctx context.Context, req *pb.ReadStreamRequest) (*pb.ReadStreamResponse, error) {
-	return &pb.ReadStreamResponse{}, nil
-}
-
-func (m *mockAgentService) CloseStdin(ctx context.Context, req *pb.CloseStdinRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) TtyWinResize(ctx context.Context, req *pb.TtyWinResizeRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) UpdateInterface(ctx context.Context, req *pb.UpdateInterfaceRequest) (*protocols.Interface, error) {
-	return &protocols.Interface{}, nil
-}
-
-func (m *mockAgentService) UpdateRoutes(ctx context.Context, req *pb.UpdateRoutesRequest) (*pb.Routes, error) {
-	return &pb.Routes{}, nil
-}
-
-func (m *mockAgentService) ListInterfaces(ctx context.Context, req *pb.ListInterfacesRequest) (*pb.Interfaces, error) {
-	return &pb.Interfaces{}, nil
-}
-
-func (m *mockAgentService) ListRoutes(ctx context.Context, req *pb.ListRoutesRequest) (*pb.Routes, error) {
-	return &pb.Routes{}, nil
-}
-
-func (m *mockAgentService) AddARPNeighbors(ctx context.Context, req *pb.AddARPNeighborsRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) GetIPTables(ctx context.Context, req *pb.GetIPTablesRequest) (*pb.GetIPTablesResponse, error) {
-	return &pb.GetIPTablesResponse{}, nil
-}
-
-func (m *mockAgentService) SetIPTables(ctx context.Context, req *pb.SetIPTablesRequest) (*pb.SetIPTablesResponse, error) {
-	return &pb.SetIPTablesResponse{}, nil
-}
-
-func (m *mockAgentService) GetMetrics(ctx context.Context, req *pb.GetMetricsRequest) (*pb.Metrics, error) {
-	return &pb.Metrics{}, nil
-}
-
-func (m *mockAgentService) CreateSandbox(ctx context.Context, req *pb.CreateSandboxRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) DestroySandbox(ctx context.Context, req *pb.DestroySandboxRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) OnlineCPUMem(ctx context.Context, req *pb.OnlineCPUMemRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) ReseedRandomDev(ctx context.Context, req *pb.ReseedRandomDevRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) GetGuestDetails(ctx context.Context, req *pb.GuestDetailsRequest) (*pb.GuestDetailsResponse, error) {
-	return &pb.GuestDetailsResponse{}, nil
-}
-
-func (m *mockAgentService) MemHotplugByProbe(ctx context.Context, req *pb.MemHotplugByProbeRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) SetGuestDateTime(ctx context.Context, req *pb.SetGuestDateTimeRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) CopyFile(ctx context.Context, req *pb.CopyFileRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) GetOOMEvent(ctx context.Context, req *pb.GetOOMEventRequest) (*pb.OOMEvent, error) {
-	return &pb.OOMEvent{}, nil
-}
-
-func (m *mockAgentService) AddSwap(ctx context.Context, req *pb.AddSwapRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) GetVolumeStats(ctx context.Context, req *pb.VolumeStatsRequest) (*pb.VolumeStatsResponse, error) {
-	return &pb.VolumeStatsResponse{}, nil
-}
-
-func (m *mockAgentService) ResizeVolume(ctx context.Context, req *pb.ResizeVolumeRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) RemoveStaleVirtiofsShareMounts(ctx context.Context, req *pb.RemoveStaleVirtiofsShareMountsRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) Check(ctx context.Context, req *pb.CheckRequest) (*pb.HealthCheckResponse, error) {
-	return &pb.HealthCheckResponse{}, nil
-}
-
-func (m *mockAgentService) Version(ctx context.Context, req *pb.CheckRequest) (*pb.VersionCheckResponse, error) {
-	return &pb.VersionCheckResponse{}, nil
-}
-
-func (m *mockAgentService) SetPolicy(ctx context.Context, req *pb.SetPolicyRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) AddSwapPath(ctx context.Context, req *pb.AddSwapPathRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) MemAgentMemcgSet(ctx context.Context, req *pb.MemAgentMemcgConfig) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) MemAgentCompactSet(ctx context.Context, req *pb.MemAgentCompactConfig) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, nil
-}
-
-func (m *mockAgentService) GetDiagnosticData(ctx context.Context, req *pb.GetDiagnosticDataRequest) (*pb.GetDiagnosticDataResponse, error) {
-	return &pb.GetDiagnosticDataResponse{}, nil
+func newMockAgentService() *mockAgentService {
+	return &mockAgentService{
+		MockAgentServiceClient:  &testutil.MockAgentServiceClient{},
+		MockHealthServiceClient: &testutil.MockHealthServiceClient{},
+	}
 }
 
 // errorReturningMockAgent is a mock that returns errors for testing error handling
 type errorReturningMockAgent struct {
-	mockAgentService
+	*mockAgentService
 }
 
 func (m *errorReturningMockAgent) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (*emptypb.Empty, error) {
@@ -211,8 +44,9 @@ func setupMockAgent(t *testing.T) (*ttrpc.Server, net.Listener) {
 	agentServer, err := ttrpc.NewServer()
 	require.NoError(t, err, "failed to create ttrpc server")
 
-	pb.RegisterAgentServiceService(agentServer, &mockAgentService{})
-	pb.RegisterHealthService(agentServer, &mockAgentService{})
+	mockAgent := newMockAgentService()
+	pb.RegisterAgentServiceService(agentServer, mockAgent)
+	pb.RegisterHealthService(agentServer, mockAgent)
 
 	agentListener, err := net.Listen("tcp", testListenAddressProxy)
 	require.NoError(t, err, "failed to create listener")

--- a/src/cloud-api-adaptor/pkg/forwarder/forwarder_test.go
+++ b/src/cloud-api-adaptor/pkg/forwarder/forwarder_test.go
@@ -14,22 +14,12 @@ import (
 
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/podnetwork/tunneler"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/agentproto"
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/agentproto/testutil"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/tlsutil"
 )
 
-type mockConn struct{}
-
-func (*mockConn) Read(b []byte) (n int, err error)   { return 0, nil }
-func (*mockConn) Write(b []byte) (n int, err error)  { return 0, nil }
-func (*mockConn) Close() error                       { return nil }
-func (*mockConn) LocalAddr() net.Addr                { return nil }
-func (*mockConn) RemoteAddr() net.Addr               { return nil }
-func (*mockConn) SetDeadline(t time.Time) error      { return nil }
-func (*mockConn) SetReadDeadline(t time.Time) error  { return nil }
-func (*mockConn) SetWriteDeadline(t time.Time) error { return nil }
-
 func dummyDialer(ctx context.Context) (net.Conn, error) {
-	return &mockConn{}, nil
+	return testutil.NewMockConn(), nil
 }
 
 type mockPodNode struct {

--- a/src/cloud-api-adaptor/pkg/forwarder/interceptor/interceptor_test.go
+++ b/src/cloud-api-adaptor/pkg/forwarder/interceptor/interceptor_test.go
@@ -15,52 +15,31 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/types/known/emptypb"
 
-	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/agentproto"
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/agentproto/testutil"
 )
 
-type mockRedirector struct {
-	agentproto.Redirector
-	createContainerCalled bool
-	startContainerCalled  bool
-	removeContainerCalled bool
-	createSandboxCalled   bool
-	destroySandboxCalled  bool
-	createContainerError  error
-	startContainerError   error
-	removeContainerError  error
-	createSandboxError    error
-	destroySandboxError   error
+type testRedirector struct {
+	*testutil.MockAgentServiceClient
+	*testutil.MockHealthServiceClient
 }
 
-func (m *mockRedirector) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (*emptypb.Empty, error) {
-	m.createContainerCalled = true
-	return &emptypb.Empty{}, m.createContainerError
-}
-
-func (m *mockRedirector) StartContainer(ctx context.Context, req *pb.StartContainerRequest) (*emptypb.Empty, error) {
-	m.startContainerCalled = true
-	return &emptypb.Empty{}, m.startContainerError
-}
-
-func (m *mockRedirector) RemoveContainer(ctx context.Context, req *pb.RemoveContainerRequest) (*emptypb.Empty, error) {
-	m.removeContainerCalled = true
-	return &emptypb.Empty{}, m.removeContainerError
-}
-
-func (m *mockRedirector) CreateSandbox(ctx context.Context, req *pb.CreateSandboxRequest) (*emptypb.Empty, error) {
-	m.createSandboxCalled = true
-	return &emptypb.Empty{}, m.createSandboxError
-}
-
-func (m *mockRedirector) DestroySandbox(ctx context.Context, req *pb.DestroySandboxRequest) (*emptypb.Empty, error) {
-	m.destroySandboxCalled = true
-	return &emptypb.Empty{}, m.destroySandboxError
-}
-
-func (m *mockRedirector) Close() error {
+func (r *testRedirector) Connect(context.Context) error {
 	return nil
+}
+
+func (r *testRedirector) Close() error {
+	return nil
+}
+
+func newTestInterceptor(mock *testutil.MockAgentServiceClient, nsPath string) *interceptor {
+	return &interceptor{
+		Redirector: &testRedirector{
+			MockAgentServiceClient:  mock,
+			MockHealthServiceClient: &testutil.MockHealthServiceClient{},
+		},
+		nsPath: nsPath,
+	}
 }
 
 func TestNewInterceptor(t *testing.T) {
@@ -134,11 +113,8 @@ func TestIsTargetPath(t *testing.T) {
 func TestInterceptorCreateContainer(t *testing.T) {
 	t.Run("adds network namespace to container spec", func(t *testing.T) {
 		nsPath := "/run/netns/podns"
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-			nsPath:     nsPath,
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, nsPath)
 
 		req := &pb.CreateContainerRequest{
 			ContainerId: "test-container",
@@ -153,7 +129,7 @@ func TestInterceptorCreateContainer(t *testing.T) {
 		_, err := i.CreateContainer(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createContainerCalled)
+		assert.True(t, mock.CreateContainerCalled)
 
 		// Verify network namespace was added
 		found := false
@@ -170,11 +146,8 @@ func TestInterceptorCreateContainer(t *testing.T) {
 		tmpDir := t.TempDir()
 		mountSource := filepath.Join(tmpDir, "nonexistent", "mount")
 
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-			nsPath:     "/run/netns/podns",
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "/run/netns/podns")
 
 		req := &pb.CreateContainerRequest{
 			ContainerId: "test-container",
@@ -195,7 +168,7 @@ func TestInterceptorCreateContainer(t *testing.T) {
 		_, err := i.CreateContainer(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createContainerCalled)
+		assert.True(t, mock.CreateContainerCalled)
 
 		// Verify directory was created
 		_, err = os.Stat(mountSource)
@@ -207,11 +180,8 @@ func TestInterceptorCreateContainer(t *testing.T) {
 		mountSource := filepath.Join(tmpDir, "existing")
 		require.NoError(t, os.MkdirAll(mountSource, 0o755))
 
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-			nsPath:     "/run/netns/podns",
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "/run/netns/podns")
 
 		req := &pb.CreateContainerRequest{
 			ContainerId: "test-container",
@@ -232,15 +202,12 @@ func TestInterceptorCreateContainer(t *testing.T) {
 		_, err := i.CreateContainer(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createContainerCalled)
+		assert.True(t, mock.CreateContainerCalled)
 	})
 
 	t.Run("handles non-bind mount types", func(t *testing.T) {
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-			nsPath:     "/run/netns/podns",
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "/run/netns/podns")
 
 		req := &pb.CreateContainerRequest{
 			ContainerId: "test-container",
@@ -261,18 +228,15 @@ func TestInterceptorCreateContainer(t *testing.T) {
 		_, err := i.CreateContainer(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createContainerCalled)
+		assert.True(t, mock.CreateContainerCalled)
 	})
 
 	t.Run("propagates redirector errors", func(t *testing.T) {
 		expectedErr := assert.AnError
-		mock := &mockRedirector{
-			createContainerError: expectedErr,
+		mock := &testutil.MockAgentServiceClient{
+			CreateContainerErr: expectedErr,
 		}
-		i := &interceptor{
-			Redirector: mock,
-			nsPath:     "/run/netns/podns",
-		}
+		i := newTestInterceptor(mock, "/run/netns/podns")
 
 		req := &pb.CreateContainerRequest{
 			ContainerId: "test-container",
@@ -288,16 +252,14 @@ func TestInterceptorCreateContainer(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Equal(t, expectedErr, err)
-		assert.True(t, mock.createContainerCalled)
+		assert.True(t, mock.CreateContainerCalled)
 	})
 }
 
 func TestInterceptorStartContainer(t *testing.T) {
 	t.Run("successfully starts container", func(t *testing.T) {
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "")
 
 		req := &pb.StartContainerRequest{
 			ContainerId: "test-container",
@@ -307,17 +269,15 @@ func TestInterceptorStartContainer(t *testing.T) {
 		_, err := i.StartContainer(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.startContainerCalled)
+		assert.True(t, mock.StartContainerCalled)
 	})
 
 	t.Run("propagates redirector errors", func(t *testing.T) {
 		expectedErr := assert.AnError
-		mock := &mockRedirector{
-			startContainerError: expectedErr,
+		mock := &testutil.MockAgentServiceClient{
+			StartContainerErr: expectedErr,
 		}
-		i := &interceptor{
-			Redirector: mock,
-		}
+		i := newTestInterceptor(mock, "")
 
 		req := &pb.StartContainerRequest{
 			ContainerId: "test-container",
@@ -328,16 +288,14 @@ func TestInterceptorStartContainer(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Equal(t, expectedErr, err)
-		assert.True(t, mock.startContainerCalled)
+		assert.True(t, mock.StartContainerCalled)
 	})
 }
 
 func TestInterceptorRemoveContainer(t *testing.T) {
 	t.Run("successfully removes container", func(t *testing.T) {
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "")
 
 		req := &pb.RemoveContainerRequest{
 			ContainerId: "test-container",
@@ -347,17 +305,15 @@ func TestInterceptorRemoveContainer(t *testing.T) {
 		_, err := i.RemoveContainer(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.removeContainerCalled)
+		assert.True(t, mock.RemoveContainerCalled)
 	})
 
 	t.Run("propagates redirector errors", func(t *testing.T) {
 		expectedErr := assert.AnError
-		mock := &mockRedirector{
-			removeContainerError: expectedErr,
+		mock := &testutil.MockAgentServiceClient{
+			RemoveContainerErr: expectedErr,
 		}
-		i := &interceptor{
-			Redirector: mock,
-		}
+		i := newTestInterceptor(mock, "")
 
 		req := &pb.RemoveContainerRequest{
 			ContainerId: "test-container",
@@ -368,16 +324,14 @@ func TestInterceptorRemoveContainer(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Equal(t, expectedErr, err)
-		assert.True(t, mock.removeContainerCalled)
+		assert.True(t, mock.RemoveContainerCalled)
 	})
 }
 
 func TestInterceptorCreateSandbox(t *testing.T) {
 	t.Run("successfully creates sandbox", func(t *testing.T) {
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "")
 
 		req := &pb.CreateSandboxRequest{
 			Hostname:  "test-host",
@@ -388,14 +342,12 @@ func TestInterceptorCreateSandbox(t *testing.T) {
 		_, err := i.CreateSandbox(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createSandboxCalled)
+		assert.True(t, mock.CreateSandboxCalled)
 	})
 
 	t.Run("removes DNS settings from request", func(t *testing.T) {
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "")
 
 		req := &pb.CreateSandboxRequest{
 			Hostname:  "test-host",
@@ -407,15 +359,13 @@ func TestInterceptorCreateSandbox(t *testing.T) {
 		_, err := i.CreateSandbox(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createSandboxCalled)
+		assert.True(t, mock.CreateSandboxCalled)
 		assert.Nil(t, req.Dns, "Expected DNS to be removed from request")
 	})
 
 	t.Run("handles empty DNS settings", func(t *testing.T) {
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "")
 
 		req := &pb.CreateSandboxRequest{
 			Hostname:  "test-host",
@@ -427,17 +377,15 @@ func TestInterceptorCreateSandbox(t *testing.T) {
 		_, err := i.CreateSandbox(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createSandboxCalled)
+		assert.True(t, mock.CreateSandboxCalled)
 	})
 
 	t.Run("propagates redirector errors", func(t *testing.T) {
 		expectedErr := assert.AnError
-		mock := &mockRedirector{
-			createSandboxError: expectedErr,
+		mock := &testutil.MockAgentServiceClient{
+			CreateSandboxErr: expectedErr,
 		}
-		i := &interceptor{
-			Redirector: mock,
-		}
+		i := newTestInterceptor(mock, "")
 
 		req := &pb.CreateSandboxRequest{
 			Hostname:  "test-host",
@@ -449,16 +397,14 @@ func TestInterceptorCreateSandbox(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Equal(t, expectedErr, err)
-		assert.True(t, mock.createSandboxCalled)
+		assert.True(t, mock.CreateSandboxCalled)
 	})
 }
 
 func TestInterceptorDestroySandbox(t *testing.T) {
 	t.Run("successfully destroys sandbox", func(t *testing.T) {
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "")
 
 		req := &pb.DestroySandboxRequest{}
 
@@ -466,17 +412,15 @@ func TestInterceptorDestroySandbox(t *testing.T) {
 		_, err := i.DestroySandbox(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.destroySandboxCalled)
+		assert.True(t, mock.DestroySandboxCalled)
 	})
 
 	t.Run("propagates redirector errors", func(t *testing.T) {
 		expectedErr := assert.AnError
-		mock := &mockRedirector{
-			destroySandboxError: expectedErr,
+		mock := &testutil.MockAgentServiceClient{
+			DestroySandboxErr: expectedErr,
 		}
-		i := &interceptor{
-			Redirector: mock,
-		}
+		i := newTestInterceptor(mock, "")
 
 		req := &pb.DestroySandboxRequest{}
 
@@ -485,7 +429,7 @@ func TestInterceptorDestroySandbox(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Equal(t, expectedErr, err)
-		assert.True(t, mock.destroySandboxCalled)
+		assert.True(t, mock.DestroySandboxCalled)
 	})
 }
 
@@ -497,11 +441,8 @@ func TestInterceptorWithAnnotations(t *testing.T) {
 		mountSource := filepath.Join(tmpDir, "actual-mount")
 		require.NoError(t, os.MkdirAll(mountSource, 0o755))
 
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-			nsPath:     "/run/netns/podns",
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "/run/netns/podns")
 
 		req := &pb.CreateContainerRequest{
 			ContainerId: "test-container",
@@ -525,7 +466,7 @@ func TestInterceptorWithAnnotations(t *testing.T) {
 		_, err := i.CreateContainer(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createContainerCalled)
+		assert.True(t, mock.CreateContainerCalled)
 	})
 
 	t.Run("handles empty volume target path annotation", func(t *testing.T) {
@@ -533,11 +474,8 @@ func TestInterceptorWithAnnotations(t *testing.T) {
 		mountSource := filepath.Join(tmpDir, "volume")
 		require.NoError(t, os.MkdirAll(mountSource, 0o755))
 
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-			nsPath:     "/run/netns/podns",
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "/run/netns/podns")
 
 		req := &pb.CreateContainerRequest{
 			ContainerId: "test-container",
@@ -561,7 +499,7 @@ func TestInterceptorWithAnnotations(t *testing.T) {
 		_, err := i.CreateContainer(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createContainerCalled)
+		assert.True(t, mock.CreateContainerCalled)
 	})
 
 	t.Run("handles missing volume target path annotation", func(t *testing.T) {
@@ -569,11 +507,8 @@ func TestInterceptorWithAnnotations(t *testing.T) {
 		mountSource := filepath.Join(tmpDir, "volume")
 		require.NoError(t, os.MkdirAll(mountSource, 0o755))
 
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-			nsPath:     "/run/netns/podns",
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "/run/netns/podns")
 
 		req := &pb.CreateContainerRequest{
 			ContainerId: "test-container",
@@ -595,7 +530,7 @@ func TestInterceptorWithAnnotations(t *testing.T) {
 		_, err := i.CreateContainer(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createContainerCalled)
+		assert.True(t, mock.CreateContainerCalled)
 	})
 }
 
@@ -619,11 +554,8 @@ func TestInterceptorCreateContainerWithMountErrors(t *testing.T) {
 		// Try to create a subdirectory in the non-writable directory
 		mountSource := filepath.Join(restrictedDir, "subdir", "test-mount-should-fail")
 
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-			nsPath:     "/run/netns/podns",
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "/run/netns/podns")
 
 		req := &pb.CreateContainerRequest{
 			ContainerId: "test-container",
@@ -645,7 +577,7 @@ func TestInterceptorCreateContainerWithMountErrors(t *testing.T) {
 		_, err = i.CreateContainer(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createContainerCalled)
+		assert.True(t, mock.CreateContainerCalled)
 	})
 
 	t.Run("handles multiple mounts with mixed types", func(t *testing.T) {
@@ -653,11 +585,8 @@ func TestInterceptorCreateContainerWithMountErrors(t *testing.T) {
 		bindMount := filepath.Join(tmpDir, "bind")
 		require.NoError(t, os.MkdirAll(bindMount, 0o755))
 
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-			nsPath:     "/run/netns/podns",
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "/run/netns/podns")
 
 		req := &pb.CreateContainerRequest{
 			ContainerId: "test-container",
@@ -686,15 +615,12 @@ func TestInterceptorCreateContainerWithMountErrors(t *testing.T) {
 		_, err := i.CreateContainer(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createContainerCalled)
+		assert.True(t, mock.CreateContainerCalled)
 	})
 
 	t.Run("handles container with no mounts", func(t *testing.T) {
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-			nsPath:     "/run/netns/podns",
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "/run/netns/podns")
 
 		req := &pb.CreateContainerRequest{
 			ContainerId: "test-container",
@@ -710,15 +636,12 @@ func TestInterceptorCreateContainerWithMountErrors(t *testing.T) {
 		_, err := i.CreateContainer(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createContainerCalled)
+		assert.True(t, mock.CreateContainerCalled)
 	})
 
 	t.Run("handles container with nil mounts", func(t *testing.T) {
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-			nsPath:     "/run/netns/podns",
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "/run/netns/podns")
 
 		req := &pb.CreateContainerRequest{
 			ContainerId: "test-container",
@@ -734,18 +657,15 @@ func TestInterceptorCreateContainerWithMountErrors(t *testing.T) {
 		_, err := i.CreateContainer(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createContainerCalled)
+		assert.True(t, mock.CreateContainerCalled)
 	})
 }
 
 func TestInterceptorCreateContainerWithNamespaces(t *testing.T) {
 	t.Run("adds network namespace to existing namespaces", func(t *testing.T) {
 		nsPath := "/run/netns/podns"
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-			nsPath:     nsPath,
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, nsPath)
 
 		req := &pb.CreateContainerRequest{
 			ContainerId: "test-container",
@@ -769,7 +689,7 @@ func TestInterceptorCreateContainerWithNamespaces(t *testing.T) {
 		_, err := i.CreateContainer(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createContainerCalled)
+		assert.True(t, mock.CreateContainerCalled)
 
 		// Verify network namespace was added
 		assert.Len(t, req.OCI.Linux.Namespaces, 3)
@@ -784,11 +704,8 @@ func TestInterceptorCreateContainerWithNamespaces(t *testing.T) {
 	})
 
 	t.Run("handles empty namespace path", func(t *testing.T) {
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-			nsPath:     "",
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "")
 
 		req := &pb.CreateContainerRequest{
 			ContainerId: "test-container",
@@ -803,7 +720,7 @@ func TestInterceptorCreateContainerWithNamespaces(t *testing.T) {
 		_, err := i.CreateContainer(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createContainerCalled)
+		assert.True(t, mock.CreateContainerCalled)
 
 		// Verify network namespace was added even with empty path
 		found := false
@@ -820,10 +737,8 @@ func TestInterceptorCreateContainerWithNamespaces(t *testing.T) {
 
 func TestInterceptorCreateSandboxWithDNS(t *testing.T) {
 	t.Run("handles single DNS server", func(t *testing.T) {
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "")
 
 		req := &pb.CreateSandboxRequest{
 			Hostname:  "test-host",
@@ -835,15 +750,13 @@ func TestInterceptorCreateSandboxWithDNS(t *testing.T) {
 		_, err := i.CreateSandbox(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createSandboxCalled)
+		assert.True(t, mock.CreateSandboxCalled)
 		assert.Nil(t, req.Dns)
 	})
 
 	t.Run("handles many DNS servers", func(t *testing.T) {
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "")
 
 		req := &pb.CreateSandboxRequest{
 			Hostname:  "test-host",
@@ -855,15 +768,13 @@ func TestInterceptorCreateSandboxWithDNS(t *testing.T) {
 		_, err := i.CreateSandbox(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createSandboxCalled)
+		assert.True(t, mock.CreateSandboxCalled)
 		assert.Nil(t, req.Dns)
 	})
 
 	t.Run("handles nil DNS", func(t *testing.T) {
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "")
 
 		req := &pb.CreateSandboxRequest{
 			Hostname:  "test-host",
@@ -875,7 +786,7 @@ func TestInterceptorCreateSandboxWithDNS(t *testing.T) {
 		_, err := i.CreateSandbox(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createSandboxCalled)
+		assert.True(t, mock.CreateSandboxCalled)
 		assert.Nil(t, req.Dns)
 	})
 }
@@ -888,11 +799,8 @@ func TestInterceptorWithComplexAnnotations(t *testing.T) {
 		mountSource := filepath.Join(tmpDir, "mount")
 		require.NoError(t, os.MkdirAll(mountSource, 0o755))
 
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-			nsPath:     "/run/netns/podns",
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "/run/netns/podns")
 
 		req := &pb.CreateContainerRequest{
 			ContainerId: "test-container",
@@ -916,7 +824,7 @@ func TestInterceptorWithComplexAnnotations(t *testing.T) {
 		_, err := i.CreateContainer(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createContainerCalled)
+		assert.True(t, mock.CreateContainerCalled)
 	})
 
 	t.Run("handles annotation with single path and comma", func(t *testing.T) {
@@ -925,11 +833,8 @@ func TestInterceptorWithComplexAnnotations(t *testing.T) {
 		mountSource := filepath.Join(tmpDir, "mount")
 		require.NoError(t, os.MkdirAll(mountSource, 0o755))
 
-		mock := &mockRedirector{}
-		i := &interceptor{
-			Redirector: mock,
-			nsPath:     "/run/netns/podns",
-		}
+		mock := &testutil.MockAgentServiceClient{}
+		i := newTestInterceptor(mock, "/run/netns/podns")
 
 		req := &pb.CreateContainerRequest{
 			ContainerId: "test-container",
@@ -953,7 +858,7 @@ func TestInterceptorWithComplexAnnotations(t *testing.T) {
 		_, err := i.CreateContainer(ctx, req)
 
 		require.NoError(t, err)
-		assert.True(t, mock.createContainerCalled)
+		assert.True(t, mock.CreateContainerCalled)
 	})
 }
 

--- a/src/cloud-api-adaptor/pkg/util/agentproto/redirector_test.go
+++ b/src/cloud-api-adaptor/pkg/util/agentproto/redirector_test.go
@@ -1,0 +1,701 @@
+package agentproto
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/agentproto/testutil"
+	pb "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols/grpc"
+)
+
+// setupTestRedirector creates a test redirector with the given mock clients
+func setupTestRedirector(t *testing.T, mockAgent *testutil.MockAgentServiceClient, mockHealth *testutil.MockHealthServiceClient) *redirector {
+	t.Helper()
+
+	r := &redirector{
+		agentClient: &client{
+			AgentServiceService: mockAgent,
+			HealthService:       mockHealth,
+		},
+		dialer: func(ctx context.Context) (net.Conn, error) {
+			return testutil.NewMockConn(), nil
+		},
+	}
+	r.once.Do(func() {}) // Pre-initialize to avoid connection logic
+	return r
+}
+
+// TestNewRedirector tests the NewRedirector constructor
+func TestNewRedirector(t *testing.T) {
+	tests := []struct {
+		name   string
+		dialer func(context.Context) (net.Conn, error)
+	}{
+		{
+			name: "valid dialer",
+			dialer: func(ctx context.Context) (net.Conn, error) {
+				return testutil.NewMockConn(), nil
+			},
+		},
+		{
+			name:   "nil dialer",
+			dialer: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewRedirector(tt.dialer)
+			if r == nil {
+				t.Fatal("NewRedirector returned nil")
+			}
+
+			redirectorImpl, ok := r.(*redirector)
+			if !ok {
+				t.Fatal("NewRedirector did not return *redirector type")
+			}
+
+			if tt.dialer != nil && redirectorImpl.dialer == nil {
+				t.Error("dialer was not set correctly")
+			}
+		})
+	}
+}
+
+// TestConnect tests the Connect method with various scenarios
+func TestConnect(t *testing.T) {
+	tests := []struct {
+		name      string
+		dialer    func(context.Context) (net.Conn, error)
+		cancelCtx bool
+		wantErr   bool
+	}{
+		{
+			name: "successful connection",
+			dialer: func(ctx context.Context) (net.Conn, error) {
+				return testutil.NewMockConn(), nil
+			},
+			wantErr: false,
+		},
+		{
+			name: "connection failure",
+			dialer: func(ctx context.Context) (net.Conn, error) {
+				return nil, errors.New("connection failed")
+			},
+			wantErr: true,
+		},
+		{
+			name: "context cancellation",
+			dialer: func(ctx context.Context) (net.Conn, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+			cancelCtx: true,
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &redirector{dialer: tt.dialer}
+
+			ctx := context.Background()
+			if tt.cancelCtx {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+
+			err := r.Connect(ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Connect() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestConnectConcurrency tests concurrent Connect calls
+func TestConnectConcurrency(t *testing.T) {
+	mockAgent := &testutil.MockAgentServiceClient{}
+	r := setupTestRedirector(t, mockAgent, nil)
+
+	ctx := context.Background()
+	const numGoroutines = 10
+
+	var wg sync.WaitGroup
+	errors := make(chan error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := r.Connect(ctx); err != nil {
+				errors <- err
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errors)
+
+	for err := range errors {
+		t.Errorf("concurrent Connect failed: %v", err)
+	}
+}
+
+// TestClose tests the Close method
+func TestClose(t *testing.T) {
+	mockAgent := &testutil.MockAgentServiceClient{}
+	r := setupTestRedirector(t, mockAgent, nil)
+
+	if err := r.Close(); err != nil {
+		t.Errorf("Close() error = %v", err)
+	}
+}
+
+// TestContainerOperations tests container operations
+func TestContainerOperations(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupMock func(*testutil.MockAgentServiceClient)
+		operation func(*redirector, context.Context) error
+		wantErr   bool
+	}{
+		{
+			name: "CreateContainer success",
+			setupMock: func(m *testutil.MockAgentServiceClient) {
+				m.CreateContainerErr = nil
+			},
+			operation: func(r *redirector, ctx context.Context) error {
+				_, err := r.CreateContainer(ctx, &pb.CreateContainerRequest{})
+				return err
+			},
+			wantErr: false,
+		},
+		{
+			name: "CreateContainer failure",
+			setupMock: func(m *testutil.MockAgentServiceClient) {
+				m.CreateContainerErr = errors.New("create failed")
+			},
+			operation: func(r *redirector, ctx context.Context) error {
+				_, err := r.CreateContainer(ctx, &pb.CreateContainerRequest{})
+				return err
+			},
+			wantErr: true,
+		},
+		{
+			name: "StartContainer success",
+			setupMock: func(m *testutil.MockAgentServiceClient) {
+				m.StartContainerErr = nil
+			},
+			operation: func(r *redirector, ctx context.Context) error {
+				_, err := r.StartContainer(ctx, &pb.StartContainerRequest{})
+				return err
+			},
+			wantErr: false,
+		},
+		{
+			name: "RemoveContainer success",
+			setupMock: func(m *testutil.MockAgentServiceClient) {
+				m.RemoveContainerErr = nil
+			},
+			operation: func(r *redirector, ctx context.Context) error {
+				_, err := r.RemoveContainer(ctx, &pb.RemoveContainerRequest{})
+				return err
+			},
+			wantErr: false,
+		},
+		{
+			name: "UpdateContainer success",
+			setupMock: func(m *testutil.MockAgentServiceClient) {
+				m.UpdateContainerErr = nil
+			},
+			operation: func(r *redirector, ctx context.Context) error {
+				_, err := r.UpdateContainer(ctx, &pb.UpdateContainerRequest{})
+				return err
+			},
+			wantErr: false,
+		},
+		{
+			name:      "StatsContainer success",
+			setupMock: func(m *testutil.MockAgentServiceClient) {},
+			operation: func(r *redirector, ctx context.Context) error {
+				_, err := r.StatsContainer(ctx, &pb.StatsContainerRequest{})
+				return err
+			},
+			wantErr: false,
+		},
+		{
+			name:      "PauseContainer success",
+			setupMock: func(m *testutil.MockAgentServiceClient) {},
+			operation: func(r *redirector, ctx context.Context) error {
+				_, err := r.PauseContainer(ctx, &pb.PauseContainerRequest{})
+				return err
+			},
+			wantErr: false,
+		},
+		{
+			name:      "ResumeContainer success",
+			setupMock: func(m *testutil.MockAgentServiceClient) {},
+			operation: func(r *redirector, ctx context.Context) error {
+				_, err := r.ResumeContainer(ctx, &pb.ResumeContainerRequest{})
+				return err
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockAgent := &testutil.MockAgentServiceClient{}
+			tt.setupMock(mockAgent)
+			r := setupTestRedirector(t, mockAgent, nil)
+
+			ctx := context.Background()
+			err := tt.operation(r, ctx)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("%s error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestProcessOperations tests process operations
+func TestProcessOperations(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupMock func(*testutil.MockAgentServiceClient)
+		operation func(*redirector, context.Context) error
+		wantErr   bool
+	}{
+		{
+			name: "ExecProcess success",
+			setupMock: func(m *testutil.MockAgentServiceClient) {
+				m.ExecProcessErr = nil
+			},
+			operation: func(r *redirector, ctx context.Context) error {
+				_, err := r.ExecProcess(ctx, &pb.ExecProcessRequest{})
+				return err
+			},
+			wantErr: false,
+		},
+		{
+			name: "SignalProcess success",
+			setupMock: func(m *testutil.MockAgentServiceClient) {
+				m.SignalProcessErr = nil
+			},
+			operation: func(r *redirector, ctx context.Context) error {
+				_, err := r.SignalProcess(ctx, &pb.SignalProcessRequest{})
+				return err
+			},
+			wantErr: false,
+		},
+		{
+			name: "WaitProcess success",
+			setupMock: func(m *testutil.MockAgentServiceClient) {
+				m.WaitProcessErr = nil
+			},
+			operation: func(r *redirector, ctx context.Context) error {
+				resp, err := r.WaitProcess(ctx, &pb.WaitProcessRequest{})
+				if err == nil && resp == nil {
+					return errors.New("nil response")
+				}
+				return err
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockAgent := &testutil.MockAgentServiceClient{}
+			tt.setupMock(mockAgent)
+			r := setupTestRedirector(t, mockAgent, nil)
+
+			ctx := context.Background()
+			err := tt.operation(r, ctx)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("%s error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestStreamOperations tests I/O stream operations
+func runRedirectorTests(t *testing.T, tests []struct {
+	name string
+	run  func(*redirector, context.Context) error
+}) {
+	t.Helper()
+
+	mockAgent := &testutil.MockAgentServiceClient{}
+	r := setupTestRedirector(t, mockAgent, nil)
+	ctx := context.Background()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.run(r, ctx); err != nil {
+				t.Errorf("%s() error = %v", tt.name, err)
+			}
+		})
+	}
+}
+
+// TestStreamOperations tests I/O stream operations
+func TestStreamOperations(t *testing.T) {
+	runRedirectorTests(t, []struct {
+		name string
+		run  func(*redirector, context.Context) error
+	}{
+		{
+			name: "WriteStdin",
+			run: func(r *redirector, ctx context.Context) error {
+				resp, err := r.WriteStdin(ctx, &pb.WriteStreamRequest{Data: []byte("test")})
+				if err == nil && resp == nil {
+					return errors.New("nil response")
+				}
+				return err
+			},
+		},
+		{
+			name: "ReadStdout",
+			run: func(r *redirector, ctx context.Context) error {
+				resp, err := r.ReadStdout(ctx, &pb.ReadStreamRequest{})
+				if err == nil && resp == nil {
+					return errors.New("nil response")
+				}
+				return err
+			},
+		},
+		{
+			name: "ReadStderr",
+			run: func(r *redirector, ctx context.Context) error {
+				resp, err := r.ReadStderr(ctx, &pb.ReadStreamRequest{})
+				if err == nil && resp == nil {
+					return errors.New("nil response")
+				}
+				return err
+			},
+		},
+		{
+			name: "CloseStdin",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.CloseStdin(ctx, &pb.CloseStdinRequest{})
+				return err
+			},
+		},
+		{
+			name: "TtyWinResize",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.TtyWinResize(ctx, &pb.TtyWinResizeRequest{})
+				return err
+			},
+		},
+	})
+}
+
+// TestNetworkOperations tests network operations
+func TestNetworkOperations(t *testing.T) {
+	runRedirectorTests(t, []struct {
+		name string
+		run  func(*redirector, context.Context) error
+	}{
+		{
+			name: "UpdateInterface",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.UpdateInterface(ctx, &pb.UpdateInterfaceRequest{})
+				return err
+			},
+		},
+		{
+			name: "UpdateRoutes",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.UpdateRoutes(ctx, &pb.UpdateRoutesRequest{})
+				return err
+			},
+		},
+		{
+			name: "ListInterfaces",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.ListInterfaces(ctx, &pb.ListInterfacesRequest{})
+				return err
+			},
+		},
+		{
+			name: "ListRoutes",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.ListRoutes(ctx, &pb.ListRoutesRequest{})
+				return err
+			},
+		},
+		{
+			name: "AddARPNeighbors",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.AddARPNeighbors(ctx, &pb.AddARPNeighborsRequest{})
+				return err
+			},
+		},
+	})
+}
+
+// TestSandboxOperations tests sandbox operations
+func TestSandboxOperations(t *testing.T) {
+	runRedirectorTests(t, []struct {
+		name string
+		run  func(*redirector, context.Context) error
+	}{
+		{
+			name: "CreateSandbox",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.CreateSandbox(ctx, &pb.CreateSandboxRequest{})
+				return err
+			},
+		},
+		{
+			name: "DestroySandbox",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.DestroySandbox(ctx, &pb.DestroySandboxRequest{})
+				return err
+			},
+		},
+	})
+}
+
+// TestMountOperations tests mount operations
+func TestMountOperations(t *testing.T) {
+	runRedirectorTests(t, []struct {
+		name string
+		run  func(*redirector, context.Context) error
+	}{
+		{
+			name: "UpdateEphemeralMounts",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.UpdateEphemeralMounts(ctx, &pb.UpdateEphemeralMountsRequest{})
+				return err
+			},
+		},
+		{
+			name: "RemoveStaleVirtiofsShareMounts",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.RemoveStaleVirtiofsShareMounts(ctx, &pb.RemoveStaleVirtiofsShareMountsRequest{})
+				return err
+			},
+		},
+	})
+}
+
+// TestIPTablesOperations tests IPTables operations
+func TestIPTablesOperations(t *testing.T) {
+	runRedirectorTests(t, []struct {
+		name string
+		run  func(*redirector, context.Context) error
+	}{
+		{
+			name: "GetIPTables",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.GetIPTables(ctx, &pb.GetIPTablesRequest{})
+				return err
+			},
+		},
+		{
+			name: "SetIPTables",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.SetIPTables(ctx, &pb.SetIPTablesRequest{})
+				return err
+			},
+		},
+	})
+}
+
+// TestMemoryOperations tests memory operations
+func TestMemoryOperations(t *testing.T) {
+	runRedirectorTests(t, []struct {
+		name string
+		run  func(*redirector, context.Context) error
+	}{
+		{
+			name: "OnlineCPUMem",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.OnlineCPUMem(ctx, &pb.OnlineCPUMemRequest{})
+				return err
+			},
+		},
+		{
+			name: "MemHotplugByProbe",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.MemHotplugByProbe(ctx, &pb.MemHotplugByProbeRequest{})
+				return err
+			},
+		},
+		{
+			name: "MemAgentMemcgSet",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.MemAgentMemcgSet(ctx, &pb.MemAgentMemcgConfig{})
+				return err
+			},
+		},
+		{
+			name: "MemAgentCompactSet",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.MemAgentCompactSet(ctx, &pb.MemAgentCompactConfig{})
+				return err
+			},
+		},
+	})
+}
+
+// TestStorageOperations tests storage operations
+func TestStorageOperations(t *testing.T) {
+	runRedirectorTests(t, []struct {
+		name string
+		run  func(*redirector, context.Context) error
+	}{
+		{
+			name: "GetVolumeStats",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.GetVolumeStats(ctx, &pb.VolumeStatsRequest{})
+				return err
+			},
+		},
+		{
+			name: "ResizeVolume",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.ResizeVolume(ctx, &pb.ResizeVolumeRequest{})
+				return err
+			},
+		},
+		{
+			name: "AddSwap",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.AddSwap(ctx, &pb.AddSwapRequest{})
+				return err
+			},
+		},
+		{
+			name: "AddSwapPath",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.AddSwapPath(ctx, &pb.AddSwapPathRequest{})
+				return err
+			},
+		},
+	})
+}
+
+// TestMiscellaneousOperations tests miscellaneous operations
+func TestMiscellaneousOperations(t *testing.T) {
+	runRedirectorTests(t, []struct {
+		name string
+		run  func(*redirector, context.Context) error
+	}{
+		{
+			name: "GetMetrics",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.GetMetrics(ctx, &pb.GetMetricsRequest{})
+				return err
+			},
+		},
+		{
+			name: "ReseedRandomDev",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.ReseedRandomDev(ctx, &pb.ReseedRandomDevRequest{})
+				return err
+			},
+		},
+		{
+			name: "GetGuestDetails",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.GetGuestDetails(ctx, &pb.GuestDetailsRequest{})
+				return err
+			},
+		},
+		{
+			name: "SetGuestDateTime",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.SetGuestDateTime(ctx, &pb.SetGuestDateTimeRequest{})
+				return err
+			},
+		},
+		{
+			name: "CopyFile",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.CopyFile(ctx, &pb.CopyFileRequest{})
+				return err
+			},
+		},
+		{
+			name: "GetOOMEvent",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.GetOOMEvent(ctx, &pb.GetOOMEventRequest{})
+				return err
+			},
+		},
+		{
+			name: "SetPolicy",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.SetPolicy(ctx, &pb.SetPolicyRequest{})
+				return err
+			},
+		},
+		{
+			name: "GetDiagnosticData",
+			run: func(r *redirector, ctx context.Context) error {
+				_, err := r.GetDiagnosticData(ctx, &pb.GetDiagnosticDataRequest{})
+				return err
+			},
+		},
+	})
+}
+
+// TestHealthService tests health service operations
+func TestHealthService(t *testing.T) {
+	tests := []struct {
+		name       string
+		checkErr   error
+		versionErr error
+	}{
+		{
+			name:       "successful health check",
+			checkErr:   nil,
+			versionErr: nil,
+		},
+		{
+			name:       "health check failure",
+			checkErr:   errors.New("health check failed"),
+			versionErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockAgent := &testutil.MockAgentServiceClient{}
+			mockHealth := &testutil.MockHealthServiceClient{
+				CheckErr:   tt.checkErr,
+				VersionErr: tt.versionErr,
+			}
+			r := setupTestRedirector(t, mockAgent, mockHealth)
+			ctx := context.Background()
+
+			_, err := r.Check(ctx, &pb.CheckRequest{})
+			if (err != nil) != (tt.checkErr != nil) {
+				t.Errorf("Check() error = %v, wantErr %v", err, tt.checkErr != nil)
+			}
+
+			_, err = r.Version(ctx, &pb.CheckRequest{})
+			if (err != nil) != (tt.versionErr != nil) {
+				t.Errorf("Version() error = %v, wantErr %v", err, tt.versionErr != nil)
+			}
+		})
+	}
+}
+
+// TestInterfaceCompliance verifies interface implementation
+func TestInterfaceCompliance(t *testing.T) {
+	var _ Redirector = (*redirector)(nil)
+	var _ pb.AgentServiceService = (*client)(nil)
+	var _ pb.HealthService = (*client)(nil)
+}

--- a/src/cloud-api-adaptor/pkg/util/agentproto/testutil/mocks.go
+++ b/src/cloud-api-adaptor/pkg/util/agentproto/testutil/mocks.go
@@ -1,0 +1,311 @@
+package testutil
+
+import (
+	"context"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols"
+	pb "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// MockConn implements net.Conn for testing
+type MockConn struct {
+	net.Conn
+	closed bool
+	mu     sync.Mutex
+}
+
+func NewMockConn() *MockConn {
+	return &MockConn{}
+}
+
+func (m *MockConn) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closed = true
+	return nil
+}
+
+func (m *MockConn) Read(b []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (m *MockConn) Write(b []byte) (n int, err error) {
+	return len(b), nil
+}
+
+func (m *MockConn) LocalAddr() net.Addr {
+	return &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8080}
+}
+
+func (m *MockConn) RemoteAddr() net.Addr {
+	return &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 9090}
+}
+
+func (m *MockConn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (m *MockConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (m *MockConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+// MockAgentServiceClient implements pb.AgentServiceService for testing
+type MockAgentServiceClient struct {
+	pb.AgentServiceService
+	CreateContainerErr    error
+	StartContainerErr     error
+	RemoveContainerErr    error
+	ExecProcessErr        error
+	SignalProcessErr      error
+	WaitProcessErr        error
+	UpdateContainerErr    error
+	CreateSandboxErr      error
+	DestroySandboxErr     error
+	CreateContainerCalled bool
+	StartContainerCalled  bool
+	RemoveContainerCalled bool
+	CreateSandboxCalled   bool
+	DestroySandboxCalled  bool
+}
+
+// Container operations
+func (m *MockAgentServiceClient) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (*emptypb.Empty, error) {
+	m.CreateContainerCalled = true
+	if m.CreateContainerErr != nil {
+		return nil, m.CreateContainerErr
+	}
+	return &emptypb.Empty{}, nil
+}
+
+func (m *MockAgentServiceClient) StartContainer(ctx context.Context, req *pb.StartContainerRequest) (*emptypb.Empty, error) {
+	m.StartContainerCalled = true
+	if m.StartContainerErr != nil {
+		return nil, m.StartContainerErr
+	}
+	return &emptypb.Empty{}, nil
+}
+
+func (m *MockAgentServiceClient) RemoveContainer(ctx context.Context, req *pb.RemoveContainerRequest) (*emptypb.Empty, error) {
+	m.RemoveContainerCalled = true
+	if m.RemoveContainerErr != nil {
+		return nil, m.RemoveContainerErr
+	}
+	return &emptypb.Empty{}, nil
+}
+
+func (m *MockAgentServiceClient) UpdateContainer(ctx context.Context, req *pb.UpdateContainerRequest) (*emptypb.Empty, error) {
+	if m.UpdateContainerErr != nil {
+		return nil, m.UpdateContainerErr
+	}
+	return &emptypb.Empty{}, nil
+}
+
+func (m *MockAgentServiceClient) StatsContainer(ctx context.Context, req *pb.StatsContainerRequest) (*pb.StatsContainerResponse, error) {
+	return &pb.StatsContainerResponse{}, nil
+}
+
+func (m *MockAgentServiceClient) PauseContainer(ctx context.Context, req *pb.PauseContainerRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *MockAgentServiceClient) ResumeContainer(ctx context.Context, req *pb.ResumeContainerRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+// Process operations
+func (m *MockAgentServiceClient) ExecProcess(ctx context.Context, req *pb.ExecProcessRequest) (*emptypb.Empty, error) {
+	if m.ExecProcessErr != nil {
+		return nil, m.ExecProcessErr
+	}
+	return &emptypb.Empty{}, nil
+}
+
+func (m *MockAgentServiceClient) SignalProcess(ctx context.Context, req *pb.SignalProcessRequest) (*emptypb.Empty, error) {
+	if m.SignalProcessErr != nil {
+		return nil, m.SignalProcessErr
+	}
+	return &emptypb.Empty{}, nil
+}
+
+func (m *MockAgentServiceClient) WaitProcess(ctx context.Context, req *pb.WaitProcessRequest) (*pb.WaitProcessResponse, error) {
+	if m.WaitProcessErr != nil {
+		return nil, m.WaitProcessErr
+	}
+	return &pb.WaitProcessResponse{Status: 0}, nil
+}
+
+// Stream operations
+func (m *MockAgentServiceClient) WriteStdin(ctx context.Context, req *pb.WriteStreamRequest) (*pb.WriteStreamResponse, error) {
+	return &pb.WriteStreamResponse{Len: uint32(len(req.Data))}, nil
+}
+
+func (m *MockAgentServiceClient) ReadStdout(ctx context.Context, req *pb.ReadStreamRequest) (*pb.ReadStreamResponse, error) {
+	return &pb.ReadStreamResponse{Data: []byte("stdout data")}, nil
+}
+
+func (m *MockAgentServiceClient) ReadStderr(ctx context.Context, req *pb.ReadStreamRequest) (*pb.ReadStreamResponse, error) {
+	return &pb.ReadStreamResponse{Data: []byte("stderr data")}, nil
+}
+
+func (m *MockAgentServiceClient) CloseStdin(ctx context.Context, req *pb.CloseStdinRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *MockAgentServiceClient) TtyWinResize(ctx context.Context, req *pb.TtyWinResizeRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+// Network operations
+func (m *MockAgentServiceClient) UpdateInterface(ctx context.Context, req *pb.UpdateInterfaceRequest) (*protocols.Interface, error) {
+	return &protocols.Interface{}, nil
+}
+
+func (m *MockAgentServiceClient) UpdateRoutes(ctx context.Context, req *pb.UpdateRoutesRequest) (*pb.Routes, error) {
+	return &pb.Routes{}, nil
+}
+
+func (m *MockAgentServiceClient) ListInterfaces(ctx context.Context, req *pb.ListInterfacesRequest) (*pb.Interfaces, error) {
+	return &pb.Interfaces{}, nil
+}
+
+func (m *MockAgentServiceClient) ListRoutes(ctx context.Context, req *pb.ListRoutesRequest) (*pb.Routes, error) {
+	return &pb.Routes{}, nil
+}
+
+func (m *MockAgentServiceClient) AddARPNeighbors(ctx context.Context, req *pb.AddARPNeighborsRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+// Sandbox operations
+func (m *MockAgentServiceClient) CreateSandbox(ctx context.Context, req *pb.CreateSandboxRequest) (*emptypb.Empty, error) {
+	m.CreateSandboxCalled = true
+	if m.CreateSandboxErr != nil {
+		return nil, m.CreateSandboxErr
+	}
+	return &emptypb.Empty{}, nil
+}
+
+func (m *MockAgentServiceClient) DestroySandbox(ctx context.Context, req *pb.DestroySandboxRequest) (*emptypb.Empty, error) {
+	m.DestroySandboxCalled = true
+	if m.DestroySandboxErr != nil {
+		return nil, m.DestroySandboxErr
+	}
+	return &emptypb.Empty{}, nil
+}
+
+// Mount operations
+func (m *MockAgentServiceClient) UpdateEphemeralMounts(ctx context.Context, req *pb.UpdateEphemeralMountsRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *MockAgentServiceClient) RemoveStaleVirtiofsShareMounts(ctx context.Context, req *pb.RemoveStaleVirtiofsShareMountsRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+// IPTables operations
+func (m *MockAgentServiceClient) GetIPTables(ctx context.Context, req *pb.GetIPTablesRequest) (*pb.GetIPTablesResponse, error) {
+	return &pb.GetIPTablesResponse{}, nil
+}
+
+func (m *MockAgentServiceClient) SetIPTables(ctx context.Context, req *pb.SetIPTablesRequest) (*pb.SetIPTablesResponse, error) {
+	return &pb.SetIPTablesResponse{}, nil
+}
+
+// Memory operations
+func (m *MockAgentServiceClient) OnlineCPUMem(ctx context.Context, req *pb.OnlineCPUMemRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *MockAgentServiceClient) MemHotplugByProbe(ctx context.Context, req *pb.MemHotplugByProbeRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *MockAgentServiceClient) MemAgentMemcgSet(ctx context.Context, req *pb.MemAgentMemcgConfig) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *MockAgentServiceClient) MemAgentCompactSet(ctx context.Context, req *pb.MemAgentCompactConfig) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+// Storage operations
+func (m *MockAgentServiceClient) GetVolumeStats(ctx context.Context, req *pb.VolumeStatsRequest) (*pb.VolumeStatsResponse, error) {
+	return &pb.VolumeStatsResponse{}, nil
+}
+
+func (m *MockAgentServiceClient) ResizeVolume(ctx context.Context, req *pb.ResizeVolumeRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *MockAgentServiceClient) AddSwap(ctx context.Context, req *pb.AddSwapRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *MockAgentServiceClient) AddSwapPath(ctx context.Context, req *pb.AddSwapPathRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+// Miscellaneous operations
+func (m *MockAgentServiceClient) GetMetrics(ctx context.Context, req *pb.GetMetricsRequest) (*pb.Metrics, error) {
+	return &pb.Metrics{}, nil
+}
+
+func (m *MockAgentServiceClient) ReseedRandomDev(ctx context.Context, req *pb.ReseedRandomDevRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *MockAgentServiceClient) GetGuestDetails(ctx context.Context, req *pb.GuestDetailsRequest) (*pb.GuestDetailsResponse, error) {
+	return &pb.GuestDetailsResponse{}, nil
+}
+
+func (m *MockAgentServiceClient) SetGuestDateTime(ctx context.Context, req *pb.SetGuestDateTimeRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *MockAgentServiceClient) CopyFile(ctx context.Context, req *pb.CopyFileRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *MockAgentServiceClient) GetOOMEvent(ctx context.Context, req *pb.GetOOMEventRequest) (*pb.OOMEvent, error) {
+	return &pb.OOMEvent{}, nil
+}
+
+func (m *MockAgentServiceClient) SetPolicy(ctx context.Context, req *pb.SetPolicyRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *MockAgentServiceClient) GetDiagnosticData(ctx context.Context, req *pb.GetDiagnosticDataRequest) (*pb.GetDiagnosticDataResponse, error) {
+	return &pb.GetDiagnosticDataResponse{}, nil
+}
+
+// MockHealthServiceClient implements pb.HealthService for testing
+type MockHealthServiceClient struct {
+	pb.HealthService
+	CheckErr   error
+	VersionErr error
+}
+
+func (m *MockHealthServiceClient) Check(ctx context.Context, req *pb.CheckRequest) (*pb.HealthCheckResponse, error) {
+	if m.CheckErr != nil {
+		return nil, m.CheckErr
+	}
+	return &pb.HealthCheckResponse{Status: pb.HealthCheckResponse_SERVING}, nil
+}
+
+func (m *MockHealthServiceClient) Version(ctx context.Context, req *pb.CheckRequest) (*pb.VersionCheckResponse, error) {
+	if m.VersionErr != nil {
+		return nil, m.VersionErr
+	}
+	return &pb.VersionCheckResponse{
+		GrpcVersion:  "1.0.0",
+		AgentVersion: "2.0.0",
+	}, nil
+}


### PR DESCRIPTION
Add redirector_test.go with enhanced test coverage for the agent protocol redirector implementation. Tests cover connection management, all AgentServiceService and HealthService methods, error handling, and concurrent access scenarios. Add common mocks.go and update forwarder_test.go and interceptor_test.go

 ```
agentproto]# go test -v -cover -tags "aws,ibmcloud,libvirt,azure"
=== RUN   TestNewRedirector
=== RUN   TestNewRedirector/valid_dialer
=== RUN   TestNewRedirector/nil_dialer
--- PASS: TestNewRedirector (0.00s)
    --- PASS: TestNewRedirector/valid_dialer (0.00s)
    --- PASS: TestNewRedirector/nil_dialer (0.00s)
=== RUN   TestConnect
=== RUN   TestConnect/successful_connection
=== RUN   TestConnect/connection_failure
=== RUN   TestConnect/context_cancellation
--- PASS: TestConnect (0.00s)
    --- PASS: TestConnect/successful_connection (0.00s)
    --- PASS: TestConnect/connection_failure (0.00s)
    --- PASS: TestConnect/context_cancellation (0.00s)
=== RUN   TestConnectConcurrency
--- PASS: TestConnectConcurrency (0.00s)
=== RUN   TestClose
--- PASS: TestClose (0.00s)
=== RUN   TestContainerOperations
=== RUN   TestContainerOperations/CreateContainer_success
=== RUN   TestContainerOperations/CreateContainer_failure
=== RUN   TestContainerOperations/StartContainer_success
=== RUN   TestContainerOperations/RemoveContainer_success
=== RUN   TestContainerOperations/UpdateContainer_success
=== RUN   TestContainerOperations/StatsContainer_success
=== RUN   TestContainerOperations/PauseContainer_success
=== RUN   TestContainerOperations/ResumeContainer_success
--- PASS: TestContainerOperations (0.00s)
    --- PASS: TestContainerOperations/CreateContainer_success (0.00s)
    --- PASS: TestContainerOperations/CreateContainer_failure (0.00s)
    --- PASS: TestContainerOperations/StartContainer_success (0.00s)
    --- PASS: TestContainerOperations/RemoveContainer_success (0.00s)
    --- PASS: TestContainerOperations/UpdateContainer_success (0.00s)
    --- PASS: TestContainerOperations/StatsContainer_success (0.00s)
    --- PASS: TestContainerOperations/PauseContainer_success (0.00s)
    --- PASS: TestContainerOperations/ResumeContainer_success (0.00s)
=== RUN   TestProcessOperations
=== RUN   TestProcessOperations/ExecProcess_success
=== RUN   TestProcessOperations/SignalProcess_success
=== RUN   TestProcessOperations/WaitProcess_success
--- PASS: TestProcessOperations (0.00s)
    --- PASS: TestProcessOperations/ExecProcess_success (0.00s)
    --- PASS: TestProcessOperations/SignalProcess_success (0.00s)
    --- PASS: TestProcessOperations/WaitProcess_success (0.00s)
=== RUN   TestStreamOperations
=== RUN   TestStreamOperations/WriteStdin
=== RUN   TestStreamOperations/ReadStdout
=== RUN   TestStreamOperations/ReadStderr
=== RUN   TestStreamOperations/CloseStdin
=== RUN   TestStreamOperations/TtyWinResize
--- PASS: TestStreamOperations (0.00s)
    --- PASS: TestStreamOperations/WriteStdin (0.00s)
    --- PASS: TestStreamOperations/ReadStdout (0.00s)
    --- PASS: TestStreamOperations/ReadStderr (0.00s)
    --- PASS: TestStreamOperations/CloseStdin (0.00s)
    --- PASS: TestStreamOperations/TtyWinResize (0.00s)
=== RUN   TestNetworkOperations
=== RUN   TestNetworkOperations/UpdateInterface
=== RUN   TestNetworkOperations/UpdateRoutes
=== RUN   TestNetworkOperations/ListInterfaces
=== RUN   TestNetworkOperations/ListRoutes
=== RUN   TestNetworkOperations/AddARPNeighbors
--- PASS: TestNetworkOperations (0.00s)
    --- PASS: TestNetworkOperations/UpdateInterface (0.00s)
    --- PASS: TestNetworkOperations/UpdateRoutes (0.00s)
    --- PASS: TestNetworkOperations/ListInterfaces (0.00s)
    --- PASS: TestNetworkOperations/ListRoutes (0.00s)
    --- PASS: TestNetworkOperations/AddARPNeighbors (0.00s)
=== RUN   TestSandboxOperations
=== RUN   TestSandboxOperations/CreateSandbox
=== RUN   TestSandboxOperations/DestroySandbox
--- PASS: TestSandboxOperations (0.00s)
    --- PASS: TestSandboxOperations/CreateSandbox (0.00s)
    --- PASS: TestSandboxOperations/DestroySandbox (0.00s)
=== RUN   TestMountOperations
=== RUN   TestMountOperations/UpdateEphemeralMounts
=== RUN   TestMountOperations/RemoveStaleVirtiofsShareMounts
--- PASS: TestMountOperations (0.00s)
    --- PASS: TestMountOperations/UpdateEphemeralMounts (0.00s)
    --- PASS: TestMountOperations/RemoveStaleVirtiofsShareMounts (0.00s)
=== RUN   TestIPTablesOperations
=== RUN   TestIPTablesOperations/GetIPTables
=== RUN   TestIPTablesOperations/SetIPTables
--- PASS: TestIPTablesOperations (0.00s)
    --- PASS: TestIPTablesOperations/GetIPTables (0.00s)
    --- PASS: TestIPTablesOperations/SetIPTables (0.00s)
=== RUN   TestMemoryOperations
=== RUN   TestMemoryOperations/OnlineCPUMem
=== RUN   TestMemoryOperations/MemHotplugByProbe
=== RUN   TestMemoryOperations/MemAgentMemcgSet
=== RUN   TestMemoryOperations/MemAgentCompactSet
--- PASS: TestMemoryOperations (0.00s)
    --- PASS: TestMemoryOperations/OnlineCPUMem (0.00s)
    --- PASS: TestMemoryOperations/MemHotplugByProbe (0.00s)
    --- PASS: TestMemoryOperations/MemAgentMemcgSet (0.00s)
    --- PASS: TestMemoryOperations/MemAgentCompactSet (0.00s)
=== RUN   TestStorageOperations
=== RUN   TestStorageOperations/GetVolumeStats
=== RUN   TestStorageOperations/ResizeVolume
=== RUN   TestStorageOperations/AddSwap
=== RUN   TestStorageOperations/AddSwapPath
--- PASS: TestStorageOperations (0.00s)
    --- PASS: TestStorageOperations/GetVolumeStats (0.00s)
    --- PASS: TestStorageOperations/ResizeVolume (0.00s)
    --- PASS: TestStorageOperations/AddSwap (0.00s)
    --- PASS: TestStorageOperations/AddSwapPath (0.00s)
=== RUN   TestMiscellaneousOperations
=== RUN   TestMiscellaneousOperations/GetMetrics
=== RUN   TestMiscellaneousOperations/ReseedRandomDev
=== RUN   TestMiscellaneousOperations/GetGuestDetails
=== RUN   TestMiscellaneousOperations/SetGuestDateTime
=== RUN   TestMiscellaneousOperations/CopyFile
=== RUN   TestMiscellaneousOperations/GetOOMEvent
=== RUN   TestMiscellaneousOperations/SetPolicy
=== RUN   TestMiscellaneousOperations/GetDiagnosticData
--- PASS: TestMiscellaneousOperations (0.00s)
    --- PASS: TestMiscellaneousOperations/GetMetrics (0.00s)
    --- PASS: TestMiscellaneousOperations/ReseedRandomDev (0.00s)
    --- PASS: TestMiscellaneousOperations/GetGuestDetails (0.00s)
    --- PASS: TestMiscellaneousOperations/SetGuestDateTime (0.00s)
    --- PASS: TestMiscellaneousOperations/CopyFile (0.00s)
    --- PASS: TestMiscellaneousOperations/GetOOMEvent (0.00s)
    --- PASS: TestMiscellaneousOperations/SetPolicy (0.00s)
    --- PASS: TestMiscellaneousOperations/GetDiagnosticData (0.00s)
=== RUN   TestHealthService
=== RUN   TestHealthService/successful_health_check
=== RUN   TestHealthService/health_check_failure
--- PASS: TestHealthService (0.00s)
    --- PASS: TestHealthService/successful_health_check (0.00s)
    --- PASS: TestHealthService/health_check_failure (0.00s)
=== RUN   TestInterfaceCompliance
--- PASS: TestInterfaceCompliance (0.00s)
PASS
coverage: 69.3% of statements
ok  	github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/agentproto	0.016s
```

Assisted-by: IBM Bob