### PR TITLE
ci: migrate peerpod-ctrl to native multi-arch builds

### DIFF
--- a/.github/workflows/peerpod-ctrl_image.yaml
+++ b/.github/workflows/peerpod-ctrl_image.yaml
@@ -1,7 +1,7 @@
 # Copyright Confidential Containers Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-# Push peerpod-ctrl image
+# Build and push peerpod-ctrl multi-arch manifest image
 ---
 name: (Callable) Build and push peerpod-ctrl image
 
@@ -14,7 +14,7 @@ on:
         required: false
         type: string
       image_tags:
-        description: 'Comma-separated list of tags for the dev built image (e.g. latest,ci-dev). By default uses the values from hack/build.sh'
+        description: 'Comma-separated list of tags for the built image (e.g. latest,v1.0.0)'
         required: true
         type: string
       git_ref:
@@ -26,19 +26,26 @@ on:
       QUAY_PASSWORD:
         required: true
 
-
 permissions: {}
 
 jobs:
-  peerpod_push:
+  build_push_job:
     name: build and push peerpod-ctrl
-    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        types: [
+          { arch: linux/amd64,   runner: ubuntu-24.04 },
+          { arch: linux/arm64,   runner: ubuntu-24.04-arm },
+          { arch: linux/ppc64le, runner: ubuntu-24.04-ppc64le },
+          { arch: linux/s390x,   runner: ubuntu-24.04-s390x },
+        ]
+    runs-on: ${{ matrix.types.runner }}
     defaults:
       run:
         working-directory: src/peerpod-ctrl
     permissions:
-      contents: read
-      packages: write
+      packages: write  # Required for pushing to GitHub Container Registry
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -46,8 +53,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           ref: "${{ inputs.git_ref }}"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
       - name: Login to Quay container Registry
         if: ${{ startsWith(inputs.registry, 'quay.io') }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -55,6 +64,7 @@ jobs:
           registry: quay.io
           username: ${{ vars.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+
       - name: Login to Github Container Registry
         if: ${{ startsWith(inputs.registry, 'ghcr.io') }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -62,19 +72,33 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Validate build args contains the essentials
         run: |
            make list-build-args | grep -e 'CGO_ENABLED=[0|1]' && \
            make list-build-args | grep 'GOFLAGS=' | grep -E '\-tags=[a-z,]*'
+
+      - name: Extract architecture name
+        id: arch
+        env:
+          MATRIX_ARCH: ${{ matrix.types.arch }}
+        run: |
+          arch_name=$(echo "${MATRIX_ARCH}" | cut -d'/' -f2)
+          echo "name=${arch_name}" >> "$GITHUB_OUTPUT"
+
       - name: Determine tags
         id: tags
+        env:
+          IMAGE_TAGS: ${{ inputs.image_tags }}
+          REGISTRY: ${{ inputs.registry }}
+          ARCH_NAME: ${{ steps.arch.outputs.name }}
         run: |
-          tags="${{ inputs.image_tags }}"
           tags_new=""
-          for t in ${tags/,/ }; do
-          tags_new+="${{ inputs.registry }}/peerpod-ctrl:${t},"
+          for t in ${IMAGE_TAGS//,/ }; do
+            tags_new+="${REGISTRY}/peerpod-ctrl:${t}-${ARCH_NAME},"
           done
           echo "tags=${tags_new}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
@@ -82,6 +106,49 @@ jobs:
           push: true
           context: src
           file: src/peerpod-ctrl/Dockerfile
-          platforms: linux/amd64, linux/s390x, linux/ppc64le, linux/arm64
+          platforms: ${{ matrix.types.arch }}
           build-args: |
             GOFLAGS=-tags=aws,azure,ibmcloud,ibmcloud_powervs,libvirt
+
+  manifest_job:
+    name: generate peerpod-ctrl multi-arch manifest
+    runs-on: ubuntu-24.04
+    needs: [build_push_job]
+    permissions:
+      packages: write  # Required for pushing to GitHub Container Registry
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: "${{ inputs.git_ref }}"
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Login to Quay Container Registry
+        if: ${{ startsWith(inputs.registry, 'quay.io') }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ vars.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Login to Github Container Registry
+        if: ${{ startsWith(inputs.registry, 'ghcr.io') }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish multi-arch manifest
+        working-directory: src/cloud-api-adaptor
+        run: |
+          ./hack/publish.sh publish-multiarch-manifest
+        env:
+          IMAGE_REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: "peerpod-ctrl"
+          IMAGE_TAGS: ${{ inputs.image_tags }}
+          ARCHES: "amd64,arm64,ppc64le,s390x"

--- a/.github/workflows/publish_images_on_push.yaml
+++ b/.github/workflows/publish_images_on_push.yaml
@@ -55,10 +55,8 @@ jobs:
       image_tags: latest,${{ github.sha }}
       git_ref: ${{ github.sha }}
       registry: ${{ inputs.registry != '' && inputs.registry || (github.repository == 'confidential-containers/cloud-api-adaptor' && 'quay.io/confidential-containers' || format('ghcr.io/{0}', github.repository_owner)) }}
-
     permissions:
-      contents: read
-      packages: write
+      packages: write  # Required for pushing to GitHub Container Registry
     secrets:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,8 +40,7 @@ jobs:
       image_tags: ${{ github.event.release.tag_name }}
       git_ref: ${{ github.ref }}
     permissions:
-      contents: read
-      packages: write
+      packages: write  # Required for pushing to GitHub Container Registry
     secrets:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 


### PR DESCRIPTION
Replace emulated multi-arch builds with native builds on dedicated runners, following the pattern established in PR #2777 for cloud-api-adaptor.

Changes:
- Build each architecture (amd64, arm64, ppc64le, s390x) natively on dedicated runners instead of using emulation on a single runner
- Add manifest job to combine arch-specific images into multi-arch manifest
- Update release.yaml and publish_images_on_push.yaml to use new workflow

Benefits:
- Reduces build time
- Improves build reliability by avoiding emulation issues
- Maintains consistency with CAA build pattern

The workflow now:
1. Builds each arch in parallel on native runners
2. Pushes arch-specific tags (e.g., peerpod-ctrl:v1.0.0-amd64)
3. Creates multi-arch manifest combining all architectures
4. Final image supports all 4 architectures transparently

Assisted-by: IBM Bob