### PR TITLE
Switch AWS CI to use mkosi podvm image

### DIFF
--- a/.github/workflows/e2e_aws.yaml
+++ b/.github/workflows/e2e_aws.yaml
@@ -18,11 +18,6 @@ on:
         description: Git ref to checkout the cloud-api-adaptor repository. Defaults to main.
         required: false
         type: string
-      oras:
-        description: Whether the podvm_image is oras published
-        default: false
-        required: false
-        type: boolean
       cluster_type:
         description: Specify the cluster type. Accepted values are "onprem" or "eks".
         default: onprem
@@ -122,19 +117,7 @@ jobs:
         with:
           version: ${{ env.ORAS_VERSION }}
 
-      - name: Extract qcow2 from ${{ inputs.podvm_image }}
-        if: ${{ !inputs.oras }}
-        run: |
-           # shellcheck disable=SC2001
-           qcow2=$(echo "${PODVM_IMAGE}" | sed -e "s#.*/\(.*\):.*#\1.qcow2#")
-           ./hack/download-image.sh "${PODVM_IMAGE}" . -o "${qcow2}" --clean-up
-           echo "PODVM_QCOW2=$(pwd)/${qcow2}" >> "$GITHUB_ENV"
-           # Clean up docker images to make space
-           docker system prune -a -f
-        working-directory: src/cloud-api-adaptor/podvm
-
-      - name: Use oras to get qcow2 from ${{ inputs.podvm_image }}
-        if: ${{ inputs.oras }}
+      - name: Get qcow2 file from ${{ inputs.podvm_image }}
         run: |
           oras pull "${PODVM_IMAGE}"
           tar xvJpf podvm.tar.xz

--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -192,18 +192,12 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'test_e2e_aws')
-    needs: [podvm, caa_image_amd64]
+    needs: [podvm_ubuntu_amd64, caa_image_amd64]
     strategy:
       fail-fast: false
       matrix:
         container_runtime:
           - crio
-        os:
-          - ubuntu
-        provider:
-          - generic
-        arch:
-          - amd64
     permissions:
       id-token: write # Required by aws-actions/configure-aws-credentials
       contents: read  # Required by aws-actions/configure-aws-credentials
@@ -211,9 +205,8 @@ jobs:
     with:
       caa_image: ${{ inputs.registry }}/cloud-api-adaptor:${{ inputs.caa_image_tag }}-dev-amd64
       container_runtime: ${{ matrix.container_runtime }}
-      podvm_image: ${{ inputs.registry }}/podvm-${{ matrix.provider }}-${{ matrix.os }}-${{ matrix.arch }}:${{ inputs.podvm_image_tag }}
+      podvm_image: ${{ needs.podvm_ubuntu_amd64.outputs.qcow2_oras_image }}
       git_ref: ${{ inputs.git_ref }}
-      oras: false
     secrets:
       AWS_IAM_ROLE_ARN: ${{ secrets.AWS_IAM_ROLE_ARN }}
 

--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.images/system/mkosi.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.images/system/mkosi.conf
@@ -9,6 +9,8 @@ KernelInitrdModules=dm-mod
                     virtio_pci
                     virtio_blk
                     virtio_scsi
+                    nvme
+                    nvme_core
                     ahci
                     libahci
                     ata_piix

--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -137,6 +137,7 @@ Use the properties on the table below for AWS:
 |pause_image|Kubernetes pause image||
 |peerpods_secret_name|Name of the Kubernetes secret for AWS credentials. When set, Helm will use reference mode (`secrets.mode=reference`) instead of direct injection. If empty, credentials are passed directly via Helm values||
 |podvm_aws_ami_id|AWS AMI ID of the podvm||
+|podvm_instance_type|AWS EC2 instance type for the podvm|t3.medium|
 |ssh_kp_name|AWS SSH key-pair name ||
 |use_public_ip|Set `true` to instantiate VMs with public IP. If `cluster_type=onprem` then this property is implictly applied||
 |tunnel_type|Tunnel type||

--- a/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
@@ -68,6 +68,7 @@ type Vpc struct {
 	Client            *ec2.Client
 	ID                string
 	InternetGatewayID string
+	PodvmInstanceType string
 	Region            string
 	RouteTableID      string
 	SecurityGroupID   string
@@ -323,7 +324,7 @@ func (a *AWSProvisioner) GetProperties(ctx context.Context, cfg *envconf.Config)
 		"pause_image":          a.PauseImage,
 		"podvm_launchtemplate": "",
 		"podvm_ami":            a.Image.ID,
-		"podvm_instance_type":  "t3.medium",
+		"podvm_instance_type":  a.Vpc.PodvmInstanceType,
 		"sg_ids":               a.Vpc.SecurityGroupID, // TODO: what other SG needed?
 		"subnet_id":            a.Vpc.SubnetID,
 		"ssh_kp_name":          a.SSHKpName,
@@ -400,11 +401,17 @@ func NewVpc(client *ec2.Client, properties map[string]string) *Vpc {
 		cidrBlock = "10.0.0.0/24"
 	}
 
+	podvmInstanceType := properties["podvm_instance_type"]
+	if podvmInstanceType == "" {
+		podvmInstanceType = "t3.medium"
+	}
+
 	return &Vpc{
 		BaseName:          properties["resources_basename"],
 		CidrBlock:         cidrBlock,
 		Client:            client,
 		ID:                properties["aws_vpc_id"],
+		PodvmInstanceType: podvmInstanceType,
 		Region:            properties["aws_region"],
 		SecurityGroupID:   properties["aws_vpc_sg_id"],
 		SubnetID:          properties["aws_vpc_subnet_id"],

--- a/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
@@ -513,9 +513,21 @@ func (v *Vpc) createSecondarySubnet() error {
 	}
 
 	primarySubnetAz := *subnets.Subnets[0].AvailabilityZone
-	secondarySubnetAz := v.Region + "a"
-	if secondarySubnetAz == primarySubnetAz {
-		secondarySubnetAz = v.Region + "b"
+
+	azs, err := v.getPodvmInstanceTypeAZs()
+	if err != nil {
+		return fmt.Errorf("finding AZs for instance type %s: %w", v.PodvmInstanceType, err)
+	}
+
+	secondarySubnetAz := ""
+	for _, az := range azs {
+		if az != primarySubnetAz {
+			secondarySubnetAz = az
+			break
+		}
+	}
+	if secondarySubnetAz == "" {
+		return fmt.Errorf("no secondary AZ available for instance type %s (primary AZ: %s)", v.PodvmInstanceType, primarySubnetAz)
 	}
 
 	subnet, err := v.Client.CreateSubnet(context.TODO(),

--- a/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
@@ -323,7 +323,7 @@ func (a *AWSProvisioner) GetProperties(ctx context.Context, cfg *envconf.Config)
 		"pause_image":          a.PauseImage,
 		"podvm_launchtemplate": "",
 		"podvm_ami":            a.Image.ID,
-		"podvm_instance_type":  "t2.medium",
+		"podvm_instance_type":  "t3.medium",
 		"sg_ids":               a.Vpc.SecurityGroupID, // TODO: what other SG needed?
 		"subnet_id":            a.Vpc.SubnetID,
 		"ssh_kp_name":          a.SSHKpName,

--- a/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
@@ -434,10 +434,43 @@ func (v *Vpc) createVpc() error {
 	return nil
 }
 
-// createSubnet creates the VPC subnet
+// getPodvmInstanceTypeAZs returns the availability zones where the podvm instance type is offered.
+func (v *Vpc) getPodvmInstanceTypeAZs() ([]string, error) {
+	result, err := v.Client.DescribeInstanceTypeOfferings(context.TODO(),
+		&ec2.DescribeInstanceTypeOfferingsInput{
+			LocationType: ec2types.LocationTypeAvailabilityZone,
+			Filters: []ec2types.Filter{
+				{
+					Name:   aws.String("instance-type"),
+					Values: []string{v.PodvmInstanceType},
+				},
+			},
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	azs := make([]string, 0, len(result.InstanceTypeOfferings))
+	for _, offering := range result.InstanceTypeOfferings {
+		azs = append(azs, *offering.Location)
+	}
+	if len(azs) == 0 {
+		return nil, fmt.Errorf("instance type %s is not available in any AZ in region %s", v.PodvmInstanceType, v.Region)
+	}
+
+	return azs, nil
+}
+
+// createSubnet creates the VPC subnet in an AZ that supports the podvm instance type.
 func (v *Vpc) createSubnet() error {
+	azs, err := v.getPodvmInstanceTypeAZs()
+	if err != nil {
+		return fmt.Errorf("finding AZs for instance type %s: %w", v.PodvmInstanceType, err)
+	}
+
 	subnet, err := v.Client.CreateSubnet(context.TODO(),
 		&ec2.CreateSubnetInput{
+			AvailabilityZone:  aws.String(azs[0]),
 			VpcId:             aws.String(v.ID),
 			CidrBlock:         aws.String("10.0.0.0/25"),
 			TagSpecifications: defaultTagSpecifications(v.BaseName+"-subnet", ec2types.ResourceTypeSubnet),

--- a/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
@@ -1017,9 +1017,11 @@ func (i *AMIImage) registerImage(imageName string) error {
 				SnapshotId:          aws.String(i.EBSSnapshotID),
 			},
 		}},
+		BootMode:           ec2types.BootModeValuesUefi,
 		Description:        aws.String(i.Description),
 		EnaSupport:         aws.Bool(true),
 		RootDeviceName:     aws.String(i.RootDeviceName),
+		TpmSupport:         ec2types.TpmSupportValuesV20,
 		VirtualizationType: aws.String("hvm"),
 		TagSpecifications:  defaultTagSpecifications(i.BaseName+"-img", ec2types.ResourceTypeImage),
 	})


### PR DESCRIPTION
The packer-based podvm images are deprecated and will be removed eventually. The AWS CI still use those images and this PR is about making the switch to mkosi. Because life is not easy, I had to make some adjustments here and there for tests to continue passing. Most notably, mkosi image needs UEFI boot mode and currently we are using legacy mode.

Tested locally a single test case and ran full CI in https://github.com/wainersm/cc-cloud-api-adaptor/actions/runs/25454939108/job/74684191291