### PR TITLE
cloud-api-adaptor: fix unpacking image error

### DIFF
--- a/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
@@ -179,5 +179,11 @@ kata-deploy:
       enabled: false
     qemu-coco-dev-runtime-rs:
       enabled: false
+    qemu-snp-runtime-rs:
+      enabled: false
+    qemu-tdx-runtime-rs:
+      enabled: false
     remote:
       enabled: true
+      containerd:
+        snapshotter: "overlayfs"

--- a/src/cloud-api-adaptor/pkg/adaptor/proxy/proxy_test.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/proxy/proxy_test.go
@@ -37,9 +37,13 @@ const (
 	testNetworkUnix        = "unix"
 
 	// Container and annotation constants
-	testContainerIDProxy     = "123"
-	testAnnotationKeyProxy   = "aaa"
-	testAnnotationValueProxy = "111"
+	testContainerIDProxy             = "123"
+	testAnnotationKeyProxy           = "aaa"
+	testAnnotationValueProxy         = "111"
+	testAnnotationContainerTypeKey   = "io.kubernetes.cri.container-type"
+	testAnnotationContainerTypeValue = "container"
+	testAnnotationImageNameKey       = "io.kubernetes.cri.image-name"
+	testAnnotationImageNameValue     = "test-image"
 
 	// Image constants
 	testPauseImageLatest = "pause:latest"
@@ -123,7 +127,11 @@ func TestStartStop(t *testing.T) {
 	}
 
 	{
-		res, err := client.CreateContainer(context.Background(), &pb.CreateContainerRequest{ContainerId: testContainerIDProxy, OCI: &pb.Spec{Annotations: map[string]string{testAnnotationKeyProxy: testAnnotationValueProxy}}})
+		res, err := client.CreateContainer(context.Background(), &pb.CreateContainerRequest{ContainerId: testContainerIDProxy, OCI: &pb.Spec{Annotations: map[string]string{
+			testAnnotationKeyProxy:         testAnnotationValueProxy,
+			testAnnotationContainerTypeKey: testAnnotationContainerTypeValue,
+			testAnnotationImageNameKey:     testAnnotationImageNameValue,
+		}}})
 		assert.NoError(t, err, "expect no error creating container")
 		assert.NotNil(t, res, "expect non nil response")
 	}

--- a/src/cloud-api-adaptor/pkg/adaptor/proxy/proxy_test.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/proxy/proxy_test.go
@@ -37,13 +37,9 @@ const (
 	testNetworkUnix        = "unix"
 
 	// Container and annotation constants
-	testContainerIDProxy             = "123"
-	testAnnotationKeyProxy           = "aaa"
-	testAnnotationValueProxy         = "111"
-	testAnnotationContainerTypeKey   = "io.kubernetes.cri.container-type"
-	testAnnotationContainerTypeValue = "container"
-	testAnnotationImageNameKey       = "io.kubernetes.cri.image-name"
-	testAnnotationImageNameValue     = "test-image"
+	testContainerIDProxy     = "123"
+	testAnnotationKeyProxy   = "aaa"
+	testAnnotationValueProxy = "111"
 
 	// Image constants
 	testPauseImageLatest = "pause:latest"

--- a/src/cloud-api-adaptor/pkg/adaptor/proxy/service.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/proxy/service.go
@@ -6,6 +6,8 @@ package proxy
 import (
 	"context"
 	b64 "encoding/base64"
+	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -13,6 +15,7 @@ import (
 
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/agentproto"
 	pb "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols/grpc"
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/types"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -91,7 +94,24 @@ func (s *proxyService) CreateContainer(ctx context.Context, req *pb.CreateContai
 	}
 
 	if !pullImageInGuest {
-		logger.Printf("Pulling image separately not support on main. It is required to use the nydus-snapshotter, which isn't configured properly here.")
+		// There is some issue with nydus(error unpacking image) when the image layers are missing due to
+		//  - discard_unpacked_layers set to true
+		//  - other reasons we don't know yet
+		// Run: ctr -n k8s.io image check
+		// to see whether the image is complete(all layers are present)
+		//
+		// nydus adds one mount that carries the image information which is then picked up
+		// by kata shim, then kata shim passes it to kata agent in the PodVM. Without nydus, we
+		// have to add the mount point manually.
+		vol, err := handleVirtualVolumeStorageObject(req)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Storages = append(req.Storages, vol)
+		s := req.Storages[len(req.Storages)-1]
+		logger.Print("    storages added for guest_image_pull:")
+		logger.Printf("        mount_point:%s source:%s fstype:%s driver:%s", s.MountPoint, s.Source, s.Fstype, s.Driver)
 	}
 
 	res, err := s.Redirector.CreateContainer(ctx, req)
@@ -101,6 +121,92 @@ func (s *proxyService) CreateContainer(ctx context.Context, req *pb.CreateContai
 	}
 
 	return res, err
+}
+
+// The flollowing fucntions are originally from kata_agent.go
+//   - handleVirtualVolumeStorageObject
+//   - handleImageGuestPullBlockVolume
+//   - getContainerTypeforCRI
+//
+// Modified kata-containers/src/runtime/virtualcontainers/kata_agent.go::handleVirtualVolumeStorageObject
+func handleVirtualVolumeStorageObject(req *pb.CreateContainerRequest) (*pb.Storage, error) {
+	var vol *pb.Storage
+	virtVolume := &types.KataVirtualVolume{
+		VolumeType: types.KataVirtualVolumeImageGuestPullType,
+		ImagePull: &types.ImagePullVolume{
+			Metadata: map[string]string{},
+		},
+	}
+
+	var err error
+	vol = &pb.Storage{}
+	vol, err = handleImageGuestPullBlockVolume(req.OCI.Annotations, virtVolume, vol)
+	if err != nil {
+		return nil, err
+	}
+	vol.MountPoint = filepath.Join("/run/kata-containers/", req.ContainerId, "rootfs")
+	return vol, nil
+}
+
+// Modified kata-containers/src/runtime/virtualcontainers/kata_agent.go::handleImageGuestPullBlockVolume
+func handleImageGuestPullBlockVolume(containerAnnotations map[string]string, virtualVolumeInfo *types.KataVirtualVolume, vol *pb.Storage) (*pb.Storage, error) {
+	containerType, criContainerType := getContainerTypeforCRI(containerAnnotations)
+
+	var imageRef string
+	if containerType == "pod_sandbox" {
+		imageRef = "pause"
+	} else {
+		const ctrContainerType = "io.kubernetes.cri.container-type"
+		const crioContainerType = "io.kubernetes.cri-o.ContainerType"
+		const kubernetesCRIImageName = "io.kubernetes.cri.image-name"
+		const kubernetesCRIOImageName = "io.kubernetes.cri-o.ImageName"
+
+		switch criContainerType {
+		case ctrContainerType:
+			imageRef = containerAnnotations[kubernetesCRIImageName]
+		case crioContainerType:
+			imageRef = containerAnnotations[kubernetesCRIOImageName]
+		default:
+			imageRef = containerAnnotations[kubernetesCRIImageName]
+		}
+
+		if imageRef == "" {
+			return nil, fmt.Errorf("Failed to get image name from annotations")
+		}
+	}
+	virtualVolumeInfo.Source = imageRef
+
+	//merge virtualVolumeInfo.ImagePull.Metadata and container_annotations
+	for k, v := range containerAnnotations {
+		virtualVolumeInfo.ImagePull.Metadata[k] = v
+	}
+
+	no, err := json.Marshal(virtualVolumeInfo.ImagePull)
+	if err != nil {
+		return nil, err
+	}
+	vol.Driver = types.KataVirtualVolumeImageGuestPullType
+	vol.DriverOptions = append(vol.DriverOptions, types.KataVirtualVolumeImageGuestPullType+"="+string(no))
+	vol.Source = virtualVolumeInfo.Source
+	vol.Fstype = "overlay"
+	return vol, nil
+}
+
+// Modified kata-containers/src/runtime/virtualcontainers/kata_agent.go::getContainerTypeforCRI
+func getContainerTypeforCRI(containerAnnotations map[string]string) (string, string) {
+	CRIContainerTypeKeyList := []string{
+		"io.kubernetes.cri.container-type",
+		"io.kubernetes.cri-o.ContainerType",
+	}
+
+	containerType := containerAnnotations["io.katacontainers.pkg.oci.container_type"]
+	for _, key := range CRIContainerTypeKeyList {
+		_, ok := containerAnnotations[key]
+		if ok {
+			return containerType, key
+		}
+	}
+	return "", ""
 }
 
 func isNodePublishVolumeTargetPath(volumePath, directVolumesDir string) bool {

--- a/src/cloud-api-adaptor/pkg/adaptor/proxy/service.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/proxy/service.go
@@ -109,9 +109,9 @@ func (s *proxyService) CreateContainer(ctx context.Context, req *pb.CreateContai
 		}
 
 		req.Storages = append(req.Storages, vol)
-		s := req.Storages[len(req.Storages)-1]
+		storage := req.Storages[len(req.Storages)-1]
 		logger.Print("    storages added for guest_image_pull:")
-		logger.Printf("        mount_point:%s source:%s fstype:%s driver:%s", s.MountPoint, s.Source, s.Fstype, s.Driver)
+		logger.Printf("        mount_point:%s source:%s fstype:%s driver:%s", storage.MountPoint, storage.Source, storage.Fstype, storage.Driver)
 	}
 
 	res, err := s.Redirector.CreateContainer(ctx, req)
@@ -123,12 +123,12 @@ func (s *proxyService) CreateContainer(ctx context.Context, req *pb.CreateContai
 	return res, err
 }
 
-// The flollowing fucntions are originally from kata_agent.go
+// The following fucntions are originally from https://github.com/kata-containers/kata-containers/blob/main/src/runtime/virtcontainers/kata_agent.go
 //   - handleVirtualVolumeStorageObject
 //   - handleImageGuestPullBlockVolume
 //   - getContainerTypeforCRI
 //
-// Modified kata-containers/src/runtime/virtualcontainers/kata_agent.go::handleVirtualVolumeStorageObject
+// Modified handleVirtualVolumeStorageObject
 func handleVirtualVolumeStorageObject(req *pb.CreateContainerRequest) (*pb.Storage, error) {
 	var vol *pb.Storage
 	virtVolume := &types.KataVirtualVolume{
@@ -148,7 +148,7 @@ func handleVirtualVolumeStorageObject(req *pb.CreateContainerRequest) (*pb.Stora
 	return vol, nil
 }
 
-// Modified kata-containers/src/runtime/virtualcontainers/kata_agent.go::handleImageGuestPullBlockVolume
+// Modified handleImageGuestPullBlockVolume
 func handleImageGuestPullBlockVolume(containerAnnotations map[string]string, virtualVolumeInfo *types.KataVirtualVolume, vol *pb.Storage) (*pb.Storage, error) {
 	containerType, criContainerType := getContainerTypeforCRI(containerAnnotations)
 
@@ -181,18 +181,18 @@ func handleImageGuestPullBlockVolume(containerAnnotations map[string]string, vir
 		virtualVolumeInfo.ImagePull.Metadata[k] = v
 	}
 
-	no, err := json.Marshal(virtualVolumeInfo.ImagePull)
+	imagePullBytes, err := json.Marshal(virtualVolumeInfo.ImagePull)
 	if err != nil {
 		return nil, err
 	}
 	vol.Driver = types.KataVirtualVolumeImageGuestPullType
-	vol.DriverOptions = append(vol.DriverOptions, types.KataVirtualVolumeImageGuestPullType+"="+string(no))
+	vol.DriverOptions = append(vol.DriverOptions, types.KataVirtualVolumeImageGuestPullType+"="+string(imagePullBytes))
 	vol.Source = virtualVolumeInfo.Source
 	vol.Fstype = "overlay"
 	return vol, nil
 }
 
-// Modified kata-containers/src/runtime/virtualcontainers/kata_agent.go::getContainerTypeforCRI
+// Modified getContainerTypeforCRI
 func getContainerTypeforCRI(containerAnnotations map[string]string) (string, string) {
 	CRIContainerTypeKeyList := []string{
 		"io.kubernetes.cri.container-type",

--- a/src/cloud-api-adaptor/pkg/adaptor/proxy/service_test.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/proxy/service_test.go
@@ -50,12 +50,16 @@ const (
 	testSandboxID456 = "sandbox-456"
 
 	// Annotation constants
-	testAnnotationKey1     = "key1"
-	testAnnotationValue1   = "value1"
-	testAnnotationGPUKey   = "io.katacontainers.config.hypervisor.default_gpus"
-	testAnnotationGPUValue = "1"
-	testAnnotationCDIKey   = "cdi.k8s.io/peer-pods"
-	testAnnotationCDIValue = "nvidia.com/gpu=all"
+	testAnnotationKey1               = "key1"
+	testAnnotationValue1             = "value1"
+	testAnnotationGPUKey             = "io.katacontainers.config.hypervisor.default_gpus"
+	testAnnotationGPUValue           = "1"
+	testAnnotationCDIKey             = "cdi.k8s.io/peer-pods"
+	testAnnotationCDIValue           = "nvidia.com/gpu=all"
+	testAnnotationContainerTypeKey   = "io.kubernetes.cri.container-type"
+	testAnnotationContainerTypeValue = "container"
+	testAnnotationImageNameKey       = "io.kubernetes.cri.image-name"
+	testAnnotationImageNameValue     = "test-image"
 
 	// Storage and filesystem constants
 	testFstypeExt4              = "ext4"
@@ -147,7 +151,10 @@ func newCreateContainerRequest(containerID string) *createContainerRequestBuilde
 		req: &pb.CreateContainerRequest{
 			ContainerId: containerID,
 			OCI: &pb.Spec{
-				Annotations: make(map[string]string),
+				Annotations: map[string]string{
+					testAnnotationContainerTypeKey: testAnnotationContainerTypeValue,
+					testAnnotationImageNameKey:     testAnnotationImageNameValue,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #3033 

This PR addresses the error `unpacking image` by disabling `nydus` for CAA.

We've seen this error on both Azure and GCP(even after the `discard_unpacked_layers` is set to false).  Run 
```
ctr -n k8s.io image check
```
to see whether there are incomplete images that have been unpacked.

The code does two things
- Use `overlayfs` as the snapshotter for `remote` runtime.
- Add a storage to `CreateContainerRequest` which carries the image information that kata agent will pick up and use for pulling the image.

A image is not required to be complete any more(e.g, `discard_unpacked_layers=true` works fine) because nydus is not used.

We've tested the changes on both Azure and GCP with incomplete images, it's been working well so far.