### PR TITLE
adaptor: add sandbox persistence and recovery across CAA restarts

### DIFF
--- a/src/cloud-api-adaptor/cmd/cloud-api-adaptor/main.go
+++ b/src/cloud-api-adaptor/cmd/cloud-api-adaptor/main.go
@@ -99,6 +99,7 @@ func (cfg *daemonConfig) Setup() (cmd.Starter, error) {
 		// Common flags with environment variable support
 		reg.StringWithEnv(&cfg.serverConfig.SocketPath, "socket", adaptor.DefaultSocketPath, "REMOTE_HYPERVISOR_ENDPOINT", "Unix domain socket path of remote hypervisor service")
 		reg.StringWithEnv(&cfg.serverConfig.PodsDir, "pods-dir", adaptor.DefaultPodsDir, "PODS_DIR", "base directory for pod directories")
+		reg.StringWithEnv(&cfg.serverConfig.TLSMaterialPath, "tls-material-path", "/run/peerpod/tls-material.json", "TLS_MATERIAL_PATH", "Path to persist TLS material across CAA restarts")
 		reg.StringWithEnv(&cfg.serverConfig.PauseImage, "pause-image", "", "PAUSE_IMAGE", "pause image to be used for the pods")
 		reg.StringWithEnv(&cfg.serverConfig.ForwarderPort, "forwarder-port", daemon.DefaultListenPort, "FORWARDER_PORT", "port number of agent protocol forwarder")
 		reg.StringWithEnv(&tlsConfig.CAFile, "ca-cert-file", "", "CACERT_FILE", "CA certificate file for custom TLS (e.g. /etc/certificates/ca.crt)")
@@ -154,7 +155,10 @@ func (cfg *daemonConfig) Setup() (cmd.Starter, error) {
 		}
 	}
 
-	server := adaptor.NewServer(provider, &cfg.serverConfig, workerNode)
+	server, err := adaptor.NewServer(provider, &cfg.serverConfig, workerNode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create server: %w", err)
+	}
 
 	return cmd.NewStarter(server), nil
 }

--- a/src/cloud-api-adaptor/cmd/cloud-api-adaptor/main.go
+++ b/src/cloud-api-adaptor/cmd/cloud-api-adaptor/main.go
@@ -175,7 +175,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go probe.Start(config.serverConfig.SocketPath)
+	go probe.Start(ctx, config.serverConfig.SocketPath)
 
 	if err := starter.Start(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", os.Args[0], err)

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/alibabacloud.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/alibabacloud.yaml
@@ -94,6 +94,10 @@ providerConfigs:
     # (default: "")
     # TAGS: ""
 
+    # Path to persist TLS material across CAA restarts
+    # (default: "/run/peerpod/tls-material.json")
+    # TLS_MATERIAL_PATH: "/run/peerpod/tls-material.json"
+
     # Skip TLS certificate verification - use it only for testing
     # (default: "false")
     # TLS_SKIP_VERIFY: "false"

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/aws.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/aws.yaml
@@ -106,6 +106,10 @@ providerConfigs:
     # (default: "")
     # TAGS: ""
 
+    # Path to persist TLS material across CAA restarts
+    # (default: "/run/peerpod/tls-material.json")
+    # TLS_MATERIAL_PATH: "/run/peerpod/tls-material.json"
+
     # Skip TLS certificate verification - use it only for testing
     # (default: "false")
     # TLS_SKIP_VERIFY: "false"

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/azure.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/azure.yaml
@@ -114,6 +114,10 @@ providerConfigs:
     # (default: "")
     # TAGS: ""
 
+    # Path to persist TLS material across CAA restarts
+    # (default: "/run/peerpod/tls-material.json")
+    # TLS_MATERIAL_PATH: "/run/peerpod/tls-material.json"
+
     # Skip TLS certificate verification - use it only for testing
     # (default: "false")
     # TLS_SKIP_VERIFY: "false"

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/byom.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/byom.yaml
@@ -94,6 +94,10 @@ providerConfigs:
     # (default: "peerpod")
     # SSH_USERNAME: "peerpod"
 
+    # Path to persist TLS material across CAA restarts
+    # (default: "/run/peerpod/tls-material.json")
+    # TLS_MATERIAL_PATH: "/run/peerpod/tls-material.json"
+
     # Skip TLS certificate verification - use it only for testing
     # (default: "false")
     # TLS_SKIP_VERIFY: "false"

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/docker.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/docker.yaml
@@ -91,6 +91,10 @@ providerConfigs:
     # (default: "")
     # REMOTE_HYPERVISOR_ENDPOINT: ""
 
+    # Path to persist TLS material across CAA restarts
+    # (default: "/run/peerpod/tls-material.json")
+    # TLS_MATERIAL_PATH: "/run/peerpod/tls-material.json"
+
     # Skip TLS certificate verification - use it only for testing
     # (default: "false")
     # TLS_SKIP_VERIFY: "false"

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/gcp.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/gcp.yaml
@@ -110,6 +110,10 @@ providerConfigs:
     # (default: "")
     # TAGS: ""
 
+    # Path to persist TLS material across CAA restarts
+    # (default: "/run/peerpod/tls-material.json")
+    # TLS_MATERIAL_PATH: "/run/peerpod/tls-material.json"
+
     # Skip TLS certificate verification - use it only for testing
     # (default: "false")
     # TLS_SKIP_VERIFY: "false"

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/ibmcloud.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/ibmcloud.yaml
@@ -126,6 +126,10 @@ providerConfigs:
     # (default: "")
     # TAGS: ""
 
+    # Path to persist TLS material across CAA restarts
+    # (default: "/run/peerpod/tls-material.json")
+    # TLS_MATERIAL_PATH: "/run/peerpod/tls-material.json"
+
     # Skip TLS certificate verification - use it only for testing
     # (default: "false")
     # TLS_SKIP_VERIFY: "false"

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/ibmcloudpowervs.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/ibmcloudpowervs.yaml
@@ -102,6 +102,10 @@ providerConfigs:
     # (default: "")
     # REMOTE_HYPERVISOR_ENDPOINT: ""
 
+    # Path to persist TLS material across CAA restarts
+    # (default: "/run/peerpod/tls-material.json")
+    # TLS_MATERIAL_PATH: "/run/peerpod/tls-material.json"
+
     # Skip TLS certificate verification - use it only for testing
     # (default: "false")
     # TLS_SKIP_VERIFY: "false"

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/libvirt.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/libvirt.yaml
@@ -107,6 +107,10 @@ providerConfigs:
     # (default: "")
     # REMOTE_HYPERVISOR_ENDPOINT: ""
 
+    # Path to persist TLS material across CAA restarts
+    # (default: "/run/peerpod/tls-material.json")
+    # TLS_MATERIAL_PATH: "/run/peerpod/tls-material.json"
+
     # Skip TLS certificate verification - use it only for testing
     # (default: "false")
     # TLS_SKIP_VERIFY: "false"

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/vsphere.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/vsphere.yaml
@@ -77,6 +77,7 @@ providerConfigs:
     # base directory for pod directories
     # (default: "")
     # PODS_DIR: ""
+    # TLS_MATERIAL_PATH: "/run/peerpod/tls-material.json"
 
     # Maximum timeout in minutes for establishing agent proxy connection
     # (default: "")

--- a/src/cloud-api-adaptor/install/charts/peerpods/templates/daemonset.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/templates/daemonset.yaml
@@ -97,6 +97,9 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: vault-token
 {{- end }}
+      # On shutdown CAA drains each sandbox's agent proxy (up to 30s each).
+      # With up to 10 peer pods per node, draining can take ~300s total.
+      terminationGracePeriodSeconds: 360
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       nodeSelector:
@@ -128,6 +131,7 @@ spec:
 {{- end }}
       - hostPath:
           path: /run/peerpod
+          type: DirectoryOrCreate
         name: pods-dir
       - hostPath:
           path: /run/netns

--- a/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/adaptor/k8sops"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/adaptor/proxy"
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/adaptor/state"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/forwarder"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/paths"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/podnetwork"
@@ -91,8 +92,151 @@ func (s *cloudService) removeSandbox(id sandboxID) error {
 	return nil
 }
 
-func NewService(provider provider.Provider, proxyFactory proxy.Factory, workerNode podnetwork.WorkerNode,
-	serverConfig *ServerConfig) Service {
+func (s *cloudService) reconnectToInstance(ctx context.Context, st *state.SandboxState) error {
+	sid := sandboxID(st.SandboxID)
+
+	// 1. Validate network namespace still exists
+	if _, err := os.Stat(st.NetNSPath); err != nil {
+		return fmt.Errorf("netns gone: %w", err)
+	}
+
+	// 2. Get instance IP from state
+	if len(st.InstanceIPs) == 0 {
+		return fmt.Errorf("no cached IPs")
+	}
+	instanceIP := st.InstanceIPs[0]
+
+	// 3. Recreate socket path
+	podDir := filepath.Join(s.serverConfig.PodsDir, st.SandboxID)
+	socketPath := filepath.Join(podDir, proxy.SocketName)
+	os.Remove(socketPath) // Remove stale socket
+
+	// 4. Create new agent proxy
+	agentProxy := s.proxyFactory.New(st.ServerName, socketPath)
+
+	// 5. Build server URL
+	forwarderPort := st.ForwarderPort
+	if forwarderPort == "" {
+		forwarderPort = s.serverConfig.ForwarderPort
+	}
+	serverURL := &url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort(instanceIP, forwarderPort),
+		Path:   forwarder.AgentURLPath,
+	}
+
+	// 6. Start proxy in background
+	errCh := make(chan error)
+	go func() {
+		defer close(errCh)
+		if err := agentProxy.Start(ctx, serverURL); err != nil {
+			errCh <- err
+		}
+	}()
+
+	// 7. Wait for ready or timeout
+	// TODO: 30s may be too short for slow podvms under load, causing false
+	// negatives that orphan running instances. Consider using ProxyTimeout
+	// or a dedicated config, but note that longer timeouts block CAA startup
+	// (N sandboxes × timeout each, non-cancellable).
+	select {
+	case <-time.After(30 * time.Second):
+		if err := agentProxy.Shutdown(); err != nil {
+			logger.Printf("agentProxy shutdown failed: %v", err)
+		}
+		return fmt.Errorf("timeout")
+	case err := <-errCh:
+		return fmt.Errorf("proxy failed: %w", err)
+	case <-agentProxy.Ready():
+	}
+
+	// 8. Add to sandboxes map
+	s.mutex.Lock()
+	s.sandboxes[sid] = &sandbox{
+		id:           sid,
+		podName:      st.PodName,
+		podNamespace: st.PodNamespace,
+		netNSPath:    st.NetNSPath,
+		instanceID:   st.InstanceID,
+		instanceName: st.InstanceName,
+		agentProxy:   agentProxy,
+		restored:     true,
+		podNetwork:   st.PodNetwork,
+	}
+	s.mutex.Unlock()
+
+	return nil
+}
+
+func (s *cloudService) recoverSandboxes(ctx context.Context) {
+	sandboxIDs, err := s.stateManager.List()
+	if err != nil {
+		logger.Printf("failed to list sandboxes: %v", err)
+		return
+	}
+
+	if len(sandboxIDs) == 0 {
+		return
+	}
+
+	logger.Printf("recovering %d sandboxes", len(sandboxIDs))
+
+	var wg sync.WaitGroup
+	for _, sid := range sandboxIDs {
+		wg.Add(1)
+		go func(sid string) {
+			defer wg.Done()
+			s.restoreSandbox(ctx, sid)
+		}(sid)
+	}
+	wg.Wait()
+
+	logger.Printf("sandbox recovery complete")
+}
+
+func (s *cloudService) restoreSandbox(ctx context.Context, sid string) {
+	st, err := s.stateManager.Load(sid)
+	if err != nil {
+		logger.Printf("failed to load state for %s: %v (skipping)", sid, err)
+		return
+	}
+
+	// Advance podIndex past restored indices to avoid VXLAN ID collisions
+	// with tunnels that may still exist on the host.
+	if st.PodNetwork != nil {
+		podnetwork.SetMinPodIndex(st.PodNetwork.Index + 1)
+	}
+
+	if st.Running {
+		if err := s.reconnectToInstance(ctx, st); err != nil {
+			logger.Printf("failed to reconnect %s: %v (cleaning up stale state)", sid, err)
+			s.cleanupSandboxState(sid, st)
+		} else {
+			logger.Printf("reconnected sandbox %s", sid)
+		}
+		return
+	}
+
+	logger.Printf("cleaning up incomplete sandbox %s", sid)
+	s.cleanupSandboxState(sid, st)
+}
+
+func (s *cloudService) cleanupSandboxState(sid string, st *state.SandboxState) {
+	if st.PodNetwork != nil {
+		if err := s.workerNode.Teardown(st.NetNSPath, st.PodNetwork); err != nil {
+			logger.Printf("network teardown for %s failed (non-fatal): %v", sid, err)
+		}
+	}
+	if err := s.stateManager.Delete(sid); err != nil {
+		logger.Printf("state delete for %s failed (non-fatal): %v", sid, err)
+	}
+}
+
+func NewService(provider provider.Provider,
+	proxyFactory proxy.Factory,
+	workerNode podnetwork.WorkerNode,
+	serverConfig *ServerConfig,
+) Service {
 	var err error
 
 	s := &cloudService{
@@ -101,6 +245,7 @@ func NewService(provider provider.Provider, proxyFactory proxy.Factory, workerNo
 		sandboxes:    map[sandboxID]*sandbox{},
 		serverConfig: serverConfig,
 		workerNode:   workerNode,
+		stateManager: state.NewManager(serverConfig.PodsDir),
 	}
 	s.cond = sync.NewCond(&s.mutex)
 	s.ppService, err = k8sops.NewPeerPodService()
@@ -108,10 +253,31 @@ func NewService(provider provider.Provider, proxyFactory proxy.Factory, workerNo
 		logger.Printf("failed to create PeerPodService, runtime failure may result in dangling resources %s", err)
 	}
 
+	// TODO: context.Background() makes recovery non-cancellable during shutdown.
+	// Requires passing parent context from server.Start() through NewService.
+	s.recoverSandboxes(context.Background())
+
 	return s
 }
 
 func (s *cloudService) Teardown() error {
+	// Gracefully shutdown all agent proxies to drain pending requests
+	s.mutex.Lock()
+	sandboxes := make([]*sandbox, 0, len(s.sandboxes))
+	for _, sb := range s.sandboxes {
+		sandboxes = append(sandboxes, sb)
+	}
+	s.mutex.Unlock()
+
+	for _, sb := range sandboxes {
+		if sb.agentProxy != nil {
+			logger.Printf("draining sandbox %s", sb.id)
+			if err := sb.agentProxy.Shutdown(); err != nil {
+				logger.Printf("error shutting down agent proxy for sandbox %s: %v", sb.id, err)
+			}
+		}
+	}
+
 	return s.provider.Teardown()
 }
 
@@ -177,6 +343,16 @@ func (s *cloudService) CreateVM(ctx context.Context, req *pb.CreateVMRequest) (r
 	if sid == "" {
 		return nil, fmt.Errorf("empty sandbox id")
 	}
+
+	// Idempotent: if sandbox was restored, return existing socket path
+	s.mutex.Lock()
+	if existing, ok := s.sandboxes[sid]; ok && existing.restored {
+		socketPath := filepath.Join(s.serverConfig.PodsDir, string(sid), proxy.SocketName)
+		s.mutex.Unlock()
+		logger.Printf("sandbox %s already restored, returning existing socket", sid)
+		return &pb.CreateVMResponse{AgentSocketPath: socketPath}, nil
+	}
+	s.mutex.Unlock()
 
 	pod := util.GetPodName(req.Annotations)
 	if pod == "" {
@@ -326,6 +502,25 @@ func (s *cloudService) CreateVM(ctx context.Context, req *pb.CreateVMRequest) (r
 		return nil, fmt.Errorf("adding sandbox: %w", err)
 	}
 
+	if err := s.stateManager.Save(&state.SandboxState{
+		Version:      1,
+		SandboxID:    string(sid),
+		PodName:      pod,
+		PodNamespace: namespace,
+		NetNSPath:    netNSPath,
+		Running:      false,
+		CreatedAt:    time.Now(),
+
+		// agentProxy info
+		ServerName:    putil.GenerateInstanceName(pod, string(sid), 63),
+		ForwarderPort: s.serverConfig.ForwarderPort,
+
+		// Network config for teardown
+		PodNetwork: podNetworkConfig,
+	}); err != nil {
+		logger.Printf("state save for %s failed (non-fatal): %v", sid, err)
+	}
+
 	logger.Printf("create a sandbox %s for pod %s in namespace %s (netns: %s)", req.Id, pod, namespace, sandbox.netNSPath)
 
 	return &pb.CreateVMResponse{AgentSocketPath: socketPath}, nil
@@ -343,6 +538,12 @@ func (s *cloudService) StartVM(ctx context.Context, req *pb.StartVMRequest) (res
 	sandbox, err := s.getSandbox(sid)
 	if err != nil {
 		return nil, fmt.Errorf("getting sandbox: %w", err)
+	}
+
+	// Idempotent: skip if restored (instance already exists)
+	if sandbox.restored {
+		logger.Printf("sandbox %s already running (restored), skipping StartVM", sid)
+		return &pb.StartVMResponse{}, nil
 	}
 
 	instance, err := s.provider.CreateInstance(ctx, sandbox.podName, string(sid), sandbox.cloudConfig, sandbox.spec)
@@ -375,6 +576,10 @@ func (s *cloudService) StartVM(ctx context.Context, req *pb.StartVMRequest) (res
 
 	if err = s.setInstance(sid, instance.ID, instance.Name); err != nil {
 		return nil, fmt.Errorf("setting instance: %w", err)
+	}
+
+	if err = s.stateManager.UpdateInstance(string(sid), instance.ID, instance.Name, instance.IPs); err != nil {
+		logger.Printf("failed to persist instance info: %v", err)
 	}
 
 	logger.Printf("created an instance %s for sandbox %s", instance.Name, sid)
@@ -419,6 +624,11 @@ func (s *cloudService) StartVM(ctx context.Context, req *pb.StartVMRequest) (res
 	case <-sandbox.agentProxy.Ready():
 	}
 
+	// After proxy ready — persist final state including DestinationIP from Setup()
+	if err := s.stateManager.SetReady(string(sid), sandbox.podNetwork); err != nil {
+		logger.Printf("failed to mark sandbox as ready: %v", err)
+	}
+
 	logger.Print("agent proxy is ready")
 
 	return &pb.StartVMResponse{}, nil
@@ -434,8 +644,10 @@ func (s *cloudService) StopVM(ctx context.Context, req *pb.StopVMRequest) (*pb.S
 		return nil, err
 	}
 
-	if err := sandbox.agentProxy.Shutdown(); err != nil {
-		logger.Printf("stopping agent proxy: %v", err)
+	if sandbox.agentProxy != nil {
+		if err := sandbox.agentProxy.Shutdown(); err != nil {
+			logger.Printf("stopping agent proxy: %v", err)
+		}
 	}
 
 	if err := s.provider.DeleteInstance(ctx, sandbox.instanceID); err != nil {
@@ -452,6 +664,11 @@ func (s *cloudService) StopVM(ctx context.Context, req *pb.StopVMRequest) (*pb.S
 
 	if err = s.removeSandbox(sid); err != nil {
 		logger.Printf("removing sandbox %s: %v", sid, err)
+	}
+
+	// After successful cleanup
+	if err = s.stateManager.Delete(string(sid)); err != nil {
+		logger.Printf("state delete for %s failed (non-fatal): %v", sid, err)
 	}
 
 	return &pb.StopVMResponse{}, nil

--- a/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
@@ -47,6 +47,10 @@ type ServerConfig struct {
 	PeerPodsLimitPerNode    int
 	RootVolumeSize          int
 	EnableScratchSpace      bool
+	// TLSMaterialPath is the path where TLS material is persisted across
+	// CAA process restarts. Must survive process restarts (tmpfs is fine).
+	// Default: /run/peerpod/tls-material.json
+	TLSMaterialPath string
 }
 
 var logger = log.New(log.Writer(), "[adaptor/cloud] ", log.LstdFlags|log.Lmsgprefix)

--- a/src/cloud-api-adaptor/pkg/adaptor/cloud/types.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/cloud/types.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/adaptor/k8sops"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/adaptor/proxy"
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/adaptor/state"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/podnetwork"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/podnetwork/tunneler"
 	provider "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers"
@@ -32,6 +33,7 @@ type cloudService struct {
 	mutex        sync.Mutex
 	ppService    *k8sops.PeerPodService
 	serverConfig *ServerConfig
+	stateManager *state.Manager
 }
 
 type sandboxID string
@@ -47,4 +49,5 @@ type sandbox struct {
 	instanceID   string
 	netNSPath    string
 	spec         provider.InstanceTypeSpec
+	restored     bool // True if sandbox was restored after CAA restart
 }

--- a/src/cloud-api-adaptor/pkg/adaptor/proxy/factory.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/proxy/factory.go
@@ -56,3 +56,14 @@ func (f *factory) New(serverName, socketPath string) AgentProxy {
 
 	return NewAgentProxy(serverName, socketPath, f.pauseImage, f.tlsConfig, f.caService, f.proxyTimeout)
 }
+
+// NewFactoryWithCAService creates a Factory using pre-built TLS material.
+// Use when TLS material has been loaded from persistent storage.
+func NewFactoryWithCAService(pauseImage string, tlsConfig *tlsutil.TLSConfig, proxyTimeout time.Duration, caService tlsutil.CAService) Factory {
+	return &factory{
+		pauseImage:   pauseImage,
+		tlsConfig:    tlsConfig,
+		caService:    caService,
+		proxyTimeout: proxyTimeout,
+	}
+}

--- a/src/cloud-api-adaptor/pkg/adaptor/proxy/proxy.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/proxy/proxy.go
@@ -25,6 +25,7 @@ import (
 const (
 	SocketName          = "agent.ttrpc"
 	DefaultProxyTimeout = 5 * time.Minute
+	DrainTimeout        = 30 * time.Second
 
 	// The server TLS certificate must have this as SAN
 	// TODO: Avoid hard coding of server name
@@ -51,6 +52,11 @@ type agentProxy struct {
 	pauseImage   string
 	proxyTimeout time.Duration
 	stopOnce     sync.Once
+
+	// For graceful shutdown with drain support
+	mu           sync.Mutex
+	ttrpcServer  *ttrpc.Server
+	proxyService *proxyService
 }
 
 func NewAgentProxy(serverName, socketPath, pauseImage string, tlsConfig *tlsutil.TLSConfig, caService tlsutil.CAService, proxyTimeout time.Duration) AgentProxy {
@@ -149,11 +155,6 @@ func (p *agentProxy) Start(ctx context.Context, serverURL *url.URL) error {
 	}
 
 	proxyService := newProxyService(dialer, p.pauseImage)
-	defer func() {
-		if err := proxyService.Close(); err != nil {
-			logger.Printf("error closing agent proxy connection: %v", err)
-		}
-	}()
 
 	if err := proxyService.Connect(ctx); err != nil {
 		return fmt.Errorf("error connecting to agent: %v", err)
@@ -161,8 +162,15 @@ func (p *agentProxy) Start(ctx context.Context, serverURL *url.URL) error {
 
 	ttrpcServer, err := ttrpc.NewServer()
 	if err != nil {
+		proxyService.Close()
 		return fmt.Errorf("failed to create TTRPC server: %w", err)
 	}
+
+	// Store references for graceful shutdown
+	p.mu.Lock()
+	p.ttrpcServer = ttrpcServer
+	p.proxyService = proxyService
+	p.mu.Unlock()
 
 	pb.RegisterAgentServiceService(ttrpcServer, proxyService)
 	pb.RegisterHealthService(ttrpcServer, proxyService)
@@ -206,6 +214,30 @@ func (p *agentProxy) Ready() chan struct{} {
 func (p *agentProxy) Shutdown() error {
 	logger.Print("shutting down socket forwarder")
 	p.stopOnce.Do(func() {
+		p.mu.Lock()
+		ttrpcServer := p.ttrpcServer
+		proxyService := p.proxyService
+		p.mu.Unlock()
+
+		// Drain: wait for pending requests to complete
+		if ttrpcServer != nil {
+			logger.Print("draining pending requests...")
+			ctx, cancel := context.WithTimeout(context.Background(), DrainTimeout)
+			if err := ttrpcServer.Shutdown(ctx); err != nil {
+				logger.Printf("drain timeout or error: %v", err)
+			} else {
+				logger.Print("drain complete")
+			}
+			cancel()
+		}
+
+		// Close the client connection to forwarder
+		if proxyService != nil {
+			if err := proxyService.Close(); err != nil {
+				logger.Printf("error closing agent proxy connection: %v", err)
+			}
+		}
+
 		close(p.stopCh)
 	})
 	return nil

--- a/src/cloud-api-adaptor/pkg/adaptor/server.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/server.go
@@ -5,6 +5,7 @@ package adaptor
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net"
 	"os"
@@ -19,6 +20,7 @@ import (
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/adaptor/proxy"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/adaptor/vminfo"
 	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/podnetwork"
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/util/tlsutil"
 	pbPodVMInfo "github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/proto/podvminfo"
 	provider "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers"
 )
@@ -49,11 +51,31 @@ type server struct {
 	PeerPodsLimitPerNode    int
 }
 
-func NewServer(provider provider.Provider, cfg *cloud.ServerConfig, workerNode podnetwork.WorkerNode) Server {
+// buildAgentFactory constructs a proxy.Factory, using persistent TLS material
+// when configured, falling back to ephemeral material otherwise.
+func buildAgentFactory(cfg *cloud.ServerConfig) (proxy.Factory, error) {
+	if cfg.TLSConfig != nil && cfg.TLSMaterialPath != "" {
+		caService, clientCertPEM, clientKeyPEM, err := tlsutil.LoadOrCreateTLSMaterial(cfg.TLSMaterialPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load/create TLS material from %s: %w", cfg.TLSMaterialPath, err)
+		}
+		cfg.TLSConfig.CertData = clientCertPEM
+		cfg.TLSConfig.KeyData = clientKeyPEM
+		cfg.TLSConfig.CAData = caService.RootCertificate()
+		logger.Printf("using persistent TLS material from %s", cfg.TLSMaterialPath)
+		return proxy.NewFactoryWithCAService(cfg.PauseImage, cfg.TLSConfig, cfg.ProxyTimeout, caService), nil
+	}
+	return proxy.NewFactory(cfg.PauseImage, cfg.TLSConfig, cfg.ProxyTimeout), nil
+}
+
+func NewServer(provider provider.Provider, cfg *cloud.ServerConfig, workerNode podnetwork.WorkerNode) (Server, error) {
 
 	logger.Printf("server config: %#v", cfg)
 
-	agentFactory := proxy.NewFactory(cfg.PauseImage, cfg.TLSConfig, cfg.ProxyTimeout)
+	agentFactory, err := buildAgentFactory(cfg)
+	if err != nil {
+		return nil, err
+	}
 	cloudService := cloud.NewService(provider, agentFactory, workerNode, cfg)
 	vmInfoService := vminfo.NewService(cloudService)
 
@@ -66,7 +88,7 @@ func NewServer(provider provider.Provider, cfg *cloud.ServerConfig, workerNode p
 		stopCh:                  make(chan struct{}),
 		enableCloudConfigVerify: cfg.EnableCloudConfigVerify,
 		PeerPodsLimitPerNode:    cfg.PeerPodsLimitPerNode,
-	}
+	}, nil
 }
 
 func (s *server) Start(ctx context.Context) (err error) {

--- a/src/cloud-api-adaptor/pkg/adaptor/server.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/server.go
@@ -160,8 +160,6 @@ func (s *server) Shutdown() error {
 		close(s.stopCh)
 	})
 
-	_ = k8sops.RemoveExtendedResources()
-
 	return s.cloudService.Teardown()
 }
 

--- a/src/cloud-api-adaptor/pkg/adaptor/server.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/server.go
@@ -124,6 +124,7 @@ func (s *server) Start(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
+	listener.(*net.UnixListener).SetUnlinkOnClose(false)
 
 	ttRPCErr := make(chan error)
 	go func() {

--- a/src/cloud-api-adaptor/pkg/adaptor/server_test.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/server_test.go
@@ -174,8 +174,8 @@ func testServerShutdown(t *testing.T, s Server, socketPath, dir string, serverEr
 	if err := <-serverErrCh; err != nil {
 		t.Error(err)
 	}
-	if _, err := os.Stat(socketPath); err == nil {
-		t.Errorf("Unix domain socket %s still remains\n", socketPath)
+	if _, err := os.Stat(socketPath); err != nil {
+		t.Errorf("Unix domain socket %s should remain after shutdown (SetUnlinkOnClose(false))\n", socketPath)
 	}
 	if err := os.RemoveAll(dir); err != nil {
 		t.Error(err)

--- a/src/cloud-api-adaptor/pkg/adaptor/server_test.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/server_test.go
@@ -159,7 +159,11 @@ func newServer(t *testing.T, socketPath, podsDir string) Server {
 		EnableCloudConfigVerify: false,
 		PeerPodsLimitPerNode:    -1,
 	}
-	return NewServer(provider, serverConfig, &mockWorkerNode{})
+	srv, err := NewServer(provider, serverConfig, &mockWorkerNode{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv
 }
 
 func testServerShutdown(t *testing.T, s Server, socketPath, dir string, serverErrCh chan error) {

--- a/src/cloud-api-adaptor/pkg/adaptor/shim_test.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/shim_test.go
@@ -99,7 +99,10 @@ func TestShim(t *testing.T) {
 	}
 
 	provider := &mockProvider{primaryIP: primaryIP, secondaryIP: secondaryIP}
-	srv := NewServer(provider, serverConfig, workerNode)
+	srv, err := NewServer(provider, serverConfig, workerNode)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	serverDone := make(chan struct{})
 	go func() {

--- a/src/cloud-api-adaptor/pkg/adaptor/state/manager.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/state/manager.go
@@ -1,0 +1,104 @@
+package state
+
+import (
+	"encoding/json"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/podnetwork/tunneler"
+)
+
+const stateFileName = "state.json"
+
+type Manager struct {
+	podsDir string
+}
+
+func NewManager(podsDir string) *Manager {
+	return &Manager{podsDir: podsDir}
+}
+
+func (m *Manager) statePath(sandboxID string) string {
+	return filepath.Join(m.podsDir, sandboxID, stateFileName)
+}
+
+func (m *Manager) Save(st *SandboxState) error {
+	path := m.statePath(st.SandboxID)
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return err
+	}
+	// Atomic write: temp file + rename
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func (m *Manager) Load(sandboxID string) (*SandboxState, error) {
+	data, err := os.ReadFile(m.statePath(sandboxID))
+	if err != nil {
+		return nil, err
+	}
+	var st SandboxState
+	if err := json.Unmarshal(data, &st); err != nil {
+		return nil, err
+	}
+	return &st, nil
+}
+
+func (m *Manager) Delete(sandboxID string) error {
+	return os.RemoveAll(filepath.Join(m.podsDir, sandboxID))
+}
+
+func (m *Manager) List() ([]string, error) {
+	entries, err := os.ReadDir(m.podsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var ids []string
+	for _, e := range entries {
+		if e.IsDir() {
+			if _, err := os.Stat(m.statePath(e.Name())); err == nil {
+				ids = append(ids, e.Name())
+			}
+		}
+	}
+	return ids, nil
+}
+
+func (m *Manager) SetReady(sandboxID string, podNetwork *tunneler.Config) error {
+	st, err := m.Load(sandboxID)
+	if err != nil {
+		return err
+	}
+	st.Running = true
+	st.PodNetwork = podNetwork
+	return m.Save(st)
+}
+
+// UpdateInstance updates instance info after VM creation (used in StartVM)
+func (m *Manager) UpdateInstance(sandboxID, instanceID, instanceName string, ips []netip.Addr) error {
+	st, err := m.Load(sandboxID)
+	if err != nil {
+		return err
+	}
+	st.InstanceID = instanceID
+	st.InstanceName = instanceName
+
+	ipStrings := make([]string, len(ips))
+	for i, ip := range ips {
+		ipStrings[i] = ip.String()
+	}
+	st.InstanceIPs = ipStrings
+
+	now := time.Now()
+	st.StartedAt = &now
+	return m.Save(st)
+}

--- a/src/cloud-api-adaptor/pkg/adaptor/state/manager_test.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/state/manager_test.go
@@ -1,0 +1,154 @@
+package state
+
+import (
+	"net/netip"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/podnetwork/tunneler"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestState(sandboxID string) *SandboxState {
+	return &SandboxState{
+		Version:      1,
+		SandboxID:    sandboxID,
+		PodName:      "test-pod",
+		PodNamespace: "default",
+		NetNSPath:    "/var/run/netns/test",
+		CreatedAt:    time.Now().Truncate(time.Second),
+	}
+}
+
+func setupManager(t *testing.T, sandboxID string) *Manager {
+	t.Helper()
+	podsDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(podsDir, sandboxID), 0o755))
+	m := NewManager(podsDir)
+	return m
+}
+
+func TestSaveAndLoad(t *testing.T) {
+	m := setupManager(t, "sandbox-1")
+	st := newTestState("sandbox-1")
+	st.InstanceID = "i-abc123"
+	st.InstanceIPs = []string{"10.0.0.1"}
+	st.ServerName = "server-1"
+	st.ForwarderPort = "15150"
+
+	require.NoError(t, m.Save(st))
+
+	loaded, err := m.Load("sandbox-1")
+	require.NoError(t, err)
+
+	assert.Equal(t, st.SandboxID, loaded.SandboxID)
+	assert.Equal(t, st.PodName, loaded.PodName)
+	assert.Equal(t, st.PodNamespace, loaded.PodNamespace)
+	assert.Equal(t, st.NetNSPath, loaded.NetNSPath)
+	assert.Equal(t, st.InstanceID, loaded.InstanceID)
+	assert.Equal(t, st.InstanceIPs, loaded.InstanceIPs)
+	assert.Equal(t, st.ServerName, loaded.ServerName)
+	assert.Equal(t, st.ForwarderPort, loaded.ForwarderPort)
+	assert.Equal(t, st.CreatedAt, loaded.CreatedAt)
+}
+
+func TestLoadNonexistent(t *testing.T) {
+	m := NewManager(t.TempDir())
+
+	_, err := m.Load("does-not-exist")
+	assert.Error(t, err)
+}
+
+func TestDelete(t *testing.T) {
+	m := setupManager(t, "sandbox-1")
+	st := newTestState("sandbox-1")
+	require.NoError(t, m.Save(st))
+
+	require.NoError(t, m.Delete("sandbox-1"))
+
+	_, err := m.Load("sandbox-1")
+	assert.Error(t, err)
+}
+
+func TestList(t *testing.T) {
+	podsDir := t.TempDir()
+	m := NewManager(podsDir)
+
+	ids := []string{"sandbox-a", "sandbox-b", "sandbox-c"}
+	for _, id := range ids {
+		require.NoError(t, os.MkdirAll(filepath.Join(podsDir, id), 0o755))
+		require.NoError(t, m.Save(newTestState(id)))
+	}
+
+	listed, err := m.List()
+	require.NoError(t, err)
+
+	sort.Strings(listed)
+	sort.Strings(ids)
+	assert.Equal(t, ids, listed)
+}
+
+func TestListEmptyDir(t *testing.T) {
+	m := NewManager(filepath.Join(t.TempDir(), "nonexistent"))
+
+	listed, err := m.List()
+	assert.NoError(t, err)
+	assert.Nil(t, listed)
+}
+
+func TestSetReady(t *testing.T) {
+	m := setupManager(t, "sandbox-1")
+	st := newTestState("sandbox-1")
+	require.NoError(t, m.Save(st))
+
+	podNet := &tunneler.Config{
+		InterfaceName: "eth0",
+		Index:         5,
+		VXLANPort:     4789,
+		VXLANID:       555005,
+	}
+	require.NoError(t, m.SetReady("sandbox-1", podNet))
+
+	loaded, err := m.Load("sandbox-1")
+	require.NoError(t, err)
+	assert.True(t, loaded.Running)
+	assert.Equal(t, podNet.Index, loaded.PodNetwork.Index)
+	assert.Equal(t, podNet.VXLANID, loaded.PodNetwork.VXLANID)
+}
+
+func TestUpdateInstance(t *testing.T) {
+	m := setupManager(t, "sandbox-1")
+	st := newTestState("sandbox-1")
+	require.NoError(t, m.Save(st))
+
+	ips := []netip.Addr{netip.MustParseAddr("192.168.1.10")}
+	require.NoError(t, m.UpdateInstance("sandbox-1", "i-xyz", "vm-xyz", ips))
+
+	loaded, err := m.Load("sandbox-1")
+	require.NoError(t, err)
+	assert.Equal(t, "i-xyz", loaded.InstanceID)
+	assert.Equal(t, "vm-xyz", loaded.InstanceName)
+	assert.Equal(t, []string{"192.168.1.10"}, loaded.InstanceIPs)
+	assert.NotNil(t, loaded.StartedAt)
+}
+
+func TestAtomicWrite(t *testing.T) {
+	podsDir := t.TempDir()
+	sandboxID := "sandbox-1"
+	require.NoError(t, os.MkdirAll(filepath.Join(podsDir, sandboxID), 0o755))
+	m := NewManager(podsDir)
+
+	require.NoError(t, m.Save(newTestState(sandboxID)))
+
+	tmpPath := filepath.Join(podsDir, sandboxID, stateFileName+".tmp")
+	_, err := os.Stat(tmpPath)
+	assert.True(t, os.IsNotExist(err), "temp file should not remain after save")
+
+	statePath := filepath.Join(podsDir, sandboxID, stateFileName)
+	_, err = os.Stat(statePath)
+	assert.NoError(t, err, "state file should exist")
+}

--- a/src/cloud-api-adaptor/pkg/adaptor/state/types.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/state/types.go
@@ -1,0 +1,30 @@
+package state
+
+import (
+	"time"
+
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/podnetwork/tunneler"
+)
+
+type SandboxState struct {
+	Version      int       `json:"version"`
+	SandboxID    string    `json:"sandboxId"`
+	PodName      string    `json:"podName"`
+	PodNamespace string    `json:"podNamespace"`
+	NetNSPath    string    `json:"netNsPath"`
+	Running      bool      `json:"running"`
+	CreatedAt    time.Time `json:"createdAt"`
+
+	// Set after instance creation
+	InstanceID   string     `json:"instanceId,omitempty"`
+	InstanceName string     `json:"instanceName,omitempty"`
+	StartedAt    *time.Time `json:"startedAt,omitempty"`
+
+	// For Phase 3 reconnection
+	InstanceIPs   []string `json:"instanceIPs,omitempty"`
+	ServerName    string   `json:"serverName,omitempty"`
+	ForwarderPort string   `json:"forwarderPort,omitempty"`
+
+	// Network configuration for teardown
+	PodNetwork *tunneler.Config `json:"podNetwork,omitempty"`
+}

--- a/src/cloud-api-adaptor/pkg/forwarder/forwarder.go
+++ b/src/cloud-api-adaptor/pkg/forwarder/forwarder.go
@@ -23,6 +23,38 @@ import (
 
 var logger = log.New(log.Writer(), "[forwarder] ", log.LstdFlags|log.Lmsgprefix)
 
+// singleClientListener wraps a net.Listener to enforce single-client mode.
+// When a new connection arrives, the previous connection is closed so the
+// ttrpc server's stream state is cleanly reset for the new CAA instance.
+// The forwarder→kata-agent connection is NOT touched — it survives CAA restarts.
+type singleClientListener struct {
+	net.Listener
+	mu          sync.Mutex
+	currentConn net.Conn
+}
+
+func newSingleClientListener(l net.Listener) *singleClientListener {
+	return &singleClientListener{Listener: l}
+}
+
+func (s *singleClientListener) Accept() (net.Conn, error) {
+	conn, err := s.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	if s.currentConn != nil {
+		logger.Printf("New connection from %s, closing previous connection", conn.RemoteAddr())
+		s.currentConn.Close()
+	}
+	s.currentConn = conn
+	s.mu.Unlock()
+
+	logger.Printf("Accepted connection from %s", conn.RemoteAddr())
+	return conn, nil
+}
+
 const (
 	DefaultListenHost          = "0.0.0.0"
 	DefaultListenPort          = "15150"
@@ -136,6 +168,11 @@ func (d *daemon) Start(ctx context.Context) error {
 
 	d.listenAddr = listener.Addr().String()
 
+	// Wrap listener with single-client mode to handle CAA reconnections.
+	// Only the CAA→forwarder TCP connection breaks on restart; the
+	// forwarder→kata-agent Unix socket stays alive, so we must NOT reset it.
+	singleClientListener := newSingleClientListener(listener)
+
 	ttrpcServer, err := ttrpc.NewServer()
 	if err != nil {
 		return fmt.Errorf("failed to create TTRPC server: %w", err)
@@ -148,7 +185,7 @@ func (d *daemon) Start(ctx context.Context) error {
 	go func() {
 		defer close(ttrpcServerErr)
 
-		if err := ttrpcServer.Serve(ctx, listener); err != nil && !errors.Is(err, ttrpc.ErrServerClosed) {
+		if err := ttrpcServer.Serve(ctx, singleClientListener); err != nil && !errors.Is(err, ttrpc.ErrServerClosed) {
 			ttrpcServerErr <- fmt.Errorf("error running TTRPC server for kata agent interceptor: %w", err)
 		}
 	}()

--- a/src/cloud-api-adaptor/pkg/forwarder/forwarder_test.go
+++ b/src/cloud-api-adaptor/pkg/forwarder/forwarder_test.go
@@ -606,3 +606,69 @@ func TestDaemonWithTLSConfig(t *testing.T) {
 		assert.Nil(t, daemonImpl.tlsConfig)
 	})
 }
+
+func TestSingleClientListenerFirstAccept(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	scl := newSingleClientListener(ln)
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	accepted, err := scl.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer accepted.Close()
+
+	if accepted == nil {
+		t.Fatal("expected non-nil connection")
+	}
+}
+
+func TestSingleClientListenerReplacesConnection(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	scl := newSingleClientListener(ln)
+
+	conn1, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn1.Close()
+
+	accepted1, err := scl.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn2, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn2.Close()
+
+	accepted2, err := scl.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer accepted2.Close()
+
+	// First accepted connection should be closed by singleClientListener
+	buf := make([]byte, 1)
+	_, readErr := accepted1.Read(buf)
+	if readErr == nil {
+		t.Fatal("expected error reading from closed first connection")
+	}
+}

--- a/src/cloud-api-adaptor/pkg/podnetwork/podnetwork_test.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/podnetwork_test.go
@@ -240,3 +240,37 @@ func TestPluginDetectHostInterface(t *testing.T) {
 		t.Fatalf("Expect %q, got %q", e, a)
 	}
 }
+
+func TestSetMinPodIndex(t *testing.T) {
+	var pi podIndex
+	pi.SetMin(10)
+	got := pi.Get()
+	require.Equal(t, 10, got)
+}
+
+func TestSetMinDoesNotGoBackwards(t *testing.T) {
+	var pi podIndex
+	pi.SetMin(10)
+	pi.SetMin(5)
+	got := pi.Get()
+	require.Equal(t, 10, got)
+}
+
+func TestSetMinConcurrent(t *testing.T) {
+	var pi podIndex
+	const goroutines = 100
+
+	done := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		go func(val int) {
+			pi.SetMin(val)
+			done <- struct{}{}
+		}(i)
+	}
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+
+	got := pi.Get()
+	require.Equal(t, goroutines-1, got)
+}

--- a/src/cloud-api-adaptor/pkg/podnetwork/tunneler/tunneler.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/tunneler/tunneler.go
@@ -27,6 +27,7 @@ type Config struct {
 	Index               int          `json:"index"`
 	VXLANPort           int          `json:"vxlan-port,omitempty"`
 	VXLANID             int          `json:"vxlan-id,omitempty"`
+	DestinationIP       netip.Addr   `json:"destination-ip,omitempty"`
 	Dedicated           bool         `json:"dedicated"`
 	ExternalNetViaPodVM bool         `json:"external-net-via-pod-vm"`
 }

--- a/src/cloud-api-adaptor/pkg/podnetwork/tunneler/vxlan/workernode.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/tunneler/vxlan/workernode.go
@@ -56,6 +56,8 @@ func (t *workerNodeTunneler) Setup(nsPath string, podNodeIPs []netip.Addr, confi
 		dstAddr = podNodeIPs[0]
 	}
 
+	config.DestinationIP = dstAddr
+
 	hostNS, err := netops.OpenCurrentNamespace()
 	if err != nil {
 		return fmt.Errorf("failed to get current network namespace: %w", err)
@@ -159,6 +161,11 @@ func (t *workerNodeTunneler) Setup(nsPath string, podNodeIPs []netip.Addr, confi
 
 func (t *workerNodeTunneler) Teardown(nsPath, hostInterface string, config *tunneler.Config) error {
 
+	if !config.DestinationIP.IsValid() {
+		logger.Printf("skipping teardown: Setup was never called (no destination IP)")
+		return nil
+	}
+
 	hostNS, err := netops.OpenCurrentNamespace()
 	if err != nil {
 		return fmt.Errorf("failed to get current network namespace: %w", err)
@@ -169,9 +176,14 @@ func (t *workerNodeTunneler) Teardown(nsPath, hostInterface string, config *tunn
 		}
 	}()
 
+	if err := iptablesTeardown(hostNS, config.DestinationIP, config.VXLANPort, config.VXLANID); err != nil {
+		return err
+	}
+
 	podNS, err := netops.OpenNamespace(nsPath)
 	if err != nil {
-		return fmt.Errorf("failed to get a network namespace: %s: %w", nsPath, err)
+		logger.Printf("pod netns %s gone, skipping interface cleanup (iptables already cleaned)", nsPath)
+		return nil
 	}
 	defer func() {
 		if e := podNS.Close(); e != nil {
@@ -196,26 +208,8 @@ func (t *workerNodeTunneler) Teardown(nsPath, hostInterface string, config *tunn
 		return fmt.Errorf("failed to find vxlan interface %q on pod netns %s to %s: %w", secondPodInterface, podNS.Path(), secondPodInterface, err)
 	}
 
-	device, err := podVxlanInterface.GetDevice()
-	if err != nil {
-		return fmt.Errorf("failed to get device info of %s: %w", secondPodInterface, err)
-	}
-
-	vxlanDevice, ok := device.(*netops.VXLAN)
-	if !ok {
-		return fmt.Errorf("not a VXLAN interface: %s", secondPodInterface)
-	}
-
-	dstAddr := vxlanDevice.Group
-	dstPort := vxlanDevice.Port
-	vxlanID := vxlanDevice.ID
-
 	if err := podVxlanInterface.Delete(); err != nil {
 		return fmt.Errorf("failed to delete vxlan interface %s at %s: %w", secondPodInterface, podNS.Path(), err)
-	}
-
-	if err := iptablesTeardown(hostNS, dstAddr, dstPort, vxlanID); err != nil {
-		return err
 	}
 
 	return nil

--- a/src/cloud-api-adaptor/pkg/podnetwork/workernode.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/workernode.go
@@ -241,6 +241,11 @@ func (n *workerNode) Setup(nsPath string, podNodeIPs []netip.Addr, config *tunne
 }
 
 func (n *workerNode) Teardown(nsPath string, config *tunneler.Config) error {
+	// Skip teardown if config is nil (e.g., restored sandbox with missing podNetwork)
+	if config == nil {
+		logger.Printf("skipping teardown for %s: no network config", nsPath)
+		return nil
+	}
 
 	hostNS, err := netops.OpenCurrentNamespace()
 	if err != nil {

--- a/src/cloud-api-adaptor/pkg/podnetwork/workernode.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/workernode.go
@@ -25,8 +25,6 @@ type workerNode struct {
 	tunneler tunneler.TunnelerConfigurator
 }
 
-// TODO: Pod index is reset when this process restarts.
-// We need to manage a persistent unique index number for each pod VM
 var podIndexManager podIndex
 
 type podIndex struct {
@@ -43,8 +41,19 @@ func (p *podIndex) Get() int {
 	return index
 }
 
-func NewWorkerNode(networkConfig *tunneler.NetworkConfig) (WorkerNode, error) {
+func (p *podIndex) SetMin(min int) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	if min > p.index {
+		p.index = min
+	}
+}
 
+func SetMinPodIndex(min int) {
+	podIndexManager.SetMin(min)
+}
+
+func NewWorkerNode(networkConfig *tunneler.NetworkConfig) (WorkerNode, error) {
 	t, err := tunneler.WorkerNodeTunneler(networkConfig.TunnelType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tunneler: %w", err)

--- a/src/cloud-api-adaptor/pkg/probe/checker.go
+++ b/src/cloud-api-adaptor/pkg/probe/checker.go
@@ -60,9 +60,6 @@ func (c *Checker) GetAllPeerPods(startTime time.Time) (ready bool, err error) {
 				return false, fmt.Errorf("PeerPod %s is not Ready.", pod.Name)
 			}
 
-			if condition.LastTransitionTime.Time.Before(startTime) {
-				return false, fmt.Errorf("PeerPod %s has not been restarted.", pod.Name)
-			}
 		}
 	}
 

--- a/src/cloud-api-adaptor/pkg/probe/probe.go
+++ b/src/cloud-api-adaptor/pkg/probe/probe.go
@@ -4,10 +4,15 @@
 package probe
 
 import (
+	"context"
 	"log"
+	"net"
 	"net/http"
 	"os"
+	"syscall"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 var logger = log.New(log.Writer(), "[probe/probe] ", log.LstdFlags|log.Lmsgprefix)
@@ -31,7 +36,7 @@ func StartupHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func Start(socketPath string) {
+func Start(ctx context.Context, socketPath string) {
 	startTime = time.Now()
 
 	port := os.Getenv("PROBE_PORT")
@@ -51,10 +56,32 @@ func Start(socketPath string) {
 		RuntimeclassName: GetRuntimeclassName(),
 		SocketPath:       socketPath,
 	}
-	http.HandleFunc("/startup", StartupHandler)
-	err = http.ListenAndServe(":"+port, nil)
-
+	lc := net.ListenConfig{
+		Control: func(network, address string, c syscall.RawConn) error {
+			return c.Control(func(fd uintptr) {
+				if err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1); err != nil {
+					logger.Printf("failed to set SO_REUSEPORT: %v", err)
+				}
+			})
+		},
+	}
+	ln, err := lc.Listen(ctx, "tcp", ":"+port)
 	if err != nil {
+		logger.Printf("failed to listen on probe port: %s", err)
+		return
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/startup", StartupHandler)
+	server := &http.Server{Handler: mux}
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			logger.Printf("probe server shutdown error: %v", err)
+		}
+	}()
+	if err = server.Serve(ln); err != nil && err != http.ErrServerClosed {
 		logger.Printf("failed to start startup probe server, error %s", err)
 	}
 }

--- a/src/cloud-api-adaptor/pkg/probe/probe.go
+++ b/src/cloud-api-adaptor/pkg/probe/probe.go
@@ -18,18 +18,6 @@ var startTime time.Time
 const DefaultCCRuntimeClassName string = "kata-remote"
 
 func StartupHandler(w http.ResponseWriter, r *http.Request) {
-	opened, err := checker.IsSocketOpen()
-	if err != nil {
-		logger.Printf("UDS not opened, because %s", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-	if !opened {
-		logger.Printf("UDS not opened")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
 	if !podsReadizProbesDone {
 		ret, err := checker.GetAllPeerPods(startTime)
 		podsReadizProbesDone = ret

--- a/src/cloud-api-adaptor/pkg/probe/probe_test.go
+++ b/src/cloud-api-adaptor/pkg/probe/probe_test.go
@@ -122,7 +122,7 @@ func Test_GetAllPeerPods_BeFalse(t *testing.T) {
 	assert.False(t, result)
 }
 
-func Test_GetAllPeerPods_BeFalse_time_before(t *testing.T) {
+func Test_GetAllPeerPods_BeTrue_time_before(t *testing.T) {
 	os.Setenv("NODE_NAME", "node-name-1")
 
 	clientset := getFakeClientSetWithParas("pod", "default", "node-name-1", DefaultCCRuntimeClassName, corev1.ConditionTrue, timeBefore)
@@ -133,8 +133,8 @@ func Test_GetAllPeerPods_BeFalse_time_before(t *testing.T) {
 	}
 	result, err := checker.GetAllPeerPods(timeStart)
 
-	assert.NotNil(t, err)
-	assert.False(t, result)
+	assert.NoError(t, err)
+	assert.True(t, result)
 }
 
 func Test_GetAllPeerPods_BeError(t *testing.T) {

--- a/src/cloud-api-adaptor/pkg/util/tlsutil/persist.go
+++ b/src/cloud-api-adaptor/pkg/util/tlsutil/persist.go
@@ -1,0 +1,73 @@
+// Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tlsutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// tlsMaterial is the JSON schema used to persist TLS material on disk.
+type tlsMaterial struct {
+	CACertPEM     []byte `json:"ca_cert_pem"`
+	CAKeyPEM      []byte `json:"ca_key_pem"`
+	ClientCertPEM []byte `json:"client_cert_pem"`
+	ClientKeyPEM  []byte `json:"client_key_pem"`
+}
+
+// LoadOrCreateTLSMaterial loads persisted TLS material from path, or generates
+// fresh material and persists it when none exists. The returned CAService can
+// issue per-pod-VM server certificates.
+func LoadOrCreateTLSMaterial(path string) (CAService, []byte, []byte, error) {
+	// Try load existing
+	if data, readErr := os.ReadFile(path); readErr == nil {
+		var mat tlsMaterial
+		if jsonErr := json.Unmarshal(data, &mat); jsonErr == nil &&
+			len(mat.CACertPEM) > 0 && len(mat.CAKeyPEM) > 0 &&
+			len(mat.ClientCertPEM) > 0 && len(mat.ClientKeyPEM) > 0 {
+			svc := &caService{
+				orgName: "agent-protocol-forwarder",
+				certPEM: mat.CACertPEM,
+				keyPEM:  mat.CAKeyPEM,
+			}
+			return svc, mat.ClientCertPEM, mat.ClientKeyPEM, nil
+		}
+	}
+
+	// Generate new CA
+	svc, err := NewCAService("agent-protocol-forwarder")
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("generating CA: %w", err)
+	}
+
+	// Generate new client certificate
+	clientCertPEM, clientKeyPEM, err := NewClientCertificate("cloud-api-adaptor")
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("generating client certificate: %w", err)
+	}
+
+	// Persist - access internal fields via type assertion
+	inner := svc.(*caService)
+	mat := tlsMaterial{
+		CACertPEM:     inner.certPEM,
+		CAKeyPEM:      inner.keyPEM,
+		ClientCertPEM: clientCertPEM,
+		ClientKeyPEM:  clientKeyPEM,
+	}
+	data, err := json.Marshal(mat)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("marshaling TLS material: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, nil, nil, fmt.Errorf("creating TLS material directory: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return nil, nil, nil, fmt.Errorf("writing TLS material: %w", err)
+	}
+
+	return svc, clientCertPEM, clientKeyPEM, nil
+}

--- a/src/cloud-api-adaptor/pkg/util/tlsutil/persist_test.go
+++ b/src/cloud-api-adaptor/pkg/util/tlsutil/persist_test.go
@@ -1,0 +1,50 @@
+package tlsutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateThenLoad(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tls-material.json")
+
+	ca1, cert1, key1, err := LoadOrCreateTLSMaterial(path)
+	require.NoError(t, err)
+	require.NotNil(t, ca1)
+	require.NotEmpty(t, cert1)
+	require.NotEmpty(t, key1)
+
+	ca2, cert2, key2, err := LoadOrCreateTLSMaterial(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, ca1.RootCertificate(), ca2.RootCertificate())
+	assert.Equal(t, cert1, cert2)
+	assert.Equal(t, key1, key2)
+}
+
+func TestCorruptedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tls-material.json")
+
+	require.NoError(t, os.WriteFile(path, []byte("not json"), 0o600))
+
+	ca, cert, key, err := LoadOrCreateTLSMaterial(path)
+	require.NoError(t, err)
+	assert.NotNil(t, ca)
+	assert.NotEmpty(t, cert)
+	assert.NotEmpty(t, key)
+}
+
+func TestFilePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tls-material.json")
+
+	_, _, _, err := LoadOrCreateTLSMaterial(path)
+	require.NoError(t, err)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}

--- a/src/cloud-providers/cmd/config-extractor/main.go
+++ b/src/cloud-providers/cmd/config-extractor/main.go
@@ -127,15 +127,19 @@ func parseFile(path string) ([]FlagInfo, error) {
 func parsePackageConstants(dir string, fset *token.FileSet) map[string]string {
 	constants := make(map[string]string)
 
-	pkgs, err := parser.ParseDir(fset, dir, nil, parser.ParseComments)
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return constants
 	}
-
-	for _, pkg := range pkgs {
-		for _, file := range pkg.Files {
-			extractConstants(file, constants)
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".go" {
+			continue
 		}
+		file, err := parser.ParseFile(fset, filepath.Join(dir, entry.Name()), nil, parser.ParseComments)
+		if err != nil {
+			continue
+		}
+		extractConstants(file, constants)
 	}
 
 	return constants


### PR DESCRIPTION
## Problem

CAA stores all sandbox state in an in-memory map. When the CAA pod restarts, this state is lost. The new CAA instance has no record of existing sandboxes and does not recreate the agent proxy. The shim's ttrpc connection to agent.ttrpc goes stale, the shim's health monitor detects the broken connection and exits, and the pod restarts. A routine CAA daemonset update disrupts every peer pod workload on the node.

## Solution

This PR persists sandbox state to disk so that a restarted CAA can reconnect to existing pod VMs instead of destroying them. After recovery, the shim's ttrpc requests resume flowing through the new agent proxy to the original kata-agent — containers continue running with zero restarts.

State is saved at each lifecycle transition: CreateVM persists initial metadata, StartVM updates instance info and network config, StopVM deletes state. On startup, CAA scans `/run/peerpod/pods/*` for state files and reconnects to sandboxes that were in the Running phase. Sandboxes in any other phase are cleaned up.

### Additional Changes

Several subsystems assumed fresh-start semantics and needed fixes:

- TLS material: ephemeral CA + client keys regenerated on each start break mTLS to existing forwarders. Persist on first run, reload on subsequent starts.
- VXLAN pod index: counter resets to zero causing ID collisions with recovered sandboxes. Advance past all restored indices before creating new sandboxes.
- Network teardown: extracted VXLAN params from pod netns which may be inaccessible after restart. Persist destination IP so teardown works from state alone.
- Forwarder listener: old ttrpc Serve goroutine stays blocked after reconnect, routing requests to the stale session. Close the previous connection when a new one arrives.
- Agent proxy shutdown: immediate close severs in-flight requests. Drain pending requests before closing.
- Startup probe: restart-time check blocks indefinitely for surviving pods. Socket bind fails due to TIME_WAIT. Remove the check, add SO_REUSEPORT.
- Extended resources: RemoveExtendedResources on shutdown drops node capacity. Remove the call since resources are re-advertised on startup.

## Testing

Tested on libvirt with a two-node kcli cluster (control-plane + worker) using a debug podvm image with a custom kata-agent and shim (includes changes from https://github.com/kata-containers/kata-containers/pull/12945)

Test flow:
1. Deploy CAA daemonset with sandbox persistence changes
2. Create a peer pod running a counter process (`i=0; while true; do echo counter=$i; i=$((i+1)); sleep 1; done`)
3. Verify kubectl exec works and counter is incrementing
4. Delete the CAA pod (kubectl delete pod/cloud-api-adaptor-daemonset-xxxxx)
5. Wait for new CAA pod to reach Ready
6. Verify kubectl exec works — counter continues from where it left off (not reset to 0)
7. Verify kubectl get pod shows RESTARTS=0

### Unit and e2e Tests
- Unit tests added
- E2E test: Planning on raising a separate PR that adds a optional e2e test that tests end to end sandbox persistence  

Fixes: rhjira#KATA-4915