### PR TITLE
cloud-api-adaptor: support Workload Identity on GKE

### DIFF
--- a/src/cloud-api-adaptor/entrypoint.sh
+++ b/src/cloud-api-adaptor/entrypoint.sh
@@ -67,11 +67,17 @@ alibabacloud() {
 }
 
 gcp() {
-    test_vars GCP_CREDENTIALS GCP_PROJECT_ID GCP_ZONE PODVM_IMAGE_NAME
+    test_vars GCP_PROJECT_ID GCP_ZONE PODVM_IMAGE_NAME
 
-    # Avoid using node's metadata service credentials for GCP authentication
-    echo "$GCP_CREDENTIALS" > /tmp/gcp-creds.json
-    export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-creds.json
+    if [[ -n "$GCP_CREDENTIALS" ]]; then
+        # Static service-account key: write to disk and point the SDK at it.
+        # This bypasses the node's metadata service.
+        echo "$GCP_CREDENTIALS" > /tmp/gcp-creds.json
+        export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-creds.json
+    fi
+    # If GCP_CREDENTIALS is unset, the Google SDK falls back to Application
+    # Default Credentials — i.e. the GKE metadata server, which is how
+    # Workload Identity delivers a token for the pod's bound service account.
 
     set -x
     exec cloud-api-adaptor gcp ${optionals}

--- a/src/cloud-api-adaptor/install/charts/peerpods/templates/daemonset.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/templates/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: cloud-api-adaptor
       containers:
       - command:
-        - /usr/local/bin/entrypoint.sh
+        {{- toYaml .Values.daemonset.command | nindent 8 }}
         env:
         - name: NODE_NAME
           valueFrom:

--- a/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
@@ -92,6 +92,11 @@ limit: "10"
 
 # DaemonSet configuration
 daemonset:
+  # Command to run in the CAA container. Default uses the entrypoint script
+  # which validates required env vars per provider before exec'ing the binary.
+  # Override to bypass the entrypoint.
+  command:
+    - /usr/local/bin/entrypoint.sh
   # Update strategy controls how the CAA DaemonSet performs rolling updates
   updateStrategy:
     # maxUnavailable: Maximum number of pods that can be unavailable during update


### PR DESCRIPTION
# GCP: entrypoint.sh blocks Workload Identity on GKE

## Summary
When running `cloud-api-adaptor` on GKE with Workload Identity, there is no service-account JSON key to provide — the pod's KSA is bound to a GSA and the Google SDK obtains tokens via the node's metadata server (Application Default Credentials). However, `src/cloud-api-adaptor/entrypoint.sh` hard-requires `GCP_CREDENTIALS` and exits before launching the binary, making the WI path unusable without bypassing the entrypoint entirely.

The Go provider already handles this correctly — see `src/cloud-providers/gcp/provider.go`
when `GcpCredentials` is empty it falls through to `compute.NewInstancesRESTClient(context.TODO())`, which uses ADC. So this is purely a gap in the shell wrapper (and, by extension, the Helm chart, which pins command to the entrypoint).

## Steps to reproduce
- Create a GKE cluster with Workload Identity enabled.
- Bind the cloud-api-adaptor KSA to a GSA that has the required compute roles.
- Install the peerpods Helm chart with `provider=gcp` and `GCP_PROJECT_ID`, `GCP_ZONE`, `PODVM_IMAGE_NAME` set, but no `GCP_CREDENTIALS`.
- The `DaemonSet` pod logs: `$GCP_CREDENTIALS is NOT set` and the container exits 1 without ever invoking `cloud-api-adaptor gcp`.

## Expected behavior
`entrypoint.sh` should treat `GCP_CREDENTIALS` as optional. When unset, leave `GOOGLE_APPLICATION_CREDENTIALS` unset so the Google SDK falls back to ADC.

## Proposed change
In `src/cloud-api-adaptor/entrypoint.sh`, drop `GCP_CREDENTIALS` from the required-vars list:
```
  gcp() {
      test_vars GCP_PROJECT_ID GCP_ZONE PODVM_IMAGE_NAME

      if [[ -n "$GCP_CREDENTIALS" ]]; then
          # Static service-account key: write to disk and point the SDK at it.
          echo "$GCP_CREDENTIALS" > /tmp/gcp-creds.json
          export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-creds.json
      fi
      # If GCP_CREDENTIALS is unset, the Google SDK uses Application Default
      # Credentials — i.e. the GKE metadata server, which is how Workload
      # Identity delivers tokens for the pod's bound service account.

      set -x
      exec cloud-api-adaptor gcp ${optionals}
  }
```

This is fully backward-compatible: every existing deployment that sets `GCP_CREDENTIALS` continues to work identically.