### PR TITLE
charts: support imagePullSecrets on peerpods and peerpod-ctrl

### DIFF
--- a/src/cloud-api-adaptor/install/charts/peerpods/templates/daemonset.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/templates/daemonset.yaml
@@ -23,6 +23,10 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: cloud-api-adaptor
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - command:
         - /usr/local/bin/entrypoint.sh

--- a/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
@@ -82,6 +82,13 @@ image:
   name: quay.io/confidential-containers/cloud-api-adaptor
   tag: "2d2e7c2c0736ec41c889cd98442a598b8b93bc0b"
 
+# imagePullSecrets attached to the cloud-api-adaptor DaemonSet pods for
+# pulling the CAA image from a private registry.
+# Example:
+#   imagePullSecrets:
+#     - name: regcred
+imagePullSecrets: []
+
 # Cloud provider: libvirt, aws, azure, gcp, ibmcloud, vsphere
 provider: libvirt
 

--- a/src/peerpod-ctrl/chart/templates/deployment.yaml
+++ b/src/peerpod-ctrl/chart/templates/deployment.yaml
@@ -120,6 +120,10 @@ spec:
       securityContext:
         runAsNonRoot: false
       serviceAccountName: {{ .Values.namePrefix }}controller-manager
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 10
       volumes:
       - name: ssh

--- a/src/peerpod-ctrl/chart/values.yaml
+++ b/src/peerpod-ctrl/chart/values.yaml
@@ -7,6 +7,13 @@ image:
   tag: 2d2e7c2c0736ec41c889cd98442a598b8b93bc0b
   pullPolicy: IfNotPresent
 
+# imagePullSecrets attached to the controller-manager pod for pulling the
+# manager and (when enabled) kube-rbac-proxy images from private registries.
+# Example:
+#   imagePullSecrets:
+#     - name: regcred
+imagePullSecrets: []
+
 # kube-rbac-proxy: Sidecar container that protects the /metrics endpoint with RBAC authentication
 # When enabled, only authenticated clients with proper RBAC permissions can access metrics
 # Set to false to expose metrics without authentication (not recommended for production)


### PR DESCRIPTION
Expose imagePullSecrets as a configurable Helm value on both charts:

* peerpods: attaches to the cloud-api-adaptor DaemonSet pods so the CAA image can be pulled from a private registry.
* peerpod-ctrl: attaches to the controller-manager pod so its image (and kube-rbac-proxy sidecar when enabled) can be pulled from a private registry.

Defaults to an empty list, so existing deployments are unaffected.