### PR TITLE
userdata: use IMDSv2 token for AWS metadata with IMDSv1 fallback

### DIFF
--- a/src/cloud-api-adaptor/pkg/userdata/imds.go
+++ b/src/cloud-api-adaptor/pkg/userdata/imds.go
@@ -6,11 +6,48 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 )
 
 type kvPair struct {
 	k string
 	v string
+}
+
+const awsIMDSv2TokenFetchTimeout = 5 * time.Second
+
+func awsIMDSv2Token(ctx context.Context, tokenURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, tokenURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create IMDSv2 token request: %w", err)
+	}
+	req.Header.Set("X-aws-ec2-metadata-token-ttl-seconds", AWSIMDSv2TokenTTL)
+
+	client := &http.Client{Timeout: awsIMDSv2TokenFetchTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send IMDSv2 token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("IMDSv2 token endpoint returned %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read IMDSv2 token response: %w", err)
+	}
+	return string(body), nil
+}
+
+func awsIMDSHeaders(ctx context.Context, tokenURL string) []kvPair {
+	token, err := awsIMDSv2Token(ctx, tokenURL)
+	if err != nil {
+		logger.Printf("IMDSv2 token fetch failed (%v); falling back to IMDSv1\n", err)
+		return nil
+	}
+	return []kvPair{{"X-aws-ec2-metadata-token", token}}
 }
 
 func imdsGet(ctx context.Context, url string, b64 bool, headers []kvPair) ([]byte, error) {

--- a/src/cloud-api-adaptor/pkg/userdata/provision.go
+++ b/src/cloud-api-adaptor/pkg/userdata/provision.go
@@ -23,6 +23,9 @@ const (
 	// Ref: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html
 	AWSImdsURL         = "http://169.254.169.254/latest/dynamic/instance-identity/document"
 	AWSUserDataImdsURL = "http://169.254.169.254/latest/user-data"
+	// Ref: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-IMDS-use-IMDSv2.html
+	AWSIMDSv2TokenURL = "http://169.254.169.254/latest/api/token"
+	AWSIMDSv2TokenTTL = "60"
 	// Ref: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/instance-metadata-service
 	AzureImdsURL         = "http://169.254.169.254/metadata/instance/compute?api-version=2021-01-01"
 	AzureUserDataImdsURL = "http://169.254.169.254/metadata/instance/compute/userData?api-version=2021-01-01&format=text"
@@ -92,7 +95,7 @@ func (a AWSUserDataProvider) GetUserData(ctx context.Context) ([]byte, error) {
 	url := AWSUserDataImdsURL
 	logger.Printf("provider: AWS, userDataUrl: %s\n", url)
 	// aws user data is not base64 encoded
-	return imdsGet(ctx, url, false, nil)
+	return imdsGet(ctx, url, false, awsIMDSHeaders(ctx, AWSIMDSv2TokenURL))
 }
 
 type GCPUserDataProvider struct{ DefaultRetry }

--- a/src/cloud-api-adaptor/pkg/userdata/provision_test.go
+++ b/src/cloud-api-adaptor/pkg/userdata/provision_test.go
@@ -517,6 +517,115 @@ write_files:
 	}
 }
 
+// TestAWSIMDSv2TokenSuccess tests successful token fetch from IMDSv2 endpoint.
+func TestAWSIMDSv2TokenSuccess(t *testing.T) {
+	const expectedToken = "test-imdsv2-token"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			http.Error(w, "expected PUT", http.StatusBadRequest)
+			return
+		}
+		if r.Header.Get("X-aws-ec2-metadata-token-ttl-seconds") == "" {
+			http.Error(w, "missing TTL header", http.StatusBadRequest)
+			return
+		}
+		_, _ = io.WriteString(w, expectedToken)
+	}))
+	defer srv.Close()
+
+	token, err := awsIMDSv2Token(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("awsIMDSv2Token returned error: %v", err)
+	}
+	if token != expectedToken {
+		t.Fatalf("token mismatch: got %q, want %q", token, expectedToken)
+	}
+}
+
+// TestAWSIMDSv2TokenNon200 tests that non-200 responses return an error.
+func TestAWSIMDSv2TokenNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	_, err := awsIMDSv2Token(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatalf("expected error for 401 response, got nil")
+	}
+}
+
+// TestAWSIMDSHeadersV2 tests the IMDSv2 token header is returned.
+func TestAWSIMDSHeadersV2(t *testing.T) {
+	const expectedToken = "header-test-token"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, expectedToken)
+	}))
+	defer srv.Close()
+
+	headers := awsIMDSHeaders(context.Background(), srv.URL)
+	if len(headers) != 1 {
+		t.Fatalf("expected 1 header, got %d", len(headers))
+	}
+	if headers[0].k != "X-aws-ec2-metadata-token" || headers[0].v != expectedToken {
+		t.Fatalf("unexpected header: %+v", headers[0])
+	}
+}
+
+// TestAWSIMDSHeadersV1Fallback tests fallback to IMDSv1 when token fetch fails.
+func TestAWSIMDSHeadersV1Fallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "server error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	headers := awsIMDSHeaders(context.Background(), srv.URL)
+	if headers != nil {
+		t.Fatalf("expected nil headers (v1 fallback), got %+v", headers)
+	}
+}
+
+// TestAWSIMDSv1FallbackEndToEnd tests the full fallback path: a token endpoint
+// that returns 401 forces awsIMDSHeaders to nil, after which imdsGet performs a
+// bare IMDSv1 GET that succeeds without the token header.
+func TestAWSIMDSv1FallbackEndToEnd(t *testing.T) {
+	const userData = "fallback-user-data"
+	const tokenPath = "/latest/api/token"
+	const userDataPath = "/latest/user-data"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case tokenPath:
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		case userDataPath:
+			if r.Header.Get("X-aws-ec2-metadata-token") != "" {
+				http.Error(w, "v2 header present on v1 fallback", http.StatusBadRequest)
+				return
+			}
+			_, _ = io.WriteString(w, userData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	headers := awsIMDSHeaders(ctx, srv.URL+tokenPath)
+	if headers != nil {
+		t.Fatalf("expected nil headers after 401, got %+v", headers)
+	}
+
+	body, err := imdsGet(ctx, srv.URL+userDataPath, false, headers)
+	if err != nil {
+		t.Fatalf("imdsGet fallback returned error: %v", err)
+	}
+	if string(body) != userData {
+		t.Fatalf("body mismatch: got %q, want %q", string(body), userData)
+	}
+}
+
 // TestFailPlainTextUserData tests with plain text userData
 func TestFailPlainTextUserData(t *testing.T) {
 	// startTestServerPlainText


### PR DESCRIPTION
AWSUserDataProvider currently issues a bare GET to /latest/user-data (IMDSv1). On EC2 instances configured with MetadataOptions.HttpTokens=required (IMDSv2-only), this returns 401 and peer-pod boot fails before kata-agent starts. Many enterprise AWS organizations enforce IMDSv2 via an SCP, so the bare IMDSv1 path is unusable in those environments, and AWS now defaults new EC2 launches to v2-only as well.

This change adds an IMDSv2 token PUT before the user-data GET and attaches the returned session token via the X-aws-ec2-metadata-token header. If the token PUT fails for any reason (network policy blocks PUT, legacy IMDSv1-only configuration, transient error), the helper returns nil headers so the existing IMDSv1 GET path is preserved as a fallback. No existing flow regresses.

Validated on an AWS organization with SCP-enforced HttpTokens=required: peer-pod boots end to end, /dev/sev-guest reachable inside the SEV-SNP guest, attestation report retrieved.

Unit tests cover the success path, non-200 token response, the returned headers shape, and an end-to-end fallback where the token endpoint 401s and the user-data GET succeeds without the token header.

Ref: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-options.html