### PR TITLE
ci: fix peerpod-ctrl build to create single-arch images

### DIFF
--- a/.github/workflows/peerpod-ctrl_image.yaml
+++ b/.github/workflows/peerpod-ctrl_image.yaml
@@ -107,6 +107,7 @@ jobs:
           context: src
           file: src/peerpod-ctrl/Dockerfile
           platforms: ${{ matrix.types.arch }}
+          provenance: false
           build-args: |
             GOFLAGS=-tags=aws,azure,ibmcloud,ibmcloud_powervs,libvirt
 


### PR DESCRIPTION
Add provenance: false to docker/build-push-action to prevent creation of manifest lists for single-arch builds.

Problem:
The peerpod-ctrl workflow was failing during manifest creation because Docker Buildx was creating manifest lists instead of simple single-arch images. The error was:
  "quay.io/confidential-containers/peerpod-ctrl:latest-amd64 is a manifest list"

The hack/publish.sh script expects simple single-arch images with architecture suffixes (e.g., peerpod-ctrl:latest-amd64) which it then combines into a multi-arch manifest.

Solution:
By default, Docker Buildx with --platform creates a manifest list even for a single architecture. Setting provenance: false disables attestation and forces creation of a simple single-arch image instead.

This allows the manifest job to properly combine the four single-arch images (amd64, arm64, ppc64le, s390x) into a multi-arch manifest.


Assisted-by IBM Bob