### PR TITLE
ci: build peerpod-ctrl and webhook images in nightly e2e

### DIFF
--- a/.github/workflows/e2e_aws.yaml
+++ b/.github/workflows/e2e_aws.yaml
@@ -18,6 +18,16 @@ on:
         description: Git ref to checkout the cloud-api-adaptor repository. Defaults to main.
         required: false
         type: string
+      peerpod_ctrl_image:
+        description: The peerpod-ctrl OCI image (including tag)
+        required: false
+        default: ''
+        type: string
+      webhook_image:
+        description: The peer-pods-webhook OCI image (including tag)
+        required: false
+        default: ''
+        type: string
       cluster_type:
         description: Specify the cluster type. Accepted values are "onprem" or "eks".
         default: onprem
@@ -70,8 +80,10 @@ jobs:
         CAA_IMAGE: "${{ inputs.caa_image }}"
         CLUSTER_TYPE: "${{ inputs.cluster_type }}"
         CONTAINER_RUNTIME: "${{ inputs.container_runtime }}"
+        PEERPOD_CTRL_IMAGE: "${{ inputs.peerpod_ctrl_image }}"
         PODVM_IMAGE: "${{ inputs.podvm_image }}"
         RESOURCES_BASENAME: "ci-caa-${{ github.run_id }}-${{ github.run_attempt }}"
+        WEBHOOK_IMAGE: "${{ inputs.webhook_image }}"
     permissions:
       id-token: write # Required by aws-actions/configure-aws-credentials
       contents: read  # Required by aws-actions/configure-aws-credentials

--- a/.github/workflows/e2e_byom.yaml
+++ b/.github/workflows/e2e_byom.yaml
@@ -13,6 +13,16 @@ on:
       caa_image:
         type: string
         required: true
+      peerpod_ctrl_image:
+        description: The peerpod-ctrl OCI image (including tag)
+        required: false
+        default: ''
+        type: string
+      webhook_image:
+        description: The peer-pods-webhook OCI image (including tag)
+        required: false
+        default: ''
+        type: string
       git_ref:
         default: 'main'
         description: Git ref to checkout the cloud-api-adaptor repository. Defaults to main.
@@ -36,6 +46,8 @@ jobs:
     env:
       CAA_IMAGE: "${{ inputs.caa_image }}"
       BYOM_PODVM_IMAGE: "${{ inputs.podvm_image }}"
+      PEERPOD_CTRL_IMAGE: "${{ inputs.peerpod_ctrl_image }}"
+      WEBHOOK_IMAGE: "${{ inputs.webhook_image }}"
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/e2e_docker.yaml
+++ b/.github/workflows/e2e_docker.yaml
@@ -23,6 +23,16 @@ on:
         description: Name of the container runtime. Either containerd or crio.
         required: false
         type: string
+      peerpod_ctrl_image:
+        description: The peerpod-ctrl OCI image (including tag)
+        required: false
+        default: ''
+        type: string
+      webhook_image:
+        description: The peer-pods-webhook OCI image (including tag)
+        required: false
+        default: ''
+        type: string
     secrets:
       QUAY_PASSWORD:
         required: true
@@ -44,6 +54,8 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       CAA_IMAGE: "${{ inputs.caa_image }}"
+      PEERPOD_CTRL_IMAGE: "${{ inputs.peerpod_ctrl_image }}"
+      WEBHOOK_IMAGE: "${{ inputs.webhook_image }}"
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -28,6 +28,16 @@ on:
         description: Name of the container runtime. Either containerd or crio.
         required: false
         type: string
+      peerpod_ctrl_image:
+        description: The peerpod-ctrl OCI image (including tag)
+        required: false
+        default: ''
+        type: string
+      webhook_image:
+        description: The peer-pods-webhook OCI image (including tag)
+        required: false
+        default: ''
+        type: string
     secrets:
       REGISTRY_CREDENTIAL_ENCODED:
         required: true
@@ -162,10 +172,12 @@ jobs:
           CLOUD_PROVIDER: libvirt
           CONTAINER_RUNTIME: ${{ inputs.container_runtime }}
           DEPLOY_KBS: "true"
+          PEERPOD_CTRL_IMAGE: "${{ inputs.peerpod_ctrl_image }}"
           TEST_TEARDOWN: "no"
           TEST_PROVISION_FILE: ${{ github.workspace }}/src/cloud-api-adaptor/libvirt.properties
           TEST_PODVM_IMAGE: ${{ env.PODVM_QCOW2 }}
           TEST_E2E_TIMEOUT: "75m"
+          WEBHOOK_IMAGE: "${{ inputs.webhook_image }}"
         run: |
           # Default: provision cluster and install CAA
           export TEST_PROVISION="yes"

--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -185,6 +185,48 @@ jobs:
     secrets:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 
+  # Build and push the peerpod-ctrl image (per-arch)
+  peerpod_ctrl_image_amd64:
+    uses: ./.github/workflows/peerpod-ctrl_build_and_push.yaml
+    with:
+      registry: ${{ inputs.registry }}
+      image_tags: ${{ inputs.caa_image_tag }}
+      git_ref: ${{ inputs.git_ref }}
+      arch: linux/amd64
+      runner: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write # Required to publish the image to ghcr
+    secrets:
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+
+  peerpod_ctrl_image_s390x:
+    uses: ./.github/workflows/peerpod-ctrl_build_and_push.yaml
+    with:
+      registry: ${{ inputs.registry }}
+      image_tags: ${{ inputs.caa_image_tag }}
+      git_ref: ${{ inputs.git_ref }}
+      arch: linux/s390x
+      runner: ubuntu-24.04-s390x
+    permissions:
+      contents: read
+      packages: write # Required to publish the image to ghcr
+    secrets:
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+
+  # Build and push the webhook image
+  webhook_image:
+    uses: ./.github/workflows/webhook_image.yaml
+    with:
+      registry: ${{ inputs.registry }}
+      image_tags: ${{ inputs.caa_image_tag }}
+      git_ref: ${{ inputs.git_ref }}
+    permissions:
+      contents: read
+      packages: write # Required to publish the image to ghcr
+    secrets:
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+
   # Run AWS e2e tests if pull request labeled 'test_e2e_aws'
   aws:
     name: aws
@@ -192,7 +234,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'test_e2e_aws')
-    needs: [podvm_ubuntu_amd64, caa_image_amd64]
+    needs: [podvm_ubuntu_amd64, caa_image_amd64, peerpod_ctrl_image_amd64, webhook_image]
     strategy:
       fail-fast: false
       matrix:
@@ -207,6 +249,8 @@ jobs:
       container_runtime: ${{ matrix.container_runtime }}
       podvm_image: ${{ needs.podvm_ubuntu_amd64.outputs.qcow2_oras_image }}
       git_ref: ${{ inputs.git_ref }}
+      peerpod_ctrl_image: ${{ inputs.registry }}/peerpod-ctrl:${{ inputs.caa_image_tag }}-amd64
+      webhook_image: ${{ inputs.registry }}/peer-pods-webhook:${{ inputs.caa_image_tag }}
     secrets:
       AWS_IAM_ROLE_ARN: ${{ secrets.AWS_IAM_ROLE_ARN }}
 
@@ -234,13 +278,15 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'test_e2e_libvirt') ||
       contains(github.event.pull_request.labels.*.name, 'test_e2e_libvirt_amd64')
-    needs: [podvm_mkosi_amd64, libvirt_e2e_arch_prep, caa_image_amd64]
+    needs: [podvm_mkosi_amd64, libvirt_e2e_arch_prep, caa_image_amd64, peerpod_ctrl_image_amd64, webhook_image]
     uses: ./.github/workflows/e2e_libvirt.yaml
     with:
       runner: ubuntu-24.04
       caa_image: ${{ inputs.registry }}/cloud-api-adaptor:${{ inputs.caa_image_tag }}-dev-amd64
       podvm_image: ${{ needs.podvm_mkosi_amd64.outputs.qcow2_oras_image }}
       git_ref: ${{ inputs.git_ref }}
+      peerpod_ctrl_image: ${{ inputs.registry }}/peerpod-ctrl:${{ inputs.caa_image_tag }}-amd64
+      webhook_image: ${{ inputs.registry }}/peer-pods-webhook:${{ inputs.caa_image_tag }}
     secrets:
       REGISTRY_CREDENTIAL_ENCODED: ${{ secrets.REGISTRY_CREDENTIAL_ENCODED }}
 
@@ -252,13 +298,15 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'test_e2e_libvirt') ||
       contains(github.event.pull_request.labels.*.name, 'test_e2e_libvirt_s390x')
-    needs: [podvm_mkosi_s390x, libvirt_e2e_arch_prep, caa_image_s390x]
+    needs: [podvm_mkosi_s390x, libvirt_e2e_arch_prep, caa_image_s390x, peerpod_ctrl_image_s390x, webhook_image]
     uses: ./.github/workflows/e2e_libvirt.yaml
     with:
       runner: s390x-large
       caa_image: ${{ inputs.registry }}/cloud-api-adaptor:${{ inputs.caa_image_tag }}-dev-s390x
       podvm_image: ${{ needs.podvm_mkosi_s390x.outputs.qcow2_oras_image }}
       git_ref: ${{ inputs.git_ref }}
+      peerpod_ctrl_image: ${{ inputs.registry }}/peerpod-ctrl:${{ inputs.caa_image_tag }}-s390x
+      webhook_image: ${{ inputs.registry }}/peer-pods-webhook:${{ inputs.caa_image_tag }}
     secrets:
       REGISTRY_CREDENTIAL_ENCODED: ${{ secrets.REGISTRY_CREDENTIAL_ENCODED }}
 
@@ -270,13 +318,15 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'test_e2e_libvirt') ||
       contains(github.event.pull_request.labels.*.name, 'test_e2e_libvirt_amd64')
-    needs: [podvm_ubuntu_amd64, libvirt_e2e_arch_prep, caa_image_amd64]
+    needs: [podvm_ubuntu_amd64, libvirt_e2e_arch_prep, caa_image_amd64, peerpod_ctrl_image_amd64, webhook_image]
     uses: ./.github/workflows/e2e_libvirt.yaml
     with:
       runner: ubuntu-24.04
       caa_image: ${{ inputs.registry }}/cloud-api-adaptor:${{ inputs.caa_image_tag }}-amd64-dev
       podvm_image: ${{ needs.podvm_ubuntu_amd64.outputs.qcow2_oras_image }}
       git_ref: ${{ inputs.git_ref }}
+      peerpod_ctrl_image: ${{ inputs.registry }}/peerpod-ctrl:${{ inputs.caa_image_tag }}-amd64
+      webhook_image: ${{ inputs.registry }}/peer-pods-webhook:${{ inputs.caa_image_tag }}
     secrets:
       REGISTRY_CREDENTIAL_ENCODED: ${{ secrets.REGISTRY_CREDENTIAL_ENCODED }}
 
@@ -288,13 +338,15 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'test_e2e_libvirt') ||
       contains(github.event.pull_request.labels.*.name, 'test_e2e_libvirt_s390x')
-    needs: [podvm_ubuntu_s390x, libvirt_e2e_arch_prep, caa_image_s390x]
+    needs: [podvm_ubuntu_s390x, libvirt_e2e_arch_prep, caa_image_s390x, peerpod_ctrl_image_s390x, webhook_image]
     uses: ./.github/workflows/e2e_libvirt.yaml
     with:
       runner: s390x-large
       caa_image: ${{ inputs.registry }}/cloud-api-adaptor:${{ inputs.caa_image_tag }}-s390x-dev
       podvm_image: ${{ needs.podvm_ubuntu_s390x.outputs.qcow2_oras_image }}
       git_ref: ${{ inputs.git_ref }}
+      peerpod_ctrl_image: ${{ inputs.registry }}/peerpod-ctrl:${{ inputs.caa_image_tag }}-s390x
+      webhook_image: ${{ inputs.registry }}/peer-pods-webhook:${{ inputs.caa_image_tag }}
     secrets:
       REGISTRY_CREDENTIAL_ENCODED: ${{ secrets.REGISTRY_CREDENTIAL_ENCODED }}
 
@@ -305,7 +357,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'test_e2e_docker')
-    needs: [podvm_mkosi_amd64, caa_image_amd64]
+    needs: [podvm_mkosi_amd64, caa_image_amd64, peerpod_ctrl_image_amd64, webhook_image]
     strategy:
       fail-fast: false
       matrix:
@@ -323,6 +375,8 @@ jobs:
       container_runtime: ${{ matrix.container_runtime }}
       podvm_image: ${{ needs.podvm_mkosi_amd64.outputs.docker_oci_image }}
       git_ref: ${{ inputs.git_ref }}
+      peerpod_ctrl_image: ${{ inputs.registry }}/peerpod-ctrl:${{ inputs.caa_image_tag }}-amd64
+      webhook_image: ${{ inputs.registry }}/peer-pods-webhook:${{ inputs.caa_image_tag }}
     secrets:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 
@@ -333,9 +387,11 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'test_e2e_byom')
-    needs: [podvm_ubuntu_amd64, caa_image_amd64]
+    needs: [podvm_ubuntu_amd64, caa_image_amd64, peerpod_ctrl_image_amd64, webhook_image]
     uses: ./.github/workflows/e2e_byom.yaml
     with:
       caa_image: ${{ inputs.registry }}/cloud-api-adaptor:${{ inputs.caa_image_tag }}-dev-amd64
       podvm_image: ${{ needs.podvm_ubuntu_amd64.outputs.byom_e2e_image }}
       git_ref: ${{ inputs.git_ref }}
+      peerpod_ctrl_image: ${{ inputs.registry }}/peerpod-ctrl:${{ inputs.caa_image_tag }}-amd64
+      webhook_image: ${{ inputs.registry }}/peer-pods-webhook:${{ inputs.caa_image_tag }}

--- a/.github/workflows/peerpod-ctrl_build_and_push.yaml
+++ b/.github/workflows/peerpod-ctrl_build_and_push.yaml
@@ -1,7 +1,7 @@
 # Copyright Confidential Containers Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-# Build and push peerpod-ctrl multi-arch manifest image
+# Build and push peerpod-ctrl image for a single architecture
 ---
 name: (Callable) Build and push peerpod-ctrl image
 
@@ -22,6 +22,16 @@ on:
         description: Git ref to checkout the cloud-api-adaptor repository. Defaults to main.
         required: false
         type: string
+      arch:
+        default: 'linux/amd64'
+        description: 'Target architecture in docker buildx format (e.g. linux/amd64)'
+        required: false
+        type: string
+      runner:
+        default: 'ubuntu-24.04'
+        description: The runner to execute the workflow on. Defaults to 'ubuntu-24.04'.
+        required: false
+        type: string
     secrets:
       QUAY_PASSWORD:
         required: true
@@ -30,17 +40,8 @@ permissions: {}
 
 jobs:
   build_push_job:
-    name: build and push peerpod-ctrl
-    strategy:
-      fail-fast: false
-      matrix:
-        types: [
-          { arch: linux/amd64,   runner: ubuntu-24.04 },
-          { arch: linux/arm64,   runner: ubuntu-24.04-arm },
-          { arch: linux/ppc64le, runner: ubuntu-24.04-ppc64le },
-          { arch: linux/s390x,   runner: ubuntu-24.04-s390x },
-        ]
-    runs-on: ${{ matrix.types.runner }}
+    name: build and push peerpod-ctrl (${{ inputs.arch }})
+    runs-on: ${{ inputs.runner }}
     defaults:
       run:
         working-directory: src/peerpod-ctrl
@@ -81,9 +82,9 @@ jobs:
       - name: Extract architecture name
         id: arch
         env:
-          MATRIX_ARCH: ${{ matrix.types.arch }}
+          ARCH: ${{ inputs.arch }}
         run: |
-          arch_name=$(echo "${MATRIX_ARCH}" | cut -d'/' -f2)
+          arch_name=$(echo "${ARCH}" | cut -d'/' -f2)
           echo "name=${arch_name}" >> "$GITHUB_OUTPUT"
 
       - name: Determine tags
@@ -106,50 +107,7 @@ jobs:
           push: true
           context: src
           file: src/peerpod-ctrl/Dockerfile
-          platforms: ${{ matrix.types.arch }}
+          platforms: ${{ inputs.arch }}
           provenance: false
           build-args: |
             GOFLAGS=-tags=aws,azure,ibmcloud,ibmcloud_powervs,libvirt
-
-  manifest_job:
-    name: generate peerpod-ctrl multi-arch manifest
-    runs-on: ubuntu-24.04
-    needs: [build_push_job]
-    permissions:
-      packages: write  # Required for pushing to GitHub Container Registry
-    steps:
-      - name: Checkout the code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          ref: "${{ inputs.git_ref }}"
-          persist-credentials: false
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Login to Quay Container Registry
-        if: ${{ startsWith(inputs.registry, 'quay.io') }}
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ inputs.registry }}
-          username: ${{ vars.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-
-      - name: Login to Github Container Registry
-        if: ${{ startsWith(inputs.registry, 'ghcr.io') }}
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ inputs.registry }}
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish multi-arch manifest
-        working-directory: src/cloud-api-adaptor
-        run: |
-          ./hack/publish.sh publish-multiarch-manifest
-        env:
-          IMAGE_REGISTRY: ${{ inputs.registry }}
-          IMAGE_NAME: "peerpod-ctrl"
-          IMAGE_TAGS: ${{ inputs.image_tags }}
-          ARCHES: "amd64,arm64,ppc64le,s390x"

--- a/.github/workflows/peerpod-ctrl_build_and_push_all_arches.yaml
+++ b/.github/workflows/peerpod-ctrl_build_and_push_all_arches.yaml
@@ -1,0 +1,96 @@
+# Copyright Confidential Containers Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build and push peerpod-ctrl multi-arch manifest image for all arch combinations
+---
+name: (Callable) Build and push peerpod-ctrl multi-arch manifest image for all arch combinations
+
+on:
+  workflow_call:
+    inputs:
+      registry:
+        default: 'quay.io/confidential-containers'
+        description: 'Image registry (e.g. "ghcr.io/confidential-containers") where the built image will be pushed to'
+        required: false
+        type: string
+      image_tags:
+        description: 'Comma-separated list of tags for the built image (e.g. latest,v1.0.0)'
+        required: true
+        type: string
+      git_ref:
+        default: 'main'
+        description: Git ref to checkout the cloud-api-adaptor repository. Defaults to main.
+        required: false
+        type: string
+    secrets:
+      QUAY_PASSWORD:
+        required: true
+
+permissions: {}
+
+jobs:
+  build_push_job:
+    name: build and push single arch image
+    strategy:
+      fail-fast: false
+      matrix:
+        types: [
+          { arch: linux/amd64,   runner: ubuntu-24.04 },
+          { arch: linux/arm64,   runner: ubuntu-24.04-arm },
+          { arch: linux/ppc64le, runner: ubuntu-24.04-ppc64le },
+          { arch: linux/s390x,   runner: ubuntu-24.04-s390x },
+        ]
+    uses: ./.github/workflows/peerpod-ctrl_build_and_push.yaml
+    with:
+      arch: ${{ matrix.types.arch }}
+      image_tags: ${{ inputs.image_tags }}
+      git_ref: ${{ inputs.git_ref }}
+      registry: ${{ inputs.registry }}
+      runner: ${{ matrix.types.runner }}
+    secrets:
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+    permissions:
+      packages: write  # Required for pushing to GitHub Container Registry
+
+  manifest_job:
+    name: generate peerpod-ctrl multi-arch manifest
+    runs-on: ubuntu-24.04
+    needs: [build_push_job]
+    permissions:
+      packages: write  # Required for pushing to GitHub Container Registry
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: "${{ inputs.git_ref }}"
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Login to Quay Container Registry
+        if: ${{ startsWith(inputs.registry, 'quay.io') }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ vars.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Login to Github Container Registry
+        if: ${{ startsWith(inputs.registry, 'ghcr.io') }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish multi-arch manifest
+        working-directory: src/cloud-api-adaptor
+        run: |
+          ./hack/publish.sh publish-multiarch-manifest
+        env:
+          IMAGE_REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: "peerpod-ctrl"
+          IMAGE_TAGS: ${{ inputs.image_tags }}
+          ARCHES: "amd64,arm64,ppc64le,s390x"

--- a/.github/workflows/publish_images_on_push.yaml
+++ b/.github/workflows/publish_images_on_push.yaml
@@ -50,7 +50,7 @@ jobs:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 
   peerpod-ctrl:
-    uses: ./.github/workflows/peerpod-ctrl_image.yaml
+    uses: ./.github/workflows/peerpod-ctrl_build_and_push_all_arches.yaml
     with:
       image_tags: latest,${{ github.sha }}
       git_ref: ${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 
   peerpod-ctrl:
-    uses: ./.github/workflows/peerpod-ctrl_image.yaml
+    uses: ./.github/workflows/peerpod-ctrl_build_and_push_all_arches.yaml
     with:
       image_tags: ${{ github.event.release.tag_name }}
       git_ref: ${{ github.ref }}

--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -89,6 +89,13 @@ Other options are provided via environment variables if you need to further cust
 - `TEST_CAA_NAMESPACE` - This option is available, primarily for running the e2e tests on a downstream version
 of confidential containers, where the cloud-api-adaptor pod is deployed to a different namespace than the default
  `confidential-containers-system`.
+- `PEERPOD_CTRL_IMAGE` - Override the peerpod-ctrl container image used by the Helm sub-chart
+(e.g. `ghcr.io/confidential-containers/peerpod-ctrl:latest`). When set, the provisioner overrides
+the Helm values `resourceCtrl.image.repository` and `resourceCtrl.image.tag`. If unset, the sub-chart
+defaults are used.
+- `WEBHOOK_IMAGE` - Override the peer-pods-webhook container image used by the Helm sub-chart
+(e.g. `ghcr.io/confidential-containers/peer-pods-webhook:latest`). When set, the provisioner overrides
+the Helm values `webhook.image.repository` and `webhook.image.tag`. If unset, the sub-chart defaults are used.
 
 # Running end-to-end tests against pre-configured cluster
 

--- a/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
@@ -1186,6 +1186,8 @@ func NewAwsInstallChart(installDir, provider string) (pv.InstallChart, error) {
 	}, nil
 }
 
+func (a *AwsInstallChart) GetHelm() *pv.Helm { return a.Helm }
+
 func (a *AwsInstallChart) Install(ctx context.Context, cfg *envconf.Config) error {
 	return a.Helm.Install(ctx, cfg)
 }

--- a/src/cloud-api-adaptor/test/provisioner/azure/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/azure/provision_common.go
@@ -392,6 +392,8 @@ func NewAzureInstallChart(installDir, provider string) (pv.InstallChart, error) 
 	}, nil
 }
 
+func (a *AzureInstallChart) GetHelm() *pv.Helm { return a.Helm }
+
 func (a *AzureInstallChart) Install(ctx context.Context, cfg *envconf.Config) error {
 	if err := a.Helm.Install(ctx, cfg); err != nil {
 		return err

--- a/src/cloud-api-adaptor/test/provisioner/byom/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/byom/provision_common.go
@@ -257,6 +257,8 @@ func NewByomInstallChart(installDir, provider string) (pv.InstallChart, error) {
 	}, nil
 }
 
+func (b *ByomInstallChart) GetHelm() *pv.Helm { return b.Helm }
+
 func (b *ByomInstallChart) Install(ctx context.Context, cfg *envconf.Config) error {
 	// Create SSH key secret before installing Helm chart
 	if err := b.createSSHKeySecret(ctx, cfg); err != nil {

--- a/src/cloud-api-adaptor/test/provisioner/docker/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/docker/provision_common.go
@@ -220,6 +220,8 @@ func NewDockerInstallChart(installDir, provider string) (pv.InstallChart, error)
 	}, nil
 }
 
+func (d *DockerInstallChart) GetHelm() *pv.Helm { return d.Helm }
+
 func (d *DockerInstallChart) Install(ctx context.Context, cfg *envconf.Config) error {
 	return d.Helm.Install(ctx, cfg)
 }

--- a/src/cloud-api-adaptor/test/provisioner/gcp/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/gcp/provision_common.go
@@ -138,6 +138,8 @@ func NewGCPInstallChart(installDir, provider string) (pv.InstallChart, error) {
 	}, nil
 }
 
+func (g *GCPInstallChart) GetHelm() *pv.Helm { return g.Helm }
+
 func (g *GCPInstallChart) Install(ctx context.Context, cfg *envconf.Config) error {
 	return g.Helm.Install(ctx, cfg)
 }

--- a/src/cloud-api-adaptor/test/provisioner/helm.go
+++ b/src/cloud-api-adaptor/test/provisioner/helm.go
@@ -14,6 +14,37 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
+// ConfigureSubchartImages sets helm override values for sub-chart images
+// (peerpod-ctrl and webhook) from environment variables. These overrides are
+// provider-agnostic and applied centrally from Deploy().
+func (h *Helm) ConfigureSubchartImages() {
+	if img := os.Getenv("PEERPOD_CTRL_IMAGE"); img != "" {
+		parts := strings.SplitN(img, ":", 2)
+		if parts[0] == "" {
+			log.Warnf("PEERPOD_CTRL_IMAGE has empty repository: %q, skipping", img)
+		} else {
+			h.OverrideValues["resourceCtrl.image.repository"] = parts[0]
+			if len(parts) == 2 && parts[1] != "" {
+				h.OverrideValues["resourceCtrl.image.tag"] = parts[1]
+			}
+			log.Infof("Configuring helm: peerpod-ctrl image override (%s)", img)
+		}
+	}
+
+	if img := os.Getenv("WEBHOOK_IMAGE"); img != "" {
+		parts := strings.SplitN(img, ":", 2)
+		if parts[0] == "" {
+			log.Warnf("WEBHOOK_IMAGE has empty repository: %q, skipping", img)
+		} else {
+			h.OverrideValues["webhook.image.repository"] = parts[0]
+			if len(parts) == 2 && parts[1] != "" {
+				h.OverrideValues["webhook.image.tag"] = parts[1]
+			}
+			log.Infof("Configuring helm: webhook image override (%s)", img)
+		}
+	}
+}
+
 // Helm represents a Helm chart installer
 type Helm struct {
 	ChartPath               string            // path to the chart directory

--- a/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_helm.go
+++ b/src/cloud-api-adaptor/test/provisioner/ibmcloud/provision_helm.go
@@ -33,6 +33,8 @@ func NewIBMCloudInstallChart(installDir, provider string) (pv.InstallChart, erro
 	}, nil
 }
 
+func (i *IBMCloudInstallChart) GetHelm() *pv.Helm { return i.Helm }
+
 func (i *IBMCloudInstallChart) Install(ctx context.Context, cfg *envconf.Config) error {
 	return i.Helm.Install(ctx, cfg)
 }

--- a/src/cloud-api-adaptor/test/provisioner/libvirt/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/libvirt/provision_common.go
@@ -330,6 +330,8 @@ func NewLibvirtInstallChart(installDir, provider string) (pv.InstallChart, error
 	}, nil
 }
 
+func (l *LibvirtInstallChart) GetHelm() *pv.Helm { return l.Helm }
+
 func (l *LibvirtInstallChart) Install(ctx context.Context, cfg *envconf.Config) error {
 	return l.Helm.Install(ctx, cfg)
 }

--- a/src/cloud-api-adaptor/test/provisioner/provision.go
+++ b/src/cloud-api-adaptor/test/provisioner/provision.go
@@ -83,6 +83,8 @@ type InstallChart interface {
 	Uninstall(ctx context.Context, cfg *envconf.Config) error
 	// Configure changes chart values
 	Configure(ctx context.Context, cfg *envconf.Config, properties map[string]string) error
+	// GetHelm returns the underlying Helm instance for provider-agnostic configuration
+	GetHelm() *Helm
 }
 
 type NewInstallChartFunc func(installDir, provider string) (InstallChart, error)
@@ -168,6 +170,7 @@ func (p *CloudAPIAdaptor) Deploy(ctx context.Context, cfg *envconf.Config, props
 	if err := chart.Configure(ctx, cfg, props); err != nil {
 		return err
 	}
+	chart.GetHelm().ConfigureSubchartImages()
 	if err := chart.Install(ctx, cfg); err != nil {
 		return err
 	}


### PR DESCRIPTION
After the kustomize-to-helm migration, nightly e2e tests deploy peerpod-ctrl and webhook as sub-charts but use stale `latest` images from quay.io. Since peerpod-ctrl shares the cloud-providers Go module with caa, version skew can mask breaking changes.

Build both images alongside caa/podvm in the nightly pipeline and wire their references through to the helm install via PEERPOD_CTRL_IMAGE and WEBHOOK_IMAGE environment variables.

The subchart image override logic is centralized in Helm.ConfigureSubchartImages() to avoid duplicating code across all provider implementations.

Assisted-by: Claude