### PR TITLE
libvirt: add cpuset support for CPU pinning

### DIFF
--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/libvirt.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/libvirt.yaml
@@ -51,6 +51,10 @@ providerConfigs:
     # (default: "2")
     # LIBVIRT_CPU: "2"
 
+    # CPU set for pinning vCPUs to physical CPUs (e.g., \"0,2,4,6\" or \"0-3\" or \"0-3,8,10-12\")
+    # (default: "")
+    # LIBVIRT_CPUSET: ""
+
     # Path to OVMF
     # (default: "/usr/share/OVMF/OVMF_CODE_4M.fd")
     # LIBVIRT_EFI_FIRMWARE: "/usr/share/OVMF/OVMF_CODE_4M.fd"

--- a/src/cloud-providers/libvirt/libvirt.go
+++ b/src/cloud-providers/libvirt/libvirt.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
+	"regexp"
 	"strings"
 	"time"
 
@@ -31,6 +32,23 @@ const (
 	// The sleep time between retries to get the domain IP addresses
 	GetDomainIPsSleep = time.Second * 3
 )
+
+// validateCPUSet validates the CPUSet format.
+func validateCPUSet(cpuset string) error {
+	if cpuset == "" {
+		return nil // Empty is valid (no pinning)
+	}
+
+	// CPUSet format: comma-separated list of CPU numbers or ranges
+	// Valid examples: "0,2,4,6", "0-3", "0,2,4-7,10"
+	// Invalid examples: "ABC", "0-", "-3", "0,a,2"
+	cpusetRegex := regexp.MustCompile(`^(\d+(-\d+)?)(,\d+(-\d+)?)*$`)
+	if !cpusetRegex.MatchString(cpuset) {
+		return fmt.Errorf("invalid CPUSet format: %s (expected format: comma-separated CPU numbers or ranges, e.g., '0,2,4,6' or '0-3')", cpuset)
+	}
+
+	return nil
+}
 
 type domainConfig struct {
 	name        string
@@ -235,7 +253,8 @@ func createDomainXMLs390x(client *libvirtClient, cfg *domainConfig, vm *vmConfig
 			Value: cfg.mem, Unit: "MiB",
 		},
 		VCPU: &libvirtxml.DomainVCPU{
-			Value: cfg.cpu,
+			Value:  cfg.cpu,
+			CPUSet: vm.cpuset,
 		},
 		Clock: &libvirtxml.DomainClock{
 			Offset: "utc",
@@ -294,7 +313,7 @@ func createDomainXMLx86_64(client *libvirtClient, cfg *domainConfig, vm *vmConfi
 		Name:        cfg.name,
 		Description: "This Virtual Machine is the peer-pod VM",
 		Memory:      &libvirtxml.DomainMemory{Value: cfg.mem, Unit: "MiB", DumpCore: "on"},
-		VCPU:        &libvirtxml.DomainVCPU{Value: cfg.cpu},
+		VCPU:        &libvirtxml.DomainVCPU{Value: cfg.cpu, CPUSet: vm.cpuset},
 		OS: &libvirtxml.DomainOS{
 			Type: &libvirtxml.DomainOSType{Arch: "x86_64", Type: typeHardwareVirtualMachine},
 		},
@@ -444,7 +463,7 @@ func createDomainXMLaarch64(client *libvirtClient, cfg *domainConfig, vm *vmConf
 			Firmware: "efi",
 		},
 		Memory: &libvirtxml.DomainMemory{Value: cfg.mem, Unit: "MiB"},
-		VCPU:   &libvirtxml.DomainVCPU{Value: cfg.cpu},
+		VCPU:   &libvirtxml.DomainVCPU{Value: cfg.cpu, CPUSet: vm.cpuset},
 		CPU:    &libvirtxml.DomainCPU{Mode: "host-passthrough"},
 		Devices: &libvirtxml.DomainDeviceList{
 			Disks: []libvirtxml.DomainDisk{

--- a/src/cloud-providers/libvirt/libvirt_test.go
+++ b/src/cloud-providers/libvirt/libvirt_test.go
@@ -284,6 +284,33 @@ func TestConfigVerifier(t *testing.T) {
 			expectedError: "Memory must be greater than zero",
 		},
 		{
+			name: "invalid cpuset fails",
+			provider: &libvirtProvider{
+				serviceConfig: newConfig(func(c *Config) {
+					c.CPUSet = "ABC"
+				}),
+			},
+			expectedError: "invalid CPUSet format",
+		},
+		{
+			name: "invalid cpuset with mixed alphanumeric fails",
+			provider: &libvirtProvider{
+				serviceConfig: newConfig(func(c *Config) {
+					c.CPUSet = "0,a,2"
+				}),
+			},
+			expectedError: "invalid CPUSet format",
+		},
+		{
+			name: "valid cpuset passes",
+			provider: &libvirtProvider{
+				serviceConfig: newConfig(func(c *Config) {
+					c.CPUSet = "0,2,4-7"
+				}),
+			},
+			expectedError: "",
+		},
+		{
 			name: "valid config passes",
 			provider: &libvirtProvider{
 				serviceConfig: newConfig(nil),
@@ -299,7 +326,193 @@ func TestConfigVerifier(t *testing.T) {
 				return
 			}
 
-			assert.EqualError(t, err, tc.expectedError)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tc.expectedError)
+		})
+	}
+}
+
+func TestValidateCPUSet(t *testing.T) {
+	testCases := []struct {
+		name        string
+		cpuset      string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "valid comma-separated",
+			cpuset:      "0,2,4,6",
+			expectError: false,
+		},
+		{
+			name:        "valid range",
+			cpuset:      "0-3",
+			expectError: false,
+		},
+		{
+			name:        "valid mixed format",
+			cpuset:      "0,2,4-7,10",
+			expectError: false,
+		},
+		{
+			name:        "empty cpuset is valid",
+			cpuset:      "",
+			expectError: false,
+		},
+		{
+			name:        "invalid alphabetic characters",
+			cpuset:      "ABC",
+			expectError: true,
+			errorMsg:    "invalid CPUSet format",
+		},
+		{
+			name:        "invalid mixed alphanumeric",
+			cpuset:      "0,a,2",
+			expectError: true,
+			errorMsg:    "invalid CPUSet format",
+		},
+		{
+			name:        "invalid incomplete range",
+			cpuset:      "0-",
+			expectError: true,
+			errorMsg:    "invalid CPUSet format",
+		},
+		{
+			name:        "invalid leading dash",
+			cpuset:      "-3",
+			expectError: true,
+			errorMsg:    "invalid CPUSet format",
+		},
+		{
+			name:        "invalid special characters",
+			cpuset:      "0,2@4",
+			expectError: true,
+			errorMsg:    "invalid CPUSet format",
+		},
+		{
+			name:        "invalid trailing comma",
+			cpuset:      "0,2,",
+			expectError: true,
+			errorMsg:    "invalid CPUSet format",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateCPUSet(tc.cpuset)
+			if tc.expectError {
+				assert.Error(t, err, "Expected error for cpuset: %s", tc.cpuset)
+				if tc.errorMsg != "" {
+					assert.Contains(t, err.Error(), tc.errorMsg)
+				}
+			} else {
+				assert.NoError(t, err, "Expected no error for cpuset: %s", tc.cpuset)
+			}
+		})
+	}
+}
+
+func TestCPUSetInDomainXML(t *testing.T) {
+	checkConfig(t)
+
+	client, err := NewLibvirtClient(testCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.connection.Close()
+
+	testCases := []struct {
+		name           string
+		cpuset         string
+		expectedCPUSet string
+	}{
+		{
+			name:           "with cpuset specified",
+			cpuset:         "0,2,4,6",
+			expectedCPUSet: "0,2,4,6",
+		},
+		{
+			name:           "with cpuset range",
+			cpuset:         "0-3",
+			expectedCPUSet: "0-3",
+		},
+		{
+			name:           "with empty cpuset",
+			cpuset:         "",
+			expectedCPUSet: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			vm := vmConfig{
+				cpuset: tc.cpuset,
+			}
+
+			domainCfg := domainConfig{
+				name:        "TestCPUSet",
+				cpu:         4,
+				mem:         4096,
+				networkName: client.networkName,
+				bootDisk:    "/var/lib/libvirt/images/root.qcow2",
+				cidataDisk:  "/var/lib/libvirt/images/cidata.iso",
+			}
+
+			domCfg, err := createDomainXML(client, &domainCfg, &vm)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			assert.Equal(t, tc.expectedCPUSet, domCfg.VCPU.CPUSet,
+				"CPUSet should be set correctly in domain XML")
+		})
+	}
+}
+
+func TestCPUSetXMLMarshaling(t *testing.T) {
+	// Test that CPUSet is correctly marshaled to XML without requiring libvirt connection
+	testCases := []struct {
+		name           string
+		cpuset         string
+		expectedSubstr string
+	}{
+		{
+			name:           "cpuset with comma-separated values",
+			cpuset:         "0,2,4,6",
+			expectedSubstr: `cpuset="0,2,4,6"`,
+		},
+		{
+			name:           "cpuset with range",
+			cpuset:         "0-7",
+			expectedSubstr: `cpuset="0-7"`,
+		},
+		{
+			name:           "cpuset with mixed format",
+			cpuset:         "0,2,4-7,10",
+			expectedSubstr: `cpuset="0,2,4-7,10"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			domain := &libvirtxml.Domain{
+				Type: "kvm",
+				Name: "test-vm",
+				VCPU: &libvirtxml.DomainVCPU{
+					Value:  4,
+					CPUSet: tc.cpuset,
+				},
+			}
+
+			xmlStr, err := domain.Marshal()
+			if err != nil {
+				t.Errorf("Failed to marshal domain XML: %v", err)
+				return
+			}
+
+			assert.Contains(t, xmlStr, tc.expectedSubstr,
+				"Marshaled XML should contain cpuset attribute")
 		})
 	}
 }

--- a/src/cloud-providers/libvirt/manager.go
+++ b/src/cloud-providers/libvirt/manager.go
@@ -43,6 +43,7 @@ func (*Manager) ParseCmd(flags *flag.FlagSet) {
 	reg.StringWithEnv(&libvirtcfg.Firmware, "firmware", defaultFirmware, "LIBVIRT_EFI_FIRMWARE", "Path to OVMF")
 	reg.UintWithEnv(&libvirtcfg.CPU, "cpu", 2, "LIBVIRT_CPU", "Number of processors allocated")
 	reg.UintWithEnv(&libvirtcfg.Memory, "memory", 8192, "LIBVIRT_MEMORY", "Amount of memory in MiB")
+	reg.StringWithEnv(&libvirtcfg.CPUSet, "cpuset", "", "LIBVIRT_CPUSET", "CPU set for pinning vCPUs to physical CPUs (e.g., \"0,2,4,6\" or \"0-3\" or \"0-3,8,10-12\")")
 
 	// Flags without environment variable support (pass empty string for envVarName)
 	reg.StringWithEnv(&libvirtcfg.DataDir, "data-dir", defaultDataDir, "", "libvirt storage dir")

--- a/src/cloud-providers/libvirt/provider.go
+++ b/src/cloud-providers/libvirt/provider.go
@@ -71,7 +71,7 @@ func (p *libvirtProvider) CreateInstance(ctx context.Context, podName, sandboxID
 	}
 
 	// TODO: Specify the maximum instance name length in Libvirt
-	vm := &vmConfig{name: instanceName, cpu: instanceVCPUs, mem: instanceMemory, userData: userData, firmware: p.serviceConfig.Firmware}
+	vm := &vmConfig{name: instanceName, cpu: instanceVCPUs, mem: instanceMemory, userData: userData, firmware: p.serviceConfig.Firmware, cpuset: p.serviceConfig.CPUSet}
 
 	if p.serviceConfig.DisableCVM {
 		vm.launchSecurityType = NoLaunchSecurity
@@ -182,6 +182,10 @@ func (p *libvirtProvider) ConfigVerifier() error {
 
 	if config.Memory == 0 {
 		return fmt.Errorf("Memory must be greater than zero")
+	}
+
+	if err := validateCPUSet(config.CPUSet); err != nil {
+		return err
 	}
 
 	return nil

--- a/src/cloud-providers/libvirt/types.go
+++ b/src/cloud-providers/libvirt/types.go
@@ -22,7 +22,8 @@ type Config struct {
 	LaunchSecurity string
 	Firmware       string
 	CPU            uint
-	Memory         uint // It stores the value in MiB
+	Memory         uint   // It stores the value in MiB
+	CPUSet         string // CPU set for pinning vCPUs (e.g., "0,2,4,6" or "0-3")
 }
 
 type vmConfig struct {
@@ -35,6 +36,7 @@ type vmConfig struct {
 	instanceID         string // Domain UUID - keeping it consistent with sandbox.vsi
 	launchSecurityType LaunchSecurityType
 	firmware           string
+	cpuset             string // CPU set for pinning vCPUs (e.g., "0,2,4,6" or "0-3")
 }
 
 type createDomainOutput struct {


### PR DESCRIPTION
Add --cpuset flag and LIBVIRT_CPUSET env var to pin vCPUs to specific physical CPUs. Useful for AI inferencing where cores from different sockets improve performance.

Changes:
- Add CPUSet field to Config and vmConfig structures
- Add --cpuset CLI flag and LIBVIRT_CPUSET environment variable
- Embed CPUSet attribute in Domain XML for all architectures
- Expose LIBVIRT_CPUSET in Helm chart values for deployment
- Add unit tests for CPUSet functionality

Revives PR #2744 with Helm chart adaptation (replaces kustomization.yaml).

Fixes: #2397