### PR TITLE
caa: add BYOM provider to release builds

### DIFF
--- a/src/cloud-api-adaptor/Makefile
+++ b/src/cloud-api-adaptor/Makefile
@@ -26,7 +26,7 @@ RESOURCE_CTRL ?= true
 WEBHOOK_ENABLED ?= true
 # BUILTIN_CLOUD_PROVIDERS is used for binary build -- what providers are built in the binaries.
 ifeq ($(RELEASE_BUILD),true)
-	BUILTIN_CLOUD_PROVIDERS ?= alibabacloud aws azure gcp ibmcloud ibmcloud_powervs
+	BUILTIN_CLOUD_PROVIDERS ?= alibabacloud aws azure byom gcp ibmcloud ibmcloud_powervs
 else
 	BUILTIN_CLOUD_PROVIDERS ?= alibabacloud aws azure byom gcp ibmcloud ibmcloud_powervs libvirt docker
 endif

--- a/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
@@ -82,7 +82,7 @@ image:
   name: quay.io/confidential-containers/cloud-api-adaptor
   tag: "2d2e7c2c0736ec41c889cd98442a598b8b93bc0b"
 
-# Cloud provider: libvirt, aws, azure, gcp, ibmcloud, vsphere
+# Cloud provider: libvirt, aws, azure, byom, gcp, ibmcloud, vsphere
 provider: libvirt
 
 # Maximum number of peer pods allowed to run simultaneously


### PR DESCRIPTION
Helm install in BYOM e2e using the latest CAA image fails with `Unsupported cloud provider: byom`.

Publish CAA image with BYOM provider.

```
# kubectl logs cloud-api-adaptor-daemonset-lc7sk -n confidential-containers-system
+ exec cloud-api-adaptor byom
2026/05/18 13:50:15 [adaptor/cloud] Cloud provider external plugin loading is disabled, skipping plugin loading
cloud-api-adaptor: Unsupported cloud provider: byom

Usage: cloud-api-adaptor <provider-name> [options] | help | version

Supported cloud providers are:
        azure
        aws
        ibmcloud
        ibmcloud-powervs
        gcp
        alibabacloud

Use "cloud-api-adaptor <provider-name> -help" to show options for a cloud provider
```