### PR TITLE
peerpods: support GCP direct Workload Identity Federation in helm chart

### DIFF
--- a/src/cloud-api-adaptor/install/charts/peerpods/templates/_helpers.tpl
+++ b/src/cloud-api-adaptor/install/charts/peerpods/templates/_helpers.tpl
@@ -53,6 +53,24 @@ true
 {{- end -}}
 
 {{/*
+GCP direct Workload Identity Federation: mount a projected K8s SA token
+and an external-account credentials config so the cloud-api-adaptor
+authenticates to GCP as .Values.gcp.workloadIdentityFederation.serviceAccount.
+
+This path is required on GKE when the daemonset runs with hostNetwork: true,
+because the metadata-server-based Workload Identity proxy is bypassed in
+that case. See:
+https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#use_workload_identity_for_a_pod_using_hostnetwork
+
+Returns non-empty "true" when WIF should be wired up.
+*/}}
+{{- define "peerpods.gcpWifEnabled" -}}
+{{- if and (eq .Values.provider "gcp") .Values.gcp .Values.gcp.workloadIdentityFederation .Values.gcp.workloadIdentityFederation.enable -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
 Check if custom TLS certificates are configured.
 Returns "true" when CACERT_FILE is set in providerConfigs for the active
 provider AND a TLS secret name is available (either chart-managed or external).

--- a/src/cloud-api-adaptor/install/charts/peerpods/templates/daemonset.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/templates/daemonset.yaml
@@ -31,6 +31,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+{{- if include "peerpods.gcpWifEnabled" . }}
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/run/secrets/gcp-creds/credentials.json
+{{- end }}
         envFrom:
 {{- if include "peerpods.secretName" . }}
         - secretRef:
@@ -69,6 +73,14 @@ spec:
 {{- if include "peerpods.alibabacloudRrsaEnabled" . }}
         - mountPath: /var/run/secrets/ack.alibabacloud.com/rrsa-tokens
           name: rrsa-oidc-token
+          readOnly: true
+{{- end }}
+{{- if include "peerpods.gcpWifEnabled" . }}
+        - mountPath: /var/run/secrets/tokens/gcp-ksa
+          name: gcp-ksa
+          readOnly: true
+        - mountPath: /var/run/secrets/gcp-creds
+          name: gcp-creds
           readOnly: true
 {{- end }}
         - mountPath: /run/peerpod
@@ -125,6 +137,22 @@ spec:
               audience: "sts.aliyuncs.com"
               expirationSeconds: 3600
               path: token
+{{- end }}
+{{- if include "peerpods.gcpWifEnabled" . }}
+      - name: gcp-ksa
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              audience: {{ required "gcp.workloadIdentityFederation.workloadPool is required when gcp.workloadIdentityFederation.enable is true" .Values.gcp.workloadIdentityFederation.workloadPool | quote }}
+              expirationSeconds: 3600
+              path: token
+      - name: gcp-creds
+        configMap:
+          name: gcp-direct-wi-creds-config
+          items:
+          - key: credentials.json
+            path: credentials.json
 {{- end }}
       - hostPath:
           path: /run/peerpod

--- a/src/cloud-api-adaptor/install/charts/peerpods/templates/gcp-wif-configmap.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/templates/gcp-wif-configmap.yaml
@@ -1,0 +1,36 @@
+{{/*
+GCP direct Workload Identity Federation credentials config.
+
+Rendered when .Values.gcp.workloadIdentityFederation.enable is true.
+Mounted by the cloud-api-adaptor daemonset at /var/run/secrets/gcp-creds/
+and referenced by the GOOGLE_APPLICATION_CREDENTIALS env var, so the
+Google Cloud SDK reads it on every API call: exchange the projected
+K8s SA token at STS, then impersonate the configured GSA via the IAM
+Credentials API.
+
+This is the only way to use GKE Workload Identity from a pod with
+hostNetwork: true (which CAA requires). See:
+https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#use_workload_identity_for_a_pod_using_hostnetwork
+*/}}
+{{- if include "peerpods.gcpWifEnabled" . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gcp-direct-wi-creds-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: cloud-api-adaptor
+data:
+  credentials.json: |
+    {
+      "type": "external_account",
+      "audience": "identitynamespace:{{ required "gcp.workloadIdentityFederation.workloadPool is required" .Values.gcp.workloadIdentityFederation.workloadPool }}:{{ required "gcp.workloadIdentityFederation.cluster is required" .Values.gcp.workloadIdentityFederation.cluster }}",
+      "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+      "token_url": "https://sts.googleapis.com/v1/token",
+      "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{{ required "gcp.workloadIdentityFederation.serviceAccount is required" .Values.gcp.workloadIdentityFederation.serviceAccount }}:generateAccessToken",
+      "credential_source": {
+        "file": "/var/run/secrets/tokens/gcp-ksa/token",
+        "format": { "type": "text" }
+      }
+    }
+{{- end }}

--- a/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
@@ -90,6 +90,28 @@ provider: libvirt
 # Set to "0" for unlimited (not recommended for production)
 limit: "10"
 
+# GCP-specific configuration. Only consulted when provider: gcp.
+#
+# Direct Workload Identity Federation:
+# The cloud-api-adaptor daemonset runs with hostNetwork: true, which
+# bypasses the GKE metadata-server-based Workload Identity proxy. To
+# authenticate as a Google service account without distributing a
+# static key, enable direct WIF — the chart will mount a projected
+# K8s SA token and a credentials-config JSON, and set
+# GOOGLE_APPLICATION_CREDENTIALS on the container.
+#
+# The cloud-api-adaptor KSA must have roles/iam.workloadIdentityUser
+# on the configured GSA before installing.
+#
+# Example:
+# gcp:
+#   workloadIdentityFederation:
+#     enable: true
+#     serviceAccount: "peerpods@my-project.iam.gserviceaccount.com"
+#     workloadPool: "my-project.svc.id.goog"
+#     cluster: "https://container.googleapis.com/v1/projects/my-project/locations/us-central1-a/clusters/my-cluster"
+gcp: {}
+
 # DaemonSet configuration
 daemonset:
   # Update strategy controls how the CAA DaemonSet performs rolling updates


### PR DESCRIPTION
## Summary

Adds opt-in GCP **direct Workload Identity Federation (WIF)** to the peerpods helm chart so the `cloud-api-adaptor` daemonset can authenticate to GCP as a Google service account without distributing a static JSON key, even though it runs with `hostNetwork: true`.

Pure chart change — no Go modifications. When enabled, the chart:

- mounts a projected K8s SA token at `/var/run/secrets/tokens/gcp-ksa/token`,
- renders an `external_account` credentials config into a `ConfigMap` and mounts it at `/var/run/secrets/gcp-creds/credentials.json`,
- sets `GOOGLE_APPLICATION_CREDENTIALS` on the container.

The existing `cloud-providers/gcp/provider.go` already falls through to ADC when `GCP_CREDENTIALS` is empty (calls `compute.NewInstancesRESTClient(ctx)` with no auth option), so the Google SDK auto-discovers the credentials file and performs the STS token exchange + GSA impersonation on every API call. No code change needed.

## Motivation

On GKE, the `cloud-api-adaptor` daemonset requires `hostNetwork: true` for the pod-VM tunnel. GKE's default Workload Identity is implemented as a **metadata-server proxy** on each node, which `hostNetwork: true` bypasses — the pod ends up reading the *node's* GSA from the GCE metadata server instead of the WI-bound GSA. This is documented by Google here:

https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#use_workload_identity_for_a_pod_using_hostnetwork

Side-by-side proof (same KSA, same node, only `hostNetwork` differs):

```sh
NODE=gke-…-w9tt

# hostNetwork=true → node GSA (Server: Metadata Server for VM)
kubectl run wi-test-host --rm -i --restart=Never --image=curlimages/curl \
  --overrides='{\"spec\":{\"hostNetwork\":true,\"serviceAccountName\":\"cloud-api-adaptor\",\"nodeName\":\"'\"\$NODE\"'\"}}' \
  -n confidential-containers-system -- \
  curl -sH 'Metadata-Flavor: Google' \
  http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email
# → 288376110310-compute@developer.gserviceaccount.com  (node default)

# hostNetwork=false → WI-bound GSA (Server: GKE Metadata Server)
kubectl run wi-test-pod  --rm -i --restart=Never --image=curlimages/curl \
  --overrides='{\"spec\":{\"serviceAccountName\":\"cloud-api-adaptor\",\"nodeName\":\"'\"\$NODE\"'\"}}' \
  -n confidential-containers-system -- \
  curl -sH 'Metadata-Flavor: Google' \
  http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email
# → peerpods@my-project.iam.gserviceaccount.com  (WI-bound)
```

The standard fix for `hostNetwork: true` pods on GCP is to skip the metadata-server proxy entirely and use **direct WIF** — the pod reads its own projected SA token from disk and exchanges it with Google STS directly.

## Precedent

The same shape ("if no static credentials are provided, fall back to a federated/workload identity source") is already implemented in two cloud providers in this repo:

- **Azure**: `cloud-providers/azure/client.go` — `if config.ClientSecret == \"\" { return azidentity.NewWorkloadIdentityCredential(nil) }`. Reads the projected SA token, exchanges with Entra ID, no metadata server involved.
- **Alibaba Cloud**: `cloud-providers/alibabacloud/provider.go` — `if len(config.AccessKeyID) == 0 || len(config.SecretKey) == 0 { ... credentials.NewCredential(nil) ... }`. Uses ACK RRSA via `ALIBABA_CLOUD_ROLE_ARN` / `ALIBABA_CLOUD_OIDC_PROVIDER_ARN` / `ALIBABA_CLOUD_OIDC_TOKEN_FILE`.

AWS's `cloud-providers/aws/ec2.go` even carries an explicit `// TODO: Use IAM role` for the same gap. GCP is the laggard. This PR closes that gap via chart wiring rather than Go-side code changes, because GCP's SDK already discovers external_account credentials via ADC.

## Design choice: `identitynamespace:` vs. explicit Workload Identity Pool

GCP supports two `external_account` shapes:

1. **`identitynamespace:WORKLOAD_POOL:CLUSTER_URI`** — uses GKE's implicit identity namespace (`<project>.svc.id.goog`). No pre-provisioning of a Workload Identity Pool or OIDC Provider required.
2. **`//iam.googleapis.com/projects/{NUM}/locations/global/workloadIdentityPools/{POOL}/providers/{PROVIDER}`** — requires the operator to create a Workload Identity Pool + OIDC Provider in advance.

This PR uses (1) because it has zero pre-provisioning beyond what GKE Workload Identity itself already requires (which the operator has likely already done). Users who want (2) for an existing federated setup will need a small follow-up.

## Compatibility

- Default `gcp: {}` — non-GCP installs unaffected.
- All gated by `peerpods.gcpWifEnabled`, which requires `provider == \"gcp\"` AND `gcp.workloadIdentityFederation.enable: true`. Off by default for GCP installs too — opt-in.
- No changes to `cloud-providers/gcp` or any Go code.

## Required RBAC

Before installing with WIF enabled, the cluster operator needs:

1. The `cloud-api-adaptor` KSA → GSA binding for impersonation:
   ```
   gcloud iam service-accounts add-iam-policy-binding \
     --role roles/iam.workloadIdentityUser \
     --member \"serviceAccount:<project>.svc.id.goog[<release-namespace>/cloud-api-adaptor]\" \
     <gsa>@<project>.iam.gserviceaccount.com
   ```
2. The GSA itself granted whatever GCP API permissions the CAA needs (compute instance admin, etc.) — same as before.

## Test plan

- [x] `helm template` renders cleanly with WIF disabled (default) — no new objects, no changes to daemonset env/volumes.
- [x] `helm template` with WIF enabled renders the `gcp-direct-wi-creds-config` ConfigMap with substituted `workloadPool`, `cluster`, `serviceAccount`.
- [x] `helm template` with `gcp.workloadIdentityFederation.enable: true` but missing `workloadPool` / `cluster` / `serviceAccount` fails fast with `helm install`'s `required` error.
- [ ] End-to-end: deploy peerpods on GKE with WIF enabled, verify `kubectl exec` into the daemonset pod and `curl ...` against the metadata server is no longer the path used (the projected token in `/var/run/secrets/tokens/gcp-ksa/token` is what gets exchanged). Confirm peer-pod VM creation succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)