### PR TITLE
tests/provisioner: enforce IMDSv2 on CI-built podvm AMI

### DIFF
--- a/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
@@ -1075,6 +1075,7 @@ func (i *AMIImage) registerImage(imageName string) error {
 		RootDeviceName:     aws.String(i.RootDeviceName),
 		TpmSupport:         ec2types.TpmSupportValuesV20,
 		VirtualizationType: aws.String("hvm"),
+		ImdsSupport:        ec2types.ImdsSupportValuesV20,
 		TagSpecifications:  defaultTagSpecifications(i.BaseName+"-img", ec2types.ResourceTypeImage),
 	})
 	if err != nil {


### PR DESCRIPTION
Set ImdsSupport=v2.0 on the AMI registered by the e2e provisioner so instances launched from it default to HttpTokens=required. This lets CI validate the IMDSv2 user-data fetch path (PR #3058) without changing account-level settings.

Assisted-by: Claude

---

This is a follow up of PR #3058. IMDSv2 is more secure and the AWS recommended version, so I think we should be testing it by default. As I don't want to change the aws account settings, let's enforce its use via AMI.