### PR TITLE
 podvm-mkosi: blacklist vmgenid driver init to fix AWS SEV-SNP boot hang

### DIFF
--- a/src/cloud-api-adaptor/podvm-mkosi/mkosi.images/system/mkosi.conf
+++ b/src/cloud-api-adaptor/podvm-mkosi/mkosi.images/system/mkosi.conf
@@ -21,6 +21,7 @@ KernelCommandLine=console=ttyS0
 KernelCommandLine=systemd.firstboot=off
 KernelCommandLine=systemd.volatile=state
 KernelCommandLine=selinux=0 enforcing=0 audit=0
+KernelCommandLine=initcall_blacklist=vmgenid_plaform_driver_init
 
 Initrds=../../build/initrd
 


### PR DESCRIPTION
One-line addition to `podvm-mkosi/mkosi.images/system/mkosi.conf`:

```
KernelCommandLine=initcall_blacklist=vmgenid_plaform_driver_init
```

Fixes the AWS SEV-SNP PodVM boot failure first reported in #2691. The mkosi-built Fedora PodVM image fails to come up on EC2 instances launched with `CpuOptions.AmdSevSnp=enabled` — in my environment the kernel panics during early init (the EC2 serial console shows the `vmgenid` driver loading and platform / device probing wedging before systemd ever starts), while #2691 reports a related manifestation where the guest exits with `Client.InstanceInitiatedShutdown` ~12s into kernel init. Same image boots fine on non-SNP instances; toggling only the `AmdSevSnp` CpuOption flips the same build between booting and not booting.

The fix matches the patch @bpradipt posted in [#2691 (comment, 2025-12-23)](https://github.com/confidential-containers/cloud-api-adaptor/issues/2691#issuecomment-3686504001) — blacklisting the `vmgenid` platform-driver initcall lets boot proceed past the early-init wedge.

## Background

This fix was originally included in #2729 (Fedora 43 upgrade) but dropped when that PR was superseded by the slimmer #2914. Per @mkulke's [comment on #2729](https://github.com/confidential-containers/cloud-api-adaptor/pull/2729#issuecomment-3778580352) on 2026-01-21 — *"a PR would be better (if the fix is urgent), since there is probably more work required for s390x"* — this PR carries the kernel-cli line in isolation, separate from any Fedora-version bump.

`vmgenid` is x86-only, so `initcall_blacklist=vmgenid_plaform_driver_init` is a no-op on s390x kernels — no s390x-specific handling needed. The line is placed in base `mkosi.conf` to match the location of the originally posted patch.

(The `plaform` typo is intentional — it matches the kernel symbol name in `drivers/virt/vmgenid.c`, which declares `static struct platform_driver vmgenid_plaform_driver`.)

## Reproduction (without this PR, on current main)

1. From `src/cloud-api-adaptor/podvm-mkosi/`, build a Fedora-based PodVM image:
   ```bash
   TEE_PLATFORM=amd make image-debug
   ```
2. Upload the resulting raw image and register an AMI in your AWS account (`uplosi`, or manual `aws ec2 import-snapshot` + `register-image`).
3. Launch an EC2 instance from the AMI with SEV-SNP enabled:
   ```bash
   aws ec2 run-instances \
     --instance-type c6a.2xlarge \
     --image-id <ami-id> \
     --cpu-options 'AmdSevSnp=enabled' \
     --subnet-id <subnet> --security-group-ids <sg>
   ```
4. Observe via the EC2 serial console (`aws ec2 get-console-output`) that the kernel begins boot, reaches the vmgenid driver init, and wedges / panics before systemd starts. The instance either hangs in a bad state or transitions to `Client.InstanceInitiatedShutdown` shortly after kernel start (depending on the failure mode).
5. Relaunch the same AMI with `--cpu-options 'AmdSevSnp=disabled'` (or omitted): boot succeeds normally. The only variable is the SEV-SNP CpuOption.

With this PR applied, step 3 boots end to end on SEV-SNP-enabled launches.

## Validation

Validated end to end on AWS SEV-SNP peer-pods in my own POC environment (c6a.2xlarge in us-east-2):

- PodVM boots cleanly with the kernel-cli flag applied
- `CpuOptions.AmdSevSnp=enabled` confirmed via `aws ec2 describe-instances`
- kata-agent comes up and serves its agent endpoint over the vxlan tunnel from the worker
- AMD-signed SEV-SNP attestation report retrieved from inside the guest, VLEK → ASK → ARK chain verifies against AMD's root CA

Without the flag the same image fails to boot at all on SNP-enabled launch shapes.

## Cross-distro signal

  The same boot hang is currently open against Talos: siderolabs/talos#13118 ("AMD SEV-SNP does not work on talos 1.12, on AWS, with the official images"). That suggests the underlying kernel fix
  (https://www.spinics.net/lists/kernel/msg5976520.html) has not yet propagated to widely-used distro kernels, so the workaround is still load-bearing today.

 ## Note on relevance / scope

 Filing this knowing the project is actively migrating to Ubuntu as the podvm-mkosi base (#2663, #2924, #3023, #3075). Two reasons I went ahead anyway:

  1. The bug still reproduces on current `main` today — anyone trying to build a Fedora-based PodVM AMI for AWS SNP testing hits it
  2. A maintainer-blessed one-line workaround already exists; re-extracting it from #2729 closes the loose end before Fedora is fully dismissed

  That said — happy to close this if it is considered out of scope given the Ubuntu migration trajectory, or if the upstream kernel fix is known to have landed in current Fedora 43 stable kernels and the workaround
   is no longer needed. Just let me know.

  ## Refs

  - #2691 — boot-hang issue, closed 2026-05-07 with workaround documented in comments but no PR filed
  - #2729 — original Fedora 43 upgrade PR that bundled this fix (closed, superseded by #2914)
  - #2914 — slim Fedora 43 bump that did not carry forward the kernel-cli change
  - siderolabs/talos#13118 — same kernel issue on Talos / AWS SNP, open today

  ## Test plan

  - [x] PodVM boots on AWS SNP-enabled instances (verified)
  - [x] AMD-signed attestation retrievable inside guest (verified)
  - [x] No-op on s390x (vmgenid driver does not exist on s390x kernels — kernel ignores blackli
