### PR TITLE
cloud-providers: Generate provider configs with all options uncommented

### DIFF
--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/alibabacloud.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/alibabacloud.yaml
@@ -8,35 +8,35 @@ providerConfigs:
   alibabacloud:
     # CA certificate file for custom TLS (e.g. /etc/certificates/ca.crt)
     # (default: "")
-    # CACERT_FILE: ""
+    CACERT_FILE: ""
 
     # Client certificate file for custom TLS (e.g. /etc/certificates/client.crt)
     # (default: "")
-    # CERT_FILE: ""
+    CERT_FILE: ""
 
     # Client key file for custom TLS (e.g. /etc/certificates/client.key)
     # (default: "")
-    # CERT_KEY: ""
+    CERT_KEY: ""
 
     # Enable cloud config verify - should use it for production
     # (default: "false")
-    # CLOUD_CONFIG_VERIFY: "false"
+    CLOUD_CONFIG_VERIFY: "false"
 
     # Use non-CVMs for peer pods
     # (default: "false")
-    # DISABLECVM: "false"
+    DISABLECVM: "false"
 
     # Enable encrypted scratch space for pod VMs
     # (default: "false")
-    # ENABLE_SCRATCH_SPACE: "false"
+    ENABLE_SCRATCH_SPACE: "false"
 
     # [EXPERIMENTAL] Enable external networking via pod VM
     # (default: "false")
-    # EXTERNAL_NETWORK_VIA_PODVM: "false"
+    EXTERNAL_NETWORK_VIA_PODVM: "false"
 
     # port number of agent protocol forwarder
     # (default: "")
-    # FORWARDER_PORT: ""
+    FORWARDER_PORT: ""
 
     # Pod VM image id
     # (required)
@@ -44,67 +44,67 @@ providerConfigs:
 
     # Default initdata for all Pods
     # (default: "")
-    # INITDATA: ""
+    INITDATA: ""
 
     # SSH Keypair name to be used with the Pod VM
     # (default: "")
-    # KEYNAME: ""
+    KEYNAME: ""
 
     # pause image to be used for the pods
     # (default: "")
-    # PAUSE_IMAGE: ""
+    PAUSE_IMAGE: ""
 
     # peer pods limit per node (default=10)
     # (default: "10")
-    # PEERPODS_LIMIT_PER_NODE: "10"
+    PEERPODS_LIMIT_PER_NODE: "10"
 
     # base directory for pod directories
     # (default: "")
-    # PODS_DIR: ""
+    PODS_DIR: ""
 
     # Pod VM instance type
     # (default: "ecs.g8i.xlarge")
-    # PODVM_INSTANCE_TYPE: "ecs.g8i.xlarge"
+    PODVM_INSTANCE_TYPE: "ecs.g8i.xlarge"
 
     # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
     # (default: "")
-    # POD_SUBNET_CIDRS: ""
+    POD_SUBNET_CIDRS: ""
 
     # Maximum timeout in minutes for establishing agent proxy connection
     # (default: "")
-    # PROXY_TIMEOUT: ""
+    PROXY_TIMEOUT: ""
 
     # Region
     # (default: "cn-beijing")
-    # REGION: "cn-beijing"
+    REGION: "cn-beijing"
 
     # Unix domain socket path of remote hypervisor service
     # (default: "")
-    # REMOTE_HYPERVISOR_ENDPOINT: ""
+    REMOTE_HYPERVISOR_ENDPOINT: ""
 
     # Security Group Ids to be used for the Pod VM, comma separated
     # (default: "cn-beijing")
-    # SECURITY_GROUP_IDS: "cn-beijing"
+    SECURITY_GROUP_IDS: "cn-beijing"
 
     # System Disk size (in GiB) for the Pod VMs
     # (default: "40")
-    # SYSTEM_DISK_SIZE: "40"
+    SYSTEM_DISK_SIZE: "40"
 
     # Custom tags (key=value pairs) to be used for the Pod VMs, comma separated
     # (default: "")
-    # TAGS: ""
+    TAGS: ""
 
     # Skip TLS certificate verification - use it only for testing
     # (default: "false")
-    # TLS_SKIP_VERIFY: "false"
+    TLS_SKIP_VERIFY: "false"
 
     # Tunnel provider
     # (default: "")
-    # TUNNEL_TYPE: ""
+    TUNNEL_TYPE: ""
 
     # Use Public IP for connecting to the kata-agent inside the Pod VM
     # (default: "false")
-    # USE_PUBLIC_IP: "false"
+    USE_PUBLIC_IP: "false"
 
     # vSwitch ID to be used for the Pod VMs
     # (required)
@@ -112,5 +112,5 @@ providerConfigs:
 
     # VXLAN UDP port number (VXLAN tunnel mode only
     # (default: "")
-    # VXLAN_PORT: ""
+    VXLAN_PORT: ""
 

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/aws.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/aws.yaml
@@ -8,63 +8,63 @@ providerConfigs:
   aws:
     # Region
     # (default: "")
-    # AWS_REGION: ""
+    AWS_REGION: ""
 
     # Security Group Ids to be used for the Pod VM, comma separated
     # (default: "")
-    # AWS_SG_IDS: ""
+    AWS_SG_IDS: ""
 
     # Subnet ID to be used for the Pod VMs
     # (default: "")
-    # AWS_SUBNET_ID: ""
+    AWS_SUBNET_ID: ""
 
     # CA certificate file for custom TLS (e.g. /etc/certificates/ca.crt)
     # (default: "")
-    # CACERT_FILE: ""
+    CACERT_FILE: ""
 
     # Client certificate file for custom TLS (e.g. /etc/certificates/client.crt)
     # (default: "")
-    # CERT_FILE: ""
+    CERT_FILE: ""
 
     # Client key file for custom TLS (e.g. /etc/certificates/client.key)
     # (default: "")
-    # CERT_KEY: ""
+    CERT_KEY: ""
 
     # Enable cloud config verify - should use it for production
     # (default: "false")
-    # CLOUD_CONFIG_VERIFY: "false"
+    CLOUD_CONFIG_VERIFY: "false"
 
     # Use non-CVMs for peer pods
     # (default: "false")
-    # DISABLECVM: "false"
+    DISABLECVM: "false"
 
     # Enable encrypted scratch space for pod VMs
     # (default: "false")
-    # ENABLE_SCRATCH_SPACE: "false"
+    ENABLE_SCRATCH_SPACE: "false"
 
     # [EXPERIMENTAL] Enable external networking via pod VM
     # (default: "false")
-    # EXTERNAL_NETWORK_VIA_PODVM: "false"
+    EXTERNAL_NETWORK_VIA_PODVM: "false"
 
     # port number of agent protocol forwarder
     # (default: "")
-    # FORWARDER_PORT: ""
+    FORWARDER_PORT: ""
 
     # Default initdata for all Pods
     # (default: "")
-    # INITDATA: ""
+    INITDATA: ""
 
     # pause image to be used for the pods
     # (default: "")
-    # PAUSE_IMAGE: ""
+    PAUSE_IMAGE: ""
 
     # peer pods limit per node (default=10)
     # (default: "10")
-    # PEERPODS_LIMIT_PER_NODE: "10"
+    PEERPODS_LIMIT_PER_NODE: "10"
 
     # base directory for pod directories
     # (default: "")
-    # PODS_DIR: ""
+    PODS_DIR: ""
 
     # Pod VM ami id
     # (required)
@@ -72,57 +72,57 @@ providerConfigs:
 
     # Pod VM instance type
     # (default: "m6a.large")
-    # PODVM_INSTANCE_TYPE: "m6a.large"
+    PODVM_INSTANCE_TYPE: "m6a.large"
 
     # Instance types to be used for the Pod VMs, comma separated
     # (default: "")
-    # PODVM_INSTANCE_TYPES: ""
+    PODVM_INSTANCE_TYPES: ""
 
     # AWS Launch Template Name
     # (default: "kata")
-    # PODVM_LAUNCHTEMPLATE_NAME: "kata"
+    PODVM_LAUNCHTEMPLATE_NAME: "kata"
 
     # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
     # (default: "")
-    # POD_SUBNET_CIDRS: ""
+    POD_SUBNET_CIDRS: ""
 
     # Maximum timeout in minutes for establishing agent proxy connection
     # (default: "")
-    # PROXY_TIMEOUT: ""
+    PROXY_TIMEOUT: ""
 
     # Unix domain socket path of remote hypervisor service
     # (default: "")
-    # REMOTE_HYPERVISOR_ENDPOINT: ""
+    REMOTE_HYPERVISOR_ENDPOINT: ""
 
     # Root volume size (in GiB) for the Pod VMs
     # (default: "30")
-    # ROOT_VOLUME_SIZE: "30"
+    ROOT_VOLUME_SIZE: "30"
 
     # SSH Keypair name to be used with the Pod VM
     # (default: "")
-    # SSH_KP_NAME: ""
+    SSH_KP_NAME: ""
 
     # Custom tags (key=value pairs) to be used for the Pod VMs, comma separated
     # (default: "")
-    # TAGS: ""
+    TAGS: ""
 
     # Skip TLS certificate verification - use it only for testing
     # (default: "false")
-    # TLS_SKIP_VERIFY: "false"
+    TLS_SKIP_VERIFY: "false"
 
     # Tunnel provider
     # (default: "")
-    # TUNNEL_TYPE: ""
+    TUNNEL_TYPE: ""
 
     # Use EC2 Launch Template for the Pod VMs
     # (default: "false")
-    # USE_PODVM_LAUNCHTEMPLATE: "false"
+    USE_PODVM_LAUNCHTEMPLATE: "false"
 
     # Use Public IP for connecting to the kata-agent inside the Pod VM
     # (default: "false")
-    # USE_PUBLIC_IP: "false"
+    USE_PUBLIC_IP: "false"
 
     # VXLAN UDP port number (VXLAN tunnel mode only
     # (default: "")
-    # VXLAN_PORT: ""
+    VXLAN_PORT: ""
 

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/azure.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/azure.yaml
@@ -12,15 +12,15 @@ providerConfigs:
 
     # Instance size
     # (default: "Standard_DC2as_v5")
-    # AZURE_INSTANCE_SIZE: "Standard_DC2as_v5"
+    AZURE_INSTANCE_SIZE: "Standard_DC2as_v5"
 
     # Instance sizes to be used for the Pod VMs, comma separated
     # (default: "")
-    # AZURE_INSTANCE_SIZES: ""
+    AZURE_INSTANCE_SIZES: ""
 
     # Security Group Id
     # (default: "")
-    # AZURE_NSG_ID: ""
+    AZURE_NSG_ID: ""
 
     # Region
     # (required)
@@ -40,93 +40,93 @@ providerConfigs:
 
     # CA certificate file for custom TLS (e.g. /etc/certificates/ca.crt)
     # (default: "")
-    # CACERT_FILE: ""
+    CACERT_FILE: ""
 
     # Client certificate file for custom TLS (e.g. /etc/certificates/client.crt)
     # (default: "")
-    # CERT_FILE: ""
+    CERT_FILE: ""
 
     # Client key file for custom TLS (e.g. /etc/certificates/client.key)
     # (default: "")
-    # CERT_KEY: ""
+    CERT_KEY: ""
 
     # Enable cloud config verify - should use it for production
     # (default: "false")
-    # CLOUD_CONFIG_VERIFY: "false"
+    CLOUD_CONFIG_VERIFY: "false"
 
     # Use non-CVMs for peer pods
     # (default: "false")
-    # DISABLECVM: "false"
+    DISABLECVM: "false"
 
     # Enable encrypted scratch space for pod VMs
     # (default: "false")
-    # ENABLE_SCRATCH_SPACE: "false"
+    ENABLE_SCRATCH_SPACE: "false"
 
     # Enable secure boot for the VMs
     # (default: "false")
-    # ENABLE_SECURE_BOOT: "false"
+    ENABLE_SECURE_BOOT: "false"
 
     # [EXPERIMENTAL] Enable external networking via pod VM
     # (default: "false")
-    # EXTERNAL_NETWORK_VIA_PODVM: "false"
+    EXTERNAL_NETWORK_VIA_PODVM: "false"
 
     # port number of agent protocol forwarder
     # (default: "")
-    # FORWARDER_PORT: ""
+    FORWARDER_PORT: ""
 
     # Default initdata for all Pods
     # (default: "")
-    # INITDATA: ""
+    INITDATA: ""
 
     # pause image to be used for the pods
     # (default: "")
-    # PAUSE_IMAGE: ""
+    PAUSE_IMAGE: ""
 
     # peer pods limit per node (default=10)
     # (default: "10")
-    # PEERPODS_LIMIT_PER_NODE: "10"
+    PEERPODS_LIMIT_PER_NODE: "10"
 
     # base directory for pod directories
     # (default: "")
-    # PODS_DIR: ""
+    PODS_DIR: ""
 
     # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
     # (default: "")
-    # POD_SUBNET_CIDRS: ""
+    POD_SUBNET_CIDRS: ""
 
     # Maximum timeout in minutes for establishing agent proxy connection
     # (default: "")
-    # PROXY_TIMEOUT: ""
+    PROXY_TIMEOUT: ""
 
     # Unix domain socket path of remote hypervisor service
     # (default: "")
-    # REMOTE_HYPERVISOR_ENDPOINT: ""
+    REMOTE_HYPERVISOR_ENDPOINT: ""
 
     # Root volume size in GB. Default is 0, which implies the default image disk size
     # (default: "0")
-    # ROOT_VOLUME_SIZE: "0"
+    ROOT_VOLUME_SIZE: "0"
 
     # SSH User Name
     # (default: "peerpod")
-    # SSH_USERNAME: "peerpod"
+    SSH_USERNAME: "peerpod"
 
     # Custom tags (key=value pairs) to be used for the Pod VMs, comma separated
     # (default: "")
-    # TAGS: ""
+    TAGS: ""
 
     # Skip TLS certificate verification - use it only for testing
     # (default: "false")
-    # TLS_SKIP_VERIFY: "false"
+    TLS_SKIP_VERIFY: "false"
 
     # Tunnel provider
     # (default: "")
-    # TUNNEL_TYPE: ""
+    TUNNEL_TYPE: ""
 
     # Assign public IP to the PoD VM and use to connect to kata-agent
     # (default: "false")
-    # USE_PUBLIC_IP: "false"
+    USE_PUBLIC_IP: "false"
 
     # VXLAN UDP port number (VXLAN tunnel mode only
     # (default: "")
-    # VXLAN_PORT: ""
+    VXLAN_PORT: ""
 

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/byom.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/byom.yaml
@@ -8,99 +8,99 @@ providerConfigs:
   byom:
     # CA certificate file for custom TLS (e.g. /etc/certificates/ca.crt)
     # (default: "")
-    # CACERT_FILE: ""
+    CACERT_FILE: ""
 
     # Client certificate file for custom TLS (e.g. /etc/certificates/client.crt)
     # (default: "")
-    # CERT_FILE: ""
+    CERT_FILE: ""
 
     # Client key file for custom TLS (e.g. /etc/certificates/client.key)
     # (default: "")
-    # CERT_KEY: ""
+    CERT_KEY: ""
 
     # Enable cloud config verify - should use it for production
     # (default: "false")
-    # CLOUD_CONFIG_VERIFY: "false"
+    CLOUD_CONFIG_VERIFY: "false"
 
     # Enable encrypted scratch space for pod VMs
     # (default: "false")
-    # ENABLE_SCRATCH_SPACE: "false"
+    ENABLE_SCRATCH_SPACE: "false"
 
     # [EXPERIMENTAL] Enable external networking via pod VM
     # (default: "false")
-    # EXTERNAL_NETWORK_VIA_PODVM: "false"
+    EXTERNAL_NETWORK_VIA_PODVM: "false"
 
     # port number of agent protocol forwarder
     # (default: "")
-    # FORWARDER_PORT: ""
+    FORWARDER_PORT: ""
 
     # Default initdata for all Pods
     # (default: "")
-    # INITDATA: ""
+    INITDATA: ""
 
     # Maximum number of IPs allowed in a range
     # (default: "100")
-    # MAX_RANGE_IPS: "100"
+    MAX_RANGE_IPS: "100"
 
     # pause image to be used for the pods
     # (default: "")
-    # PAUSE_IMAGE: ""
+    PAUSE_IMAGE: ""
 
     # peer pods limit per node (default=10)
     # (default: "10")
-    # PEERPODS_LIMIT_PER_NODE: "10"
+    PEERPODS_LIMIT_PER_NODE: "10"
 
     # base directory for pod directories
     # (default: "")
-    # PODS_DIR: ""
+    PODS_DIR: ""
 
     # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
     # (default: "")
-    # POD_SUBNET_CIDRS: ""
+    POD_SUBNET_CIDRS: ""
 
     # ConfigMap name for state storage
     # (default: "byom-ip-pool-state")
-    # POOL_CONFIGMAP_NAME: "byom-ip-pool-state"
+    POOL_CONFIGMAP_NAME: "byom-ip-pool-state"
 
     # Namespace for ConfigMap storage (default: auto-detect from running pod)
     # (default: "")
-    # POOL_NAMESPACE: ""
+    POOL_NAMESPACE: ""
 
     # Maximum timeout in minutes for establishing agent proxy connection
     # (default: "")
-    # PROXY_TIMEOUT: ""
+    PROXY_TIMEOUT: ""
 
     # Unix domain socket path of remote hypervisor service
     # (default: "")
-    # REMOTE_HYPERVISOR_ENDPOINT: ""
+    REMOTE_HYPERVISOR_ENDPOINT: ""
 
     # Directory containing allowed SSH host key files (enables allowlist mode if set)
     # (default: "")
-    # SSH_HOST_KEY_ALLOWLIST_DIR: ""
+    SSH_HOST_KEY_ALLOWLIST_DIR: ""
 
     # SSH private key file path
     # (default: "/root/.ssh/id_rsa")
-    # SSH_PRIV_KEY_PATH: "/root/.ssh/id_rsa"
+    SSH_PRIV_KEY_PATH: "/root/.ssh/id_rsa"
 
     # SSH public key file path
     # (default: "/root/.ssh/id_rsa.pub")
-    # SSH_PUB_KEY_PATH: "/root/.ssh/id_rsa.pub"
+    SSH_PUB_KEY_PATH: "/root/.ssh/id_rsa.pub"
 
     # SSH connection timeout in seconds
     # (default: "30")
-    # SSH_TIMEOUT: "30"
+    SSH_TIMEOUT: "30"
 
     # SSH username for VM access
     # (default: "peerpod")
-    # SSH_USERNAME: "peerpod"
+    SSH_USERNAME: "peerpod"
 
     # Skip TLS certificate verification - use it only for testing
     # (default: "false")
-    # TLS_SKIP_VERIFY: "false"
+    TLS_SKIP_VERIFY: "false"
 
     # Tunnel provider
     # (default: "")
-    # TUNNEL_TYPE: ""
+    TUNNEL_TYPE: ""
 
     # Comma-separated list of IP addresses for pre-created VMs
     # (required)
@@ -108,5 +108,5 @@ providerConfigs:
 
     # VXLAN UDP port number (VXLAN tunnel mode only
     # (default: "")
-    # VXLAN_PORT: ""
+    VXLAN_PORT: ""
 

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/gcp.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/gcp.yaml
@@ -8,51 +8,51 @@ providerConfigs:
   gcp:
     # CA certificate file for custom TLS (e.g. /etc/certificates/ca.crt)
     # (default: "")
-    # CACERT_FILE: ""
+    CACERT_FILE: ""
 
     # Client certificate file for custom TLS (e.g. /etc/certificates/client.crt)
     # (default: "")
-    # CERT_FILE: ""
+    CERT_FILE: ""
 
     # Client key file for custom TLS (e.g. /etc/certificates/client.key)
     # (default: "")
-    # CERT_KEY: ""
+    CERT_KEY: ""
 
     # Enable cloud config verify - should use it for production
     # (default: "false")
-    # CLOUD_CONFIG_VERIFY: "false"
+    CLOUD_CONFIG_VERIFY: "false"
 
     # Use non-CVMs for peer pods
     # (default: "false")
-    # DISABLECVM: "false"
+    DISABLECVM: "false"
 
     # Enable encrypted scratch space for pod VMs
     # (default: "false")
-    # ENABLE_SCRATCH_SPACE: "false"
+    ENABLE_SCRATCH_SPACE: "false"
 
     # [EXPERIMENTAL] Enable external networking via pod VM
     # (default: "false")
-    # EXTERNAL_NETWORK_VIA_PODVM: "false"
+    EXTERNAL_NETWORK_VIA_PODVM: "false"
 
     # port number of agent protocol forwarder
     # (default: "")
-    # FORWARDER_PORT: ""
+    FORWARDER_PORT: ""
 
     # Used when DisableCVM=false. i.e: TDX, SEV or SEV_SNP. Check if the machine type is compatible.
     # (default: "")
-    # GCP_CONFIDENTIAL_TYPE: ""
+    GCP_CONFIDENTIAL_TYPE: ""
 
     # Any GCP disk type (pd-standard, pd-ssd, pd-balanced or pd-extreme)
     # (default: "pd-standard")
-    # GCP_DISK_TYPE: "pd-standard"
+    GCP_DISK_TYPE: "pd-standard"
 
     # Machine types to be used for the Pod VMs, comma separated
     # (default: "")
-    # GCP_INSTANCE_TYPES: ""
+    GCP_INSTANCE_TYPES: ""
 
     # Pod VM instance type
     # (default: "e2-medium")
-    # GCP_MACHINE_TYPE: "e2-medium"
+    GCP_MACHINE_TYPE: "e2-medium"
 
     # Network ID to be used for the Pod VMs
     # (required)
@@ -64,7 +64,7 @@ providerConfigs:
 
     # Subnetwork ID to be used for the Pod VMs (required for custom subnet mode networks)
     # (default: "")
-    # GCP_SUBNETWORK: ""
+    GCP_SUBNETWORK: ""
 
     # Zone
     # (required)
@@ -72,57 +72,57 @@ providerConfigs:
 
     # Default initdata for all Pods
     # (default: "")
-    # INITDATA: ""
+    INITDATA: ""
 
     # pause image to be used for the pods
     # (default: "")
-    # PAUSE_IMAGE: ""
+    PAUSE_IMAGE: ""
 
     # peer pods limit per node (default=10)
     # (default: "10")
-    # PEERPODS_LIMIT_PER_NODE: "10"
+    PEERPODS_LIMIT_PER_NODE: "10"
 
     # base directory for pod directories
     # (default: "")
-    # PODS_DIR: ""
+    PODS_DIR: ""
 
     # Pod VM image name
     # (default: "")
-    # PODVM_IMAGE_NAME: ""
+    PODVM_IMAGE_NAME: ""
 
     # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
     # (default: "")
-    # POD_SUBNET_CIDRS: ""
+    POD_SUBNET_CIDRS: ""
 
     # Maximum timeout in minutes for establishing agent proxy connection
     # (default: "")
-    # PROXY_TIMEOUT: ""
+    PROXY_TIMEOUT: ""
 
     # Unix domain socket path of remote hypervisor service
     # (default: "")
-    # REMOTE_HYPERVISOR_ENDPOINT: ""
+    REMOTE_HYPERVISOR_ENDPOINT: ""
 
     # Root volume size (in GiB) for the Pod VMs
     # (default: "10")
-    # ROOT_VOLUME_SIZE: "10"
+    ROOT_VOLUME_SIZE: "10"
 
     # List of tags to be added to the Pod VMs. Tags must already exist in the GCP project. Format: key1=value1,key2=value2
     # (default: "")
-    # TAGS: ""
+    TAGS: ""
 
     # Skip TLS certificate verification - use it only for testing
     # (default: "false")
-    # TLS_SKIP_VERIFY: "false"
+    TLS_SKIP_VERIFY: "false"
 
     # Tunnel provider
     # (default: "")
-    # TUNNEL_TYPE: ""
+    TUNNEL_TYPE: ""
 
     # Use Public IP for connecting to the kata-agent inside the Pod VM
     # (default: "false")
-    # USE_PUBLIC_IP: "false"
+    USE_PUBLIC_IP: "false"
 
     # VXLAN UDP port number (VXLAN tunnel mode only
     # (default: "")
-    # VXLAN_PORT: ""
+    VXLAN_PORT: ""
 

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/ibmcloud.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/ibmcloud.yaml
@@ -8,51 +8,51 @@ providerConfigs:
   ibmcloud:
     # CA certificate file for custom TLS (e.g. /etc/certificates/ca.crt)
     # (default: "")
-    # CACERT_FILE: ""
+    CACERT_FILE: ""
 
     # Client certificate file for custom TLS (e.g. /etc/certificates/client.crt)
     # (default: "")
-    # CERT_FILE: ""
+    CERT_FILE: ""
 
     # Client key file for custom TLS (e.g. /etc/certificates/client.key)
     # (default: "")
-    # CERT_KEY: ""
+    CERT_KEY: ""
 
     # Enable cloud config verify - should use it for production
     # (default: "false")
-    # CLOUD_CONFIG_VERIFY: "false"
+    CLOUD_CONFIG_VERIFY: "false"
 
     # Use non-CVMs for peer pods
     # (default: "true")
-    # DISABLECVM: "true"
+    DISABLECVM: "true"
 
     # Enable encrypted scratch space for pod VMs
     # (default: "false")
-    # ENABLE_SCRATCH_SPACE: "false"
+    ENABLE_SCRATCH_SPACE: "false"
 
     # [EXPERIMENTAL] Enable external networking via pod VM
     # (default: "false")
-    # EXTERNAL_NETWORK_VIA_PODVM: "false"
+    EXTERNAL_NETWORK_VIA_PODVM: "false"
 
     # port number of agent protocol forwarder
     # (default: "")
-    # FORWARDER_PORT: ""
+    FORWARDER_PORT: ""
 
     # Cluster ID
     # (default: "")
-    # IBMCLOUD_CLUSTER_ID: ""
+    IBMCLOUD_CLUSTER_ID: ""
 
     # List of Dedicated Host Group IDs, provide one from each Zone
     # (default: "")
-    # IBMCLOUD_DEDICATED_HOST_GROUP_IDS: ""
+    IBMCLOUD_DEDICATED_HOST_GROUP_IDS: ""
 
     # List of Dedicated Host IDs, provide one from each Zone
     # (default: "")
-    # IBMCLOUD_DEDICATED_HOST_IDS: ""
+    IBMCLOUD_DEDICATED_HOST_IDS: ""
 
     # IBM Cloud IAM Service URL
     # (default: "https://iam.cloud.ibm.com/identity/token")
-    # IBMCLOUD_IAM_ENDPOINT: "https://iam.cloud.ibm.com/identity/token"
+    IBMCLOUD_IAM_ENDPOINT: "https://iam.cloud.ibm.com/identity/token"
 
     # List of Image IDs, comma separated
     # (required)
@@ -60,81 +60,81 @@ providerConfigs:
 
     # List of instance profile names to be used for the Pod VMs, comma separated
     # (default: "")
-    # IBMCLOUD_PODVM_INSTANCE_PROFILE_LIST: ""
+    IBMCLOUD_PODVM_INSTANCE_PROFILE_LIST: ""
 
     # Default instance profile name to be used for the Pod VMs
     # (default: "")
-    # IBMCLOUD_PODVM_INSTANCE_PROFILE_NAME: ""
+    IBMCLOUD_PODVM_INSTANCE_PROFILE_NAME: ""
 
     # Resource Group ID
     # (default: "")
-    # IBMCLOUD_RESOURCE_GROUP_ID: ""
+    IBMCLOUD_RESOURCE_GROUP_ID: ""
 
     # List of additional Security Group IDs to be used for the Pod VM, comma separated (cluster security group is automatically added)
     # (default: "")
-    # IBMCLOUD_SECURITY_GROUP_IDS: ""
+    IBMCLOUD_SECURITY_GROUP_IDS: ""
 
     # SSH Key ID
     # (default: "")
-    # IBMCLOUD_SSH_KEY_ID: ""
+    IBMCLOUD_SSH_KEY_ID: ""
 
     # IBM Cloud VPC Service URL
     # (default: "")
-    # IBMCLOUD_VPC_ENDPOINT: ""
+    IBMCLOUD_VPC_ENDPOINT: ""
 
     # VPC ID
     # (default: "")
-    # IBMCLOUD_VPC_ID: ""
+    IBMCLOUD_VPC_ID: ""
 
     # Primary subnet ID
     # (default: "")
-    # IBMCLOUD_VPC_SUBNET_ID: ""
+    IBMCLOUD_VPC_SUBNET_ID: ""
 
     # Zone name
     # (default: "")
-    # IBMCLOUD_ZONE: ""
+    IBMCLOUD_ZONE: ""
 
     # Default initdata for all Pods
     # (default: "")
-    # INITDATA: ""
+    INITDATA: ""
 
     # pause image to be used for the pods
     # (default: "")
-    # PAUSE_IMAGE: ""
+    PAUSE_IMAGE: ""
 
     # peer pods limit per node (default=10)
     # (default: "10")
-    # PEERPODS_LIMIT_PER_NODE: "10"
+    PEERPODS_LIMIT_PER_NODE: "10"
 
     # base directory for pod directories
     # (default: "")
-    # PODS_DIR: ""
+    PODS_DIR: ""
 
     # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
     # (default: "")
-    # POD_SUBNET_CIDRS: ""
+    POD_SUBNET_CIDRS: ""
 
     # Maximum timeout in minutes for establishing agent proxy connection
     # (default: "")
-    # PROXY_TIMEOUT: ""
+    PROXY_TIMEOUT: ""
 
     # Unix domain socket path of remote hypervisor service
     # (default: "")
-    # REMOTE_HYPERVISOR_ENDPOINT: ""
+    REMOTE_HYPERVISOR_ENDPOINT: ""
 
     # List of tags to attach to the Pod VMs, comma separated
     # (default: "")
-    # TAGS: ""
+    TAGS: ""
 
     # Skip TLS certificate verification - use it only for testing
     # (default: "false")
-    # TLS_SKIP_VERIFY: "false"
+    TLS_SKIP_VERIFY: "false"
 
     # Tunnel provider
     # (default: "")
-    # TUNNEL_TYPE: ""
+    TUNNEL_TYPE: ""
 
     # VXLAN UDP port number (VXLAN tunnel mode only
     # (default: "")
-    # VXLAN_PORT: ""
+    VXLAN_PORT: ""
 

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/ibmcloudpowervs.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/ibmcloudpowervs.yaml
@@ -8,55 +8,55 @@ providerConfigs:
   ibmcloudpowervs:
     # CA certificate file for custom TLS (e.g. /etc/certificates/ca.crt)
     # (default: "")
-    # CACERT_FILE: ""
+    CACERT_FILE: ""
 
     # Client certificate file for custom TLS (e.g. /etc/certificates/client.crt)
     # (default: "")
-    # CERT_FILE: ""
+    CERT_FILE: ""
 
     # Client key file for custom TLS (e.g. /etc/certificates/client.key)
     # (default: "")
-    # CERT_KEY: ""
+    CERT_KEY: ""
 
     # Enable cloud config verify - should use it for production
     # (default: "false")
-    # CLOUD_CONFIG_VERIFY: "false"
+    CLOUD_CONFIG_VERIFY: "false"
 
     # Enable encrypted scratch space for pod VMs
     # (default: "false")
-    # ENABLE_SCRATCH_SPACE: "false"
+    ENABLE_SCRATCH_SPACE: "false"
 
     # [EXPERIMENTAL] Enable external networking via pod VM
     # (default: "false")
-    # EXTERNAL_NETWORK_VIA_PODVM: "false"
+    EXTERNAL_NETWORK_VIA_PODVM: "false"
 
     # port number of agent protocol forwarder
     # (default: "")
-    # FORWARDER_PORT: ""
+    FORWARDER_PORT: ""
 
     # Default initdata for all Pods
     # (default: "")
-    # INITDATA: ""
+    INITDATA: ""
 
     # pause image to be used for the pods
     # (default: "")
-    # PAUSE_IMAGE: ""
+    PAUSE_IMAGE: ""
 
     # peer pods limit per node (default=10)
     # (default: "10")
-    # PEERPODS_LIMIT_PER_NODE: "10"
+    PEERPODS_LIMIT_PER_NODE: "10"
 
     # base directory for pod directories
     # (default: "")
-    # PODS_DIR: ""
+    PODS_DIR: ""
 
     # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
     # (default: "")
-    # POD_SUBNET_CIDRS: ""
+    POD_SUBNET_CIDRS: ""
 
     # Maximum timeout to build the VM
     # (default: "")
-    # POWERVS_BUILD_TIMEOUT: ""
+    POWERVS_BUILD_TIMEOUT: ""
 
     # ID of the boot image
     # (required)
@@ -64,7 +64,7 @@ providerConfigs:
 
     # Amount of memory in GB
     # (default: "2")
-    # POWERVS_MEMORY: "2"
+    POWERVS_MEMORY: "2"
 
     # ID of the network instance
     # (required)
@@ -72,11 +72,11 @@ providerConfigs:
 
     # Number of processors allocated
     # (default: "0.5")
-    # POWERVS_PROCESSORS: "0.5"
+    POWERVS_PROCESSORS: "0.5"
 
     # Name of the processor type
     # (default: "shared")
-    # POWERVS_PROCESSOR_TYPE: "shared"
+    POWERVS_PROCESSOR_TYPE: "shared"
 
     # ID of the PowerVS Service Instance
     # (required)
@@ -84,11 +84,11 @@ providerConfigs:
 
     # Name of the SSH Key
     # (default: "")
-    # POWERVS_SSH_KEY_NAME: ""
+    POWERVS_SSH_KEY_NAME: ""
 
     # Name of the system type
     # (default: "s922")
-    # POWERVS_SYSTEM_TYPE: "s922"
+    POWERVS_SYSTEM_TYPE: "s922"
 
     # PowerVS zone name
     # (required)
@@ -96,25 +96,25 @@ providerConfigs:
 
     # Maximum timeout in minutes for establishing agent proxy connection
     # (default: "")
-    # PROXY_TIMEOUT: ""
+    PROXY_TIMEOUT: ""
 
     # Unix domain socket path of remote hypervisor service
     # (default: "")
-    # REMOTE_HYPERVISOR_ENDPOINT: ""
+    REMOTE_HYPERVISOR_ENDPOINT: ""
 
     # Skip TLS certificate verification - use it only for testing
     # (default: "false")
-    # TLS_SKIP_VERIFY: "false"
+    TLS_SKIP_VERIFY: "false"
 
     # Tunnel provider
     # (default: "")
-    # TUNNEL_TYPE: ""
+    TUNNEL_TYPE: ""
 
     # Use Public IP for connecting to the agent-protocol-forwarder inside the Pod VM
     # (default: "false")
-    # USE_PUBLIC_IP: "false"
+    USE_PUBLIC_IP: "false"
 
     # VXLAN UDP port number (VXLAN tunnel mode only
     # (default: "")
-    # VXLAN_PORT: ""
+    VXLAN_PORT: ""
 

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/libvirt.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/libvirt.yaml
@@ -10,112 +10,112 @@ image:
   tag: "latest"
 
 providerConfigs:
-  libvirt: {}
+  libvirt:
     # CA certificate file for custom TLS (e.g. /etc/certificates/ca.crt)
     # (default: "")
-    # CACERT_FILE: ""
+    CACERT_FILE: ""
 
     # Client certificate file for custom TLS (e.g. /etc/certificates/client.crt)
     # (default: "")
-    # CERT_FILE: ""
+    CERT_FILE: ""
 
     # Client key file for custom TLS (e.g. /etc/certificates/client.key)
     # (default: "")
-    # CERT_KEY: ""
+    CERT_KEY: ""
 
     # Enable cloud config verify - should use it for production
     # (default: "false")
-    # CLOUD_CONFIG_VERIFY: "false"
+    CLOUD_CONFIG_VERIFY: "false"
 
     # Use non-CVMs for peer pods
     # (default: "true")
-    # DISABLECVM: "true"
+    DISABLECVM: "true"
 
     # Enable encrypted scratch space for pod VMs
     # (default: "false")
-    # ENABLE_SCRATCH_SPACE: "false"
+    ENABLE_SCRATCH_SPACE: "false"
 
     # [EXPERIMENTAL] Enable external networking via pod VM
     # (default: "false")
-    # EXTERNAL_NETWORK_VIA_PODVM: "false"
+    EXTERNAL_NETWORK_VIA_PODVM: "false"
 
     # port number of agent protocol forwarder
     # (default: "")
-    # FORWARDER_PORT: ""
+    FORWARDER_PORT: ""
 
     # Default initdata for all Pods
     # (default: "")
-    # INITDATA: ""
+    INITDATA: ""
 
     # Number of processors allocated
     # (default: "2")
-    # LIBVIRT_CPU: "2"
+    LIBVIRT_CPU: "2"
 
     # CPU set for pinning vCPUs to physical CPUs (e.g., \"0,2,4,6\" or \"0-3\" or \"0-3,8,10-12\")
     # (default: "")
-    # LIBVIRT_CPUSET: ""
+    LIBVIRT_CPUSET: ""
 
     # Path to OVMF
     # (default: "/usr/share/OVMF/OVMF_CODE_4M.fd")
-    # LIBVIRT_EFI_FIRMWARE: "/usr/share/OVMF/OVMF_CODE_4M.fd"
+    LIBVIRT_EFI_FIRMWARE: "/usr/share/OVMF/OVMF_CODE_4M.fd"
 
     # Libvirt's LaunchSecurity element for Confidential VMs: s390-pv. If omitted, will automatically determine.
     # (default: "")
-    # LIBVIRT_LAUNCH_SECURITY: ""
+    LIBVIRT_LAUNCH_SECURITY: ""
 
     # Amount of memory in MiB
     # (default: "8192")
-    # LIBVIRT_MEMORY: "8192"
+    LIBVIRT_MEMORY: "8192"
 
     # libvirt network pool
     # (default: "default")
-    # LIBVIRT_NET: "default"
+    LIBVIRT_NET: "default"
 
     # libvirt storage pool
     # (default: "default")
-    # LIBVIRT_POOL: "default"
+    LIBVIRT_POOL: "default"
 
     # libvirt URI
     # (default: "qemu+ssh://root@192.168.122.1/system?no_verify=1")
-    # LIBVIRT_URI: "qemu+ssh://root@192.168.122.1/system?no_verify=1"
+    LIBVIRT_URI: "qemu+ssh://root@192.168.122.1/system?no_verify=1"
 
     # libvirt volume name
     # (default: "podvm-base.qcow2")
-    # LIBVIRT_VOL_NAME: "podvm-base.qcow2"
+    LIBVIRT_VOL_NAME: "podvm-base.qcow2"
 
     # pause image to be used for the pods
     # (default: "")
-    # PAUSE_IMAGE: ""
+    PAUSE_IMAGE: ""
 
     # peer pods limit per node (default=10)
     # (default: "10")
-    # PEERPODS_LIMIT_PER_NODE: "10"
+    PEERPODS_LIMIT_PER_NODE: "10"
 
     # base directory for pod directories
     # (default: "")
-    # PODS_DIR: ""
+    PODS_DIR: ""
 
     # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
     # (default: "")
-    # POD_SUBNET_CIDRS: ""
+    POD_SUBNET_CIDRS: ""
 
     # Maximum timeout in minutes for establishing agent proxy connection
     # (default: "")
-    # PROXY_TIMEOUT: ""
+    PROXY_TIMEOUT: ""
 
     # Unix domain socket path of remote hypervisor service
     # (default: "")
-    # REMOTE_HYPERVISOR_ENDPOINT: ""
+    REMOTE_HYPERVISOR_ENDPOINT: ""
 
     # Skip TLS certificate verification - use it only for testing
     # (default: "false")
-    # TLS_SKIP_VERIFY: "false"
+    TLS_SKIP_VERIFY: "false"
 
     # Tunnel provider
     # (default: "")
-    # TUNNEL_TYPE: ""
+    TUNNEL_TYPE: ""
 
     # VXLAN UDP port number (VXLAN tunnel mode only
     # (default: "")
-    # VXLAN_PORT: ""
+    VXLAN_PORT: ""
 

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/vsphere.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/vsphere.yaml
@@ -8,27 +8,27 @@ providerConfigs:
   vsphere:
     # CA cert file
     # (default: "")
-    # CACERT_FILE: ""
+    CACERT_FILE: ""
 
     # cert file
     # (default: "")
-    # CERT_FILE: ""
+    CERT_FILE: ""
 
     # cert key
     # (default: "")
-    # CERT_KEY: ""
+    CERT_KEY: ""
 
     # Enable cloud config verify - should use it for production
     # (default: "false")
-    # CLOUD_CONFIG_VERIFY: "false"
+    CLOUD_CONFIG_VERIFY: "false"
 
     # Enable encrypted scratch space for pod VMs
     # (default: "false")
-    # ENABLE_SCRATCH_SPACE: "false"
+    ENABLE_SCRATCH_SPACE: "false"
 
     # port number of agent protocol forwarder
     # (default: "")
-    # FORWARDER_PORT: ""
+    FORWARDER_PORT: ""
 
     # vCenter destination datacenter name
     # (required)
@@ -36,23 +36,23 @@ providerConfigs:
 
     # vCenter datastore
     # (default: "")
-    # GOVC_DATASTORE: ""
+    GOVC_DATASTORE: ""
 
     # Use DRS for clone placement in destination Vcenter cluster
     # (default: "false")
-    # GOVC_DRS: "false"
+    GOVC_DRS: "false"
 
     # vCenter vm destination folder relative to the vm inventory path (your-data-center/vm). \nExample '-deploy-folder peerods' will create or use the existing folder peerpods as the \ndeploy-folder in /datacenter/vm/peerpods
     # (default: "")
-    # GOVC_FOLDER: ""
+    GOVC_FOLDER: ""
 
     # vCenter host name of resource pool destination
     # (default: "")
-    # GOVC_HOST: ""
+    GOVC_HOST: ""
 
     # vCenter template to deploy
     # (default: "podvm-template")
-    # GOVC_TEMPLATE: "podvm-template"
+    GOVC_TEMPLATE: "podvm-template"
 
     # URL of vCenter instance to connect to
     # (required)
@@ -60,69 +60,69 @@ providerConfigs:
 
     # vCenter destination cluster name 
     # (default: "")
-    # GOVC_VCLUSTER: ""
+    GOVC_VCLUSTER: ""
 
     # Default initdata for all Pods
     # (default: "")
-    # INITDATA: ""
+    INITDATA: ""
 
     # pause image to be used for the pods
     # (default: "")
-    # PAUSE_IMAGE: ""
+    PAUSE_IMAGE: ""
 
     # peer pods limit per node (default=10)
     # (default: "10")
-    # PEERPODS_LIMIT_PER_NODE: "10"
+    PEERPODS_LIMIT_PER_NODE: "10"
 
     # base directory for pod directories
     # (default: "")
-    # PODS_DIR: ""
+    PODS_DIR: ""
 
     # Maximum timeout in minutes for establishing agent proxy connection
     # (default: "")
-    # PROXY_TIMEOUT: ""
+    PROXY_TIMEOUT: ""
 
     # Unix domain socket path of remote hypervisor service
     # (default: "")
-    # REMOTE_HYPERVISOR_ENDPOINT: ""
+    REMOTE_HYPERVISOR_ENDPOINT: ""
 
     # Use SSH to secure communication between cluster and peer pods
     # (default: "false")
-    # SECURE_COMMS: "false"
+    SECURE_COMMS: "false"
 
     # WN Inbound tags for secure communication tunnels
     # (default: "")
-    # SECURE_COMMS_INBOUNDS: ""
+    SECURE_COMMS_INBOUNDS: ""
 
     # Address of a Trustee Service for Secure-Comms
     # (default: "kbs-service.trustee-operator-system:8080")
-    # SECURE_COMMS_KBS_ADDR: "kbs-service.trustee-operator-system:8080"
+    SECURE_COMMS_KBS_ADDR: "kbs-service.trustee-operator-system:8080"
 
     # Deliver the keys to peer pods using userdata instead of Trustee
     # (default: "false")
-    # SECURE_COMMS_NO_TRUSTEE: "false"
+    SECURE_COMMS_NO_TRUSTEE: "false"
 
     # WN Outbound tags for secure communication tunnels
     # (default: "")
-    # SECURE_COMMS_OUTBOUNDS: ""
+    SECURE_COMMS_OUTBOUNDS: ""
 
     # PP Inbound tags for secure communication tunnels
     # (default: "")
-    # SECURE_COMMS_PP_INBOUNDS: ""
+    SECURE_COMMS_PP_INBOUNDS: ""
 
     # PP Outbound tags for secure communication tunnels
     # (default: "")
-    # SECURE_COMMS_PP_OUTBOUNDS: ""
+    SECURE_COMMS_PP_OUTBOUNDS: ""
 
     # Skip TLS certificate verification - use it only for testing
     # (default: "false")
-    # TLS_SKIP_VERIFY: "false"
+    TLS_SKIP_VERIFY: "false"
 
     # Tunnel provider
     # (default: "")
-    # TUNNEL_TYPE: ""
+    TUNNEL_TYPE: ""
 
     # VXLAN UDP port number (VXLAN tunnel mode only
     # (default: "")
-    # VXLAN_PORT: ""
+    VXLAN_PORT: ""
 

--- a/src/cloud-providers/Makefile
+++ b/src/cloud-providers/Makefile
@@ -23,11 +23,7 @@ define gen-provider-values
 			empty \
 		end), \
 		"providerConfigs:", \
-		(if ([.flags[] | select(.env_var != "" and .required)] | length) > 0 then \
-			"  \(.provider):" \
-		else \
-			"  \(.provider): {}" \
-		end), \
+		"  \(.provider):", \
 		(.flags[] | select(.env_var != "") | \
 			if .required then \
 				"    # \(.description)", \
@@ -36,7 +32,7 @@ define gen-provider-values
 			else \
 				"    # \(.description)", \
 				"    # (default: \"\(.default)\")", \
-				"    # \(.env_var): \"\(.default)\"" \
+				"    \(.env_var): \"\(.default)\"" \
 			end, \
 			"" \
 		)' > $(CHART_PROVIDERS_DIR)/$(1).yaml


### PR DESCRIPTION
## Summary

- Fixes #2856
- Changed `gen-provider-values` jq script in `src/cloud-providers/Makefile` to emit all config keys as real YAML keys instead of comments
- Removed the empty map `{}` fallback for providers with no required flags
- Regenerated all 10 provider YAML files under `install/charts/peerpods/providers/`
- Manually updated `vsphere.yaml` (no `manager.go` in current source tree)

## Problem

Non-required flags were emitted as YAML comments (e.g. `# LIBVIRT_MEMORY: "8192"`) and providers without required flags got `providerConfigs.<name>: {}`. This caused `providerConfigs` to be treated as nil in some tooling (notably the Terraform Helm provider), breaking `--set-literal` overrides on keys under that section.

## Solution

Two lines changed in the Makefile's jq script:
1. Always emit `<provider>:` (never `<provider>: {}`)
2. Emit non-required flags as real keys (remove `# ` prefix)

## Why this is safe

- All default values match the Go hardcoded defaults (verified with `config-extractor`)
- Empty strings are handled gracefully by the Go code
- The `_helpers.tpl` `hasTlsCerts` check remains safe: `CACERT_FILE: ""` is falsy in Go templates, so TLS mounts only trigger when the user sets a real certificate path

## Test results

| Test | Result |
|------|--------|
| No `{}` in any provider YAML | PASS |
| No commented-out config keys | PASS |
| All 10 YAMLs parse with non-empty providerConfigs | PASS |
| All required flags are real YAML keys | PASS |
| No drift after regeneration | PASS |
| `helm lint` passes for all 10 providers | PASS |
| `helm template` renders correct ConfigMaps for all 10 providers | PASS |
| `--set-literal` override works for libvirt (original bug) | PASS |
| `--set-literal` override works for AWS | PASS |
| TLS mount NOT triggered with empty `CACERT_FILE` | PASS |
| TLS mount triggered with real `CACERT_FILE` path | PASS |
| Docker socket mount present for docker provider | PASS |
| SSH mount present for libvirt provider | PASS |
| kata-direct-volumes mount present for ibmcloud provider | PASS |
| Go defaults == YAML defaults for all 9 auto-generated providers | PASS |