### PR TITLE
podvm: fail loud when oras resolve returns empty digest

### DIFF
--- a/src/cloud-api-adaptor/podvm/Makefile.inc
+++ b/src/cloud-api-adaptor/podvm/Makefile.inc
@@ -100,7 +100,8 @@ PAUSE_BUNDLE  ?= pause_bundle
 define pull_agent_artifact
 	$(eval $(call generate_tag,tag,$(KATA_REF),$(ARCH)))
 	$(eval OCI_IMAGE := $(KATA_REGISTRY)/agent)
-	$(eval OCI_DIGEST := $(shell oras resolve $(OCI_IMAGE):${tag}))
+	$(eval OCI_DIGEST := $(strip $(shell oras resolve $(OCI_IMAGE):${tag})))
+	$(if $(OCI_DIGEST),,$(error oras resolve returned empty digest for $(OCI_IMAGE):${tag}))
 	$(eval OCI_REF := $(OCI_IMAGE)@$(OCI_DIGEST))
 	$(if $(filter yes,$(VERIFY_PROVENANCE)),$(ROOT_DIR)hack/verify-provenance.sh \
 		-a $(OCI_REF) \
@@ -114,7 +115,8 @@ endef
 define pull_gc_artifact
 	$(eval $(call generate_tag,tag,$(GUEST_COMPONENTS_REF),$(2)))
 	$(eval OCI_IMAGE := $(GUEST_COMPONENTS_REGISTRY)/$(1))
-	$(eval OCI_DIGEST := $(shell oras resolve $(OCI_IMAGE):${tag}))
+	$(eval OCI_DIGEST := $(strip $(shell oras resolve $(OCI_IMAGE):${tag})))
+	$(if $(OCI_DIGEST),,$(error oras resolve returned empty digest for $(OCI_IMAGE):${tag}))
 	$(eval OCI_REF := $(OCI_IMAGE)@$(OCI_DIGEST))
 	$(if $(filter yes,$(VERIFY_PROVENANCE)),$(ROOT_DIR)hack/verify-provenance.sh \
 		-a $(OCI_REF) \


### PR DESCRIPTION
## Summary

  `pull_agent_artifact` and `pull_gc_artifact` in `src/cloud-api-adaptor/podvm/Makefile.inc` fail with a misleading error far from the root cause when the registry does not have the tag they ask for. This PR makes
  them fail loud at the point of failure instead.

  Both functions do `OCI_DIGEST := $(shell oras resolve $OCI_IMAGE:$tag)`, then `OCI_REF := $(OCI_IMAGE)@$(OCI_DIGEST)`. When `oras resolve` exits non-zero (missing tag), `$(shell)` swallows the exit code and
  captures empty stdout, so `OCI_REF` becomes `$OCI_IMAGE@` (trailing `@`). The subsequent `oras pull` then fails with a generic usage error (`Error: "<image>@": no tag or digest specified`) — two steps removed
  from the actual problem, with nothing pointing at the missing tag or the `versions.yaml` pin that caused it.

  This change adds `$(if $(OCI_DIGEST),,$(error ...))` between the resolve and the `OCI_REF` construction. Empty digest → immediate `make` error naming the exact `image:tag` that failed to resolve.

  ## Why this matters (real-world impact)

  I hit this while iterating on `versions.yaml` pins during a CAA v0.20.0 SEV-SNP peer-pod POC on AWS: pinning a guest-components SHA whose artifact tag had not yet been published by the publish workflow makes the
  build die on an oras usage error that names neither the missing tag nor the `versions.yaml` field to fix. With this guard, the same mistake is a single self-explanatory error line at the resolve step.

  ## Reproduction (without this PR)

  1. In `src/cloud-api-adaptor/versions.yaml`, set `oci.guest-components.reference` to a 40-char SHA for which no `<sha>-snp_amd64` (or equivalent) tag has been published — for example, a fresh commit on
  `guest-components` `main` that hasn't yet been built and pushed by the publish workflow.
  2. Run `TEE_PLATFORM=amd make image-debug` from `src/cloud-api-adaptor/podvm-mkosi/`.
  3. Observe: the build fails with `Error: "ghcr.io/confidential-containers/guest-components/attestation-agent@": no tag or digest specified` from `oras pull` — a usage error that does not mention the missing tag.

  With this PR applied, step 2 instead exits with:
```
Makefile.inc:119: *** oras resolve returned empty digest for ghcr.io/confidential-containers/guest-components/attestation-agent:<sha>-snp_amd64.  Stop.
```

  ## What this PR does NOT do

  - Does not change anything for builds whose `versions.yaml` pins resolve correctly — no-op in the happy path.
  - Does not suppress or alter `oras resolve`'s own stderr — registry error details still print as before; the `$(error)` adds the make-level context on top.
  - Does not add a CI workflow to pre-validate all `versions.yaml` SHAs at PR / release time. That would be a useful follow-up but kept out of this PR to keep the diff minimal.

  ## Test plan

  - [x] Diff is minimal — both functions get the same guard, no other code path touched
  - [x] No-op in the happy path (existing successful builds unchanged)
  - [x] Error message names the exact `image:tag` that failed to resolve
  - [ ] CI: existing `podvm_mkosi_ubuntu` smoke test + AWS e2e workflow should pass unchanged on this PR
  - [ ] Reviewer can verify the failure mode by setting `GUEST_COMPONENTS_REF` to any 40-char SHA that lacks published artifacts and running `make binaries`

Happy to follow this up with a CI workflow that pre-validates all `versions.yaml::oci.*.reference` SHAs resolve in their registries, if maintainers see value.