### PR TITLE
webhook: retry cert-manager apply on transient failures

### DIFF
--- a/src/webhook/Makefile
+++ b/src/webhook/Makefile
@@ -165,11 +165,19 @@ kind-deploy: docker-build kind-load deploy ## deploy the webhook in the local ki
 deploy-cert-manager: ## Deploy cert-manager for webhook.
 	curl -fsSL -o cmctl https://github.com/cert-manager/cmctl/releases/latest/download/cmctl_${OS}_${ARCH}
 	chmod +x cmctl
-	# Deploy cert-manager
-	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml
+	# Deploy cert-manager (retry to tolerate transient etcd timeouts)
+	@for i in 1 2 3; do \
+	  echo "Applying cert-manager manifest (attempt $$i)..."; \
+	  kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml && { \
+	    echo "cert-manager applied successfully"; break; }; \
+	  if [ $$i -eq 3 ]; then \
+	    echo "cert-manager apply failed after 3 attempts"; exit 1; \
+	  fi; \
+	  echo "Apply failed, retrying in 10s..."; sleep 10; \
+	done
 	# Wait for service to be up
-	kubectl wait --timeout=360s -n cert-manager endpoints/cert-manager --for=jsonpath='{.subsets[0].addresses[0].ip}'
-	kubectl wait --timeout=360s -n cert-manager endpoints/cert-manager-webhook --for=jsonpath='{.subsets[0].addresses[0].ip}'
+	kubectl wait --timeout=360s -n cert-manager --for=condition=Available deployment/cert-manager
+	kubectl wait --timeout=360s -n cert-manager --for=condition=Available deployment/cert-manager-webhook
 	# Wait for few seconds for the cert-manager API to be ready
 	# otherwise you'll hit the error "x509: certificate signed by unknown authority"
 	# Best is to use cmctl - https://cert-manager.io/docs/installation/kubectl/#2-optional-wait-for-cert-manager-webhook-to-be-ready


### PR DESCRIPTION
The `kubectl apply` of the cert-manager manifest occasionally fails with an etcd timeout ([log](https://github.com/confidential-containers/cloud-api-adaptor/actions/runs/26434517527/job/77815218201)):

```
Error from server: error when creating ".../cert-manager.yaml":
etcdserver: request timed out
```

The manifest creates a large batch of resources (6 CRDs, RBAC, deployments, webhook configs) in a single apply, and individual writes can occasionally exceed the API server's request timeout under transient cluster load.

Wrap the apply in a retry loop (3 attempts, 10s backoff). `kubectl apply` is idempotent, so retrying after a partial failure simply creates the missing resources without disturbing the ones already applied. On the observed failing run, everything except (likely) the last webhook config got created, and the retry will fill in the gap.

For `kubectl wait`, the Endpoints object isn't created by the cert-manager manifest directly. It's created by the kube-controller-manager's endpoints controller after the Service is created and once matching pods exist.
Right after `kubectl apply` returns, there's a brief window where the Service exists but its Endpoints object hasn't been populated yet. The apply just finished, so `kubectl wait` raced ahead of the controller.

Assisted-by: IBM Bob
Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>