### PR TITLE
ci: add artifact-metadata permission to podvm-ubuntu-mkosi job

### DIFF
--- a/.github/workflows/podvm_publish.yaml
+++ b/.github/workflows/podvm_publish.yaml
@@ -102,6 +102,7 @@ jobs:
       packages: write # Required to publish the oras package to ghcr
       id-token: write # Required to publish the attestation provenance to ghcr
       attestations: write # Required to publish the attestation provenance to ghcr
+      artifact-metadata: write # Required by podvm_mkosi_ubuntu.yaml to write attestation metadata
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The podvm-ubuntu-mkosi job calls podvm_mkosi_ubuntu.yaml which requires artifact-metadata: write permission for the actions/attest@v4.1.0 action to write attestation metadata. Without this permission, the workflow fails with "The nested job 'build-image' is requesting 'artifact-metadata: write', but is only allowed 'artifact-metadata: none'."

This matches the permission already granted to the podvm-mkosi job on line 84.


Generated-By: IBM Bob