### PR TITLE
fix: prevent template injection in webhook_image workflow

### DIFF
--- a/.github/workflows/webhook_image.yaml
+++ b/.github/workflows/webhook_image.yaml
@@ -72,20 +72,23 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push image
+        env:
+          IMAGE_TAGS: ${{ inputs.image_tags }}
+          REGISTRY: ${{ inputs.registry }}
         run: |
-          tags="${{ inputs.image_tags }}"
+          tags="${IMAGE_TAGS}"
           latest=0
           for t in ${tags/,/ }; do
             if [ "$t" = "latest" ]; then
               latest=1
             else
               echo "::group::Build and push tag ${t}"
-              make docker-load docker-push IMG="${{ inputs.registry }}/peer-pods-webhook:${t}"
+              make docker-load docker-push IMG="${REGISTRY}/peer-pods-webhook:${t}"
               echo "::endgroup::"
             fi
           done
           if [ $latest -eq 1 ]; then
             echo "::group::Push latest"
-            make docker-push IMG=${{ inputs.registry }}/peer-pods-webhook:latest
+            make docker-push IMG="${REGISTRY}/peer-pods-webhook:latest"
             echo "::endgroup::"
           fi


### PR DESCRIPTION
This PR fixes 3 template injection vulnerabilities in the webhook_image.yaml workflow identified by the zizmor security audit tool.

Problem
The workflow was directly interpolating user-controlled inputs (inputs.image_tags and inputs.registry) into shell commands without proper sanitization. This creates a security risk where malicious input containing shell metacharacters could potentially be used for command injection attacks.

Vulnerable code locations:

Line 76: tags="${{ inputs.image_tags }}" - Direct interpolation in shell variable
Line 83: IMG="${{ inputs.registry }}/peer-pods-webhook:${t}" - Direct interpolation in make command
Line 89: IMG=${{ inputs.registry }}/peer-pods-webhook:latest - Direct interpolation in make command
Solution
Following GitHub Actions security best practices, all template expressions have been moved to environment variables in the env: block. GitHub Actions automatically escapes environment variable values, preventing injection attacks.

Changes made:

Added env: block to the "Build and push image" step with:
IMAGE_TAGS: ${{ inputs.image_tags }}
REGISTRY: ${{ inputs.registry }}
Replaced all direct template expressions with environment variable references:
${{ inputs.image_tags }} → ${IMAGE_TAGS}
${{ inputs.registry }} → ${REGISTRY}
Testing
 Workflow syntax is valid
 No functional changes to the workflow behavior
 Security vulnerabilities are resolved
References
Zizmor Documentation: https://docs.zizmor.sh/audits/#template-injection

Security Impact
This change eliminates potential command injection vulnerabilities while maintaining the same functionality. The workflow will continue to work exactly as before, but with improved security posture.

Created with help of Bob