### PR TITLE
Dockerfile: add ca-certificates to release image

### DIFF
--- a/src/cloud-api-adaptor/Dockerfile
+++ b/src/cloud-api-adaptor/Dockerfile
@@ -59,7 +59,7 @@ RUN echo "Building iptables-wrapper... " \
 FROM $BASE AS base-release
 
 RUN apt-get update && \
-    apt-get install -y iptables && \
+    apt-get install -y ca-certificates iptables && \
     rm -rf /var/lib/apt/lists/*
 RUN --mount=type=cache,target=/iptables,from=iptables,source=/iptables,readonly \
     cp /iptables/iptables-wrapper /usr/sbin \


### PR DESCRIPTION
debian:trixie-slim ships without CA certificates. The dev build got them transitively via openssh-client, but the release build only installed iptables, causing Go TLS verification to fail against ec2.<region>.amazonaws.com with x509: certificate signed by unknown authority.