### PR TITLE
fix: Resolved template injection vulnerabilities in e2e_docker workflow

### DIFF
--- a/.github/workflows/e2e_docker.yaml
+++ b/.github/workflows/e2e_docker.yaml
@@ -56,6 +56,8 @@ jobs:
       CAA_IMAGE: "${{ inputs.caa_image }}"
       PEERPOD_CTRL_IMAGE: "${{ inputs.peerpod_ctrl_image }}"
       WEBHOOK_IMAGE: "${{ inputs.webhook_image }}"
+      PODVM_IMAGE: "${{ inputs.podvm_image }}"
+      CONTAINER_RUNTIME: "${{ inputs.container_runtime }}"
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -125,10 +127,10 @@ jobs:
       - name: Config docker
         run: |
           cat <<- EOF > docker.properties
-          DOCKER_PODVM_IMAGE="${{ inputs.podvm_image }}"
+          DOCKER_PODVM_IMAGE="${PODVM_IMAGE}"
           DOCKER_HOST="unix:///var/run/docker.sock"
           DOCKER_NETWORK_NAME="kind"
-          CONTAINER_RUNTIME="${{ inputs.container_runtime }}"
+          CONTAINER_RUNTIME="${CONTAINER_RUNTIME}"
           DOCKER_API_VERSION="1.44"
           EOF
 
@@ -145,12 +147,12 @@ jobs:
         id: runTests
         run: |
           export CLOUD_PROVIDER=docker
-          export CONTAINER_RUNTIME="${{ inputs.container_runtime }}"
+          export CONTAINER_RUNTIME="${CONTAINER_RUNTIME}"
           export DEPLOY_KBS=false
           export TEST_PROVISION=yes
           export TEST_TEARDOWN=no
           export TEST_PROVISION_FILE="$PWD/docker.properties"
-          export TEST_PODVM_IMAGE="${{ inputs.podvm_image }}"
+          export TEST_PODVM_IMAGE="${PODVM_IMAGE}"
           export TEST_E2E_TIMEOUT="50m"
 
           make test-e2e


### PR DESCRIPTION
Fixed template injection security issues identified by zizmor in the Docker e2e workflow by moving template expressions to environment variables

- Added PODVM_IMAGE and CONTAINER_RUNTIME to job-level env block
- Replaced ${{ inputs.podvm_image }} with ${PODVM_IMAGE}
- Replaced ${{ inputs.container_runtime }} with ${CONTAINER_RUNTIME}