### PR TITLE
libvirt: enable memory ballooning for s390x

### DIFF
--- a/src/cloud-providers/libvirt/libvirt.go
+++ b/src/cloud-providers/libvirt/libvirt.go
@@ -266,7 +266,10 @@ func createDomainXMLs390x(client *libvirtClient, cfg *domainConfig, vm *vmConfig
 			},
 			Emulator: guest.Arch.Emulator,
 			MemBalloon: &libvirtxml.DomainMemBalloon{
-				Model: "none",
+				Model: "virtio",
+				Driver: &libvirtxml.DomainMemBalloonDriver{
+					IOMMU: "on",
+				},
 			},
 			RNGs: []libvirtxml.DomainRNG{
 				{


### PR DESCRIPTION
Enable virtio-balloon for s390x by changing MemBalloon Model from "none" to "virtio" with IOMMU driver support. This matches the aarch64 implementation and brings s390x to feature parity with other architectures.

The virtio-balloon driver is architecture-independent and s390x's virtio-ccw transport supports all virtio devices. IOMMU is required for s390x virtio devices.

This enables dynamic memory reclamation from peer pod VMs, improving resource utilization on s390x hosts.

Assisted-by: IBM Bob <noreply@ibm.com>