### PR TITLE
Skip vcpu tests

### DIFF
--- a/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
@@ -88,7 +88,8 @@ func (s *cloudService) removeSandbox(id sandboxID) error {
 }
 
 func NewService(provider provider.Provider, proxyFactory proxy.Factory, workerNode podnetwork.WorkerNode,
-	serverConfig *ServerConfig) Service {
+	serverConfig *ServerConfig,
+) Service {
 	var err error
 
 	s := &cloudService{
@@ -169,6 +170,7 @@ func (s *cloudService) CreateVM(ctx context.Context, req *pb.CreateVMRequest) (r
 	}()
 
 	sid := sandboxID(req.Id)
+	logger.Printf("CreateVM request received for sandbox %s with annotations: %v", sid, req.Annotations)
 
 	if sid == "" {
 		return nil, fmt.Errorf("empty sandbox id")
@@ -189,6 +191,7 @@ func (s *cloudService) CreateVM(ctx context.Context, req *pb.CreateVMRequest) (r
 
 	// Get Pod VM cpu, memory and gpu from annotations
 	vcpus, memory, gpus := util.GetPodvmResourcesFromAnnotation(req.Annotations)
+	logger.Printf("CreateVM for pod %s/%s: vCPUs=%d, memory=%d, GPUs=%d", namespace, pod, vcpus, memory, gpus)
 
 	// Get Pod VM image from annotations
 	image := util.GetImageFromAnnotation(req.Annotations)

--- a/src/cloud-api-adaptor/test/e2e/common_suite.go
+++ b/src/cloud-api-adaptor/test/e2e/common_suite.go
@@ -282,7 +282,8 @@ func DoTestCreatePeerPodWithAuthenticatedImageWithoutCredentials(t *testing.T, e
 }
 
 func DoTestPodVMwithNoAnnotations(t *testing.T, e env.Environment, assert CloudAssert, expectedType string) {
-
+	// sandbox allocation is not working. See #3117
+	SkipTestOnCI(t)
 	podName := "no-annotations"
 	containerName := "busybox"
 	imageName := getBusyboxTestImage(t)
@@ -302,6 +303,8 @@ func DoTestPodVMwithAnnotationsInstanceType(t *testing.T, e env.Environment, ass
 }
 
 func DoTestPodVMWithAnnotationsCPUMemory(t *testing.T, e env.Environment, assert CloudAssert, expectedType string) {
+	// sandbox allocation is not working. See #3117
+	SkipTestOnCI(t)
 	podName := "annotations-cpu-mem"
 	containerName := "busybox"
 	imageName := getBusyboxTestImage(t)
@@ -787,7 +790,8 @@ func DoTestPodWithCPUMemLimitsAndRequests(t *testing.T, e env.Environment, asser
 
 // Test to create a peer pod with cpu request as annotation
 func DoTestPodVMWithAnnotationCPU(t *testing.T, e env.Environment, assert CloudAssert, expectedType string) {
-
+	// sandbox allocation is not working. See #3117
+	SkipTestOnCI(t)
 	podName := "annotations-cpu"
 	containerName := "busybox"
 	imageName := getBusyboxTestImage(t)
@@ -800,7 +804,8 @@ func DoTestPodVMWithAnnotationCPU(t *testing.T, e env.Environment, assert CloudA
 
 // Test to create a peer pod with memory request as annotation
 func DoTestPodVMWithAnnotationMemory(t *testing.T, e env.Environment, assert CloudAssert, expectedType string) {
-
+	// sandbox allocation is not working. See #3117
+	SkipTestOnCI(t)
 	podName := "annotations-mem"
 	containerName := "busybox"
 	imageName := getBusyboxTestImage(t)


### PR DESCRIPTION
Skip the tests due to restore the CI working, and add some more logging, whilst a regression in kata-containers needs investigating and fixing. See https://github.com/confidential-containers/cloud-api-adaptor/issues/3117 for more information.