### PR TITLE
workflows: Update zizmor reporting

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -16,10 +16,7 @@ concurrency:
 jobs:
   zizmor:
     name: Run zizmor
-    runs-on: ubuntu-22.04
-    permissions:
-      security-events: write # Require writing security events to upload results to security tab
-
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -30,4 +27,6 @@ jobs:
     - name: Run zizmor
       uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
       with:
+        advanced-security: false
+        annotations: true
         persona: auditor


### PR DESCRIPTION
Set zizmor-action to have `advanced-security: false`, so it will not upload results to Advanced Security, and will instead print them to the console for job reporting. Also turn on zizmor github annotations to try and highlight any issues in code being actively updated.