### PR TITLE
entrypoint: fix AWS auth validation logic

### DIFF
--- a/src/cloud-api-adaptor/entrypoint.sh
+++ b/src/cloud-api-adaptor/entrypoint.sh
@@ -42,7 +42,16 @@ one_of() {
 }
 
 aws() {
-    [ -z "${AWS_WEB_IDENTITY_TOKEN_FILE}" ] && test_vars AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY || test_vars AWS_WEB_IDENTITY_TOKEN_FILE AWS_ROLE_ARN
+    # Check that at least one authentication method is configured
+    one_of AWS_SECRET_ACCESS_KEY AWS_ROLE_ARN
+
+    # If using web identity, require role ARN and token file
+    if [ -n "${AWS_ROLE_ARN}" ]; then
+        test_vars AWS_WEB_IDENTITY_TOKEN_FILE AWS_ROLE_ARN
+    else
+        # If using access keys, require both key and secret
+        test_vars AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+    fi
 
     set -x
     exec cloud-api-adaptor aws ${optionals}


### PR DESCRIPTION
The previous implementation used test_vars with && and || operators, which caused incorrect behavior because test_vars exits on failure. This has caused CI failure.

Changed to use one_of to verify at least one auth method is available, then use if/else to validate the specific method's required variables. This properly handles both access key and web identity token auth flows.

Assisted-by: Claude AI