### PR TITLE
versions: Bump golang to 1.25.11

### DIFF
--- a/src/cloud-api-adaptor/Dockerfile
+++ b/src/cloud-api-adaptor/Dockerfile
@@ -1,9 +1,9 @@
 ARG BUILD_TYPE=dev
-# golang:1.25.10 (based on Debian 13 trixie)
-ARG BUILDER_BASE=golang@sha256:3965b9511a9bed199f0b4eb146f99c31971a5c0adb3240d9f25e233cbd9e01c8
-# debian:trixie-slim (matches golang:1.25.10 base for library compatibility)
-# Multi-arch manifest list digest supporting amd64, arm64, ppc64le,, s390x
-ARG BASE=debian@sha256:109e2c65005bf160609e4ba6acf7783752f8502ad218e298253428690b9eaa4b
+# golang:1.25.11 (based on Debian 13 trixie)
+ARG BUILDER_BASE=golang@sha256:dd7d32e19b28621cd982082397fc0510d396805b717d5e77466aa2dd692340de
+# debian:trixie-slim (matches golang:1.25.11 base for library compatibility)
+# Multi-arch manifest list digest supporting amd64, arm64, ppc64le, s390x
+ARG BASE=debian@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8
 
 # This dockerfile uses Go cross-compilation to build the binary,
 # we build on the host platform ($BUILDPLATFORM) and then copy the

--- a/src/cloud-api-adaptor/docs/addnewprovider.md
+++ b/src/cloud-api-adaptor/docs/addnewprovider.md
@@ -219,7 +219,7 @@ go mod tidy
 
 ```bash
 cat > Dockerfile <<EOF
-# golang:1.25.10
+# golang:1.25.11
 ARG BUILDER_BASE=golang@sha256:3965b9511a9bed199f0b4eb146f99c31971a5c0adb3240d9f25e233cbd9e01c8
 FROM --platform="\$TARGETPLATFORM" \$BUILDER_BASE AS builder
 RUN apt-get update && apt-get install -y libvirt-dev pkg-config && rm -rf /var/lib/apt/lists/*

--- a/src/cloud-api-adaptor/go.mod
+++ b/src/cloud-api-adaptor/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -30,7 +30,7 @@ tools:
   cert-manager: v1.15.3
   bats: 1.10.0
   iptables-wrapper: bfef9e5087a198b50a4124bb9ce9d2c7c99025dd
-  golang: 1.25.10
+  golang: 1.25.11
   kcli: 99.0.202507200957
   mkosi: v26
   protoc: 3.16.0

--- a/src/cloud-providers/go.mod
+++ b/src/cloud-providers/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers
 
-go 1.25.10
+go 1.25.11
 
 require (
 	cloud.google.com/go/compute v1.61.0

--- a/src/peerpod-ctrl/Dockerfile
+++ b/src/peerpod-ctrl/Dockerfile
@@ -1,6 +1,6 @@
 # Build the manager binary
-# golang:1.25.10
-FROM --platform=$TARGETPLATFORM golang@sha256:3965b9511a9bed199f0b4eb146f99c31971a5c0adb3240d9f25e233cbd9e01c8 AS builder
+# golang:1.25.11
+FROM --platform=$TARGETPLATFORM golang@sha256:dd7d32e19b28621cd982082397fc0510d396805b717d5e77466aa2dd692340de AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG CGO_ENABLED=1
@@ -35,8 +35,8 @@ COPY peerpod-ctrl/controllers/ controllers/
 RUN CC=gcc CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build ${GOFLAGS} -a -o manager main.go
 
 # Target Image
-# debian:trixie-slim (matches golang:1.25.10 base for library compatibility)
-FROM --platform=$TARGETPLATFORM debian@sha256:109e2c65005bf160609e4ba6acf7783752f8502ad218e298253428690b9eaa4b
+# debian:trixie-slim (matches golang:1.25.11 base for library compatibility)
+FROM --platform=$TARGETPLATFORM debian@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8
 ARG CGO_ENABLED=1
 
 RUN if [ "$CGO_ENABLED" = 1 ] ; then \

--- a/src/peerpod-ctrl/go.mod
+++ b/src/peerpod-ctrl/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/peerpod-ctrl
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers v0.0.0-00010101000000-000000000000

--- a/src/webhook/Dockerfile
+++ b/src/webhook/Dockerfile
@@ -1,6 +1,6 @@
 # Build the manager binary
-# golang:1.25.10
-FROM --platform=$BUILDPLATFORM golang@sha256:3965b9511a9bed199f0b4eb146f99c31971a5c0adb3240d9f25e233cbd9e01c8 AS builder
+# golang:1.25.11
+FROM --platform=$BUILDPLATFORM golang@sha256:dd7d32e19b28621cd982082397fc0510d396805b717d5e77466aa2dd692340de AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/src/webhook/go.mod
+++ b/src/webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/webhook
 
-go 1.25.10
+go 1.25.11
 
 require (
 	k8s.io/api v0.35.2


### PR DESCRIPTION
Bump go version and dockerfiles to resolve CVEs:
- GO-2026-5037
- GO-2026-5038
- GO-2026-5039

Assisted-by: IBM Bob