### PR TITLE
ci: fix podvm_mkosi concurrency group conflicts

### DIFF
--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -63,7 +63,7 @@ defaults:
     working-directory: src/cloud-api-adaptor
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-mkosi-${{ toJSON(inputs) }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/podvm_mkosi_ubuntu.yaml
+++ b/.github/workflows/podvm_mkosi_ubuntu.yaml
@@ -65,7 +65,7 @@ on:
         value: ${{ jobs.build-image.outputs.byom_e2e_image }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-mkosi-ubuntu-${{ inputs.arch }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-mkosi-ubuntu-${{ toJSON(inputs) }}
   cancel-in-progress: true
 
 defaults:


### PR DESCRIPTION
The podvm_mkosi.yaml workflow's concurrency group didn't vary based on inputs, causing builds with different architectures to cancel each other when called from e2e_run_all.yaml.

Updated the concurrency group to include all inputs using toJSON(), ensuring each unique combination of inputs gets its own concurrency group.

Update podvm_mkosi_ubuntu.yaml to match for robustness

#Fixes: 02a28c205dc532ab26314a10d2b3fef6eefe7703


Generated-By: IBM Bob