### PR TITLE
Ensure azure' admission enforcer is disabled for the webhook

### DIFF
--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/azure.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/azure.yaml
@@ -130,3 +130,8 @@ providerConfigs:
     # (default: "")
     # VXLAN_PORT: ""
 
+webhook:
+  annotations:
+    # This is required to ensure the azure admission enforcer does not take
+    # ownership of the namespaceSelector field, completely preventing helm upgrade
+    admissions.enforcer/disabled: "true"

--- a/src/cloud-providers/Makefile
+++ b/src/cloud-providers/Makefile
@@ -39,7 +39,16 @@ define gen-provider-values
 				"    # \(.env_var): \"\(.default)\"" \
 			end, \
 			"" \
-		)' > $(CHART_PROVIDERS_DIR)/$(1).yaml
+		), \
+		(if .provider == "azure" then \
+			"webhook:", \
+			"  annotations:", \
+			"    # This is required to ensure the azure admission enforcer does not take", \
+			"    # ownership of the namespaceSelector field, completely preventing helm upgrade", \
+			"    admissions.enforcer/disabled: \"true\"" \
+		else \
+			empty \
+		end)' > $(CHART_PROVIDERS_DIR)/$(1).yaml
 endef
 
 define gen-provider-secrets

--- a/src/webhook/Makefile
+++ b/src/webhook/Makefile
@@ -71,7 +71,9 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 	@sed -i 's/namespace: system/namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}/' chart/templates/webhook-config.yaml
 	@sed -i 's/failurePolicy: Fail/failurePolicy: {{ .Values.webhook.failurePolicy }}/' chart/templates/webhook-config.yaml
 	# Add cert-manager CA injection annotation (equivalent to webhookcainjection_patch.yaml)
-	@sed -i '/^metadata:/a\{{- if .Values.certManager.enabled }}\n  annotations:\n    cert-manager.io/inject-ca-from: {{ .Values.namespaceOverride | default .Release.Namespace }}/{{ .Values.namePrefix }}serving-cert\n{{- end }}' chart/templates/webhook-config.yaml
+	# plus support for provider-supplied webhook.annotations / webhook.labels (e.g. the
+	# azure admissions.enforcer/disabled annotation set in the peerpods provider values).
+	@sed -i '/^metadata:/a\{{- if or .Values.certManager.enabled .Values.webhook.annotations }}\n  annotations:\n    {{- if .Values.certManager.enabled }}\n    cert-manager.io/inject-ca-from: {{ .Values.namespaceOverride | default .Release.Namespace }}/{{ .Values.namePrefix }}serving-cert\n    {{- end }}\n    {{- with .Values.webhook.annotations }}\n    {{- toYaml . | nindent 4 }}\n    {{- end }}\n{{- end }}\n  {{- with .Values.webhook.labels }}\n  labels:\n    {{- toYaml . | nindent 4 }}\n  {{- end }}' chart/templates/webhook-config.yaml
 	# Add namespaceSelector to exclude webhook namespace and kube-system (equivalent to namespace_selector_patch.yaml)
 	@sed -i '/  name: mwebhook.peerpods.io/a\  namespaceSelector:\n    matchExpressions:\n    - key: kubernetes.io/metadata.name\n      operator: NotIn\n      values:\n      - {{ .Values.namespaceOverride | default .Release.Namespace }}\n      - kube-system' chart/templates/webhook-config.yaml
 	# Add scope to rules (equivalent to inline scope patch in kustomization.yaml)

--- a/src/webhook/chart/templates/webhook-config.yaml
+++ b/src/webhook/chart/templates/webhook-config.yaml
@@ -3,10 +3,19 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-{{- if .Values.certManager.enabled }}
+{{- if or .Values.certManager.enabled .Values.webhook.annotations }}
   annotations:
+    {{- if .Values.certManager.enabled }}
     cert-manager.io/inject-ca-from: {{ .Values.namespaceOverride | default .Release.Namespace }}/{{ .Values.namePrefix }}serving-cert
+    {{- end }}
+    {{- with .Values.webhook.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}
+  {{- with .Values.webhook.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ .Values.namePrefix }}mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/src/webhook/chart/values.yaml
+++ b/src/webhook/chart/values.yaml
@@ -35,6 +35,8 @@ webhook:
   podVMExtendedResource: kata.peerpods.io/vm
   # Webhook failure policy: Fail or Ignore
   failurePolicy: Fail
+  annotations: {}
+  labels: {}
 
 # kube-rbac-proxy: Sidecar container that protects the /metrics endpoint with RBAC authentication
 # When enabled, only authenticated clients with proper RBAC permissions can access metrics


### PR DESCRIPTION
fixes #3141

ensures annotations are applied to the webhook due to the azure admission enforcer, which is a microsoft feature on AKS Clusters