### PR TITLE
libvirt: set CPU host-model for s390x domain XML

### DIFF
--- a/src/cloud-providers/libvirt/libvirt.go
+++ b/src/cloud-providers/libvirt/libvirt.go
@@ -31,6 +31,14 @@ const (
 	GetDomainIPsRetries = 20
 	// The sleep time between retries to get the domain IP addresses
 	GetDomainIPsSleep = time.Second * 3
+
+	// cpuModeHostModel asks libvirt to select the closest named CPU model that
+	// the host supports and expose its full feature set to the guest.
+	cpuModeHostModel = "host-model"
+
+	// cpuModeHostPassthrough exposes the exact host CPU to the guest with no
+	// model abstraction.
+	cpuModeHostPassthrough = "host-passthrough"
 )
 
 // validateCPUSet validates the CPUSet format.
@@ -256,6 +264,7 @@ func createDomainXMLs390x(client *libvirtClient, cfg *domainConfig, vm *vmConfig
 			Value:  cfg.cpu,
 			CPUSet: vm.cpuset,
 		},
+		CPU: &libvirtxml.DomainCPU{Mode: cpuModeHostModel},
 		Clock: &libvirtxml.DomainClock{
 			Offset: "utc",
 		},
@@ -326,7 +335,7 @@ func createDomainXMLx86_64(client *libvirtClient, cfg *domainConfig, vm *vmConfi
 			APIC:   &libvirtxml.DomainFeatureAPIC{},
 			VMPort: &libvirtxml.DomainFeatureState{State: "off"},
 		},
-		CPU:      &libvirtxml.DomainCPU{Mode: "host-model"},
+		CPU:      &libvirtxml.DomainCPU{Mode: cpuModeHostModel},
 		OnReboot: "restart",
 		Devices: &libvirtxml.DomainDeviceList{
 			// Disks.
@@ -467,7 +476,7 @@ func createDomainXMLaarch64(client *libvirtClient, cfg *domainConfig, vm *vmConf
 		},
 		Memory: &libvirtxml.DomainMemory{Value: cfg.mem, Unit: "MiB"},
 		VCPU:   &libvirtxml.DomainVCPU{Value: cfg.cpu, CPUSet: vm.cpuset},
-		CPU:    &libvirtxml.DomainCPU{Mode: "host-passthrough"},
+		CPU:    &libvirtxml.DomainCPU{Mode: cpuModeHostPassthrough},
 		Devices: &libvirtxml.DomainDeviceList{
 			Disks: []libvirtxml.DomainDisk{
 				bootDisk,

--- a/src/cloud-providers/libvirt/libvirt_test.go
+++ b/src/cloud-providers/libvirt/libvirt_test.go
@@ -839,7 +839,7 @@ func createMockCaps(arch, emulator string, machines ...libvirtxml.CapsGuestMachi
 	}
 }
 
-// TestCreateDomainXMLs390xWithMocks tests s390x domain XML generation using mocks
+// TestCreateDomainXMLArchitecturesWithMocks tests domain XML generation for s390x and aarch64 architectures using mocks
 func TestCreateDomainXMLArchitecturesWithMocks(t *testing.T) {
 	tests := []struct {
 		name                 string
@@ -854,6 +854,7 @@ func TestCreateDomainXMLArchitecturesWithMocks(t *testing.T) {
 		createFunc           func(*libvirtClient, *domainConfig, *vmConfig) (*libvirtxml.Domain, error)
 		expectedFirmware     string
 		expectSCSIController bool
+		expectedCPUMode      string
 	}{
 		{
 			name:             "s390x architecture",
@@ -866,6 +867,7 @@ func TestCreateDomainXMLArchitecturesWithMocks(t *testing.T) {
 			machineName:      "s390-ccw-virtio",
 			machineCanonical: "s390-ccw-virtio-rhel9.0.0",
 			createFunc:       createDomainXMLs390x,
+			expectedCPUMode:  "host-model",
 		},
 		{
 			name:                 "aarch64 architecture",
@@ -880,6 +882,7 @@ func TestCreateDomainXMLArchitecturesWithMocks(t *testing.T) {
 			createFunc:           createDomainXMLaarch64,
 			expectedFirmware:     "efi",
 			expectSCSIController: true,
+			expectedCPUMode:      "host-passthrough",
 		},
 	}
 
@@ -930,6 +933,12 @@ func TestCreateDomainXMLArchitecturesWithMocks(t *testing.T) {
 			if tt.expectSCSIController {
 				assert.Len(t, domain.Devices.Controllers, 1)
 				assert.Equal(t, "scsi", domain.Devices.Controllers[0].Type)
+			}
+
+			// Verify CPU mode is set as expected for the architecture
+			if tt.expectedCPUMode != "" {
+				require.NotNil(t, domain.CPU, "CPU configuration should be set")
+				assert.Equal(t, tt.expectedCPUMode, domain.CPU.Mode)
 			}
 		})
 	}


### PR DESCRIPTION
Without an explicit `<cpu>` element, the guest CPU has no named model contract. host-model causes libvirt to resolve the best matching IBM Z model (e.g. gen17a on z17), ensuring live migration safety between hosts of the same generation, full feature support of the respective generation, and consistent behaviour with the x86_64 and aarch64 implementations.

Also adds CPU mode assertions to TestCreateDomainXMLArchitecturesWithMocks for s390x and aarch64.

Assisted-by: IBM Bob <noreply@ibm.com>
Signed-off-by: Ajay Victor <ajvictor@in.ibm.com>