### PR TITLE
podvm: Switch Ubuntu  image to 26.04 (Resolute)

### DIFF
--- a/.github/workflows/podvm_smoketest.yaml
+++ b/.github/workflows/podvm_smoketest.yaml
@@ -76,6 +76,7 @@ jobs:
     needs: build
 
     strategy:
+      fail-fast: false
       matrix:
         test-mode:
           - name: podvm-ubuntu

--- a/.github/workflows/podvm_smoketest.yaml
+++ b/.github/workflows/podvm_smoketest.yaml
@@ -92,8 +92,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            gdisk \
             genisoimage \
-            qemu-utils\
+            qemu-utils \
             socat \
             virt-manager
 

--- a/src/cloud-api-adaptor/podvm/hack/smoke_test.sh
+++ b/src/cloud-api-adaptor/podvm/hack/smoke_test.sh
@@ -258,7 +258,7 @@ fi
 
 sudo virt-install \
 	--name "${VM_NAME}" \
-	--ram 1024 \
+	--ram 2048 \
 	--vcpus 2 \
 	--disk "path=${IMAGE},format=${FMT}" \
 	--disk "path=${WORKDIR}/cloud-init.iso,device=cdrom" \

--- a/src/cloud-api-adaptor/podvm/hack/smoke_test.sh
+++ b/src/cloud-api-adaptor/podvm/hack/smoke_test.sh
@@ -237,8 +237,16 @@ chmod a+rwx "${WORKDIR}"
 sudo chown -R libvirt-qemu "${WORKDIR}" || sudo chown -R qemu "${WORKDIR}" || true
 sudo chmod +x "${WORKDIR}"
 
-# Resize the VM disk image to add free space
+# Resize the VM disk image to add free space, then fix the GPT backup
+# header which qemu-img resize leaves at the wrong position. Without
+# this, systemd-repart silently skips partition creation (no trusted_store
+# partition appears) and scratch-storage.service cannot find its device.
+# sgdisk requires a block device, so expose the qcow2 via NBD first.
 sudo qemu-img resize -f "${FMT}" "${IMAGE}" +1G
+sudo modprobe nbd max_part=8
+sudo qemu-nbd --connect=/dev/nbd0 "${IMAGE}"
+sudo sgdisk -e /dev/nbd0
+sudo qemu-nbd --disconnect /dev/nbd0
 
 # Start the VM
 echo "::debug:: Starting VM for test mode: $TEST_MODE"

--- a/src/cloud-api-adaptor/podvm/mkosi.conf
+++ b/src/cloud-api-adaptor/podvm/mkosi.conf
@@ -10,5 +10,5 @@ OutputDirectory=build
 
 [Distribution]
 Distribution=ubuntu
-Release=noble
+Release=resolute
 Repositories=universe

--- a/src/cloud-api-adaptor/podvm/mkosi.images/initrd/mkosi.conf
+++ b/src/cloud-api-adaptor/podvm/mkosi.images/initrd/mkosi.conf
@@ -14,3 +14,7 @@ Packages=systemd
          util-linux
          kmod
          tpm2-tools
+         systemd-cryptsetup
+KernelInitrdModules=default
+                    dm-verity
+                    dm-crypt

--- a/src/cloud-api-adaptor/podvm/mkosi.images/initrd/mkosi.conf
+++ b/src/cloud-api-adaptor/podvm/mkosi.images/initrd/mkosi.conf
@@ -14,5 +14,7 @@ Packages=systemd
          util-linux
          kmod
 KernelInitrdModules=default
+                    dm-mod
+                    dm-bufio
                     dm-verity
                     dm-crypt

--- a/src/cloud-api-adaptor/podvm/mkosi.images/initrd/mkosi.conf
+++ b/src/cloud-api-adaptor/podvm/mkosi.images/initrd/mkosi.conf
@@ -13,8 +13,6 @@ Packages=systemd
          udev
          util-linux
          kmod
-         tpm2-tools
-         systemd-cryptsetup
 KernelInitrdModules=default
                     dm-verity
                     dm-crypt

--- a/src/cloud-api-adaptor/podvm/mkosi.images/initrd/mkosi.conf.d/ubuntu-amd64.conf
+++ b/src/cloud-api-adaptor/podvm/mkosi.images/initrd/mkosi.conf.d/ubuntu-amd64.conf
@@ -1,0 +1,7 @@
+[Match]
+Distribution=ubuntu
+Architecture=x86-64
+
+[Content]
+Packages=systemd-cryptsetup
+         tpm2-tools

--- a/src/cloud-api-adaptor/podvm/mkosi.images/initrd/mkosi.conf.d/ubuntu.conf
+++ b/src/cloud-api-adaptor/podvm/mkosi.images/initrd/mkosi.conf.d/ubuntu.conf
@@ -5,5 +5,4 @@ Distribution=ubuntu
 CleanPackageMetadata=true
 Packages=dmsetup
          cryptsetup
-         systemd-cryptsetup
 RemoveFiles=/var/cache/ldconfig/aux-cache

--- a/src/cloud-api-adaptor/podvm/mkosi.images/initrd/mkosi.conf.d/ubuntu.conf
+++ b/src/cloud-api-adaptor/podvm/mkosi.images/initrd/mkosi.conf.d/ubuntu.conf
@@ -4,4 +4,6 @@ Distribution=ubuntu
 [Content]
 CleanPackageMetadata=true
 Packages=dmsetup
+         cryptsetup
+         systemd-cryptsetup
 RemoveFiles=/var/cache/ldconfig/aux-cache

--- a/src/cloud-api-adaptor/podvm/mkosi.images/initrd/mkosi.conf.d/ubuntu.conf
+++ b/src/cloud-api-adaptor/podvm/mkosi.images/initrd/mkosi.conf.d/ubuntu.conf
@@ -5,4 +5,5 @@ Distribution=ubuntu
 CleanPackageMetadata=true
 Packages=dmsetup
          cryptsetup
+         libseccomp2
 RemoveFiles=/var/cache/ldconfig/aux-cache

--- a/src/cloud-api-adaptor/podvm/mkosi.images/system/mkosi.conf
+++ b/src/cloud-api-adaptor/podvm/mkosi.images/system/mkosi.conf
@@ -2,7 +2,9 @@
 Bootable=true
 Bootloader=uki
 KernelInitrdModules=dm-mod
+                    dm-bufio
                     dm-verity
+                    dm-crypt
                     squashfs
                     loop
                     virtio

--- a/src/cloud-api-adaptor/podvm/mkosi.images/system/mkosi.conf.d/ubuntu.conf
+++ b/src/cloud-api-adaptor/podvm/mkosi.images/system/mkosi.conf.d/ubuntu.conf
@@ -9,6 +9,7 @@ Packages=
     udev
     util-linux
     systemd
+    libseccomp2
     dbus
     tpm2-tools
     iproute2

--- a/src/cloud-api-adaptor/podvm/mkosi.images/system/mkosi.conf.d/ubuntu.conf
+++ b/src/cloud-api-adaptor/podvm/mkosi.images/system/mkosi.conf.d/ubuntu.conf
@@ -9,6 +9,7 @@ Packages=
     udev
     util-linux
     systemd
+    systemd-repart
     libseccomp2
     dbus
     tpm2-tools

--- a/src/cloud-api-adaptor/podvm/mkosi.images/system/mkosi.repart/20-root-verity.conf
+++ b/src/cloud-api-adaptor/podvm/mkosi.images/system/mkosi.repart/20-root-verity.conf
@@ -2,5 +2,5 @@
 Type=root-verity
 Verity=hash
 VerityMatchKey=root
-SizeMinBytes=64M
-SizeMaxBytes=64M
+SizeMinBytes=72M
+SizeMaxBytes=72M


### PR DESCRIPTION
Updated mkosi configuration and documentation to support Ubuntu 26.04 (Resolute) as the base image for podvm builds. This enables building podvm images on the latest Ubuntu LTS release.

Generated-By: IBM Bob