### PR TITLE
smoke-test: Fix OVMF boot configuration for Ubuntu 24.04 hosts

### DIFF
--- a/.github/workflows/podvm_smoketest_ubuntu.yaml
+++ b/.github/workflows/podvm_smoketest_ubuntu.yaml
@@ -75,9 +75,7 @@ jobs:
 
   test:
     name: Test the image
-    # We're pinning the runner to 22.04 b/c libvirt struggles with the
-    # OVMF_CODE_4M firmware that is default on 24.04.
-    runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-24.04'
     needs: build
 
     strategy:

--- a/src/cloud-api-adaptor/podvm/hack/smoke_test.sh
+++ b/src/cloud-api-adaptor/podvm/hack/smoke_test.sh
@@ -244,7 +244,18 @@ sudo qemu-img resize -f "${FMT}" "${IMAGE}" +1G
 echo "::debug:: Starting VM for test mode: $TEST_MODE"
 VM_NAME="smoketest_${IMAGE_SUFFIX}"
 # TODO: Add AAVMF for arm
-[ -e "/usr/share/OVMF/OVMF_CODE.fd" ] && OVMF="/usr/share/OVMF/OVMF_CODE.fd"
+# Set OVMF paths for UEFI boot
+if [ -e "/usr/share/OVMF/OVMF_CODE_4M.fd" ]; then
+	OVMF_CODE="/usr/share/OVMF/OVMF_CODE_4M.fd"
+	OVMF_VARS="/usr/share/OVMF/OVMF_VARS_4M.fd"
+	BOOT_OPTS="--boot loader=${OVMF_CODE},loader.readonly=yes,loader.type=pflash,nvram.template=${OVMF_VARS}"
+elif [ -e "/usr/share/OVMF/OVMF_CODE.fd" ]; then
+	OVMF_CODE="/usr/share/OVMF/OVMF_CODE.fd"
+	BOOT_OPTS="--boot loader=${OVMF_CODE}"
+else
+	BOOT_OPTS=""
+fi
+
 sudo virt-install \
 	--name "${VM_NAME}" \
 	--ram 1024 \
@@ -256,7 +267,7 @@ sudo virt-install \
 	--os-variant detect=on,require=off \
 	--graphics none \
 	--virt-type=kvm \
-	--boot loader="${OVMF}" \
+	${BOOT_OPTS} \
 	--transient \
 	--noautoconsole \
 	--channel unix,mode=bind,path=${WORKDIR}/${VM_NAME}.agent,target_type=virtio,name=org.qemu.guest_agent.0 \


### PR DESCRIPTION
The smoke_test.sh script was using an incorrect OVMF boot configuration that fails on Ubuntu 24.04 hosts. The simple `--boot loader=` format doesn't work with the OVMF_CODE_4M.fd firmware that is default on Ubuntu 24.04.

This commit updates the boot configuration to use the proper pflash format with readonly loader and nvram template, which is required for UEFI boot with the 4M OVMF firmware.

This fixes the error:
ERROR internal error: process exited while connecting to monitor: qemu: could not load PC BIOS '/usr/share/OVMF/OVMF_CODE_4M.fd'

Generated-by: IBM Bob