### PR TITLE
libvirt: add configurable root disk size

### DIFF
--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/libvirt.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/libvirt.yaml
@@ -75,6 +75,10 @@ providerConfigs:
     # (default: "default")
     # LIBVIRT_POOL: "default"
 
+    # Root disk size in GiB for the podVM
+    # (default: "10")
+    # LIBVIRT_ROOT_DISK_SIZE: "10"
+
     # libvirt URI
     # (default: "qemu+ssh://root@192.168.122.1/system?no_verify=1")
     # LIBVIRT_URI: "qemu+ssh://root@192.168.122.1/system?no_verify=1"

--- a/src/cloud-providers/cmd/config-extractor/main.go
+++ b/src/cloud-providers/cmd/config-extractor/main.go
@@ -173,6 +173,11 @@ func exprToLiteral(expr ast.Expr) (string, bool) {
 				return "-" + val, true
 			}
 		}
+	case *ast.CallExpr:
+		// Handle type-conversion expressions like uint64(10) used in const declarations.
+		if len(e.Args) == 1 {
+			return exprToLiteral(e.Args[0])
+		}
 	}
 	return "", false
 }
@@ -207,6 +212,8 @@ func extractFlagRegistrarCall(call *ast.CallExpr, fset *token.FileSet, constants
 			flagType = "int"
 		case "UintWithEnv":
 			flagType = "uint"
+		case "Uint64WithEnv":
+			flagType = "uint64"
 		case "Float64WithEnv":
 			flagType = "float64"
 		case "BoolWithEnv":
@@ -300,6 +307,13 @@ func exprToString(expr ast.Expr, constants map[string]string) string {
 		// Handle negative numbers
 		if e.Op == token.SUB {
 			return "-" + exprToString(e.X, constants)
+		}
+	case *ast.CallExpr:
+		// Handle type-conversion expressions like uint64(10) or int(5).
+		// These appear when a const is declared as: defaultFoo = uint64(10)
+		// and passed directly as a flag default argument.
+		if len(e.Args) == 1 {
+			return exprToString(e.Args[0], constants)
 		}
 	}
 	return ""

--- a/src/cloud-providers/libvirt/libvirt.go
+++ b/src/cloud-providers/libvirt/libvirt.go
@@ -557,9 +557,19 @@ func getDomainIPs(dom *libvirt.Domain) ([]netip.Addr, error) {
 	return ips, nil
 }
 
+// normalizeRootDiskSize returns size if non-zero, otherwise defaultRootDiskSize.
+// Extracted so the defaulting logic can be unit-tested without a live libvirt
+// connection.
+func normalizeRootDiskSize(size uint64) uint64 {
+	if size == 0 {
+		return defaultRootDiskSize
+	}
+	return size
+}
+
 func CreateDomain(ctx context.Context, libvirtClient *libvirtClient, v *vmConfig) (result *createDomainOutput, err error) {
 
-	v.rootDiskSize = uint64(10)
+	v.rootDiskSize = normalizeRootDiskSize(v.rootDiskSize)
 
 	exists, err := checkDomainExistsByName(v.name, libvirtClient)
 	if err != nil {

--- a/src/cloud-providers/libvirt/libvirt_test.go
+++ b/src/cloud-providers/libvirt/libvirt_test.go
@@ -1181,3 +1181,115 @@ func TestVerifyDomainXMLIOMMU(t *testing.T) {
 		})
 	}
 }
+
+// TestNormalizeRootDiskSize calls the production helper directly so that any
+// change to the defaulting logic in CreateDomain is automatically caught here.
+func TestNormalizeRootDiskSize(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    uint64
+		expected uint64
+	}{
+		{"zero returns default", 0, defaultRootDiskSize},
+		{"explicit 20 GiB preserved", 20, 20},
+		{"minimum 1 GiB preserved", 1, 1},
+		{"large 500 GiB preserved", 500, 500},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, normalizeRootDiskSize(tc.input))
+		})
+	}
+}
+
+// TestVolumeCapacityBytes calls the production helper directly and covers the
+// GiB→bytes conversion, the backing-image floor guard, and overflow detection.
+func TestVolumeCapacityBytes(t *testing.T) {
+	const gib = uint64(1024 * 1024 * 1024)
+
+	testCases := []struct {
+		name                 string
+		volSizeGiB           uint64
+		backingCapacityBytes uint64
+		expectedBytes        uint64
+		wantErr              bool
+	}{
+		{
+			name:                 "requested size larger than backing image",
+			volSizeGiB:           20,
+			backingCapacityBytes: 10 * gib,
+			expectedBytes:        20 * gib,
+		},
+		{
+			name:                 "backing image larger than requested size",
+			volSizeGiB:           10,
+			backingCapacityBytes: 15 * gib,
+			expectedBytes:        15 * gib,
+		},
+		{
+			name:                 "requested size equal to backing image",
+			volSizeGiB:           10,
+			backingCapacityBytes: 10 * gib,
+			expectedBytes:        10 * gib,
+		},
+		{
+			name:                 "GiB to bytes conversion is correct",
+			volSizeGiB:           1,
+			backingCapacityBytes: 0,
+			expectedBytes:        gib,
+		},
+		{
+			// uint64 overflows at volSizeGiB >= 17179869184 (16 EiB).
+			// max uint64 (18446744073709551615) is well above that threshold.
+			name:       "max uint64 GiB overflows",
+			volSizeGiB: ^uint64(0),
+			wantErr:    true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := volumeCapacityBytes(tc.volSizeGiB, tc.backingCapacityBytes)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedBytes, got)
+			}
+		})
+	}
+}
+
+// TestNewDefVolumeCapacity verifies that newDefVolume creates a volume definition
+// with the expected initial capacity.
+func TestNewDefVolumeCapacity(t *testing.T) {
+	testCases := []struct {
+		name         string
+		volName      string
+		expectedUnit string
+	}{
+		{
+			name:         "root volume has bytes capacity unit",
+			volName:      "podvm-root.qcow2",
+			expectedUnit: "bytes",
+		},
+		{
+			name:         "cloudinit volume has bytes capacity unit",
+			volName:      "podvm-cloudinit.iso",
+			expectedUnit: "bytes",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			vol := newDefVolume(tc.volName)
+
+			require.NotNil(t, vol.Capacity, "volume capacity should not be nil")
+			assert.Equal(t, tc.expectedUnit, vol.Capacity.Unit,
+				"volume capacity unit should be bytes")
+			assert.Equal(t, "qcow2", vol.Target.Format.Type,
+				"volume format should be qcow2")
+			assert.Equal(t, tc.volName, vol.Name,
+				"volume name should match input")
+		})
+	}
+}

--- a/src/cloud-providers/libvirt/manager.go
+++ b/src/cloud-providers/libvirt/manager.go
@@ -25,6 +25,7 @@ const (
 	defaultFirmware       = "/usr/share/OVMF/OVMF_CODE_4M.fd"
 	defaultCPU            = "2"
 	defaultMemory         = "8192"
+	defaultRootDiskSize   = uint64(10)
 )
 
 func init() {
@@ -44,6 +45,7 @@ func (*Manager) ParseCmd(flags *flag.FlagSet) {
 	reg.UintWithEnv(&libvirtcfg.CPU, "cpu", 2, "LIBVIRT_CPU", "Number of processors allocated")
 	reg.UintWithEnv(&libvirtcfg.Memory, "memory", 8192, "LIBVIRT_MEMORY", "Amount of memory in MiB")
 	reg.StringWithEnv(&libvirtcfg.CPUSet, "cpuset", "", "LIBVIRT_CPUSET", "CPU set for pinning vCPUs to physical CPUs (e.g., \"0,2,4,6\" or \"0-3\" or \"0-3,8,10-12\")")
+	reg.Uint64WithEnv(&libvirtcfg.RootDiskSize, "root-disk-size", defaultRootDiskSize, "LIBVIRT_ROOT_DISK_SIZE", "Root disk size in GiB for the podVM")
 
 	// Flags without environment variable support (pass empty string for envVarName)
 	reg.StringWithEnv(&libvirtcfg.DataDir, "data-dir", defaultDataDir, "", "libvirt storage dir")

--- a/src/cloud-providers/libvirt/manager_test.go
+++ b/src/cloud-providers/libvirt/manager_test.go
@@ -23,6 +23,7 @@ func resetLibvirtConfig() {
 		CPU:            2,
 		Memory:         8192,
 		DisableCVM:     true,
+		RootDiskSize:   defaultRootDiskSize,
 	}
 }
 
@@ -47,6 +48,7 @@ func TestManagerParseCmdWithEnvVars(t *testing.T) {
 	t.Setenv("LIBVIRT_CPU", "8")
 	t.Setenv("LIBVIRT_MEMORY", "16384")
 	t.Setenv("DISABLECVM", "false")
+	t.Setenv("LIBVIRT_ROOT_DISK_SIZE", "20")
 
 	_, _ = setupManagerTest(t)
 
@@ -60,6 +62,7 @@ func TestManagerParseCmdWithEnvVars(t *testing.T) {
 	assert.Equal(t, uint(8), libvirtcfg.CPU)
 	assert.Equal(t, uint(16384), libvirtcfg.Memory)
 	assert.False(t, libvirtcfg.DisableCVM)
+	assert.Equal(t, uint64(20), libvirtcfg.RootDiskSize)
 }
 
 func TestManagerParseCmdFlagOverridesEnv(t *testing.T) {
@@ -120,6 +123,18 @@ func TestManagerParseCmdInvalidValues(t *testing.T) {
 			flagName:     "memory",
 			invalidValue: "-1",
 			description:  "negative memory value should be rejected",
+		},
+		{
+			name:         "invalid root-disk-size value",
+			flagName:     "root-disk-size",
+			invalidValue: "notanumber",
+			description:  "non-numeric root-disk-size should be rejected",
+		},
+		{
+			name:         "negative root-disk-size value",
+			flagName:     "root-disk-size",
+			invalidValue: "-5",
+			description:  "negative root-disk-size should be rejected",
 		},
 	}
 
@@ -229,6 +244,7 @@ func TestDefaultConstants(t *testing.T) {
 	assert.Equal(t, "/usr/share/OVMF/OVMF_CODE_4M.fd", defaultFirmware)
 	assert.Equal(t, "2", defaultCPU)
 	assert.Equal(t, "8192", defaultMemory)
+	assert.Equal(t, uint64(10), defaultRootDiskSize)
 }
 
 func TestManagerParseCmdFlags(t *testing.T) {
@@ -309,6 +325,13 @@ func TestManagerParseCmdFlags(t *testing.T) {
 			expectedValue: false,
 			getActual:     func() interface{} { return libvirtcfg.DisableCVM },
 		},
+		{
+			name:          "root-disk-size flag",
+			flagName:      "root-disk-size",
+			flagValue:     "20",
+			expectedValue: uint64(20),
+			getActual:     func() interface{} { return libvirtcfg.RootDiskSize },
+		},
 	}
 
 	for _, tc := range tests {
@@ -321,4 +344,15 @@ func TestManagerParseCmdFlags(t *testing.T) {
 			assert.Equal(t, tc.expectedValue, tc.getActual())
 		})
 	}
+}
+
+// TestManagerRootDiskSizeInvalidEnv is an integration-level guard that exercises the
+// full ParseCmd path (setupManagerTest → ParseCmd → libvirtcfg global) with an invalid
+// env var.  TestUint64WithEnv covers the util helper in isolation; this test verifies
+// that the wiring in manager.go also degrades gracefully.
+func TestManagerRootDiskSizeInvalidEnv(t *testing.T) {
+	t.Setenv("LIBVIRT_ROOT_DISK_SIZE", "notanumber")
+	_, _ = setupManagerTest(t)
+	assert.Equal(t, defaultRootDiskSize, libvirtcfg.RootDiskSize,
+		"invalid LIBVIRT_ROOT_DISK_SIZE env var must silently fall back to default (%d GiB)", defaultRootDiskSize)
 }

--- a/src/cloud-providers/libvirt/provider.go
+++ b/src/cloud-providers/libvirt/provider.go
@@ -71,7 +71,7 @@ func (p *libvirtProvider) CreateInstance(ctx context.Context, podName, sandboxID
 	}
 
 	// TODO: Specify the maximum instance name length in Libvirt
-	vm := &vmConfig{name: instanceName, cpu: instanceVCPUs, mem: instanceMemory, userData: userData, firmware: p.serviceConfig.Firmware, cpuset: p.serviceConfig.CPUSet}
+	vm := &vmConfig{name: instanceName, cpu: instanceVCPUs, mem: instanceMemory, rootDiskSize: p.serviceConfig.RootDiskSize, userData: userData, firmware: p.serviceConfig.Firmware, cpuset: p.serviceConfig.CPUSet}
 
 	if p.serviceConfig.DisableCVM {
 		vm.launchSecurityType = NoLaunchSecurity

--- a/src/cloud-providers/libvirt/provider_test.go
+++ b/src/cloud-providers/libvirt/provider_test.go
@@ -90,6 +90,19 @@ func withLaunchSecurity(security string) func(*Config) {
 	return func(c *Config) { c.LaunchSecurity = security }
 }
 
+func withRootDiskSize(size uint64) func(*Config) {
+	return func(c *Config) { c.RootDiskSize = size }
+}
+
+// TestProviderRootDiskSizeWired verifies that RootDiskSize flows from Config
+// into the provider's service config (and from there into vmConfig at CreateInstance time).
+func TestProviderRootDiskSizeWired(t *testing.T) {
+	cfg := newTestConfig(withRootDiskSize(30))
+	p := &libvirtProvider{serviceConfig: cfg}
+
+	assert.Equal(t, uint64(30), p.serviceConfig.RootDiskSize)
+}
+
 func TestNewProvider(t *testing.T) {
 	t.Run("invalid URI", func(t *testing.T) {
 		config := newTestConfig(withURI(testInvalidURI))

--- a/src/cloud-providers/libvirt/types.go
+++ b/src/cloud-providers/libvirt/types.go
@@ -24,6 +24,8 @@ type Config struct {
 	CPU            uint
 	Memory         uint   // It stores the value in MiB
 	CPUSet         string // CPU set for pinning vCPUs (e.g., "0,2,4,6" or "0-3")
+	RootDiskSize   uint64 // Root disk size in GiB. Zero is treated as the default
+	// size for backwards compatibility.
 }
 
 type vmConfig struct {

--- a/src/cloud-providers/libvirt/volume.go
+++ b/src/cloud-providers/libvirt/volume.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/bits"
 	"time"
 
 	libvirt "libvirt.org/go/libvirt"
@@ -182,7 +183,34 @@ func newCopier(conn *libvirt.Connect, volume *libvirt.StorageVol, size uint64) f
 	return copier
 }
 
-func createVolume(volName string, volSize uint64, baseVolName string, libvirtClient *libvirtClient) (err error) {
+const bytesPerGiB = uint64(1024 * 1024 * 1024)
+
+// volumeCapacityBytes returns the capacity in bytes to use for a new volume.
+// It takes the larger of the requested size (converted from GiB) and the
+// backing image's actual capacity.
+//
+// If volSizeGiB is smaller than the backing image, the backing image's size
+// is used instead. This means operators cannot shrink below the base podvm
+// image size — a value of e.g. 5 GiB on a 10 GiB backing image will
+// silently produce a 10 GiB volume. This is intentional: a qcow2 overlay
+// must always be at least as large as its backing store.
+//
+// Returns an error if the GiB→bytes conversion overflows uint64.
+//
+// Extracted as a pure function so the GiB→bytes conversion and the floor
+// guard can be unit-tested independently of libvirt.
+func volumeCapacityBytes(volSizeGiB, backingCapacityBytes uint64) (uint64, error) {
+	hi, requested := bits.Mul64(volSizeGiB, bytesPerGiB)
+	if hi != 0 {
+		return 0, fmt.Errorf("root-disk-size %d GiB overflows uint64 when converted to bytes", volSizeGiB)
+	}
+	return max(requested, backingCapacityBytes), nil
+}
+
+// createVolume creates a qcow2 volume backed by baseVolName.
+// volSizeGiB is the requested size in GiB; libvirt uses the larger of this
+// value and the backing image's actual capacity.
+func createVolume(volName string, volSizeGiB uint64, baseVolName string, libvirtClient *libvirtClient) (err error) {
 	volumeDef := newDefVolume(volName)
 	volumeDef.Target.Format.Type = "qcow2"
 
@@ -199,11 +227,11 @@ func createVolume(volName string, volSize uint64, baseVolName string, libvirtCli
 		return fmt.Errorf("Can't retrieve volume info %s", baseVolName)
 	}
 
-	if baseVolumeInfo.Capacity > volSize {
-		volumeDef.Capacity.Value = baseVolumeInfo.Capacity
-	} else {
-		volumeDef.Capacity.Value = volSize
+	capacityBytes, err := volumeCapacityBytes(volSizeGiB, baseVolumeInfo.Capacity)
+	if err != nil {
+		return fmt.Errorf("invalid volume size: %w", err)
 	}
+	volumeDef.Capacity.Value = capacityBytes
 
 	backingStoreDef, err := newDefBackingStoreFromLibvirt(baseVolume)
 	if err != nil {

--- a/src/cloud-providers/util.go
+++ b/src/cloud-providers/util.go
@@ -255,6 +255,24 @@ func (r *FlagRegistrar) UintWithEnv(field *uint, flagName string, hardcodedDefau
 	r.flags.UintVar(field, flagName, *field, usage)
 }
 
+// Uint64WithEnv registers a uint64 flag with environment variable support.
+// Optional FlagOption parameters (Required(), Secret()) are metadata-only (used by config-extractor).
+func (r *FlagRegistrar) Uint64WithEnv(field *uint64, flagName string, hardcodedDefault uint64, envVarName, usage string, opts ...FlagOption) {
+	_ = applyOptions(opts) // metadata-only, used by config-extractor
+
+	*field = hardcodedDefault
+
+	if envVarName != "" {
+		if envValue, exists := os.LookupEnv(envVarName); exists && envValue != "" {
+			if uintVal, err := strconv.ParseUint(envValue, 10, 64); err == nil {
+				*field = uintVal
+			}
+		}
+	}
+
+	r.flags.Uint64Var(field, flagName, *field, usage)
+}
+
 // Float64WithEnv registers a float64 flag with environment variable support.
 // Optional FlagOption parameters (Required(), Secret()) are metadata-only (used by config-extractor).
 func (r *FlagRegistrar) Float64WithEnv(field *float64, flagName string, hardcodedDefault float64, envVarName, usage string, opts ...FlagOption) {

--- a/src/cloud-providers/util_test.go
+++ b/src/cloud-providers/util_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"reflect"
@@ -755,6 +756,90 @@ func TestSelectInstanceTypeToUse(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("SelectInstanceTypeToUse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUint64WithEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		envName     string
+		envValue    string
+		setEnv      bool
+		flagValue   string
+		setFlag     bool
+		hardDefault uint64
+		expectedVal uint64
+	}{
+		{
+			name:        "uses hardcoded default when no env or flag",
+			hardDefault: 10,
+			expectedVal: 10,
+		},
+		{
+			name:        "env var overrides hardcoded default",
+			envName:     "TEST_UINT64_SIZE",
+			envValue:    "20",
+			setEnv:      true,
+			hardDefault: 10,
+			expectedVal: 20,
+		},
+		{
+			name:        "invalid env var silently falls back to hardcoded default",
+			envName:     "TEST_UINT64_SIZE",
+			envValue:    "abc",
+			setEnv:      true,
+			hardDefault: 10,
+			expectedVal: 10,
+		},
+		{
+			name:        "empty env var uses hardcoded default",
+			envName:     "TEST_UINT64_SIZE",
+			envValue:    "",
+			setEnv:      true,
+			hardDefault: 10,
+			expectedVal: 10,
+		},
+		{
+			name:        "flag overrides env var",
+			envName:     "TEST_UINT64_SIZE",
+			envValue:    "20",
+			setEnv:      true,
+			flagValue:   "30",
+			setFlag:     true,
+			hardDefault: 10,
+			expectedVal: 30,
+		},
+		{
+			name:        "max uint64 value",
+			envName:     "TEST_UINT64_SIZE",
+			envValue:    "18446744073709551615",
+			setEnv:      true,
+			hardDefault: 10,
+			expectedVal: 18446744073709551615,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				t.Setenv(tt.envName, tt.envValue)
+			}
+
+			var field uint64
+			flags := flag.NewFlagSet("test", flag.ContinueOnError)
+			reg := NewFlagRegistrar(flags)
+			reg.Uint64WithEnv(&field, "test-uint64", tt.hardDefault, tt.envName, "test flag")
+
+			if tt.setFlag {
+				if err := flags.Set("test-uint64", tt.flagValue); err != nil {
+					t.Fatalf("failed to set flag: %v", err)
+				}
+			}
+
+			if field != tt.expectedVal {
+				t.Errorf("Uint64WithEnv() = %d, want %d", field, tt.expectedVal)
 			}
 		})
 	}


### PR DESCRIPTION
The libvirt provider hardcodes the root disk size to 10 GiB with no way to override it at runtime. Every other provider (AWS, Azure, GCP, Alibaba) already exposes a configurable root volume size. This brings libvirt to parity by adding a --root-disk size flag (env: LIBVIRT_ROOT_DISK_SIZE, default: 10 GiB). Deployments that do not set the variable get the same behaviour as before.

This also fixes a pre-existing unit mismatch in createVolume(): the volume size parameter was compared directly against the backing image capacity in bytes without converting GiB to bytes first, making any non-default size produce the wrong result. The parameter is now explicitly converted using math/bits.Mul64, which also detects overflow for pathologically large inputs and returns a clean error instead of silent integer wraparound.

The defaulting and capacity sizing logic is extracted into pure helper functions (normalizeRootDiskSize, volumeCapacityBytes) so they can be unit tested without a live libvirt connection. The config-extractor AST tool is updated to recognise Uint64WithEnv registrations and to unwrap typed numeric constants like uint64(10) so that libvirt.yaml is regenerated correctly.

Assisted-by: IBM Bob \<noreply@ibm.com\>
Fixes: #3162