### PR TITLE
Add full lifecycle E2E tests for CSI volume passthrough

### DIFF
--- a/src/cloud-api-adaptor/go.mod
+++ b/src/cloud-api-adaptor/go.mod
@@ -120,7 +120,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.33.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.6 // indirect
-	github.com/aws/smithy-go v1.27.8 // indirect
+	github.com/aws/smithy-go v1.27.8
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/src/cloud-api-adaptor/go.mod
+++ b/src/cloud-api-adaptor/go.mod
@@ -116,7 +116,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.31.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.36.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.3 // indirect
-	github.com/aws/smithy-go v1.27.1 // indirect
+	github.com/aws/smithy-go v1.27.1
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -251,6 +251,114 @@ EOF
 - For `PODVM_IMAGE_ID`, the vpc image id uploaded to ibmcloud.
 - For `CAA_IMAGE_TAG`, the commit id of project. The commit id can be found here: <https://github.com/confidential-containers/cloud-api-adaptor/commits/main/>
 
+# Running CSI Volume Lifecycle E2E Tests
+
+The lifecycle tests verify the full cloud-native volume passthrough flow: PVC creation → pod write → detach → reattach → read → PVC deletion → cloud disk cleanup verification. They prove that no orphan cloud resources (EBS volumes / Azure Disks) are left behind after the full lifecycle.
+
+These tests are **opt-in** (gated by `CSI_LIFECYCLE_E2E=true`) and do not interfere with existing CI pipelines.
+
+## Prerequisites
+
+1. A Kubernetes cluster (EKS / AKS) with:
+   - **Kata Containers** installed (RuntimeClass `kata-remote` available)
+   - **Cloud API Adaptor (CAA)** deployed and healthy
+   - **caa-csi-block-driver** deployed (CSI driver registered)
+   - **fuse** package installed on worker nodes (required for nydus image guest-pull)
+2. Cloud credentials configured locally (AWS CLI profile or Azure identity)
+3. `KUBECONFIG` pointing to your cluster
+4. Go 1.22+ installed
+
+### Cluster setup notes
+
+- The **PodVM subnet** and the **StorageClass AZ** must match. If EBS volumes are created in `us-east-2b`, the CAA must launch PodVMs in `us-east-2b` as well (via `AWS_SUBNET_ID`).
+- The **security group** must allow inbound TCP/15150 (agent proxy) and UDP/4789 (VXLAN) from the cluster to PodVMs.
+- Worker nodes need the `fuse` package for the nydus-for-kata-tee snapshotter to work (`yum install -y fuse` or `dnf install -y fuse` on Amazon Linux).
+
+## Running on AWS
+
+### Single disk test
+
+```bash
+export CSI_LIFECYCLE_E2E=true
+export CLOUD_PROVIDER=aws
+export AWS_REGION=us-east-2
+export AWS_AVAILABILITY_ZONE=us-east-2b        # must match CAA subnet AZ
+export TEST_PROVISION=no
+export TEST_INSTALL_CAA=no
+export TEST_TEARDOWN=no
+export TEST_PROVISION_FILE=/tmp/dummy.properties  # can be empty, required by test framework
+
+# Single disk lifecycle
+go test -v -tags=aws -timeout 25m -run "TestCSIFullLifecycle$" -count=1 ./test/e2e/
+
+# Multi-disk lifecycle (2 volumes on one pod)
+go test -v -tags=aws -timeout 30m -run "TestCSIFullLifecycleMultiDisk" -count=1 ./test/e2e/
+```
+
+### What the flags mean
+
+| Flag | Why it's needed |
+|------|----------------|
+| `-tags=aws` | Compiles the AWS provider code |
+| `TEST_PROVISION=no` | Skips cluster provisioning (you already have one) |
+| `TEST_INSTALL_CAA=no` | Skips CAA installation (already deployed) |
+| `TEST_TEARDOWN=no` | Skips cluster teardown after test |
+| `TEST_PROVISION_FILE` | Required by test framework's TestMain; can point to any file |
+
+## Running on Azure
+
+```bash
+export CSI_LIFECYCLE_E2E=true
+export CLOUD_PROVIDER=azure
+export AZURE_SUBSCRIPTION_ID=<your-subscription-id>
+export AZURE_RESOURCE_GROUP=<your-resource-group>
+export AZURE_TENANT_ID=<your-tenant-id>
+export AZURE_CLIENT_ID=<your-client-id>
+export AZURE_LOCATION=eastus
+export TEST_PROVISION=no
+export TEST_INSTALL_CAA=no
+export TEST_TEARDOWN=no
+export TEST_PROVISION_FILE=/tmp/dummy.properties
+
+# Single disk lifecycle
+go test -v -tags=azure -timeout 25m -run "TestCSIFullLifecycle$" -count=1 ./test/e2e/
+
+# Multi-disk lifecycle
+go test -v -tags=azure -timeout 30m -run "TestCSIFullLifecycleMultiDisk" -count=1 ./test/e2e/
+```
+
+## What the tests verify
+
+| Test | Coverage |
+|------|----------|
+| `TestCSIFullLifecycle` | Single disk: PVC create → write data → pod delete (verify disk detaches) → reattach to new pod → read data back → PVC delete → verify cloud disk is gone |
+| `TestCSIFullLifecycleMultiDisk` | Same flow with 2 PVCs attached to a single pod — proves multi-volume passthrough works |
+
+The tests create a StorageClass with `reclaimPolicy: Delete` so that PVC deletion triggers cloud disk cleanup. The final phase calls the cloud provider API directly to confirm the disk no longer exists.
+
+## Environment variables
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `CSI_LIFECYCLE_E2E` | Yes | Set to `true` to enable these tests |
+| `CLOUD_PROVIDER` | Yes | `aws` or `azure` |
+| `AWS_REGION` | AWS | Region for EBS API calls |
+| `AWS_AVAILABILITY_ZONE` | AWS (optional) | AZ for StorageClass; must match CAA subnet |
+| `AZURE_SUBSCRIPTION_ID` | Azure | Subscription for Disk API calls |
+| `AZURE_RESOURCE_GROUP` | Azure | Resource group for Disk API calls |
+| `AZURE_TENANT_ID` | Azure (optional) | Used in StorageClass parameters |
+| `AZURE_CLIENT_ID` | Azure (optional) | Used in StorageClass parameters |
+| `AZURE_LOCATION` | Azure (optional) | Used in StorageClass parameters |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `InvalidVolume.ZoneMismatch` | EBS volume in different AZ than PodVM | Set `AWS_AVAILABILITY_ZONE` to match CAA's `AWS_SUBNET_ID` AZ |
+| `mount.fuse: executable file not found` | Worker node missing fuse package | Install fuse: `yum install -y fuse` on the node |
+| `dial tcp ...:15150: connection timed out` | Security group blocks PodVM traffic | Open TCP/15150 and UDP/4789 in the SG used by PodVMs |
+| `Pod did not complete within 8m` | PodVM boot too slow or image pull issue | Check CAA logs and pod events for specific errors |
+
 # Adding support for a new cloud provider
 
 In order to add a test pipeline for a new cloud provider, you will need to implement some

--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -285,6 +285,114 @@ EOF
 - For `PODVM_IMAGE_ID`, the vpc image id uploaded to ibmcloud.
 - For `CAA_IMAGE_TAG`, the commit id of project. The commit id can be found here: <https://github.com/confidential-containers/cloud-api-adaptor/commits/main/>
 
+# Running CSI Volume Lifecycle E2E Tests
+
+The lifecycle tests verify the full cloud-native volume passthrough flow: PVC creation → pod write → detach → reattach → read → PVC deletion → cloud disk cleanup verification. They prove that no orphan cloud resources (EBS volumes / Azure Disks) are left behind after the full lifecycle.
+
+These tests are **opt-in** (gated by `CSI_LIFECYCLE_E2E=true`) and do not interfere with existing CI pipelines.
+
+## Prerequisites
+
+1. A Kubernetes cluster (EKS / AKS) with:
+   - **Kata Containers** installed (RuntimeClass `kata-remote` available)
+   - **Cloud API Adaptor (CAA)** deployed and healthy
+   - **caa-csi-block-driver** deployed (CSI driver registered)
+   - **fuse** package installed on worker nodes (required for nydus image guest-pull)
+2. Cloud credentials configured locally (AWS CLI profile or Azure identity)
+3. `KUBECONFIG` pointing to your cluster
+4. Go 1.22+ installed
+
+### Cluster setup notes
+
+- The **PodVM subnet** and the **StorageClass AZ** must match. If EBS volumes are created in `us-east-2b`, the CAA must launch PodVMs in `us-east-2b` as well (via `AWS_SUBNET_ID`).
+- The **security group** must allow inbound TCP/15150 (agent proxy) and UDP/4789 (VXLAN) from the cluster to PodVMs.
+- Worker nodes need the `fuse` package for the nydus-for-kata-tee snapshotter to work (`yum install -y fuse` or `dnf install -y fuse` on Amazon Linux).
+
+## Running on AWS
+
+### Single disk test
+
+```bash
+export CSI_LIFECYCLE_E2E=true
+export CLOUD_PROVIDER=aws
+export AWS_REGION=us-east-2
+export AWS_AVAILABILITY_ZONE=us-east-2b        # must match CAA subnet AZ
+export TEST_PROVISION=no
+export TEST_INSTALL_CAA=no
+export TEST_TEARDOWN=no
+export TEST_PROVISION_FILE=/tmp/dummy.properties  # can be empty, required by test framework
+
+# Single disk lifecycle
+go test -v -tags=aws -timeout 25m -run "TestCSIFullLifecycle$" -count=1 ./test/e2e/
+
+# Multi-disk lifecycle (2 volumes on one pod)
+go test -v -tags=aws -timeout 30m -run "TestCSIFullLifecycleMultiDisk" -count=1 ./test/e2e/
+```
+
+### What the flags mean
+
+| Flag | Why it's needed |
+|------|----------------|
+| `-tags=aws` | Compiles the AWS provider code |
+| `TEST_PROVISION=no` | Skips cluster provisioning (you already have one) |
+| `TEST_INSTALL_CAA=no` | Skips CAA installation (already deployed) |
+| `TEST_TEARDOWN=no` | Skips cluster teardown after test |
+| `TEST_PROVISION_FILE` | Required by test framework's TestMain; can point to any file |
+
+## Running on Azure
+
+```bash
+export CSI_LIFECYCLE_E2E=true
+export CLOUD_PROVIDER=azure
+export AZURE_SUBSCRIPTION_ID=<your-subscription-id>
+export AZURE_RESOURCE_GROUP=<your-resource-group>
+export AZURE_TENANT_ID=<your-tenant-id>
+export AZURE_CLIENT_ID=<your-client-id>
+export AZURE_LOCATION=eastus
+export TEST_PROVISION=no
+export TEST_INSTALL_CAA=no
+export TEST_TEARDOWN=no
+export TEST_PROVISION_FILE=/tmp/dummy.properties
+
+# Single disk lifecycle
+go test -v -tags=azure -timeout 25m -run "TestCSIFullLifecycle$" -count=1 ./test/e2e/
+
+# Multi-disk lifecycle
+go test -v -tags=azure -timeout 30m -run "TestCSIFullLifecycleMultiDisk" -count=1 ./test/e2e/
+```
+
+## What the tests verify
+
+| Test | Coverage |
+|------|----------|
+| `TestCSIFullLifecycle` | Single disk: PVC create → write data → pod delete (verify disk detaches) → reattach to new pod → read data back → PVC delete → verify cloud disk is gone |
+| `TestCSIFullLifecycleMultiDisk` | Same flow with 2 PVCs attached to a single pod — proves multi-volume passthrough works |
+
+The tests create a StorageClass with `reclaimPolicy: Delete` so that PVC deletion triggers cloud disk cleanup. The final phase calls the cloud provider API directly to confirm the disk no longer exists.
+
+## Environment variables
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `CSI_LIFECYCLE_E2E` | Yes | Set to `true` to enable these tests |
+| `CLOUD_PROVIDER` | Yes | `aws` or `azure` |
+| `AWS_REGION` | AWS | Region for EBS API calls |
+| `AWS_AVAILABILITY_ZONE` | AWS (optional) | AZ for StorageClass; must match CAA subnet |
+| `AZURE_SUBSCRIPTION_ID` | Azure | Subscription for Disk API calls |
+| `AZURE_RESOURCE_GROUP` | Azure | Resource group for Disk API calls |
+| `AZURE_TENANT_ID` | Azure (optional) | Used in StorageClass parameters |
+| `AZURE_CLIENT_ID` | Azure (optional) | Used in StorageClass parameters |
+| `AZURE_LOCATION` | Azure (optional) | Used in StorageClass parameters |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `InvalidVolume.ZoneMismatch` | EBS volume in different AZ than PodVM | Set `AWS_AVAILABILITY_ZONE` to match CAA's `AWS_SUBNET_ID` AZ |
+| `mount.fuse: executable file not found` | Worker node missing fuse package | Install fuse: `yum install -y fuse` on the node |
+| `dial tcp ...:15150: connection timed out` | Security group blocks PodVM traffic | Open TCP/15150 and UDP/4789 in the SG used by PodVMs |
+| `Pod did not complete within 8m` | PodVM boot too slow or image pull issue | Check CAA logs and pod events for specific errors |
+
 # Adding support for a new cloud provider
 
 In order to add a test pipeline for a new cloud provider, you will need to implement some

--- a/src/cloud-api-adaptor/test/e2e/README.md
+++ b/src/cloud-api-adaptor/test/e2e/README.md
@@ -320,7 +320,7 @@ export AWS_AVAILABILITY_ZONE=us-east-2b        # must match CAA subnet AZ
 export TEST_PROVISION=no
 export TEST_INSTALL_CAA=no
 export TEST_TEARDOWN=no
-export TEST_PROVISION_FILE=/tmp/dummy.properties  # can be empty, required by test framework
+export TEST_PROVISION_FILE=/tmp/dummy.properties  # must be valid TOML or empty; required by test framework
 
 # Single disk lifecycle
 go test -v -tags=aws -timeout 25m -run "TestCSIFullLifecycle$" -count=1 ./test/e2e/
@@ -337,7 +337,7 @@ go test -v -tags=aws -timeout 30m -run "TestCSIFullLifecycleMultiDisk" -count=1 
 | `TEST_PROVISION=no` | Skips cluster provisioning (you already have one) |
 | `TEST_INSTALL_CAA=no` | Skips CAA installation (already deployed) |
 | `TEST_TEARDOWN=no` | Skips cluster teardown after test |
-| `TEST_PROVISION_FILE` | Required by test framework's TestMain; can point to any file |
+| `TEST_PROVISION_FILE` | Required by test framework's TestMain; must be valid TOML (`key = "value"`) or an empty file |
 
 ## Running on Azure
 
@@ -352,7 +352,7 @@ export AZURE_LOCATION=eastus
 export TEST_PROVISION=no
 export TEST_INSTALL_CAA=no
 export TEST_TEARDOWN=no
-export TEST_PROVISION_FILE=/tmp/dummy.properties
+export TEST_PROVISION_FILE=/tmp/dummy.properties  # must be valid TOML or empty
 
 # Single disk lifecycle
 go test -v -tags=azure -timeout 25m -run "TestCSIFullLifecycle$" -count=1 ./test/e2e/

--- a/src/cloud-api-adaptor/test/e2e/cloudutil/azure.go
+++ b/src/cloud-api-adaptor/test/e2e/cloudutil/azure.go
@@ -1,0 +1,33 @@
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudutil
+
+import "strings"
+
+// ExtractAzureResourceGroup extracts the resource group from a full ARM resource ID.
+// Returns empty string if the input is not a full ARM path.
+// Example: /subscriptions/.../resourceGroups/MC_mygroup/providers/Microsoft.Compute/disks/mydisk
+func ExtractAzureResourceGroup(diskID string) string {
+	const rgSegment = "/resourcegroups/"
+	lower := strings.ToLower(diskID)
+	idx := strings.Index(lower, rgSegment)
+	if idx == -1 {
+		return ""
+	}
+	rest := diskID[idx+len(rgSegment):]
+	if slashIdx := strings.Index(rest, "/"); slashIdx != -1 {
+		return rest[:slashIdx]
+	}
+	return rest
+}
+
+// ExtractAzureDiskName extracts the disk name from a full Azure resource ID
+// or returns the input as-is if it's already just a name.
+func ExtractAzureDiskName(diskID string) string {
+	parts := strings.Split(diskID, "/")
+	if len(parts) > 1 {
+		return parts[len(parts)-1]
+	}
+	return diskID
+}

--- a/src/cloud-api-adaptor/test/e2e/cloudutil/azure_test.go
+++ b/src/cloud-api-adaptor/test/e2e/cloudutil/azure_test.go
@@ -1,9 +1,7 @@
-//go:build azure
-
 // (C) Copyright Confidential Containers Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-package e2e
+package cloudutil
 
 import "testing"
 
@@ -46,9 +44,9 @@ func TestExtractAzureResourceGroup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := extractAzureResourceGroup(tt.diskID)
+			got := ExtractAzureResourceGroup(tt.diskID)
 			if got != tt.want {
-				t.Errorf("extractAzureResourceGroup(%q) = %q, want %q", tt.diskID, got, tt.want)
+				t.Errorf("ExtractAzureResourceGroup(%q) = %q, want %q", tt.diskID, got, tt.want)
 			}
 		})
 	}
@@ -83,9 +81,9 @@ func TestExtractAzureDiskName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := extractAzureDiskName(tt.diskID)
+			got := ExtractAzureDiskName(tt.diskID)
 			if got != tt.want {
-				t.Errorf("extractAzureDiskName(%q) = %q, want %q", tt.diskID, got, tt.want)
+				t.Errorf("ExtractAzureDiskName(%q) = %q, want %q", tt.diskID, got, tt.want)
 			}
 		})
 	}

--- a/src/cloud-api-adaptor/test/e2e/csi_cloud_verify.go
+++ b/src/cloud-api-adaptor/test/e2e/csi_cloud_verify.go
@@ -1,0 +1,87 @@
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const pollInterval = 5 * time.Second
+
+// CloudDiskVerifier checks the state of cloud-managed disks via provider APIs.
+type CloudDiskVerifier interface {
+	DiskExists(ctx context.Context, diskID string) (bool, error)
+	DiskState(ctx context.Context, diskID string) (string, error)
+}
+
+var cloudDiskVerifierFactories = map[string]func() (CloudDiskVerifier, error){}
+
+func registerCloudDiskVerifier(provider string, factory func() (CloudDiskVerifier, error)) {
+	cloudDiskVerifierFactories[provider] = factory
+}
+
+func newCloudDiskVerifier(provider string) (CloudDiskVerifier, error) {
+	factory, ok := cloudDiskVerifierFactories[strings.ToLower(provider)]
+	if !ok {
+		return nil, fmt.Errorf("unsupported cloud provider for disk verification: %s (is the correct build tag set?)", provider)
+	}
+	return factory()
+}
+
+// waitForDiskDetached polls until the disk reaches a detached state
+// ("available" on AWS, "Unattached" on Azure) or times out.
+// Returns early if the disk was already deleted (no need to wait for detach).
+func waitForDiskDetached(ctx context.Context, verifier CloudDiskVerifier, diskID string, timeout time.Duration) (string, error) {
+	deadline := time.Now().Add(timeout)
+	var lastState string
+	for time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return lastState, fmt.Errorf("context cancelled while waiting for disk detach: %w", err)
+		}
+		state, err := verifier.DiskState(ctx, diskID)
+		if err != nil {
+			return "", fmt.Errorf("checking disk state: %w", err)
+		}
+		lastState = state
+		lower := strings.ToLower(state)
+		if lower == "available" || lower == "unattached" {
+			return state, nil
+		}
+		if lower == "deleted" {
+			return "deleted (disk already removed)", nil
+		}
+		select {
+		case <-time.After(pollInterval):
+		case <-ctx.Done():
+			return lastState, fmt.Errorf("context cancelled while waiting for disk detach: %w", ctx.Err())
+		}
+	}
+	return lastState, fmt.Errorf("disk %s did not detach within %v (last state: %s)", diskID, timeout, lastState)
+}
+
+// waitForDiskDeleted polls until the disk no longer exists or times out.
+func waitForDiskDeleted(ctx context.Context, verifier CloudDiskVerifier, diskID string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("context cancelled while waiting for disk deletion: %w", err)
+		}
+		exists, err := verifier.DiskExists(ctx, diskID)
+		if err != nil {
+			return fmt.Errorf("checking disk existence: %w", err)
+		}
+		if !exists {
+			return nil
+		}
+		select {
+		case <-time.After(pollInterval):
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled while waiting for disk deletion: %w", ctx.Err())
+		}
+	}
+	return fmt.Errorf("disk %s still exists after %v", diskID, timeout)
+}

--- a/src/cloud-api-adaptor/test/e2e/csi_cloud_verify_aws.go
+++ b/src/cloud-api-adaptor/test/e2e/csi_cloud_verify_aws.go
@@ -1,0 +1,68 @@
+//go:build aws
+
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/smithy-go"
+)
+
+func init() {
+	registerCloudDiskVerifier("aws", newAWSDiskVerifier)
+}
+
+type awsDiskVerifier struct {
+	client *ec2.Client
+}
+
+func newAWSDiskVerifier() (CloudDiskVerifier, error) {
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		return nil, fmt.Errorf("AWS_REGION must be set for cloud-side verification")
+	}
+	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithRegion(region))
+	if err != nil {
+		return nil, fmt.Errorf("loading AWS config: %w", err)
+	}
+	return &awsDiskVerifier{client: ec2.NewFromConfig(cfg)}, nil
+}
+
+func (v *awsDiskVerifier) DiskExists(ctx context.Context, diskID string) (bool, error) {
+	result, err := v.client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
+		VolumeIds: []string{diskID},
+	})
+	if err != nil {
+		var apiErr smithy.APIError
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "InvalidVolume.NotFound" {
+			return false, nil
+		}
+		return false, err
+	}
+	return len(result.Volumes) > 0, nil
+}
+
+func (v *awsDiskVerifier) DiskState(ctx context.Context, diskID string) (string, error) {
+	result, err := v.client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
+		VolumeIds: []string{diskID},
+	})
+	if err != nil {
+		var apiErr smithy.APIError
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "InvalidVolume.NotFound" {
+			return "deleted", nil
+		}
+		return "", err
+	}
+	if len(result.Volumes) == 0 {
+		return "deleted", nil
+	}
+	return string(result.Volumes[0].State), nil
+}

--- a/src/cloud-api-adaptor/test/e2e/csi_cloud_verify_azure.go
+++ b/src/cloud-api-adaptor/test/e2e/csi_cloud_verify_azure.go
@@ -1,0 +1,119 @@
+//go:build azure
+
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
+)
+
+func init() {
+	registerCloudDiskVerifier("azure", newAzureDiskVerifier)
+}
+
+type azureDiskVerifier struct {
+	client        *armcompute.DisksClient
+	resourceGroup string
+}
+
+func newAzureDiskVerifier() (CloudDiskVerifier, error) {
+	subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+	resourceGroup := os.Getenv("AZURE_RESOURCE_GROUP")
+	if subscriptionID == "" || resourceGroup == "" {
+		return nil, fmt.Errorf("AZURE_SUBSCRIPTION_ID and AZURE_RESOURCE_GROUP must be set for cloud-side verification")
+	}
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating Azure credential: %w", err)
+	}
+	client, err := armcompute.NewDisksClient(subscriptionID, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating Azure disks client: %w", err)
+	}
+	return &azureDiskVerifier{
+		client:        client,
+		resourceGroup: resourceGroup,
+	}, nil
+}
+
+func isAzureNotFound(err error) bool {
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) {
+		return respErr.StatusCode == http.StatusNotFound
+	}
+	return false
+}
+
+func (v *azureDiskVerifier) resourceGroupForDisk(diskID string) string {
+	if rg := extractAzureResourceGroup(diskID); rg != "" {
+		return rg
+	}
+	return v.resourceGroup
+}
+
+func (v *azureDiskVerifier) DiskExists(ctx context.Context, diskID string) (bool, error) {
+	diskName := extractAzureDiskName(diskID)
+	rg := v.resourceGroupForDisk(diskID)
+	_, err := v.client.Get(ctx, rg, diskName, nil)
+	if err != nil {
+		if isAzureNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (v *azureDiskVerifier) DiskState(ctx context.Context, diskID string) (string, error) {
+	diskName := extractAzureDiskName(diskID)
+	rg := v.resourceGroupForDisk(diskID)
+	disk, err := v.client.Get(ctx, rg, diskName, nil)
+	if err != nil {
+		if isAzureNotFound(err) {
+			return "deleted", nil
+		}
+		return "", err
+	}
+	if disk.Properties == nil || disk.Properties.DiskState == nil {
+		return "unknown", nil
+	}
+	return string(*disk.Properties.DiskState), nil
+}
+
+// extractAzureResourceGroup extracts the resource group from a full ARM resource ID.
+// Returns empty string if the input is not a full ARM path.
+// Example: /subscriptions/.../resourceGroups/MC_mygroup/providers/Microsoft.Compute/disks/mydisk
+func extractAzureResourceGroup(diskID string) string {
+	const rgSegment = "/resourcegroups/"
+	lower := strings.ToLower(diskID)
+	idx := strings.Index(lower, rgSegment)
+	if idx == -1 {
+		return ""
+	}
+	rest := diskID[idx+len(rgSegment):]
+	if slashIdx := strings.Index(rest, "/"); slashIdx != -1 {
+		return rest[:slashIdx]
+	}
+	return rest
+}
+
+// extractAzureDiskName extracts the disk name from a full Azure resource ID
+// or returns the input as-is if it's already just a name.
+func extractAzureDiskName(diskID string) string {
+	parts := strings.Split(diskID, "/")
+	if len(parts) > 1 {
+		return parts[len(parts)-1]
+	}
+	return diskID
+}

--- a/src/cloud-api-adaptor/test/e2e/csi_cloud_verify_azure.go
+++ b/src/cloud-api-adaptor/test/e2e/csi_cloud_verify_azure.go
@@ -11,11 +11,12 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
+
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/test/e2e/cloudutil"
 )
 
 func init() {
@@ -56,14 +57,14 @@ func isAzureNotFound(err error) bool {
 }
 
 func (v *azureDiskVerifier) resourceGroupForDisk(diskID string) string {
-	if rg := extractAzureResourceGroup(diskID); rg != "" {
+	if rg := cloudutil.ExtractAzureResourceGroup(diskID); rg != "" {
 		return rg
 	}
 	return v.resourceGroup
 }
 
 func (v *azureDiskVerifier) DiskExists(ctx context.Context, diskID string) (bool, error) {
-	diskName := extractAzureDiskName(diskID)
+	diskName := cloudutil.ExtractAzureDiskName(diskID)
 	rg := v.resourceGroupForDisk(diskID)
 	_, err := v.client.Get(ctx, rg, diskName, nil)
 	if err != nil {
@@ -76,7 +77,7 @@ func (v *azureDiskVerifier) DiskExists(ctx context.Context, diskID string) (bool
 }
 
 func (v *azureDiskVerifier) DiskState(ctx context.Context, diskID string) (string, error) {
-	diskName := extractAzureDiskName(diskID)
+	diskName := cloudutil.ExtractAzureDiskName(diskID)
 	rg := v.resourceGroupForDisk(diskID)
 	disk, err := v.client.Get(ctx, rg, diskName, nil)
 	if err != nil {
@@ -91,29 +92,3 @@ func (v *azureDiskVerifier) DiskState(ctx context.Context, diskID string) (strin
 	return string(*disk.Properties.DiskState), nil
 }
 
-// extractAzureResourceGroup extracts the resource group from a full ARM resource ID.
-// Returns empty string if the input is not a full ARM path.
-// Example: /subscriptions/.../resourceGroups/MC_mygroup/providers/Microsoft.Compute/disks/mydisk
-func extractAzureResourceGroup(diskID string) string {
-	const rgSegment = "/resourcegroups/"
-	lower := strings.ToLower(diskID)
-	idx := strings.Index(lower, rgSegment)
-	if idx == -1 {
-		return ""
-	}
-	rest := diskID[idx+len(rgSegment):]
-	if slashIdx := strings.Index(rest, "/"); slashIdx != -1 {
-		return rest[:slashIdx]
-	}
-	return rest
-}
-
-// extractAzureDiskName extracts the disk name from a full Azure resource ID
-// or returns the input as-is if it's already just a name.
-func extractAzureDiskName(diskID string) string {
-	parts := strings.Split(diskID, "/")
-	if len(parts) > 1 {
-		return parts[len(parts)-1]
-	}
-	return diskID
-}

--- a/src/cloud-api-adaptor/test/e2e/csi_cloud_verify_azure_test.go
+++ b/src/cloud-api-adaptor/test/e2e/csi_cloud_verify_azure_test.go
@@ -1,0 +1,92 @@
+//go:build azure
+
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import "testing"
+
+func TestExtractAzureResourceGroup(t *testing.T) {
+	tests := []struct {
+		name   string
+		diskID string
+		want   string
+	}{
+		{
+			name:   "full ARM path with MC resource group",
+			diskID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_mygroup/providers/Microsoft.Compute/disks/mydisk",
+			want:   "MC_mygroup",
+		},
+		{
+			name:   "lowercase resourcegroups in path",
+			diskID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lowercase-rg/providers/Microsoft.Compute/disks/mydisk",
+			want:   "lowercase-rg",
+		},
+		{
+			name:   "mixed case ResourceGroups",
+			diskID: "/subscriptions/00000000-0000-0000-0000-000000000000/ResourceGroups/MixedCase-RG/providers/Microsoft.Compute/disks/mydisk",
+			want:   "MixedCase-RG",
+		},
+		{
+			name:   "plain disk name returns empty",
+			diskID: "mydisk",
+			want:   "",
+		},
+		{
+			name:   "empty string returns empty",
+			diskID: "",
+			want:   "",
+		},
+		{
+			name:   "path without resourceGroups segment",
+			diskID: "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/disks/mydisk",
+			want:   "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractAzureResourceGroup(tt.diskID)
+			if got != tt.want {
+				t.Errorf("extractAzureResourceGroup(%q) = %q, want %q", tt.diskID, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractAzureDiskName(t *testing.T) {
+	tests := []struct {
+		name   string
+		diskID string
+		want   string
+	}{
+		{
+			name:   "full ARM resource ID",
+			diskID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_mygroup/providers/Microsoft.Compute/disks/mydisk",
+			want:   "mydisk",
+		},
+		{
+			name:   "plain disk name",
+			diskID: "mydisk",
+			want:   "mydisk",
+		},
+		{
+			name:   "empty string",
+			diskID: "",
+			want:   "",
+		},
+		{
+			name:   "disk name with hyphens",
+			diskID: "/subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.Compute/disks/pvc-abc-123-def",
+			want:   "pvc-abc-123-def",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractAzureDiskName(tt.diskID)
+			if got != tt.want {
+				t.Errorf("extractAzureDiskName(%q) = %q, want %q", tt.diskID, got, tt.want)
+			}
+		})
+	}
+}

--- a/src/cloud-api-adaptor/test/e2e/csi_lifecycle_test.go
+++ b/src/cloud-api-adaptor/test/e2e/csi_lifecycle_test.go
@@ -1,0 +1,651 @@
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	lifecycleSingleNamespace = "csi-lifecycle-single"
+	lifecycleMultiNamespace  = "csi-lifecycle-multi"
+	lifecycleStorageClass    = "caa-csi-lifecycle"
+	lifecyclePVCName         = "lifecycle-pvc"
+	lifecycleWriterPod       = "lifecycle-writer"
+	lifecycleReaderPod       = "lifecycle-reader"
+	lifecycleTestData        = "lifecycle-e2e-persistence-check"
+	lifecycleMountPath       = "/mnt/data"
+	lifecyclePVCSize         = "1Gi"
+	lifecyclePodTimeout      = 8 * time.Minute
+	diskDetachTimeout        = 5 * time.Minute
+	diskDeleteTimeout        = 5 * time.Minute
+	pvDeleteTimeout          = 3 * time.Minute
+	pvcBoundTimeout          = 2 * time.Minute
+	singleTestTimeout        = 20 * time.Minute
+	multiTestTimeout         = 25 * time.Minute
+
+	busyboxImage = "busybox:1.36"
+
+	// PV volume attribute keys set by the CSI driver
+	volAttrEBSVolumeID  = "ebs-volume-id"
+	volAttrCloudVolPath = "cloud-volume-path"
+	volAttrAzureDiskID  = "azure-disk-id"
+)
+
+// pvcMountsAndVolumes builds volume mounts and volumes for multiple PVCs,
+// each mounted at /mnt/<pvcName>.
+func pvcMountsAndVolumes(pvcNames []string) ([]corev1.VolumeMount, []corev1.Volume) {
+	var mounts []corev1.VolumeMount
+	var vols []corev1.Volume
+	for _, name := range pvcNames {
+		mp := fmt.Sprintf("/mnt/%s", name)
+		mounts = append(mounts, corev1.VolumeMount{Name: name, MountPath: mp})
+		vols = append(vols, corev1.Volume{Name: name, VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: name},
+		}})
+	}
+	return mounts, vols
+}
+
+func newMultiVolumeWriterPod(namespace, podName string, pvcNames, testData []string) *corev1.Pod {
+	runtimeClassName := "kata-remote"
+	mounts, vols := pvcMountsAndVolumes(pvcNames)
+	cmd := ""
+	for i, name := range pvcNames {
+		mp := fmt.Sprintf("/mnt/%s", name)
+		cmd += fmt.Sprintf("echo %q > %s/data.txt && ", testData[i], mp)
+	}
+	cmd += "sync"
+	for _, name := range pvcNames {
+		cmd += fmt.Sprintf(" && cat /mnt/%s/data.txt", name)
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: namespace},
+		Spec: corev1.PodSpec{
+			RuntimeClassName: &runtimeClassName,
+			Containers:       []corev1.Container{{Name: "writer", Image: busyboxImage, Command: []string{"/bin/sh", "-c", cmd}, VolumeMounts: mounts}},
+			Volumes:          vols,
+			RestartPolicy:    corev1.RestartPolicyNever,
+		},
+	}
+}
+
+func newMultiVolumeReaderPod(namespace, podName string, pvcNames []string) *corev1.Pod {
+	runtimeClassName := "kata-remote"
+	mounts, vols := pvcMountsAndVolumes(pvcNames)
+	cmd := ""
+	for _, name := range pvcNames {
+		cmd += fmt.Sprintf("cat /mnt/%s/data.txt && ", name)
+	}
+	cmd += "true"
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: namespace},
+		Spec: corev1.PodSpec{
+			RuntimeClassName: &runtimeClassName,
+			Containers:       []corev1.Container{{Name: "reader", Image: busyboxImage, Command: []string{"/bin/sh", "-c", cmd}, VolumeMounts: mounts}},
+			Volumes:          vols,
+			RestartPolicy:    corev1.RestartPolicyNever,
+		},
+	}
+}
+
+func skipIfLifecycleDisabled(t *testing.T) {
+	t.Helper()
+	if os.Getenv("CSI_LIFECYCLE_E2E") != "true" {
+		t.Skip("CSI lifecycle E2E tests disabled — set CSI_LIFECYCLE_E2E=true to run")
+	}
+}
+
+func getCloudProvider(t *testing.T) string {
+	t.Helper()
+	p := os.Getenv("CLOUD_PROVIDER")
+	if p == "" {
+		t.Fatal("CLOUD_PROVIDER must be set (aws or azure)")
+	}
+	return strings.ToLower(p)
+}
+
+func newLifecycleStorageClass(provider string) *storagev1.StorageClass {
+	reclaimDelete := corev1.PersistentVolumeReclaimDelete
+	bindImmediate := storagev1.VolumeBindingImmediate
+
+	params := map[string]string{"cloudProvider": provider}
+
+	switch provider {
+	case "aws":
+		if region := os.Getenv("AWS_REGION"); region != "" {
+			params["awsRegion"] = region
+		}
+		if az := os.Getenv("AWS_AVAILABILITY_ZONE"); az != "" {
+			params["awsAvailabilityZone"] = az
+		}
+		if vt := os.Getenv("AWS_VOLUME_TYPE"); vt != "" {
+			params["awsVolumeType"] = vt
+		} else {
+			params["awsVolumeType"] = "gp3"
+		}
+	case "azure":
+		if sub := os.Getenv("AZURE_SUBSCRIPTION_ID"); sub != "" {
+			params["azureSubscriptionId"] = sub
+		}
+		if rg := os.Getenv("AZURE_RESOURCE_GROUP"); rg != "" {
+			params["azureResourceGroup"] = rg
+		}
+		if tid := os.Getenv("AZURE_TENANT_ID"); tid != "" {
+			params["azureTenantId"] = tid
+		}
+		if cid := os.Getenv("AZURE_CLIENT_ID"); cid != "" {
+			params["azureClientId"] = cid
+		}
+		if loc := os.Getenv("AZURE_LOCATION"); loc != "" {
+			params["azureLocation"] = loc
+		}
+	}
+
+	return &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: lifecycleStorageClass,
+		},
+		Provisioner:       "caa-csi-block.csi.confidentialcontainers.io",
+		ReclaimPolicy:     &reclaimDelete,
+		VolumeBindingMode: &bindImmediate,
+		Parameters:        params,
+	}
+}
+
+func newLifecyclePVC(namespace, name, storageClass, size string) *corev1.PersistentVolumeClaim {
+	sc := storageClass
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			StorageClassName: &sc,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse(size),
+				},
+			},
+		},
+	}
+}
+
+func waitForPVCBound(t *testing.T, ctx context.Context, cs *kubernetes.Clientset, namespace, name string, timeout time.Duration) *corev1.PersistentVolumeClaim {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("context cancelled while waiting for PVC %s/%s to bind: %v", namespace, name, err)
+		}
+		pvc, err := cs.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err == nil && pvc.Status.Phase == corev1.ClaimBound {
+			return pvc
+		}
+		select {
+		case <-time.After(pollInterval):
+		case <-ctx.Done():
+			t.Fatalf("context cancelled while waiting for PVC %s/%s to bind: %v", namespace, name, ctx.Err())
+		}
+	}
+	t.Fatalf("PVC %s/%s did not become Bound within %v", namespace, name, timeout)
+	return nil
+}
+
+// getPVDiskID extracts the cloud disk ID from the PV backing a bound PVC.
+func getPVDiskID(t *testing.T, ctx context.Context, cs *kubernetes.Clientset, pvc *corev1.PersistentVolumeClaim) string {
+	t.Helper()
+	pvName := pvc.Spec.VolumeName
+	if pvName == "" {
+		t.Fatal("PVC has no bound PV name")
+	}
+	pv, err := cs.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get PV %s: %v", pvName, err)
+	}
+	if pv.Spec.CSI == nil {
+		t.Fatalf("PV %s has no CSI spec", pvName)
+	}
+	attrs := pv.Spec.CSI.VolumeAttributes
+	if id, ok := attrs[volAttrEBSVolumeID]; ok && id != "" {
+		return id
+	}
+	if id, ok := attrs[volAttrCloudVolPath]; ok && id != "" {
+		return id
+	}
+	if id, ok := attrs[volAttrAzureDiskID]; ok && id != "" {
+		return id
+	}
+	t.Logf("Warning: no known volume attribute found on PV %s, falling back to VolumeHandle %q", pvName, pv.Spec.CSI.VolumeHandle)
+	return pv.Spec.CSI.VolumeHandle
+}
+
+func waitForPVDeleted(t *testing.T, ctx context.Context, cs *kubernetes.Clientset, pvName string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("context cancelled while waiting for PV %s deletion: %v", pvName, err)
+		}
+		_, err := cs.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return
+		}
+		select {
+		case <-time.After(pollInterval):
+		case <-ctx.Done():
+			t.Fatalf("context cancelled while waiting for PV %s deletion: %v", pvName, ctx.Err())
+		}
+	}
+	t.Fatalf("PV %s was not deleted within %v", pvName, timeout)
+}
+
+func waitForPodGone(t *testing.T, ctx context.Context, cs *kubernetes.Clientset, ns, name string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			t.Fatalf("context cancelled while waiting for pod %s/%s to be gone: %v", ns, name, ctx.Err())
+		default:
+		}
+		_, err := cs.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Fatalf("pod %s/%s was not gone within 30s — stale pod from a previous run may need manual cleanup", ns, name)
+}
+
+func waitForPVCGone(t *testing.T, ctx context.Context, cs *kubernetes.Clientset, ns, name string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			t.Fatalf("context cancelled while waiting for PVC %s/%s to be gone: %v", ns, name, ctx.Err())
+		default:
+		}
+		_, err := cs.CoreV1().PersistentVolumeClaims(ns).Get(ctx, name, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Logf("Warning: PVC %s/%s was not gone within 30s", ns, name)
+}
+
+func waitForStorageClassGone(t *testing.T, ctx context.Context, cs *kubernetes.Clientset, name string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			t.Fatalf("context cancelled while waiting for StorageClass %s to be gone: %v", name, ctx.Err())
+		default:
+		}
+		_, err := cs.StorageV1().StorageClasses().Get(ctx, name, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Logf("Warning: StorageClass %s was not gone within 30s", name)
+}
+
+// ensureLifecycleNamespace creates a namespace and registers cleanup via t.Cleanup.
+func ensureLifecycleNamespace(t *testing.T, cs *kubernetes.Clientset, ns string) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := cs.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			t.Fatalf("Failed to check namespace %s: %v", ns, err)
+		}
+		_, err = cs.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: ns},
+		}, metav1.CreateOptions{})
+		if err != nil && !errors.IsAlreadyExists(err) {
+			t.Fatalf("Failed to create namespace %s: %v", ns, err)
+		}
+	}
+	t.Cleanup(func() {
+		cs.CoreV1().Namespaces().Delete(context.Background(), ns, metav1.DeleteOptions{}) //nolint:errcheck
+	})
+}
+
+// ensureLifecycleStorageClass creates a StorageClass and registers cleanup via t.Cleanup.
+func ensureLifecycleStorageClass(t *testing.T, ctx context.Context, cs *kubernetes.Clientset, provider string) {
+	t.Helper()
+	scClient := cs.StorageV1().StorageClasses()
+	scClient.Delete(ctx, lifecycleStorageClass, metav1.DeleteOptions{}) //nolint:errcheck
+	waitForStorageClassGone(t, ctx, cs, lifecycleStorageClass)
+	sc := newLifecycleStorageClass(provider)
+	_, err := scClient.Create(ctx, sc, metav1.CreateOptions{})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		t.Fatalf("Failed to create StorageClass: %v", err)
+	}
+	t.Cleanup(func() {
+		scClient.Delete(context.Background(), lifecycleStorageClass, metav1.DeleteOptions{}) //nolint:errcheck
+	})
+}
+
+// TestCSIFullLifecycle exercises the complete volume passthrough lifecycle:
+//
+//	Phase 1: Setup — create StorageClass (Delete policy) + PVC, verify cloud disk exists
+//	Phase 2: Write — create writer pod, write data, verify success
+//	Phase 3: Detach — delete writer pod, verify cloud disk detaches
+//	Phase 4: Reattach & Verify — create reader pod with same PVC, verify data persistence
+//	Phase 5: Cleanup — delete reader pod, delete PVC, verify PV cleanup
+//	Phase 6: Cloud Check — verify cloud disk no longer exists
+func TestCSIFullLifecycle(t *testing.T) {
+	skipIfLifecycleDisabled(t)
+
+	provider := getCloudProvider(t)
+	cs := getClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), singleTestTimeout)
+	defer cancel()
+
+	verifier, err := newCloudDiskVerifier(provider)
+	if err != nil {
+		t.Fatalf("Failed to create cloud disk verifier: %v", err)
+	}
+
+	// ========== Phase 1: Setup ==========
+	t.Log("Phase 1: Setup — creating namespace, StorageClass, and PVC")
+
+	ensureLifecycleNamespace(t, cs, lifecycleSingleNamespace)
+	ensureLifecycleStorageClass(t, ctx, cs, provider)
+
+	cs.CoreV1().PersistentVolumeClaims(lifecycleSingleNamespace).Delete(ctx, lifecyclePVCName, metav1.DeleteOptions{}) //nolint:errcheck
+	waitForPVCGone(t, ctx, cs, lifecycleSingleNamespace, lifecyclePVCName)
+	pvc := newLifecyclePVC(lifecycleSingleNamespace, lifecyclePVCName, lifecycleStorageClass, lifecyclePVCSize)
+	_, err = cs.CoreV1().PersistentVolumeClaims(lifecycleSingleNamespace).Create(ctx, pvc, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create PVC: %v", err)
+	}
+	t.Cleanup(func() {
+		cs.CoreV1().PersistentVolumeClaims(lifecycleSingleNamespace).Delete(context.Background(), lifecyclePVCName, metav1.DeleteOptions{}) //nolint:errcheck
+	})
+
+	boundPVC := waitForPVCBound(t, ctx, cs, lifecycleSingleNamespace, lifecyclePVCName, pvcBoundTimeout)
+	pvName := boundPVC.Spec.VolumeName
+	t.Logf("PVC bound to PV: %s", pvName)
+
+	diskID := getPVDiskID(t, ctx, cs, boundPVC)
+	t.Logf("Cloud disk ID: %s", diskID)
+
+	// Safety net: detect orphaned cloud disks if normal cleanup fails
+	t.Cleanup(func() {
+		if exists, _ := verifier.DiskExists(context.Background(), diskID); exists {
+			t.Logf("ORPHAN DETECTED: cloud disk %s still exists after test cleanup — manual deletion required", diskID)
+		}
+	})
+
+	exists, err := verifier.DiskExists(ctx, diskID)
+	if err != nil {
+		t.Fatalf("Failed to check disk existence: %v", err)
+	}
+	if !exists {
+		t.Fatalf("Phase 1 FAILED: cloud disk %s does not exist after PVC bind", diskID)
+	}
+	t.Log("Phase 1 PASSED: PVC bound, cloud disk exists")
+
+	// ========== Phase 2: Write ==========
+	t.Log("Phase 2: Write — creating writer pod")
+
+	writerPod := newCSIWriterPod(lifecycleSingleNamespace, lifecycleWriterPod, lifecyclePVCName, lifecycleMountPath, lifecycleTestData)
+	cs.CoreV1().Pods(lifecycleSingleNamespace).Delete(ctx, lifecycleWriterPod, metav1.DeleteOptions{}) //nolint:errcheck
+	waitForPodGone(t, ctx, cs, lifecycleSingleNamespace, lifecycleWriterPod)
+	_, err = cs.CoreV1().Pods(lifecycleSingleNamespace).Create(ctx, writerPod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create writer pod: %v", err)
+	}
+	t.Cleanup(func() {
+		deletePodAndWait(t, cs, lifecycleSingleNamespace, lifecycleWriterPod)
+	})
+
+	logs := waitForPodCompletion(t, cs, lifecycleSingleNamespace, lifecycleWriterPod, lifecyclePodTimeout)
+	if !strings.Contains(logs, lifecycleTestData) {
+		t.Fatalf("Phase 2 FAILED: writer output %q does not contain test data %q", strings.TrimSpace(logs), lifecycleTestData)
+	}
+	t.Log("Phase 2 PASSED: data written successfully")
+
+	// ========== Phase 3: Detach ==========
+	t.Log("Phase 3: Detach — deleting writer pod, verifying disk detaches")
+
+	deletePodAndWait(t, cs, lifecycleSingleNamespace, lifecycleWriterPod)
+	t.Log("Writer pod deleted, waiting for disk to detach...")
+
+	state, err := waitForDiskDetached(ctx, verifier, diskID, diskDetachTimeout)
+	if err != nil {
+		t.Fatalf("Phase 3 FAILED: %v", err)
+	}
+	t.Logf("Phase 3 PASSED: disk detached, state=%s", state)
+
+	// ========== Phase 4: Reattach & Verify ==========
+	t.Log("Phase 4: Reattach & Verify — creating reader pod, verifying data persistence")
+
+	cs.CoreV1().Pods(lifecycleSingleNamespace).Delete(ctx, lifecycleReaderPod, metav1.DeleteOptions{}) //nolint:errcheck
+	waitForPodGone(t, ctx, cs, lifecycleSingleNamespace, lifecycleReaderPod)
+	readerPod := newCSIReaderPod(lifecycleSingleNamespace, lifecycleReaderPod, lifecyclePVCName, lifecycleMountPath)
+	_, err = cs.CoreV1().Pods(lifecycleSingleNamespace).Create(ctx, readerPod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create reader pod: %v", err)
+	}
+	t.Cleanup(func() {
+		deletePodAndWait(t, cs, lifecycleSingleNamespace, lifecycleReaderPod)
+	})
+
+	logs = waitForPodCompletion(t, cs, lifecycleSingleNamespace, lifecycleReaderPod, lifecyclePodTimeout)
+	if !strings.Contains(logs, lifecycleTestData) {
+		t.Fatalf("Phase 4 FAILED: persistence broken — reader got %q, expected to contain %q", strings.TrimSpace(logs), lifecycleTestData)
+	}
+	t.Log("Phase 4 PASSED: data persisted across pod restart")
+
+	// ========== Phase 5: Cleanup ==========
+	t.Log("Phase 5: Cleanup — deleting reader pod and PVC")
+
+	deletePodAndWait(t, cs, lifecycleSingleNamespace, lifecycleReaderPod)
+	t.Log("Reader pod deleted")
+
+	_, err = waitForDiskDetached(ctx, verifier, diskID, diskDetachTimeout)
+	if err != nil {
+		t.Logf("Warning: disk did not reach detached state before PVC delete: %v", err)
+	}
+
+	err = cs.CoreV1().PersistentVolumeClaims(lifecycleSingleNamespace).Delete(ctx, lifecyclePVCName, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Failed to delete PVC: %v", err)
+	}
+	t.Log("PVC deleted, waiting for PV cleanup...")
+
+	waitForPVDeleted(t, ctx, cs, pvName, pvDeleteTimeout)
+	t.Log("Phase 5 PASSED: PV deleted")
+
+	// ========== Phase 6: Cloud Check ==========
+	t.Log("Phase 6: Cloud Check — verifying disk no longer exists in cloud")
+
+	err = waitForDiskDeleted(ctx, verifier, diskID, diskDeleteTimeout)
+	if err != nil {
+		t.Fatalf("Phase 6 FAILED: %v", err)
+	}
+	t.Log("Phase 6 PASSED: cloud disk deleted — no orphan resources")
+
+	t.Log("ALL PHASES PASSED: Full lifecycle verified (create → write → detach → reattach+verify → delete → cloud cleanup)")
+}
+
+// TestCSIFullLifecycleMultiDisk exercises the same lifecycle with two PVCs on one pod.
+func TestCSIFullLifecycleMultiDisk(t *testing.T) {
+	skipIfLifecycleDisabled(t)
+
+	provider := getCloudProvider(t)
+	cs := getClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), multiTestTimeout)
+	defer cancel()
+
+	verifier, err := newCloudDiskVerifier(provider)
+	if err != nil {
+		t.Fatalf("Failed to create cloud disk verifier: %v", err)
+	}
+
+	// Setup
+	t.Log("Setup: creating namespace, StorageClass, and 2 PVCs")
+
+	ensureLifecycleNamespace(t, cs, lifecycleMultiNamespace)
+	ensureLifecycleStorageClass(t, ctx, cs, provider)
+
+	pvcNames := []string{"lifecycle-multi-pvc-0", "lifecycle-multi-pvc-1"}
+	testDataValues := []string{"multi-disk-0-data-lifecycle", "multi-disk-1-data-lifecycle"}
+	diskIDs := make([]string, 2)
+	pvNames := make([]string, 2)
+
+	for i, name := range pvcNames {
+		cs.CoreV1().PersistentVolumeClaims(lifecycleMultiNamespace).Delete(ctx, name, metav1.DeleteOptions{}) //nolint:errcheck
+		waitForPVCGone(t, ctx, cs, lifecycleMultiNamespace, name)
+		pvc := newLifecyclePVC(lifecycleMultiNamespace, name, lifecycleStorageClass, lifecyclePVCSize)
+		_, err = cs.CoreV1().PersistentVolumeClaims(lifecycleMultiNamespace).Create(ctx, pvc, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Failed to create PVC %s: %v", name, err)
+		}
+		pvcName := name
+		t.Cleanup(func() {
+			cs.CoreV1().PersistentVolumeClaims(lifecycleMultiNamespace).Delete(context.Background(), pvcName, metav1.DeleteOptions{}) //nolint:errcheck
+		})
+		boundPVC := waitForPVCBound(t, ctx, cs, lifecycleMultiNamespace, name, pvcBoundTimeout)
+		pvNames[i] = boundPVC.Spec.VolumeName
+		diskIDs[i] = getPVDiskID(t, ctx, cs, boundPVC)
+		t.Logf("PVC %s → PV %s → Disk %s", name, pvNames[i], diskIDs[i])
+	}
+
+	// Safety net: detect orphaned cloud disks if normal cleanup fails
+	t.Cleanup(func() {
+		for i, diskID := range diskIDs {
+			if diskID == "" {
+				continue
+			}
+			if exists, _ := verifier.DiskExists(context.Background(), diskID); exists {
+				t.Logf("ORPHAN DETECTED: cloud disk %d (%s) still exists after test cleanup — manual deletion required", i, diskID)
+			}
+		}
+	})
+
+	for i, diskID := range diskIDs {
+		exists, err := verifier.DiskExists(ctx, diskID)
+		if err != nil {
+			t.Fatalf("Disk %d (%s) existence check failed: %v", i, diskID, err)
+		}
+		if !exists {
+			t.Fatalf("Disk %d (%s) does not exist after PVC bind", i, diskID)
+		}
+	}
+	t.Log("Setup PASSED: both disks provisioned")
+
+	// Write phase
+	t.Log("Write: creating multi-volume writer pod")
+
+	writerPod := newMultiVolumeWriterPod(lifecycleMultiNamespace, "lifecycle-multi-writer", pvcNames, testDataValues)
+	cs.CoreV1().Pods(lifecycleMultiNamespace).Delete(ctx, "lifecycle-multi-writer", metav1.DeleteOptions{}) //nolint:errcheck
+	waitForPodGone(t, ctx, cs, lifecycleMultiNamespace, "lifecycle-multi-writer")
+	_, err = cs.CoreV1().Pods(lifecycleMultiNamespace).Create(ctx, writerPod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create writer pod: %v", err)
+	}
+	t.Cleanup(func() {
+		deletePodAndWait(t, cs, lifecycleMultiNamespace, "lifecycle-multi-writer")
+	})
+
+	logs := waitForPodCompletion(t, cs, lifecycleMultiNamespace, "lifecycle-multi-writer", lifecyclePodTimeout)
+	for _, d := range testDataValues {
+		if !strings.Contains(logs, d) {
+			t.Fatalf("Write FAILED: output missing %q", d)
+		}
+	}
+	t.Log("Write PASSED")
+
+	// Detach — assert disks actually detach
+	t.Log("Detach: deleting writer pod, verifying disks detach")
+	deletePodAndWait(t, cs, lifecycleMultiNamespace, "lifecycle-multi-writer")
+
+	for i, diskID := range diskIDs {
+		state, err := waitForDiskDetached(ctx, verifier, diskID, diskDetachTimeout)
+		if err != nil {
+			t.Fatalf("Detach FAILED for disk %d (%s): %v", i, diskID, err)
+		}
+		t.Logf("Disk %d detached, state=%s", i, state)
+	}
+	t.Log("Detach PASSED")
+
+	// Reattach + Verify
+	t.Log("Reattach: creating multi-volume reader pod")
+
+	readerPod := newMultiVolumeReaderPod(lifecycleMultiNamespace, "lifecycle-multi-reader", pvcNames)
+	cs.CoreV1().Pods(lifecycleMultiNamespace).Delete(ctx, "lifecycle-multi-reader", metav1.DeleteOptions{}) //nolint:errcheck
+	waitForPodGone(t, ctx, cs, lifecycleMultiNamespace, "lifecycle-multi-reader")
+	_, err = cs.CoreV1().Pods(lifecycleMultiNamespace).Create(ctx, readerPod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create reader pod: %v", err)
+	}
+	t.Cleanup(func() {
+		deletePodAndWait(t, cs, lifecycleMultiNamespace, "lifecycle-multi-reader")
+	})
+
+	logs = waitForPodCompletion(t, cs, lifecycleMultiNamespace, "lifecycle-multi-reader", lifecyclePodTimeout)
+	for _, d := range testDataValues {
+		if !strings.Contains(logs, d) {
+			t.Fatalf("Verify FAILED: reader output missing %q", d)
+		}
+	}
+	t.Log("Verify PASSED: both disks persisted data")
+
+	// Cleanup
+	t.Log("Cleanup: deleting reader pod and PVCs")
+	deletePodAndWait(t, cs, lifecycleMultiNamespace, "lifecycle-multi-reader")
+
+	for i, diskID := range diskIDs {
+		_, err := waitForDiskDetached(ctx, verifier, diskID, diskDetachTimeout)
+		if err != nil {
+			t.Logf("Warning: disk %d did not reach detached state before PVC delete: %v", i, err)
+		}
+	}
+
+	for _, name := range pvcNames {
+		if err := cs.CoreV1().PersistentVolumeClaims(lifecycleMultiNamespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+			if !errors.IsNotFound(err) {
+				t.Logf("Warning: failed to delete PVC %s: %v", name, err)
+			}
+		}
+	}
+
+	for _, pv := range pvNames {
+		waitForPVDeleted(t, ctx, cs, pv, pvDeleteTimeout)
+	}
+	t.Log("Cleanup PASSED: PVs deleted")
+
+	// Cloud check
+	t.Log("Cloud Check: verifying disks deleted")
+	for i, diskID := range diskIDs {
+		err = waitForDiskDeleted(ctx, verifier, diskID, diskDeleteTimeout)
+		if err != nil {
+			t.Fatalf("Cloud Check FAILED for disk %d: %v", i, err)
+		}
+	}
+	t.Log("Cloud Check PASSED: all disks deleted — no orphans")
+
+	t.Log("ALL PHASES PASSED: Multi-disk full lifecycle verified")
+}

--- a/src/cloud-api-adaptor/test/e2e/csi_test.go
+++ b/src/cloud-api-adaptor/test/e2e/csi_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -24,7 +25,6 @@ const (
 	csiTestNamespace    = "csi-e2e-test"
 	podReadyTimeout     = 5 * time.Minute
 	podDeleteTimeout    = 3 * time.Minute
-	pollInterval        = 5 * time.Second
 )
 
 func getClient(t *testing.T) *kubernetes.Clientset {
@@ -72,10 +72,17 @@ func waitForPodCompletion(t *testing.T, cs *kubernetes.Clientset, ns, name strin
 	for time.Now().Before(deadline) {
 		pod, err := cs.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
 		if err == nil && (pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed) {
-			if pod.Status.Phase == corev1.PodFailed {
-				t.Fatalf("Pod %s failed", name)
-			}
 			logs, _ := cs.CoreV1().Pods(ns).GetLogs(name, &corev1.PodLogOptions{}).Do(ctx).Raw()
+			if pod.Status.Phase == corev1.PodFailed {
+				t.Logf("Pod %s/%s failed — logs:\n%s", ns, name, string(logs))
+				for _, cstat := range pod.Status.ContainerStatuses {
+					if cstat.State.Terminated != nil {
+						t.Logf("Container %s exit code: %d, reason: %s, message: %s",
+							cstat.Name, cstat.State.Terminated.ExitCode, cstat.State.Terminated.Reason, cstat.State.Terminated.Message)
+					}
+				}
+				t.Fatalf("Pod %s/%s failed (see logs above)", ns, name)
+			}
 			return string(logs)
 		}
 		time.Sleep(pollInterval)
@@ -87,7 +94,16 @@ func waitForPodCompletion(t *testing.T, cs *kubernetes.Clientset, ns, name strin
 func deletePodAndWait(t *testing.T, cs *kubernetes.Clientset, ns, name string) {
 	t.Helper()
 	ctx := context.Background()
-	cs.CoreV1().Pods(ns).Delete(ctx, name, metav1.DeleteOptions{}) //nolint:errcheck
+	gracePeriod := int64(0)
+	err := cs.CoreV1().Pods(ns).Delete(ctx, name, metav1.DeleteOptions{
+		GracePeriodSeconds: &gracePeriod,
+	})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return
+		}
+		t.Logf("Warning: failed to delete pod %s/%s: %v", ns, name, err)
+	}
 	deadline := time.Now().Add(podDeleteTimeout)
 	for time.Now().Before(deadline) {
 		_, err := cs.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
@@ -96,6 +112,7 @@ func deletePodAndWait(t *testing.T, cs *kubernetes.Clientset, ns, name string) {
 		}
 		time.Sleep(pollInterval)
 	}
+	t.Logf("Warning: pod %s/%s was not fully deleted within %v", ns, name, podDeleteTimeout)
 }
 
 func newCSIPVC(namespace, name, size string) *corev1.PersistentVolumeClaim {


### PR DESCRIPTION
## Summary

Adds opt-in E2E lifecycle tests (`CSI_LIFECYCLE_E2E=true`) that verify the complete volume passthrough flow introduced in #3037.

The existing CSI tests only verify data persistence across pod restarts but don't confirm cloud-side behavior: disk detach after pod deletion, PV/PVC cleanup triggering cloud disk deletion, or absence of orphan resources. These tests close that gap by calling the cloud provider API directly (AWS EC2 `DescribeVolumes` / Azure Disks `Get`) at each lifecycle phase.

| Test | Coverage |
|------|----------|
| `TestCSIFullLifecycle` | Single disk: create → write → detach → reattach+verify → delete → cloud cleanup |
| `TestCSIFullLifecycleMultiDisk` | Same lifecycle with 2 PVCs on one pod |

Cloud disk verifiers use typed SDK error handling (`smithy.APIError` for AWS, `azcore.ResponseError` for Azure). PVCs and pods are registered with `t.Cleanup()` to prevent orphaned cloud resources on test failure. All polling loops respect context cancellation.

Also improves pod failure diagnostics in the existing `csi_test.go` — `waitForPodCompletion` now logs container output and exit codes on failure, and `deletePodAndWait` uses force-delete with proper `IsNotFound` handling.

See `test/e2e/README.md` for setup, configuration, and troubleshooting.

<details>
<summary>Test output (AWS EKS)</summary>

```
=== RUN   TestCSIFullLifecycle
    Phase 1 PASSED: PVC bound, cloud disk exists
    Phase 2 PASSED: data written successfully
    Phase 3 PASSED: disk detached, state=available
    Phase 4 PASSED: data persisted across pod restart
    Phase 5 PASSED: PV deleted
    Phase 6 PASSED: cloud disk deleted — no orphan resources
--- PASS: TestCSIFullLifecycle (182.06s)

=== RUN   TestCSIFullLifecycleMultiDisk
    Setup PASSED: both disks provisioned
    Write PASSED
    Detach PASSED
    Verify PASSED: both disks persisted data
    Cleanup PASSED: PVs deleted
    Cloud Check PASSED: all disks deleted — no orphans
--- PASS: TestCSIFullLifecycleMultiDisk (249.42s)
```

Validated on EKS 1.30 (us-east-2, m5.large) with real EBS volume provisioning and deletion.

</details>

Signed-off-by: Mohammed Adnan <muhammedadnan50007@gmail.com>