### PR TITLE
fix: preserve peer pod extended resources during CAA rolling restart

### DIFF
--- a/src/cloud-api-adaptor/cmd/cloud-api-adaptor/main.go
+++ b/src/cloud-api-adaptor/cmd/cloud-api-adaptor/main.go
@@ -209,7 +209,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go probe.Start(config.serverConfig.SocketPath)
+	go probe.Start(ctx, config.serverConfig.SocketPath)
 
 	if err := starter.Start(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", os.Args[0], err)

--- a/src/cloud-api-adaptor/install/charts/peerpods/templates/daemonset.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/templates/daemonset.yaml
@@ -31,6 +31,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         envFrom:
 {{- if include "peerpods.secretName" . }}
         - secretRef:

--- a/src/cloud-api-adaptor/install/charts/peerpods/templates/rbac.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/templates/rbac.yaml
@@ -85,6 +85,28 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: node-annotation-patcher
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-annotation-patcher
+subjects:
+- kind: ServiceAccount
+  name: cloud-api-adaptor
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: node-annotation-patcher
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: node-status-patcher
 rules:
 - apiGroups: [""]

--- a/src/cloud-api-adaptor/pkg/adaptor/k8sops/node.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/k8sops/node.go
@@ -16,9 +16,12 @@ import (
 	restclient "k8s.io/client-go/rest"
 )
 
-// AdvertiseExtendedResources sets up extended resources for the node
-func AdvertiseExtendedResources(peerPodsLimitPerNode int) error {
+const OwnerAnnotation = "kata.peerpods.io/caa-owner"
 
+// AdvertiseExtendedResources sets up extended resources for the node and records
+// ownerUID as the annotation owner so a concurrent shutdown from a previous instance
+// can detect it is no longer the current owner and skip removal.
+func AdvertiseExtendedResources(peerPodsLimitPerNode int, ownerUID string) error {
 	logger.Printf("set up extended resources")
 
 	if peerPodsLimitPerNode < 0 {
@@ -41,6 +44,13 @@ func AdvertiseExtendedResources(peerPodsLimitPerNode int) error {
 		return fmt.Errorf("failed to get k8s client: %v", err)
 	}
 
+	if ownerUID != "" {
+		if err := patchNodeAnnotation(cli, nodeName, OwnerAnnotation, ownerUID); err != nil {
+			logger.Printf("Failed to set owner annotation on node %s: %v", nodeName, err)
+			return err
+		}
+	}
+
 	err = patchNodeStatus(cli, nodeName, patch)
 	if err != nil {
 		logger.Printf("Failed to set extended resource for node %s", nodeName)
@@ -52,34 +62,50 @@ func AdvertiseExtendedResources(peerPodsLimitPerNode int) error {
 	return nil
 }
 
-// Patch the status of a node to remove extended resources
-func RemoveExtendedResources() error {
-
+// RemoveExtendedResources removes extended resources from the node. If ownerUID is
+// non-empty, it first checks the node's owner annotation; if another instance has
+// since taken ownership the removal is skipped to prevent stomping a live advertisement.
+// Returns true when this instance is the current owner (removal was performed or attempted),
+// false when ownership has passed to a newer instance and removal was skipped.
+func RemoveExtendedResources(ownerUID string) (bool, error) {
 	logger.Printf("remove extended resources")
 
 	nodeName := os.Getenv("NODE_NAME")
 
-	patch := append([]jsonPatch{}, newJSONPatch("remove", "/status/capacity", "kata.peerpods.io~1vm", ""))
-
 	config, err := getKubeConfig()
 	if err != nil {
-		return fmt.Errorf("failed to get k8s config: %v", err)
+		return false, fmt.Errorf("failed to get k8s config: %v", err)
 	}
 
 	cli, err := getClient(config)
 	if err != nil {
-		return fmt.Errorf("failed to get k8s client: %v", err)
+		return false, fmt.Errorf("failed to get k8s client: %v", err)
 	}
+
+	if ownerUID != "" {
+		node, err := cli.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("failed to get node %s: %v", nodeName, err)
+		}
+		currentOwner := node.Annotations[OwnerAnnotation]
+		if currentOwner != ownerUID {
+			logger.Printf("Skipping extended resource removal on node %s: current owner is %q, this instance is %q",
+				nodeName, currentOwner, ownerUID)
+			return false, nil
+		}
+	}
+
+	patch := append([]jsonPatch{}, newJSONPatch("remove", "/status/capacity", "kata.peerpods.io~1vm", ""))
 
 	err = patchNodeStatus(cli, nodeName, patch)
 	if err != nil {
 		logger.Printf("Failed to remove extended resource for node %s", nodeName)
-		return err
+		return true, err
 	}
 
 	logger.Printf("Successfully removed extended resource for node %s", nodeName)
 
-	return nil
+	return true, nil
 }
 
 // Auths contains Registries with credentials
@@ -99,7 +125,6 @@ type Auth struct {
 
 // GetImagePullSecrets gets image pull secrets for the specified pod
 func GetImagePullSecrets(podName string, namespace string) ([]byte, error) {
-
 	config, err := getKubeConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get k8s config: %v", err)
@@ -183,6 +208,13 @@ func addAuths(cli *k8sclient.Clientset, namespace string, secretName string, aut
 		auths.Registries[registry] = creds
 	}
 	return nil
+}
+
+// patchNodeAnnotation sets a single annotation on a node via a merge patch.
+func patchNodeAnnotation(c *k8sclient.Clientset, nodeName, key, value string) error {
+	patch := fmt.Sprintf(`{"metadata":{"annotations":{%q:%q}}}`, key, value)
+	_, err := c.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.MergePatchType, []byte(patch), metav1.PatchOptions{})
+	return err
 }
 
 // patchNodeStatus patches the status of a node

--- a/src/cloud-api-adaptor/pkg/adaptor/server.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/server.go
@@ -104,12 +104,24 @@ func (s *server) Start(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
+	if ul, ok := listener.(*net.UnixListener); ok {
+		ul.SetUnlinkOnClose(false)
+	}
 
 	ttRPCErr := make(chan error)
 	go func() {
 		defer close(ttRPCErr)
 		if err := s.ttRPC.Serve(ctx, listener); err != nil {
 			ttRPCErr <- err
+		}
+	}()
+	// Declared before the ttrpc shutdown defer so it runs after (defers are LIFO).
+	// Removes the socket only when this instance is still the current owner — skipped
+	// during rolling restarts where the new pod has already taken ownership, but runs
+	// on clean shutdown and uninstall so the file is not left on the node indefinitely.
+	defer func() {
+		if !k8sops.IsKubernetesEnvironment() || s.isOwner {
+			os.Remove(s.socketPath)
 		}
 	}()
 	defer func() {
@@ -131,6 +143,10 @@ func (s *server) Start(ctx context.Context) (err error) {
 		}
 	case <-s.stopCh:
 	case err = <-ttRPCErr:
+		shutdownErr := s.Shutdown()
+		if shutdownErr != nil && err == nil {
+			err = shutdownErr
+		}
 	}
 	return err
 }

--- a/src/cloud-api-adaptor/pkg/adaptor/server.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/server.go
@@ -47,10 +47,11 @@ type server struct {
 	stopOnce                sync.Once
 	enableCloudConfigVerify bool
 	PeerPodsLimitPerNode    int
+	ownerUID                string
+	isOwner                 bool
 }
 
 func NewServer(provider provider.Provider, cfg *cloud.ServerConfig, workerNode podnetwork.WorkerNode) Server {
-
 	logger.Printf("server config: %#v", cfg)
 
 	agentFactory := proxy.NewFactory(cfg.PauseImage, cfg.TLSConfig, cfg.ProxyTimeout)
@@ -66,6 +67,7 @@ func NewServer(provider provider.Provider, cfg *cloud.ServerConfig, workerNode p
 		stopCh:                  make(chan struct{}),
 		enableCloudConfigVerify: cfg.EnableCloudConfigVerify,
 		PeerPodsLimitPerNode:    cfg.PeerPodsLimitPerNode,
+		ownerUID:                os.Getenv("POD_UID"),
 	}
 }
 
@@ -78,7 +80,7 @@ func (s *server) Start(ctx context.Context) (err error) {
 	}
 	// Advertise node resources
 	if k8sops.IsKubernetesEnvironment() {
-		err = k8sops.AdvertiseExtendedResources(s.PeerPodsLimitPerNode)
+		err = k8sops.AdvertiseExtendedResources(s.PeerPodsLimitPerNode, s.ownerUID)
 		if err != nil {
 			return err
 		}
@@ -138,7 +140,13 @@ func (s *server) Shutdown() error {
 		close(s.stopCh)
 	})
 
-	_ = k8sops.RemoveExtendedResources()
+	if k8sops.IsKubernetesEnvironment() {
+		isOwner, err := k8sops.RemoveExtendedResources(s.ownerUID)
+		if err != nil {
+			return err
+		}
+		s.isOwner = isOwner
+	}
 
 	return s.cloudService.Teardown()
 }

--- a/src/cloud-api-adaptor/pkg/probe/probe.go
+++ b/src/cloud-api-adaptor/pkg/probe/probe.go
@@ -4,10 +4,15 @@
 package probe
 
 import (
+	"context"
 	"log"
+	"net"
 	"net/http"
 	"os"
+	"syscall"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 var logger = log.New(log.Writer(), "[probe/probe] ", log.LstdFlags|log.Lmsgprefix)
@@ -43,7 +48,7 @@ func StartupHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func Start(socketPath string) {
+func Start(ctx context.Context, socketPath string) {
 	startTime = time.Now()
 
 	port := os.Getenv("PROBE_PORT")
@@ -63,10 +68,34 @@ func Start(socketPath string) {
 		RuntimeclassName: GetRuntimeclassName(),
 		SocketPath:       socketPath,
 	}
-	http.HandleFunc("/startup", StartupHandler)
-	err = http.ListenAndServe("127.0.0.1:"+port, nil)
-
+	lc := net.ListenConfig{
+		Control: func(network, address string, c syscall.RawConn) error {
+			return c.Control(func(fd uintptr) {
+				if err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1); err != nil {
+					logger.Printf("failed to set SO_REUSEPORT: %v", err)
+				}
+			})
+		},
+	}
+	ln, err := lc.Listen(ctx, "tcp", "127.0.0.1:"+port)
 	if err != nil {
+		logger.Printf("failed to listen on probe port: %s", err)
+		return
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/startup", StartupHandler)
+	server := &http.Server{Handler: mux}
+	serveCtx, serveCancel := context.WithCancel(ctx)
+	defer serveCancel()
+	go func() {
+		<-serveCtx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			logger.Printf("probe server shutdown error: %v", err)
+		}
+	}()
+	if err = server.Serve(ln); err != nil && err != http.ErrServerClosed {
 		logger.Printf("failed to start startup probe server, error %s", err)
 	}
 }

--- a/src/cloud-api-adaptor/test/e2e/libvirt_test.go
+++ b/src/cloud-api-adaptor/test/e2e/libvirt_test.go
@@ -288,3 +288,7 @@ func TestLibvirtPodWithInitContainer(t *testing.T) {
 	assert := getLibvirtAssert(t)
 	DoTestPodWithInitContainer(t, testEnv, assert)
 }
+
+func TestLibvirtExtendedResourcesAfterRollout(t *testing.T) {
+	DoTestExtendedResourcesAfterRollout(t, testEnv)
+}

--- a/src/cloud-api-adaptor/test/e2e/rolling_update.go
+++ b/src/cloud-api-adaptor/test/e2e/rolling_update.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/adaptor/k8sops"
 	pv "github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/test/provisioner"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -282,6 +283,166 @@ func waitForCaaDaemonSetUpdated(t *testing.T, client klient.Client, ds *appsv1.D
 	}), wait.WithTimeout(WaitDeploymentAvailableTimeout)); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// DoTestExtendedResourcesAfterRollout verifies that node extended resources
+// (kata.peerpods.io/vm) survive a zero-workload CAA DaemonSet rollout restart.
+//
+// The race this exercises: the new CAA pod advertises the resource and becomes
+// Ready before the old pod finishes terminating. Without the owner-annotation
+// fix the old pod's Shutdown() removes the resource the new pod already set,
+// leaving the node with no capacity and preventing peer pod scheduling.
+func DoTestExtendedResourcesAfterRollout(t *testing.T, testEnv env.Environment) {
+	const (
+		caaDaemonSetName = "cloud-api-adaptor-daemonset"
+		extResourceName  = "kata.peerpods.io/vm"
+	)
+	caaNamespace := pv.GetCAANamespace()
+
+	feature := features.New("Extended resources survive CAA rollout restart").
+		Assess("Rollout CAA DaemonSet and verify extended resources remain on all nodes", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			clientset, err := kubernetes.NewForConfig(client.RESTConfig())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Get the DaemonSet and record the expected pod count.
+			ds := &appsv1.DaemonSet{}
+			if err = client.Resources().Get(ctx, caaDaemonSetName, caaNamespace, ds); err != nil {
+				t.Fatal(err)
+			}
+			rc := ds.Status.DesiredNumberScheduled
+			if rc == 0 {
+				t.Skip("No CAA pods scheduled; skipping test")
+			}
+
+			// List all current CAA pods to snapshot node names and pre-rollout pod UIDs.
+			caaPodList, err := clientset.CoreV1().Pods(caaNamespace).List(ctx, metav1.ListOptions{
+				LabelSelector: "app=cloud-api-adaptor",
+			})
+			if err != nil {
+				t.Fatalf("Failed to list CAA pods: %v", err)
+			}
+			if len(caaPodList.Items) == 0 {
+				t.Fatal("Expected at least one CAA pod but found none")
+			}
+
+			type nodeSnapshot struct {
+				nodeName  string
+				oldPodUID string
+			}
+			snapshots := make([]nodeSnapshot, 0, len(caaPodList.Items))
+			for _, pod := range caaPodList.Items {
+				snapshots = append(snapshots, nodeSnapshot{
+					nodeName:  pod.Spec.NodeName,
+					oldPodUID: string(pod.UID),
+				})
+				t.Logf("Pre-rollout: node=%s pod-uid=%s", pod.Spec.NodeName, pod.UID)
+			}
+
+			// Confirm extended resources are present before the rollout.
+			// If any node lacks the resource, extended resources are disabled
+			// (PeerPodsLimitPerNode < 0) and this test does not apply.
+			for _, snap := range snapshots {
+				node, err := clientset.CoreV1().Nodes().Get(ctx, snap.nodeName, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("Failed to get node %s: %v", snap.nodeName, err)
+				}
+				qty, ok := node.Status.Capacity[v1.ResourceName(extResourceName)]
+				if !ok || qty.IsZero() {
+					t.Skipf("Node %s has no %s capacity; extended resources disabled — skipping", snap.nodeName, extResourceName)
+				}
+				t.Logf("Pre-rollout: node=%s %s=%s owner=%q",
+					snap.nodeName, extResourceName, qty.String(), node.Annotations[k8sops.OwnerAnnotation])
+			}
+
+			// Trigger rollout via the same annotation kubectl rollout restart writes.
+			// This is a pure template hash bump with no functional side-effect.
+			t.Log("Triggering CAA DaemonSet rollout...")
+			if ds.Spec.Template.Annotations == nil {
+				ds.Spec.Template.Annotations = make(map[string]string)
+			}
+			ds.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+			if err = client.Resources().Update(ctx, ds); err != nil {
+				t.Fatal(err)
+			}
+
+			waitForCaaDaemonSetUpdated(t, client, ds, rc)
+			t.Log("CAA DaemonSet rollout complete")
+
+			// Assert extended resources are still present on every node.
+			for _, snap := range snapshots {
+				node, err := clientset.CoreV1().Nodes().Get(ctx, snap.nodeName, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("Post-rollout: failed to get node %s: %v", snap.nodeName, err)
+				}
+
+				qty, ok := node.Status.Capacity[v1.ResourceName(extResourceName)]
+				if !ok || qty.IsZero() {
+					t.Errorf("Post-rollout: node %s lost %s — old CAA shutdown incorrectly removed the resource",
+						snap.nodeName, extResourceName)
+				} else {
+					t.Logf("Post-rollout: node=%s %s=%s (preserved)", snap.nodeName, extResourceName, qty.String())
+				}
+
+				// Verify the owner annotation was updated to the new pod's UID,
+				// confirming the new instance took ownership before the old one shut down.
+				currentOwner := node.Annotations[k8sops.OwnerAnnotation]
+				switch currentOwner {
+				case "":
+					t.Errorf("Post-rollout: node %s is missing the %s annotation", snap.nodeName, k8sops.OwnerAnnotation)
+				case snap.oldPodUID:
+					t.Errorf("Post-rollout: node %s owner annotation still points to the old pod %s — ownership handoff failed",
+						snap.nodeName, snap.oldPodUID)
+				default:
+					t.Logf("Post-rollout: node=%s owner updated from %s to %s (ownership handed off)",
+						snap.nodeName, snap.oldPodUID, currentOwner)
+				}
+			}
+
+			return ctx
+		}).
+		Assess("Create a peer pod to verify CAA is functional after rollout", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			podOrErr := NewBusyboxPodWithName(E2eNamespace, "caa-rollout-verify-pod")
+			if podOrErr.err != nil {
+				t.Fatalf("Failed to build peer pod spec: %v", podOrErr.err)
+			}
+			pod := podOrErr.pod
+
+			t.Logf("Creating peer pod %s in namespace %s...", pod.Name, E2eNamespace)
+			if err = client.Resources().Create(ctx, pod); err != nil {
+				t.Fatalf("Failed to create peer pod: %v", err)
+			}
+			defer func() {
+				if err = client.Resources().Delete(ctx, pod); err != nil {
+					t.Logf("Failed to delete peer pod: %v", err)
+				}
+			}()
+
+			if err = wait.For(conditions.New(client.Resources()).PodPhaseMatch(pod, v1.PodRunning),
+				wait.WithTimeout(WaitPodRunningTimeout)); err != nil {
+				t.Fatalf("Peer pod did not reach Running state: %v", err)
+			}
+			if err = wait.For(conditions.New(client.Resources()).ContainersReady(pod),
+				wait.WithTimeout(WaitPodRunningTimeout)); err != nil {
+				t.Fatalf("Peer pod containers not ready: %v", err)
+			}
+			t.Logf("Peer pod %s is Running — CAA is functional after rollout", pod.Name)
+
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
 }
 
 func waitForDeploymentAvailable(t *testing.T, client klient.Client, deployment *appsv1.Deployment, rc int32) {


### PR DESCRIPTION
  ## Problem

During a CAA DaemonSet rolling update, the old pod's shutdown removes the
`kata.peerpods.io/vm` extended resource from the node after the new pod has
already re-advertised it. This leaves the node with no peer pod capacity,
blocking scheduling until CAA is manually restarted.

Two additional races exist during the handoff window:
- Old and new pods both bind port 8000 (probe server) → `EADDRINUSE`
- Old pod's `listener.Close()` deletes the hypervisor socket the new pod is serving → shim gets `ENOENT`

## Fix

 - **Owner annotation** (`kata.peerpods.io/caa-owner`): new pod records its UID on the node after advertising the resource; old pod skips removal if a newer instance has taken ownership. Socket is still cleaned
up on uninstall (no new owner).
 - **`SetUnlinkOnClose(false)`**: prevents old pod from unlinking the hypervisor socket. Explicit owner-checked `os.Remove` on shutdown ensures cleanup on uninstall.
- **`SO_REUSEPORT`** on the probe HTTP server: old and new pods can coexist on port 8000 during the handoff window.

## Test

`TestLibvirtExtendedResourcesAfterRollout` — triggers a DaemonSet rollout and asserts:
1. `kata.peerpods.io/vm` capacity is preserved on all nodes
2. Owner annotation is updated to the new pod UID
3. A peer pod reaches Running state after rollout
