### PR TITLE
ci: add govulncheck ignore list support

### DIFF
--- a/.govulncheck-ignore.toml
+++ b/.govulncheck-ignore.toml
@@ -1,0 +1,35 @@
+# .govulncheck-ignore.toml
+#
+# Ignore list for hack/govulncheck.sh.
+# Add [[IgnoredVulns]] entries to suppress specific govulncheck vulnerability
+# IDs that are known false-positives or have no upstream fix available yet.
+#
+# Format:
+#
+#   [[IgnoredVulns]]
+#   id = "GO-YYYY-NNNN"
+#   reason = "Why this is suppressed"
+#
+# Optionally add ignoreUntil (TOML local date). An expired entry still suppresses
+# the finding but prints a warning so the team knows to review it:
+#
+#   [[IgnoredVulns]]
+#   id = "GO-YYYY-NNNN"
+#   reason = "Waiting for upstream patch"
+#   ignoreUntil = 2026-12-31
+
+# All three vulns below affect github.com/containerd/containerd@v1.7.33 via the
+# CRI checkpoint/restore feature. CAA does not expose that feature, so they are
+# not exploitable in this codebase. No fix is available upstream at this time.
+
+[[IgnoredVulns]]
+id = "GO-2026-5622"
+reason = "Arbitrary host CRI log file read via symlink in containerd. Not exploitable in CAA: CRI checkpoint/restore is not exposed."
+
+[[IgnoredVulns]]
+id = "GO-2026-5338"
+reason = "CRI checkpoint import allows local image tag poisoning in containerd. Not exploitable in CAA: CRI checkpoint/restore is not exposed."
+
+[[IgnoredVulns]]
+id = "GO-2026-5064"
+reason = "containerd CRI checkpoint restore CDI annotation smuggling. Not exploitable in CAA: CRI checkpoint/restore is not exposed."

--- a/hack/govulncheck-filter.py
+++ b/hack/govulncheck-filter.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Filter for govulncheck --json output.
+
+Reads govulncheck JSON stream from stdin, suppresses vulnerability IDs listed
+in the ignore file, and exits non-zero only when non-ignored findings remain.
+
+Environment variables:
+  IGNORE_FILE   Path to .govulncheck-ignore.toml (required)
+  VERBOSE       Set to "true" to pass through config/progress/osv messages
+"""
+
+import json
+import os
+import sys
+import tomllib
+from datetime import date
+
+ignore_file = os.environ.get("IGNORE_FILE", "")
+verbose = os.environ.get("VERBOSE", "false") == "true"
+today = date.today()
+
+ignore_reason: dict[str, str] = {}
+ignore_until: dict[str, date] = {}
+if ignore_file:
+    try:
+        with open(ignore_file, "rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError) as e:
+        print(f"govulncheck-filter: failed to load {ignore_file}: {e}", file=sys.stderr)
+        sys.exit(2)
+    for entry in data.get("IgnoredVulns", []):
+        vuln_id = entry.get("id", "")
+        if not vuln_id:
+            continue
+        ignore_reason[vuln_id] = entry.get("reason", "")
+        until = entry.get("ignoreUntil")
+        if until:
+            ignore_until[vuln_id] = until if isinstance(until, date) else date.fromisoformat(str(until))
+
+announced: set[str] = set()
+failed = False
+
+# govulncheck --json is pretty-printed; use a streaming decoder to reassemble objects.
+decoder = json.JSONDecoder()
+buf = ""
+
+for raw_line in sys.stdin:
+    buf += raw_line
+    while buf.strip():
+        buf = buf.lstrip()
+        if not buf:
+            break
+        try:
+            msg, idx = decoder.raw_decode(buf)
+            buf = buf[idx:]
+        except json.JSONDecodeError:
+            break
+
+        if "finding" in msg:
+            vuln_id = msg["finding"].get("osv", "")
+            trace = msg["finding"].get("trace", [])
+            # Skip module/package-only findings: govulncheck text mode only
+            # fails on call-reachable findings (those with a "function" frame).
+            if not any("function" in frame for frame in trace):
+                continue
+            if vuln_id in ignore_reason:
+                exp = ignore_until.get(vuln_id)
+                if exp and exp < today:
+                    if vuln_id not in announced:
+                        print(f"[WARN] Ignore for {vuln_id} has expired ({exp}), please review")
+                        announced.add(vuln_id)
+                else:
+                    if vuln_id not in announced:
+                        print(f"[IGNORED] {vuln_id} \u2014 {ignore_reason[vuln_id]}")
+                        announced.add(vuln_id)
+            else:
+                location = ""
+                if trace:
+                    last = trace[-1]
+                    pos = last.get("position")
+                    if pos and pos.get("filename"):
+                        location = f" ({pos['filename']}:{pos['line']})"
+                print(f"Vulnerability: {vuln_id}{location}")
+                failed = True
+
+        elif verbose:
+            print(json.dumps(msg))
+
+sys.exit(1 if failed else 0)

--- a/hack/govulncheck.sh
+++ b/hack/govulncheck.sh
@@ -12,6 +12,9 @@ function usage() {
     echoerr
     echoerr "Options:"
     echoerr "  -v     verbose output"
+    echoerr
+    echoerr "If .govulncheck-ignore.toml exists at the repo root, vulnerability IDs listed"
+    echoerr "there are suppressed and do not cause a non-zero exit. Requires python3."
 }
 
 # Parse flags
@@ -41,6 +44,20 @@ if ! command -v govulncheck &> /dev/null; then
     echoerr "govulncheck is not installed, please install it by running:"
     echoerr "go install golang.org/x/vuln/cmd/govulncheck@latest"
     exit 1
+fi
+
+ignore_file=""
+# Use an absolute path so it resolves correctly regardless of working directory
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+if [[ -f "${repo_root}/.govulncheck-ignore.toml" ]]; then
+    ignore_file="${repo_root}/.govulncheck-ignore.toml"
+    if [ "$verbose" = true ]; then
+        echo "Using ignore file: ${ignore_file}"
+    fi
+    if ! command -v python3 &> /dev/null; then
+        echoerr "python3 is required when .govulncheck-ignore.toml is present but was not found."
+        exit 1
+    fi
 fi
 
 readarray -t <<< "$(find . -name go.mod -exec sh -c 'dirname $1' shell {} \;)"
@@ -90,7 +107,19 @@ for module in "${goModules[@]}"; do
         continue
     fi
     
-    govulncheck -C "${module}" ./... || statuscode=$?
+    if [[ -n "${ignore_file}" ]]; then
+        if ! govulncheck --json -C "${module}" ./... \
+            | IGNORE_FILE="${ignore_file}" VERBOSE="${verbose}" \
+            python3 "$(dirname "$0")/govulncheck-filter.py"; then
+            statuscode=1
+            echoerr
+            echoerr "Re-running govulncheck for human-readable output (non-ignored findings in ${module}):"
+            echoerr
+            govulncheck -C "${module}" ./... 1>&2 || true
+        fi
+    else
+        govulncheck -C "${module}" ./... || statuscode=$?
+    fi
 done
 
 exit $statuscode


### PR DESCRIPTION
Adds .govulncheck-ignore.toml (matching the format of osv-scanner's ignore list) to suppress known false-positive vulnerability IDs, and extends hack/govulncheck.sh to apply it via hack/govulncheck-filter.py when the file is present.

Each [[IgnoredVulns]] entry requires an id and reason. An optional ignoreUntil date causes the entry to warn rather than silently suppress once it has passed.

Seeded with three containerd CRI checkpoint/restore vulns with no upstream fix that are not exploitable in CAA:
- GO-2026-5622: arbitrary host CRI log file read via symlink
- GO-2026-5338: CRI checkpoint import image tag poisoning
- GO-2026-5064: CRI checkpoint restore CDI annotation smuggling

Generated-By: IBM Bob