### PR TITLE
ci: pass caa_image input to libvirt e2e test environment

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -175,6 +175,7 @@ jobs:
           CLOUD_PROVIDER: libvirt
           CONTAINER_RUNTIME: ${{ inputs.container_runtime }}
           DEPLOY_KBS: "true"
+          CAA_IMAGE: "${{ inputs.caa_image }}"
           PEERPOD_CTRL_IMAGE: "${{ inputs.peerpod_ctrl_image }}"
           TEST_TEARDOWN: "no"
           TEST_PROVISION_FILE: ${{ github.workspace }}/src/cloud-api-adaptor/libvirt.properties


### PR DESCRIPTION
The CAA_IMAGE env var was missing from the run-e2e-test step, so the caa_image workflow input was never forwarded to the test provisioner. This caused the custom CAA image to be silently ignored when specified.