### PR TITLE
gha: do not set PUSH=true for building podvm binaries

### DIFF
--- a/.github/workflows/podvm_mkosi_ubuntu.yaml
+++ b/.github/workflows/podvm_mkosi_ubuntu.yaml
@@ -148,9 +148,6 @@ jobs:
           ARCH: ${{ inputs.arch }}
           PODVM_DISTRO: ubuntu
           VERIFY_PROVENANCE: yes
-          PUSH: "true"
-          REGISTRY: ${{ inputs.registry }}
-          PODVM_TAG: ${{ inputs.image_tag }}
 
       - name: Build mkosi debug image
         if: ${{ inputs.debug == true }}


### PR DESCRIPTION
The mkosi image build has been failing due to the absence of /resources folder that is created via make podvm-binaries which was introduced as a part of this [PR](https://github.com/confidential-containers/cloud-api-adaptor/pull/2923/changes#diff-0bf9b43f3d1d5d0b239bacf784da2de3e98ceed5a84e8a4cdfbea8e0d7e01b94R151).

```
#22 [builder  2/15] RUN apt-get update && 	apt-get install -y 	bubblewrap 	git 	cpio 	systemd-repart 	kmod 	systemd-boot-efi 	libcryptsetup12 	squashfs-tools 	systemd-ukify 	dosfstools 	mtools 	python3 	debian-archive-keyring 	zstd
#22 CANCELED
------
 > [builder 13/15] COPY resources /image/resources:
------
ERROR: failed to build: failed to solve: failed to compute cache key: failed to calculate checksum of ref ceuf1574mxtqbeu4895w7qf1q::6ug49hcvk4wms1vm79pasngt3: "/resources": not found
```
Ref: https://github.com/confidential-containers/cloud-api-adaptor/actions/runs/28770462004/job/85303022034

Do not set PUSH=true which allows storing the built binaries locally.