### PR TITLE
podvm: Increase s390x boot partition from 256MiB to 512MiB

### DIFF
--- a/src/cloud-api-adaptor/hack/build-s390x-image.sh
+++ b/src/cloud-api-adaptor/hack/build-s390x-image.sh
@@ -17,8 +17,8 @@ qemu-nbd --connect="${tmp_nbd}" "${tmp_img_path}"
 
 # Partition and format
 parted -a optimal "${tmp_nbd}" mklabel gpt \
-        mkpart boot ext4 1MiB 256MiB \
-        mkpart system 256MiB "${disksize}" \
+        mkpart boot ext4 1MiB 512MiB \
+        mkpart system 512MiB "${disksize}" \
         set 1 boot on
 
 echo "Waiting for the two nbd partitions to show up"

--- a/src/cloud-api-adaptor/hack/build-s390x-se-image.sh
+++ b/src/cloud-api-adaptor/hack/build-s390x-se-image.sh
@@ -35,8 +35,8 @@ qemu-nbd --connect="${tmp_nbd}" "${tmp_img_path}"
 
 echo "Creating boot-se and root partitions"
 parted -a optimal "${tmp_nbd}" mklabel gpt \
-        mkpart boot-se ext4 1MiB 256MiB \
-        mkpart root 256MiB 6400MiB \
+        mkpart boot-se ext4 1MiB 512MiB \
+        mkpart root 512MiB 6400MiB \
         mkpart data 6400MiB ${disksize} \
         set 1 boot on
 


### PR DESCRIPTION
The boot partition in `build-s390x-image.sh` was sized 1MiB–256MiB (255 MiB usable). After the system tar extraction populates /boot, copying initrd.cpio.zst and system.vmlinuz into the already-partly -filled partition exhausted the available space, producing:

```
cp: error writing './dst_mnt/boot/vmlinuz': No space left on device
```

Increase the boot partition end from 256MiB to 512MiB and adjust the system partition start to match, providing sufficient headroom for the s390x kernel and initrd artifacts.

`build-s390x-se-image.sh` is also updated accordingly.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>