### PR TITLE
libvirt: close libvirt connection on provider teardown

### DIFF
--- a/src/cloud-providers/libvirt/provider.go
+++ b/src/cloud-providers/libvirt/provider.go
@@ -154,6 +154,16 @@ func (p *libvirtProvider) DeleteInstance(ctx context.Context, instanceID string)
 }
 
 func (p *libvirtProvider) Teardown() error {
+	if p.libvirtClient == nil {
+		return nil
+	}
+	refCount, err := p.libvirtClient.connection.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close libvirt connection: %w", err)
+	}
+	if refCount > 0 {
+		return fmt.Errorf("libvirt connection still has %d remaining references after close", refCount)
+	}
 	return nil
 }
 

--- a/src/cloud-providers/libvirt/provider_test.go
+++ b/src/cloud-providers/libvirt/provider_test.go
@@ -13,6 +13,7 @@ import (
 	provider "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	libvirt "libvirt.org/go/libvirt"
 )
 
 const (
@@ -158,10 +159,29 @@ func TestGetIPs(t *testing.T) {
 	}
 }
 
-func TestTeardown(t *testing.T) {
+func TestTeardownNilClient(t *testing.T) {
 	p := &libvirtProvider{}
-	err := p.Teardown()
-	assert.NoError(t, err)
+	assert.NoError(t, p.Teardown())
+}
+
+// TestTeardown verifies that Teardown() closes the underlying libvirt
+// connection and that any subsequent operation on it fails.
+func TestTeardown(t *testing.T) {
+	checkConfig(t)
+
+	conn, err := libvirt.NewConnect(testCfg.URI)
+	require.NoError(t, err)
+
+	p := &libvirtProvider{libvirtClient: &libvirtClient{connection: conn}}
+
+	_, err = conn.GetLibVersion()
+	require.NoError(t, err)
+
+	err = p.Teardown()
+	require.NoError(t, err)
+
+	_, err = conn.GetLibVersion()
+	assert.Error(t, err, "connection should be closed after Teardown")
 }
 
 func TestDeleteInstanceEmptyID(t *testing.T) {


### PR DESCRIPTION
The libvirtProvider opens a persistent connection to the libvirt host in NewProvider() via NewLibvirtClient(). This connection was held for the entire CAA daemon lifetime but never closed — Teardown() returned nil unconditionally, leaking the connection on the libvirt host side until its timeout.

Fix Teardown() to:

- Guard against a nil libvirtClient in case of a failed provider initialisation
- Call connection.Close() and propagate any error
- Return an error if Close() returns a positive reference count, indicating the connection was not fully released

Replace the hollow TestTeardown (which constructed a nil provider and only proved nil returns nil) with a real integration test that verifies the connection is alive before Teardown() and dead after it. The test skips automatically when LIBVIRT_URI is not set, consistent with all other integration tests in the package.

Fixes: https://github.com/confidential-containers/cloud-api-adaptor/issues/1252

Assisted-by: IBM Bob <noreply@ibm.com>