### PR TITLE
ci: add allow-unsafe-pr-checkout workaround for pull_request_target workflows

### DIFF
--- a/.github/workflows/caa_build_and_push.yaml
+++ b/.github/workflows/caa_build_and_push.yaml
@@ -69,6 +69,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           ref: "${{ inputs.git_ref }}"
+          allow-unsafe-pr-checkout: true
 
       - name: Rebase the code
         if: github.event_name == 'pull_request_target'

--- a/.github/workflows/e2e_aws.yaml
+++ b/.github/workflows/e2e_aws.yaml
@@ -94,6 +94,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Rebase the code
         if: github.event_name == 'pull_request_target'

--- a/.github/workflows/e2e_byom.yaml
+++ b/.github/workflows/e2e_byom.yaml
@@ -56,6 +56,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Rebase the code
         if: github.event_name == 'pull_request_target'

--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -63,6 +63,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Rebase the code
         if: github.event_name == 'pull_request_target'

--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -226,6 +226,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           ref: ${{ inputs.git_ref }}
+          allow-unsafe-pr-checkout: true
 
       - name: Rebase the code
         if: github.event_name == 'pull_request_target'

--- a/.github/workflows/peerpod-ctrl_build_and_push.yaml
+++ b/.github/workflows/peerpod-ctrl_build_and_push.yaml
@@ -54,6 +54,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           ref: "${{ inputs.git_ref }}"
+          allow-unsafe-pr-checkout: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0

--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -87,6 +87,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           ref: "${{ inputs.git_ref }}"
+          allow-unsafe-pr-checkout: true
 
       # Required by rootless mkosi
       - name: Un-restrict user namespaces

--- a/.github/workflows/podvm_mkosi_ubuntu.yaml
+++ b/.github/workflows/podvm_mkosi_ubuntu.yaml
@@ -87,6 +87,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           ref: "${{ inputs.git_ref }}"
+          allow-unsafe-pr-checkout: true
 
       # Required by rootless mkosi
       - name: Un-restrict user namespaces

--- a/.github/workflows/webhook_image.yaml
+++ b/.github/workflows/webhook_image.yaml
@@ -44,6 +44,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           ref: "${{ inputs.git_ref }}"
+          allow-unsafe-pr-checkout: true
       - name: Read properties from versions.yaml
         run: |
           go_version="$(yq '.tools.golang' ../cloud-api-adaptor/versions.yaml)"


### PR DESCRIPTION
GitHub's actions/checkout v7.0.0 introduced a new default that prevents checking out PR head code in pull_request_target contexts without an explicit opt-in. Without allow-unsafe-pr-checkout: true, checkouts in pull_request_target workflows now fall back to the base branch, breaking the CI pipelines that intentionally check out PR head code to test it.

Add allow-unsafe-pr-checkout: true to all actions/checkout steps that are reachable from a pull_request_target trigger:
- caa_build_and_push.yaml
- e2e_aws.yaml
- e2e_byom.yaml
- e2e_libvirt.yaml
- e2e_run_all.yaml (libvirt_e2e_arch_prep job)
- podvm_mkosi.yaml
- podvm_mkosi_ubuntu.yaml

This is a temporary workaround. The correct fix — moving CI jobs out of pull_request_target and into the safer pull_request event — is tracked in #2214.

Generated-By: IBM Bob