### PR TITLE
config: remove csi-wrapper references from config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@ src/cloud-api-adaptor/staticlib
 src/cloud-api-adaptor/pause
 src/cloud-api-adaptor/umoci
 src/cloud-api-adaptor/skopeo
-src/csi-wrapper/build
-src/csi-wrapper/vendor
 src/cloud-providers/bin
 
 # Binaries

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,10 +30,6 @@ linters:
       - legacy
       - std-error-handling
     rules:
-      - linters:
-          - staticcheck
-        path: ^src/csi-wrapper/pkg/wrapper/
-        text: 'SA1019: "github.com/golang/protobuf/jsonpb" is deprecated: Use the "google.golang.org/protobuf/encoding/protojson" package instead.'
       - path: (.+)\.go$
         text: declaration of "(err|ctx)" shadows declaration at
     paths:


### PR DESCRIPTION
Remove obsolete csi-wrapper references from .gitignore and .golangci.yaml following the removal of the csi-wrapper component.