### PR TITLE
chore: group codeql-action updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
       day: "saturday"
     cooldown:
       default-days: 7
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action*"
   - package-ecosystem: "gomod"
     directories:
       - "src/cloud-api-adaptor"


### PR DESCRIPTION
Add a dependabot group for `github/codeql-action*` so that all codeql action steps (init, analyze, upload-sarif) are bumped in a single PR. Previously they could be updated independently, causing version mismatches between steps and CI failures.

Generated-By: IBM Bob