### PR TITLE
fix: GetLaunchSecurityType opens a redundant libvirt connection

### DIFF
--- a/src/cloud-providers/libvirt/libvirt.go
+++ b/src/cloud-providers/libvirt/libvirt.go
@@ -23,8 +23,10 @@ import (
 const (
 	// architecture value for the s390x architecture
 	archS390x = "s390x"
-	// architecutre value for aarch64/arm64
+	// architecture value for aarch64/arm64
 	archAArch64 = "aarch64"
+	// architecture value for x86_64
+	archX86_64 = "x86_64"
 	// hvm indicates that the OS is one designed to run on bare metal, so requires full virtualization.
 	typeHardwareVirtualMachine = "hvm"
 	// The amount of retries to get the domain IP addresses
@@ -826,24 +828,17 @@ func freeDomain(domain *libvirt.Domain, errCtx *error) {
 	}
 }
 
-// Attempts to determine launchSecurity Type from domain capabilities and hardware
-// Currently only supports S390PV
-func GetLaunchSecurityType(uri string) (LaunchSecurityType, error) {
-	conn, err := libvirt.NewConnect(uri)
-	if err != nil {
-		return NoLaunchSecurity, fmt.Errorf("unable to get libvirt connection [%v]", err)
+// GetLaunchSecurityType determines the launch security type from the node info
+// already retrieved by the libvirt client, avoiding an extra connection.
+// Currently only supports S390PV.
+func GetLaunchSecurityType(client *libvirtClient) (LaunchSecurityType, error) {
+	if client.nodeInfo == nil {
+		return NoLaunchSecurity, fmt.Errorf("node info is not available in libvirt client")
 	}
 
-	nodeInfo, err := conn.GetNodeInfo()
-	if err != nil {
-		return NoLaunchSecurity, fmt.Errorf("error retrieving node info: %v", err)
-	}
-
-	switch nodeInfo.Model {
+	switch client.nodeInfo.Model {
 	case archS390x:
 		return S390PV, nil
-	case "x86_64":
-		return NoLaunchSecurity, nil
 	default:
 		return NoLaunchSecurity, nil
 	}

--- a/src/cloud-providers/libvirt/libvirt_test.go
+++ b/src/cloud-providers/libvirt/libvirt_test.go
@@ -255,33 +255,33 @@ func TestGetGuestForArchType(t *testing.T) {
 	}{
 		{
 			name:        "find x86_64 guest",
-			caps:        createMockCaps("x86_64", ""),
-			arch:        "x86_64",
-			ostype:      "hvm",
+			caps:        createMockCaps(archX86_64, ""),
+			arch:        archX86_64,
+			ostype:      typeHardwareVirtualMachine,
 			expectError: false,
-			expectArch:  "x86_64",
+			expectArch:  archX86_64,
 		},
 		{
 			name:        "find s390x guest",
-			caps:        createMockCaps("s390x", ""),
-			arch:        "s390x",
-			ostype:      "hvm",
+			caps:        createMockCaps(archS390x, ""),
+			arch:        archS390x,
+			ostype:      typeHardwareVirtualMachine,
 			expectError: false,
-			expectArch:  "s390x",
+			expectArch:  archS390x,
 		},
 		{
 			name:        "find aarch64 guest",
-			caps:        createMockCaps("aarch64", ""),
-			arch:        "aarch64",
-			ostype:      "hvm",
+			caps:        createMockCaps(archAArch64, ""),
+			arch:        archAArch64,
+			ostype:      typeHardwareVirtualMachine,
 			expectError: false,
-			expectArch:  "aarch64",
+			expectArch:  archAArch64,
 		},
 		{
 			name:        "architecture not found",
-			caps:        createMockCaps("x86_64", ""),
+			caps:        createMockCaps(archX86_64, ""),
 			arch:        "invalid-arch",
-			ostype:      "hvm",
+			ostype:      typeHardwareVirtualMachine,
 			expectError: true,
 		},
 		{
@@ -291,13 +291,13 @@ func TestGetGuestForArchType(t *testing.T) {
 					{
 						OSType: "xen",
 						Arch: libvirtxml.CapsGuestArch{
-							Name: "x86_64",
+							Name: archX86_64,
 						},
 					},
 				},
 			},
-			arch:        "x86_64",
-			ostype:      "hvm",
+			arch:        archX86_64,
+			ostype:      typeHardwareVirtualMachine,
 			expectError: true,
 		},
 		{
@@ -305,8 +305,8 @@ func TestGetGuestForArchType(t *testing.T) {
 			caps: &libvirtxml.Caps{
 				Guests: []libvirtxml.CapsGuest{},
 			},
-			arch:        "x86_64",
-			ostype:      "hvm",
+			arch:        archX86_64,
+			ostype:      typeHardwareVirtualMachine,
 			expectError: true,
 		},
 	}
@@ -398,10 +398,10 @@ func TestGetCanonicalMachineName(t *testing.T) {
 	}{
 		{
 			name: "find canonical machine in arch machines",
-			caps: createMockCaps("x86_64", "",
+			caps: createMockCaps(archX86_64, "",
 				libvirtxml.CapsGuestMachine{Name: "pc", Canonical: "pc-i440fx-2.12"}),
-			arch:           "x86_64",
-			virttype:       "hvm",
+			arch:           archX86_64,
+			virttype:       typeHardwareVirtualMachine,
 			targetMachine:  "pc",
 			expectedResult: "pc-i440fx-2.12",
 			expectError:    false,
@@ -411,9 +411,9 @@ func TestGetCanonicalMachineName(t *testing.T) {
 			caps: &libvirtxml.Caps{
 				Guests: []libvirtxml.CapsGuest{
 					{
-						OSType: "hvm",
+						OSType: typeHardwareVirtualMachine,
 						Arch: libvirtxml.CapsGuestArch{
-							Name: "x86_64",
+							Name: archX86_64,
 							Domains: []libvirtxml.CapsGuestDomain{
 								{
 									Machines: []libvirtxml.CapsGuestMachine{
@@ -425,26 +425,26 @@ func TestGetCanonicalMachineName(t *testing.T) {
 					},
 				},
 			},
-			arch:           "x86_64",
-			virttype:       "hvm",
+			arch:           archX86_64,
+			virttype:       typeHardwareVirtualMachine,
 			targetMachine:  "q35",
 			expectedResult: "pc-q35-2.12",
 			expectError:    false,
 		},
 		{
 			name: "machine not found returns error",
-			caps: createMockCaps("x86_64", "",
+			caps: createMockCaps(archX86_64, "",
 				libvirtxml.CapsGuestMachine{Name: "pc"}),
-			arch:          "x86_64",
-			virttype:      "hvm",
+			arch:          archX86_64,
+			virttype:      typeHardwareVirtualMachine,
 			targetMachine: "nonexistent",
 			expectError:   true,
 		},
 		{
 			name:          "architecture not found returns error",
-			caps:          createMockCaps("x86_64", ""),
+			caps:          createMockCaps(archX86_64, ""),
 			arch:          "invalid-arch",
-			virttype:      "hvm",
+			virttype:      typeHardwareVirtualMachine,
 			targetMachine: "pc",
 			expectError:   true,
 		},
@@ -819,8 +819,31 @@ func TestCPUSetXMLMarshaling(t *testing.T) {
 	}
 }
 
-func TestGetLaunchSecurityTypeInvalidURI(t *testing.T) {
-	_, err := GetLaunchSecurityType("invalid://uri")
+func TestGetLaunchSecurityType(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    string
+		expected LaunchSecurityType
+	}{
+		{name: "s390x returns S390PV", model: archS390x, expected: S390PV},
+		{name: "x86_64 returns NoLaunchSecurity", model: archX86_64, expected: NoLaunchSecurity},
+		{name: "unknown arch returns NoLaunchSecurity", model: "riscv64", expected: NoLaunchSecurity},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &libvirtClient{
+				nodeInfo: &libvirt.NodeInfo{Model: tc.model},
+			}
+			got, err := GetLaunchSecurityType(client)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestGetLaunchSecurityTypeNilNodeInfo(t *testing.T) {
+	client := &libvirtClient{}
+	_, err := GetLaunchSecurityType(client)
 	assert.Error(t, err)
 }
 
@@ -828,7 +851,7 @@ func createMockCaps(arch, emulator string, machines ...libvirtxml.CapsGuestMachi
 	return &libvirtxml.Caps{
 		Guests: []libvirtxml.CapsGuest{
 			{
-				OSType: "hvm",
+				OSType: typeHardwareVirtualMachine,
 				Arch: libvirtxml.CapsGuestArch{
 					Name:     arch,
 					Emulator: emulator,
@@ -858,7 +881,7 @@ func TestCreateDomainXMLArchitecturesWithMocks(t *testing.T) {
 	}{
 		{
 			name:             "s390x architecture",
-			arch:             "s390x",
+			arch:             archS390x,
 			vmName:           "test-s390x-vm",
 			cpu:              2,
 			mem:              2048,
@@ -867,11 +890,11 @@ func TestCreateDomainXMLArchitecturesWithMocks(t *testing.T) {
 			machineName:      "s390-ccw-virtio",
 			machineCanonical: "s390-ccw-virtio-rhel9.0.0",
 			createFunc:       createDomainXMLs390x,
-			expectedCPUMode:  "host-model",
+			expectedCPUMode:  cpuModeHostModel,
 		},
 		{
 			name:                 "aarch64 architecture",
-			arch:                 "aarch64",
+			arch:                 archAArch64,
 			vmName:               "test-aarch64-vm",
 			cpu:                  4,
 			mem:                  4096,
@@ -882,7 +905,7 @@ func TestCreateDomainXMLArchitecturesWithMocks(t *testing.T) {
 			createFunc:           createDomainXMLaarch64,
 			expectedFirmware:     "efi",
 			expectSCSIController: true,
-			expectedCPUMode:      "host-passthrough",
+			expectedCPUMode:      cpuModeHostPassthrough,
 		},
 	}
 
@@ -946,7 +969,7 @@ func TestCreateDomainXMLArchitecturesWithMocks(t *testing.T) {
 
 // TestCreateDomainXMLx86_64 tests x86_64 domain XML generation
 func TestCreateDomainXMLx86_64(t *testing.T) {
-	mockCaps := createMockCaps("x86_64", "/usr/bin/qemu-system-x86_64")
+	mockCaps := createMockCaps(archX86_64, "/usr/bin/qemu-system-x86_64")
 
 	mockClient := &libvirtClient{
 		caps:        mockCaps,
@@ -1008,7 +1031,7 @@ func TestCreateDomainXMLx86_64(t *testing.T) {
 			assert.Equal(t, tt.cfg.name, domain.Name)
 			assert.Equal(t, tt.cfg.cpu, domain.VCPU.Value)
 			assert.Equal(t, tt.cfg.mem, domain.Memory.Value)
-			assert.Equal(t, "x86_64", domain.OS.Type.Arch)
+			assert.Equal(t, archX86_64, domain.OS.Type.Arch)
 
 			// Verify disks
 			assert.Len(t, domain.Devices.Disks, 2)
@@ -1034,18 +1057,18 @@ func TestCreateDomainXML(t *testing.T) {
 	}{
 		{
 			name:         "s390x architecture",
-			arch:         "s390x",
-			expectedArch: "s390x",
+			arch:         archS390x,
+			expectedArch: archS390x,
 		},
 		{
 			name:         "aarch64 architecture",
-			arch:         "aarch64",
-			expectedArch: "aarch64",
+			arch:         archAArch64,
+			expectedArch: archAArch64,
 		},
 		{
 			name:         "x86_64 architecture (default)",
-			arch:         "x86_64",
-			expectedArch: "x86_64",
+			arch:         archX86_64,
+			expectedArch: archX86_64,
 		},
 	}
 
@@ -1054,14 +1077,14 @@ func TestCreateDomainXML(t *testing.T) {
 			// Create appropriate mock capabilities using helper function
 			var mockCaps *libvirtxml.Caps
 			switch tt.arch {
-			case "s390x":
-				mockCaps = createMockCaps("s390x", "/usr/bin/qemu-system-s390x",
+			case archS390x:
+				mockCaps = createMockCaps(archS390x, "/usr/bin/qemu-system-s390x",
 					libvirtxml.CapsGuestMachine{Name: "s390-ccw-virtio", Canonical: "s390-ccw-virtio-rhel9.0.0"})
-			case "aarch64":
-				mockCaps = createMockCaps("aarch64", "/usr/bin/qemu-system-aarch64",
+			case archAArch64:
+				mockCaps = createMockCaps(archAArch64, "/usr/bin/qemu-system-aarch64",
 					libvirtxml.CapsGuestMachine{Name: "virt", Canonical: "virt-4.2"})
 			default:
-				mockCaps = createMockCaps("x86_64", "/usr/bin/qemu-system-x86_64")
+				mockCaps = createMockCaps(archX86_64, "/usr/bin/qemu-system-x86_64")
 			}
 
 			mockClient := &libvirtClient{
@@ -1096,7 +1119,7 @@ func TestVerifyDomainXMLIOMMU(t *testing.T) {
 			name: "s390x with proper IOMMU on disks and interfaces",
 			domain: &libvirtxml.Domain{
 				OS: &libvirtxml.DomainOS{
-					Type: &libvirtxml.DomainOSType{Arch: "s390x"},
+					Type: &libvirtxml.DomainOSType{Arch: archS390x},
 				},
 				Devices: &libvirtxml.DomainDeviceList{
 					Disks: []libvirtxml.DomainDisk{
@@ -1119,7 +1142,7 @@ func TestVerifyDomainXMLIOMMU(t *testing.T) {
 			name: "s390x missing IOMMU on disk",
 			domain: &libvirtxml.Domain{
 				OS: &libvirtxml.DomainOS{
-					Type: &libvirtxml.DomainOSType{Arch: "s390x"},
+					Type: &libvirtxml.DomainOSType{Arch: archS390x},
 				},
 				Devices: &libvirtxml.DomainDeviceList{
 					Disks: []libvirtxml.DomainDisk{
@@ -1137,7 +1160,7 @@ func TestVerifyDomainXMLIOMMU(t *testing.T) {
 			name: "aarch64 missing IOMMU on interface",
 			domain: &libvirtxml.Domain{
 				OS: &libvirtxml.DomainOS{
-					Type: &libvirtxml.DomainOSType{Arch: "aarch64"},
+					Type: &libvirtxml.DomainOSType{Arch: archAArch64},
 				},
 				Devices: &libvirtxml.DomainDeviceList{
 					Interfaces: []libvirtxml.DomainInterface{
@@ -1155,7 +1178,7 @@ func TestVerifyDomainXMLIOMMU(t *testing.T) {
 			name: "x86_64 does not require IOMMU",
 			domain: &libvirtxml.Domain{
 				OS: &libvirtxml.DomainOS{
-					Type: &libvirtxml.DomainOSType{Arch: "x86_64"},
+					Type: &libvirtxml.DomainOSType{Arch: archX86_64},
 				},
 				Devices: &libvirtxml.DomainDeviceList{
 					Disks: []libvirtxml.DomainDisk{

--- a/src/cloud-providers/libvirt/provider.go
+++ b/src/cloud-providers/libvirt/provider.go
@@ -83,7 +83,7 @@ func (p *libvirtProvider) CreateInstance(ctx context.Context, podName, sandboxID
 			return nil, fmt.Errorf("[%s] is not a known launch security setting", p.serviceConfig.LaunchSecurity)
 		}
 	} else {
-		vm.launchSecurityType, err = GetLaunchSecurityType(p.serviceConfig.URI)
+		vm.launchSecurityType, err = GetLaunchSecurityType(p.libvirtClient)
 		if err != nil {
 			logger.Printf("unable to determine launch security type [%v]", err)
 			return nil, err


### PR DESCRIPTION
Previously, GetLaunchSecurityType(uri string) opened a brand-new libvirt connection (libvirt.NewConnect) purely to call GetNodeInfo() and inspect the CPU model. This was redundant because NewLibvirtClient already establishes a connection and caches the node info in libvirtClient.nodeInfo before any instance creation begins.

As a result, every call to CreateInstance that relied on auto-detection (i.e. DisableCVM=false and LaunchSecurity="") caused a second, short-lived libvirt connection to be created and immediately abandoned.

- Change the signature of GetLaunchSecurityType from accepting a URI string to accepting a *libvirtClient. The function now reads client.nodeInfo.Model directly, eliminating the extra libvirt connection that was opened on every CreateInstance call.
- Add a nil-guard on client.nodeInfo so a partially constructed client returns a clear error rather than a silent panic.
- Extract archX86_64 = "x86_64" as a named constant alongside the existing arch constants; fix typo "architecutre" -> "architecture" in the archAArch64 comment.
- Collapse case archX86_64/archAArch64 into a single default — both returned NoLaunchSecurity, so explicit arms added no value.
- Update the call site in CreateInstance (provider.go) to pass p.libvirtClient instead of p.serviceConfig.URI.
- Replace TestGetLaunchSecurityTypeInvalidURI (which tested URI-parsing error handling no longer applicable) with:
     - TestGetLaunchSecurityType: table-driven test covering s390x, x86_64, and an unknown arch against their expected security types.
     - TestGetLaunchSecurityTypeNilNodeInfo: verifies that a client with a nil nodeInfo returns an error instead of panicking.
No behaviour change for callers: the launch security detection logic
(s390x -> S390PV, everything else -> NoLaunchSecurity) is unchanged.

Fixes: #3210

Assisted-by: IBM Bob noreply@ibm.com