### PR TITLE
libvirt: free root volume handle after path lookup

### DIFF
--- a/src/cloud-providers/libvirt/libvirt.go
+++ b/src/cloud-providers/libvirt/libvirt.go
@@ -607,6 +607,10 @@ func CreateDomain(ctx context.Context, libvirtClient *libvirtClient, v *vmConfig
 	}
 
 	rootVolFile, err := rootVol.GetPath()
+	freeErr := rootVol.Free()
+	if freeErr != nil {
+		logger.Printf("Warning: failed to free root volume handle: %v", freeErr)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving volume path: %s", err)
 	}


### PR DESCRIPTION
CreateDomain() retrieves the root volume handle only to call GetPath() and then uses the resulting path string for domain XML construction.

Release the handle immediately after GetPath() instead of deferring cleanup through freeVolume(). In this function, deferred cleanup tied to the named return error is unsafe because some downstream paths return errors without updating the outer err, and a Free() failure could overwrite the real error or turn a successful VM creation into a failure.

Keeping rootVol.Free() failure as a warning because it does not affect the created volume or VM behaviour.

Assisted-by: IBM Bob <noreply@ibm.com>