### PR TITLE
gha: fix podvm byom binaries job

### DIFF
--- a/.github/workflows/podvm_byom_binaries_publish.yaml
+++ b/.github/workflows/podvm_byom_binaries_publish.yaml
@@ -77,12 +77,29 @@ jobs:
           ref: ${{ inputs.git_ref || github.sha }}
           persist-credentials: false
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Install build dependencies
+        run: |
+          command -v yq || sudo snap install yq
+          yq --version | grep -qE 'v4\.[0-9]+' || { echo "yq version is not 4.x, please install yq 4.x"; exit 1; }
+
       - name: Login to Container Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: quay.io
           username: ${{ vars.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build podvm binaries image
+        working-directory: src/cloud-api-adaptor/podvm
+        run: make podvm-binaries
+        env:
+          REGISTRY: ${{ inputs.registry != '' && inputs.registry || 'quay.io/confidential-containers' }}
+          PODVM_TAG: ${{ inputs.image_tag || github.sha }}
+          ARCH: ${{ inputs.arch }}
+          PUSH: "true"
 
       - name: Build BYOM binaries image
         working-directory: src/cloud-api-adaptor/podvm

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_byom_binaries
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_byom_binaries
@@ -11,7 +11,7 @@ ARG BINARIES_IMG="quay.io/confidential-containers/podvm-binaries-ubuntu-amd64"
 FROM ${BINARIES_IMG} AS podvm_binaries
 
 # ubuntu:24.04
-FROM ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932 as builder
+FROM ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932 AS builder
 
 COPY --from=podvm_binaries /podvm-binaries.tar.gz /src/podvm-binaries.tar.gz
 RUN mkdir /src/files && tar xvf /src/podvm-binaries.tar.gz -C /src/files


### PR DESCRIPTION
The byom binaries image uses the podvm binaries image as the base. As we do not push the podvm binaries image or have it available locally during the mkosi builds, build it explicitly for byom binaries image.