### PR TITLE
ci(libvirt): fix e2e by passing caa_image input to libvirt.properties

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -121,9 +121,11 @@ jobs:
       - name: Config Libvirt
         env:
           CONTAINER_RUNTIME: ${{ inputs.container_runtime }}
+          CAA_IMAGE: ${{ inputs.caa_image }}
         run: |
           ./libvirt/config_libvirt.sh
           echo "container_runtime=\"${CONTAINER_RUNTIME}\"" >> libvirt.properties
+          echo "CAA_IMAGE=\"${CAA_IMAGE}\"" >> libvirt.properties
           # For debugging
           cat libvirt.properties
           # Add the kcli install directory to PATH for later steps


### PR DESCRIPTION
GetCloudProvisioner only reads from the TOML properties file, so the CAA_IMAGE env var was never reaching the provisioner. Write it to libvirt.properties alongside container_runtime.