### PR TITLE
gcp: create public ips only when USE_PUBLIC_IP is `true`

### DIFF
--- a/src/cloud-providers/gcp/provider.go
+++ b/src/cloud-providers/gcp/provider.go
@@ -339,17 +339,20 @@ func (p *gcpProvider) CreateInstance(ctx context.Context, podName, sandboxID str
 	}
 
 	networkInterface := &computepb.NetworkInterface{
-		Network: proto.String(p.serviceConfig.Network),
-		AccessConfigs: []*computepb.AccessConfig{
-			{
-				Name:        proto.String("External NAT"),
-				NetworkTier: proto.String("STANDARD"),
-			},
-		},
+		Network:   proto.String(p.serviceConfig.Network),
 		StackType: proto.String("IPV4_Only"),
 	}
 	if subnetworkValue != nil {
 		networkInterface.Subnetwork = subnetworkValue
+	}
+
+	if p.serviceConfig.UsePublicIP {
+		networkInterface.AccessConfigs = []*computepb.AccessConfig{
+			{
+				Name:        proto.String("External NAT"),
+				NetworkTier: proto.String("STANDARD"),
+			},
+		}
 	}
 
 	instanceResource := &computepb.Instance{


### PR DESCRIPTION
This commit disables public IPs assignment when `USE_PUBLIC_IP` is `false`. 

With instances using private IPs for communication, and pods traffic routed through worker nodes, there's no reason for GCP instances to have public IPs assigned.