### PR TITLE
libvirt: fix volName race in CreateInstance

### DIFF
--- a/src/cloud-providers/libvirt/libvirt.go
+++ b/src/cloud-providers/libvirt/libvirt.go
@@ -585,7 +585,7 @@ func CreateDomain(ctx context.Context, libvirtClient *libvirtClient, v *vmConfig
 	}
 
 	rootVolName := v.name + "-root.qcow2"
-	err = createVolume(rootVolName, v.rootDiskSize, libvirtClient.volName, libvirtClient)
+	err = createVolume(rootVolName, v.rootDiskSize, v.volName, libvirtClient)
 	if err != nil {
 		return nil, fmt.Errorf("Error in creating volume: %s", err)
 	}

--- a/src/cloud-providers/libvirt/provider.go
+++ b/src/cloud-providers/libvirt/provider.go
@@ -47,6 +47,14 @@ func getIPs(instance *vmConfig) ([]netip.Addr, error) {
 	return instance.ips, nil
 }
 
+// resolveVolName returns specImage if non-empty, otherwise defaultVol.
+func resolveVolName(defaultVol, specImage string) string {
+	if specImage != "" {
+		return specImage
+	}
+	return defaultVol
+}
+
 func (p *libvirtProvider) CreateInstance(ctx context.Context, podName, sandboxID string, cloudConfig cloudinit.CloudConfigGenerator, spec provider.InstanceTypeSpec) (*provider.Instance, error) {
 
 	var instanceMemory uint
@@ -70,8 +78,11 @@ func (p *libvirtProvider) CreateInstance(ctx context.Context, podName, sandboxID
 		instanceVCPUs = uint(p.serviceConfig.CPU)
 	}
 
+	volName := resolveVolName(p.serviceConfig.VolName, spec.Image)
+	logger.Printf("Choosing %s as libvirt volume for the PodVM image", volName)
+
 	// TODO: Specify the maximum instance name length in Libvirt
-	vm := &vmConfig{name: instanceName, cpu: instanceVCPUs, mem: instanceMemory, rootDiskSize: p.serviceConfig.RootDiskSize, userData: userData, firmware: p.serviceConfig.Firmware, cpuset: p.serviceConfig.CPUSet}
+	vm := &vmConfig{name: instanceName, cpu: instanceVCPUs, mem: instanceMemory, rootDiskSize: p.serviceConfig.RootDiskSize, userData: userData, firmware: p.serviceConfig.Firmware, cpuset: p.serviceConfig.CPUSet, volName: volName}
 
 	if p.serviceConfig.DisableCVM {
 		vm.launchSecurityType = NoLaunchSecurity
@@ -90,14 +101,6 @@ func (p *libvirtProvider) CreateInstance(ctx context.Context, podName, sandboxID
 		}
 	}
 	logger.Printf("LaunchSecurityType: %s", vm.launchSecurityType.String())
-
-	if spec.Image != "" {
-		logger.Printf("Choosing %s as libvirt volume for the PodVM image", spec.Image)
-		p.libvirtClient.volName = spec.Image
-	} else if spec.Image == "" && p.serviceConfig.VolName != p.libvirtClient.volName {
-		logger.Printf("Choosing the default %s as libvirt volume for the PodVM image", p.serviceConfig.VolName)
-		p.libvirtClient.volName = p.serviceConfig.VolName
-	}
 
 	result, err := CreateDomain(ctx, p.libvirtClient, vm)
 	if err != nil {

--- a/src/cloud-providers/libvirt/provider_test.go
+++ b/src/cloud-providers/libvirt/provider_test.go
@@ -294,3 +294,22 @@ func TestProviderConfigVerifier(t *testing.T) {
 		}
 	})
 }
+
+func TestVolNameResolution(t *testing.T) {
+	const defaultVol = "podvm-base.qcow2"
+
+	tests := []struct {
+		name      string
+		specImage string
+		wantVol   string
+	}{
+		{name: "empty spec.Image uses default", specImage: "", wantVol: defaultVol},
+		{name: "spec.Image overrides default", specImage: "custom-image.qcow2", wantVol: "custom-image.qcow2"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.wantVol, resolveVolName(defaultVol, tc.specImage))
+		})
+	}
+}

--- a/src/cloud-providers/libvirt/types.go
+++ b/src/cloud-providers/libvirt/types.go
@@ -39,6 +39,7 @@ type vmConfig struct {
 	launchSecurityType LaunchSecurityType
 	firmware           string
 	cpuset             string // CPU set for pinning vCPUs (e.g., "0,2,4,6" or "0-3")
+	volName            string
 }
 
 type createDomainOutput struct {


### PR DESCRIPTION
`CreateInstance` wrote `spec.Image` directly to `p.libvirtClient.volName`, a field shared across all goroutines. Two concurrent pod creates with different images would race: the last write won, and one VM could boot from the wrong volume.

`volName` is now resolved per-request via `resolveVolName()` and stored on `vmConfig`. `libvirtClient.volName` is read-only after initialisation.

### Race condition proof

A minimal self-contained reproducer (no libvirt dependency) demonstrates the issue:

```go
// old pattern — bare writes to shared client state
func oldPattern() {
    client := &sharedClient{volName: "podvm-base.qcow2"}
    var wg sync.WaitGroup
    for i := 0; i < 50; i++ {
        wg.Add(1)
        go func(i int) {
            defer wg.Done()
            if i%2 == 0 {
                client.volName = "custom-image.qcow2"
            } else if client.volName != "podvm-base.qcow2" {
                client.volName = "podvm-base.qcow2"
            }
        }(i)
    }
    wg.Wait()
}

// new pattern — resolve into a local, store on per-request vmConfig
func newPattern() {
    client := &sharedClient{volName: "podvm-base.qcow2"}
    var wg sync.WaitGroup
    for i := 0; i < 50; i++ {
        wg.Add(1)
        go func(i int) {
            defer wg.Done()
            specImage := ""
            if i%2 == 0 {
                specImage = "custom-image.qcow2"
            }
            vol := client.volName // read-only after init — safe
            if specImage != "" {
                vol = specImage
            }
            _ = vmConfig{volName: vol}
        }(i)
    }
    wg.Wait()
}
```

```
$ go run -race ./internal/racedemo/

==================
WARNING: DATA RACE
Write at 0x00c0001a6020 by goroutine 8:  oldPattern.func1() main.go:36
Previous write at 0x00c0001a6020 by goroutine 7:  oldPattern.func1() main.go:36
==================
WARNING: DATA RACE
Read at 0x00c0001a6020 by goroutine 16:  oldPattern.func1() main.go:37
Previous write at 0x00c0001a6020 by goroutine 18:  oldPattern.func1() main.go:38
==================
Found 5 data race(s)
```

New pattern exits with no race warnings.

Assisted-by: IBM Bob <noreply@ibm.com>