### PR TITLE
azure: add multi-NIC support for external pod networking

### DIFF
--- a/docs/azure-multi-nic.md
+++ b/docs/azure-multi-nic.md
@@ -1,0 +1,92 @@
+# Azure multi-NIC pod networking
+
+## Overview
+
+By default a peer-pod VM on Azure has a single NIC that carries both the
+VXLAN tunnel back to the worker node (pod/cluster traffic) and any traffic
+the pod sends to the outside world. This feature attaches a second NIC to
+the Pod VM so that:
+
+- `eth0` (primary NIC) carries pod/cluster traffic over the VXLAN tunnel, as
+  before.
+- `eth1` (secondary NIC) carries the pod's traffic to destinations outside
+  the cluster directly over the Azure VNet, bypassing the worker node.
+
+This builds on the existing `EXTERNAL_NETWORK_VIA_PODVM` mechanism (already
+used by the AWS and Alibaba Cloud providers) which discovers a second NIC
+inside the Pod VM's network namespace and moves it into the pod's namespace
+as its default route.
+
+## Configuration
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: peer-pods-cm
+  namespace: confidential-containers-system
+data:
+  AZURE_SUBNET_ID: "/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<vnet>/subnets/<primary-subnet>"
+  AZURE_SECONDARY_SUBNET_ID: "/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<vnet>/subnets/<secondary-subnet>"
+  EXTERNAL_NETWORK_VIA_PODVM: "true"
+  POD_SUBNET_CIDRS: "10.128.0.0/14,172.30.0.0/16,100.64.0.0/16"
+```
+
+- `AZURE_SECONDARY_SUBNET_ID` is required to enable multi-NIC. It must be a
+  different subnet than `AZURE_SUBNET_ID`, in the same VNet — Azure requires
+  all NICs on a VM to share a VNet.
+- `EXTERNAL_NETWORK_VIA_PODVM` is the existing flag (shared with other
+  providers) that tells cloud-api-adaptor to move a second NIC into the pod
+  namespace.
+- `POD_SUBNET_CIDRS` should list the cluster's pod, service, and node CIDRs.
+  These stay routed over the VXLAN tunnel (`eth0`); everything else follows
+  the pod's default route, which points at the secondary NIC (`eth1`).
+
+If `EXTERNAL_NETWORK_VIA_PODVM` is enabled without `AZURE_SECONDARY_SUBNET_ID`
+set, `CreateInstance` fails fast with a clear error instead of creating a
+single-NIC VM that would later fail pod networking setup.
+
+## How traffic is routed
+
+The Pod VM's kernel picks the most specific matching route:
+
+| Destination | Device | Notes |
+|---|---|---|
+| CIDRs in `POD_SUBNET_CIDRS` | `eth0` | routed over the VXLAN tunnel to the worker node |
+| everything else (default route) | `eth1` | routed directly over the Azure VNet |
+
+## Secondary NIC discovery
+
+Azure does not assign a default route to a secondary NIC via DHCP, so the
+gateway can't be read off the interface directly. `getSecondaryInterfaceDetails`
+in `pkg/podnetwork/common.go` picks the first non-primary, non-filtered
+interface with a valid IPv4 address using, in order:
+
+1. its own default route (used by other providers whose secondary NIC does
+   get one), or
+2. the primary interface's gateway, if the secondary shares its subnet, or
+3. an inferred gateway at the first usable address of its subnet
+   (`x.x.x.1`), Azure's convention for subnets it manages — this is the path
+   Azure multi-NIC normally takes, since the primary and secondary NICs sit
+   on different subnets by design.
+
+## Known constraints
+
+- Both subnets must be in the same Azure VNet (`SubnetsNotInSameVnet` if
+  not).
+- Both NICs are declared in the VM creation request up front. Azure does not
+  support attaching a NIC to a running VM without first deallocating it, so
+  the secondary NIC can't be added after the fact the way AWS attaches its
+  addon ENI post-launch.
+- `AZURE_USE_PUBLIC_IP`, if enabled together with multi-NIC, attaches the
+  public IP to the secondary (external) NIC rather than the primary
+  (control-plane) NIC.
+
+## Troubleshooting
+
+```bash
+ip addr show
+ip route show
+ip route get 8.8.8.8          # should go via eth1
+ip route get <a pod/service IP>  # should go via eth0
+```

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/azure.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/azure.yaml
@@ -30,6 +30,10 @@ providerConfigs:
     # (required)
     AZURE_RESOURCE_GROUP: ""
 
+    # Secondary Network Subnet Id used for the Pod VM's secondary NIC in multi-NIC mode
+    # (default: "")
+    # AZURE_SECONDARY_SUBNET_ID: ""
+
     # Network Subnet Id
     # (required)
     AZURE_SUBNET_ID: ""

--- a/src/cloud-api-adaptor/pkg/podnetwork/common.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/common.go
@@ -141,9 +141,31 @@ func getInterfaceDetails(ns netops.Namespace, iface string) (
 		}
 	}
 
-	fmt.Printf("Interface %q IPv4 address %q and default route %v\n", iface, addrCIDR, defRoute)
+	logger.Printf("Interface %q IPv4 address %q and default route %v", iface, addrCIDR, defRoute)
 
 	return addrCIDR, defRoute, nil
+}
+
+// inferGatewayFromSubnet infers a subnet's default gateway as the first
+// usable address (x.x.x.1), which is the convention used by Azure (and
+// several other clouds) for subnets it manages. This is only used as a
+// last-resort fallback when a secondary interface has no default route of
+// its own and is not on the same subnet as the primary interface, so no
+// gateway can otherwise be discovered.
+func inferGatewayFromSubnet(addrCIDR netip.Prefix) (netip.Addr, error) {
+	if !addrCIDR.IsValid() {
+		return netip.Addr{}, fmt.Errorf("cannot infer gateway from invalid prefix")
+	}
+
+	addr := addrCIDR.Addr()
+	if !addr.Is4() {
+		return netip.Addr{}, fmt.Errorf("cannot infer gateway from non-IPv4 prefix %q", addrCIDR)
+	}
+
+	network := addrCIDR.Masked().Addr().As4()
+	network[3] = 1
+
+	return netip.AddrFrom4(network), nil
 }
 
 func getSecondaryInterfaceDetails(ns netops.Namespace, primaryInterface string) (
@@ -173,34 +195,52 @@ func getSecondaryInterfaceDetails(ns netops.Namespace, primaryInterface string) 
 			return "", netip.Prefix{}, nil, err
 		}
 
-		// The first interface other than the primary having an IPv4 address and a default route
-		// or an IPv4 address in the same subnet as the primary interface with no default route
+		// The first interface other than the primary having an IPv4 address and:
+		//  1. its own default route, or
+		//  2. no default route, but in the same subnet as the primary interface
+		//     (the primary's gateway is reused), or
+		//  3. no default route, in a different subnet than the primary, but
+		//     with a gateway that can be inferred (see inferGatewayFromSubnet)
 		// is considered the secondary interface.
 
 		if !addr.IsValid() {
-			fmt.Printf("Skipping interface %q as it has no valid IPv4 address\n", link.Name())
+			logger.Printf("Skipping interface %q as it has no valid IPv4 address", link.Name())
 			continue
 		}
 
 		if route != nil {
-			fmt.Printf("Secondary interface %q found with IPv4 address %q and route %v\n", link.Name(), addr, route)
+			logger.Printf("Secondary interface %q found with IPv4 address %q and route %v", link.Name(), addr, route)
 			return link.Name(), addr, route, nil
 		}
 
-		fmt.Printf("Route is nil, checking if %q is in the same subnet as %q\n", addr, primaryInterface)
+		logger.Printf("Interface %q has IPv4 address %q but no default route; checking if it is in the same subnet as primary interface %q", link.Name(), addr, primaryInterface)
 
 		if priAddrCIDR.Masked() == addr.Masked() {
 			secIface = link.Name()
 			secRoute = &netops.Route{
 				Destination: defRoute.Destination,
 				Gateway:     defRoute.Gateway,
-				Device:      secIface,
 				// Change the Route.Device to the secondary interface
+				Device: secIface,
 			}
-			fmt.Printf("Secondary interface %q found with IPv4 address %q and inferred route %v\n", link.Name(), addr, secRoute)
+			logger.Printf("Secondary interface %q found with IPv4 address %q and inferred same-subnet route %v", link.Name(), addr, secRoute)
 			return link.Name(), addr, secRoute, nil
 		}
 
+		gateway, err := inferGatewayFromSubnet(addr)
+		if err != nil {
+			logger.Printf("Skipping interface %q: could not infer a gateway on subnet %q: %v", link.Name(), addr, err)
+			continue
+		}
+
+		secIface = link.Name()
+		secRoute = &netops.Route{
+			Destination: defRoute.Destination,
+			Gateway:     gateway,
+			Device:      secIface,
+		}
+		logger.Printf("Secondary interface %q found with IPv4 address %q and inferred cross-subnet route %v", link.Name(), addr, secRoute)
+		return link.Name(), addr, secRoute, nil
 	}
 
 	return "", netip.Prefix{}, nil, ErrNoSecondaryInterface

--- a/src/cloud-api-adaptor/pkg/podnetwork/common_test.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/common_test.go
@@ -1,0 +1,168 @@
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package podnetwork
+
+import (
+	"errors"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	testutils "github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/internal/testing"
+	"github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/pkg/podnetwork/tuntest"
+)
+
+func TestInferGatewayFromSubnet(t *testing.T) {
+	cases := []struct {
+		name    string
+		prefix  string
+		want    string
+		wantErr bool
+	}{
+		{name: "standard /24", prefix: "192.168.1.4/24", want: "192.168.1.1"},
+		{name: "standard /16", prefix: "10.129.2.111/23", want: "10.129.2.1"},
+		{name: "already the gateway address", prefix: "10.0.0.1/24", want: "10.0.0.1"},
+		{name: "IPv6 is unsupported", prefix: "fd00::4/64", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prefix := netip.MustParsePrefix(tc.prefix)
+			gw, err := inferGatewayFromSubnet(prefix)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, gw.String())
+		})
+	}
+
+	t.Run("invalid prefix", func(t *testing.T) {
+		_, err := inferGatewayFromSubnet(netip.Prefix{})
+		require.Error(t, err)
+	})
+}
+
+// TestGetSecondaryInterfaceDetailsCrossSubnet simulates the Azure multi-NIC
+// scenario: the secondary interface has an IPv4 address but no default
+// route, and it is on a different subnet than the primary interface (so the
+// gateway cannot be reused from the primary's route and must be inferred).
+func TestGetSecondaryInterfaceDetailsCrossSubnet(t *testing.T) {
+	testutils.SkipTestIfNotRoot(t)
+
+	ns, _ := tuntest.NewNamedNS(t, "test-crosssubnet")
+	defer tuntest.DeleteNamedNS(t, ns)
+
+	tuntest.BridgeAdd(t, ns, "eth0")
+	tuntest.AddrAdd(t, ns, "eth0", "10.129.2.111/23")
+	tuntest.RouteAdd(t, ns, "", "10.129.2.1", "eth0")
+
+	tuntest.BridgeAdd(t, ns, "eth1")
+	tuntest.AddrAdd(t, ns, "eth1", "192.168.1.4/24")
+	// Deliberately no default route on eth1: Azure does not hand out a
+	// default route to secondary NICs.
+
+	err := ns.Run(func() error {
+		secIface, secAddrCIDR, secRoute, err := getSecondaryInterfaceDetails(ns, "eth0")
+		require.NoError(t, err)
+		require.Equal(t, "eth1", secIface)
+		require.Equal(t, "192.168.1.4/24", secAddrCIDR.String())
+		require.NotNil(t, secRoute)
+		require.Equal(t, "eth1", secRoute.Device)
+		require.Equal(t, "192.168.1.1", secRoute.Gateway.String())
+		require.True(t, secRoute.Destination.Bits() == 0, "expected the inferred route to be a default route")
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// TestGetSecondaryInterfaceDetailsSameSubnet exercises the pre-existing
+// fallback where the secondary interface shares the primary's subnet and
+// has no default route of its own; the primary's gateway is reused.
+func TestGetSecondaryInterfaceDetailsSameSubnet(t *testing.T) {
+	testutils.SkipTestIfNotRoot(t)
+
+	ns, _ := tuntest.NewNamedNS(t, "test-samesubnet")
+	defer tuntest.DeleteNamedNS(t, ns)
+
+	tuntest.BridgeAdd(t, ns, "eth0")
+	tuntest.AddrAdd(t, ns, "eth0", "10.0.0.4/24")
+	tuntest.RouteAdd(t, ns, "", "10.0.0.1", "eth0")
+
+	tuntest.BridgeAdd(t, ns, "eth1")
+	tuntest.AddrAdd(t, ns, "eth1", "10.0.0.5/24")
+
+	err := ns.Run(func() error {
+		secIface, _, secRoute, err := getSecondaryInterfaceDetails(ns, "eth0")
+		require.NoError(t, err)
+		require.Equal(t, "eth1", secIface)
+		require.Equal(t, "eth1", secRoute.Device)
+		require.Equal(t, "10.0.0.1", secRoute.Gateway.String())
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestGetSecondaryInterfaceDetailsNoneFound(t *testing.T) {
+	testutils.SkipTestIfNotRoot(t)
+
+	ns, _ := tuntest.NewNamedNS(t, "test-nosecondary")
+	defer tuntest.DeleteNamedNS(t, ns)
+
+	tuntest.BridgeAdd(t, ns, "eth0")
+	tuntest.AddrAdd(t, ns, "eth0", "10.0.0.4/24")
+	tuntest.RouteAdd(t, ns, "", "10.0.0.1", "eth0")
+
+	err := ns.Run(func() error {
+		_, _, _, err := getSecondaryInterfaceDetails(ns, "eth0")
+		require.True(t, errors.Is(err, ErrNoSecondaryInterface))
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// TestSetupExternalNetworkCrossSubnet verifies that a secondary interface
+// discovered on a different subnet than the primary is correctly moved into
+// the pod namespace with its address and inferred default route in place.
+func TestSetupExternalNetworkCrossSubnet(t *testing.T) {
+	testutils.SkipTestIfNotRoot(t)
+
+	hostNS, _ := tuntest.NewNamedNS(t, "test-extnet-host")
+	defer tuntest.DeleteNamedNS(t, hostNS)
+
+	tuntest.BridgeAdd(t, hostNS, "eth0")
+	tuntest.AddrAdd(t, hostNS, "eth0", "10.129.2.111/23")
+	tuntest.RouteAdd(t, hostNS, "", "10.129.2.1", "eth0")
+
+	tuntest.BridgeAdd(t, hostNS, "eth1")
+	tuntest.AddrAdd(t, hostNS, "eth1", "192.168.1.4/24")
+
+	podNS, _ := tuntest.NewNamedNS(t, "test-extnet-pod")
+	defer tuntest.DeleteNamedNS(t, podNS)
+
+	err := hostNS.Run(func() error {
+		return setupExternalNetwork(hostNS, "eth0", podNS)
+	})
+	require.NoError(t, err)
+
+	err = podNS.Run(func() error {
+		link, err := podNS.LinkFind("eth1")
+		require.NoError(t, err)
+
+		addrs, err := link.GetAddr()
+		require.NoError(t, err)
+		require.Len(t, addrs, 1)
+		require.Equal(t, "192.168.1.4/24", addrs[0].String())
+
+		defRoutes, err := podNS.GetDefaultRoutes()
+		require.NoError(t, err)
+		require.Len(t, defRoutes, 1)
+		require.Equal(t, "eth1", defRoutes[0].Device)
+		require.Equal(t, "192.168.1.1", defRoutes[0].Gateway.String())
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/src/cloud-api-adaptor/pkg/podnetwork/common_test.go
+++ b/src/cloud-api-adaptor/pkg/podnetwork/common_test.go
@@ -137,11 +137,19 @@ func TestSetupExternalNetworkCrossSubnet(t *testing.T) {
 	tuntest.AddrAdd(t, hostNS, "eth0", "10.129.2.111/23")
 	tuntest.RouteAdd(t, hostNS, "", "10.129.2.1", "eth0")
 
-	tuntest.BridgeAdd(t, hostNS, "eth1")
-	tuntest.AddrAdd(t, hostNS, "eth1", "192.168.1.4/24")
-
 	podNS, _ := tuntest.NewNamedNS(t, "test-extnet-pod")
 	defer tuntest.DeleteNamedNS(t, podNS)
+
+	// eth1 must be a veth endpoint, not a bridge: Linux bridge master
+	// devices cannot be moved between network namespaces (SetNamespace
+	// fails with EINVAL), whereas a veth endpoint can, matching how real
+	// NICs behave. peerNS just anchors the other end of the pair and is
+	// otherwise unused.
+	peerNS, _ := tuntest.NewNamedNS(t, "test-extnet-peer")
+	defer tuntest.DeleteNamedNS(t, peerNS)
+
+	tuntest.VethAdd(t, hostNS, "eth1", peerNS, "peer0")
+	tuntest.AddrAdd(t, hostNS, "eth1", "192.168.1.4/24")
 
 	err := hostNS.Run(func() error {
 		return setupExternalNetwork(hostNS, "eth0", podNS)

--- a/src/cloud-providers/azure/manager.go
+++ b/src/cloud-providers/azure/manager.go
@@ -32,6 +32,7 @@ func (*Manager) ParseCmd(flags *flag.FlagSet) {
 	// Flags without environment variable support (pass empty string for envVarName)
 	reg.StringWithEnv(&azurecfg.Zone, "zone", "", "", "Zone")
 	reg.StringWithEnv(&azurecfg.SubnetID, "subnetid", "", "AZURE_SUBNET_ID", "Network Subnet Id", provider.Required())
+	reg.StringWithEnv(&azurecfg.SecondarySubnetID, "secondary-subnetid", "", "AZURE_SECONDARY_SUBNET_ID", "Secondary Network Subnet Id used for the Pod VM's secondary NIC in multi-NIC mode")
 	reg.StringWithEnv(&azurecfg.SecurityGroupID, "securitygroupid", "", "AZURE_NSG_ID", "Security Group Id")
 	reg.StringWithEnv(&azurecfg.ImageID, "imageid", "", "AZURE_IMAGE_ID", "Image Id", provider.Required())
 	reg.StringWithEnv(&azurecfg.SSHKeyPath, "ssh-key-path", "", "", "Path to SSH public key")

--- a/src/cloud-providers/azure/multinic_test.go
+++ b/src/cloud-providers/azure/multinic_test.go
@@ -1,0 +1,169 @@
+// (C) Copyright Confidential Containers Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package azure
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
+)
+
+func TestBuildNetworkConfigsSingleNIC(t *testing.T) {
+	p := &azureProvider{serviceConfig: &Config{
+		SubnetID:    "/subscriptions/sub/.../subnets/primary",
+		UsePublicIP: true,
+	}}
+
+	configs := p.buildNetworkConfigs("instance1", false)
+	if len(configs) != 1 {
+		t.Fatalf("expected 1 NIC config, got %d", len(configs))
+	}
+
+	nic := configs[0]
+	if *nic.Name != "instance1-net" {
+		t.Errorf("expected NIC name %q, got %q", "instance1-net", *nic.Name)
+	}
+	if !*nic.Properties.Primary {
+		t.Errorf("expected the only NIC in single-NIC mode to be primary")
+	}
+	if *nic.Properties.IPConfigurations[0].Properties.Subnet.ID != p.serviceConfig.SubnetID {
+		t.Errorf("expected subnet %q, got %q", p.serviceConfig.SubnetID, *nic.Properties.IPConfigurations[0].Properties.Subnet.ID)
+	}
+	if nic.Properties.IPConfigurations[0].Properties.PublicIPAddressConfiguration == nil {
+		t.Errorf("expected a public IP configuration since UsePublicIP is true")
+	}
+}
+
+func TestBuildNetworkConfigsMultiNIC(t *testing.T) {
+	p := &azureProvider{serviceConfig: &Config{
+		SubnetID:          "/subscriptions/sub/.../subnets/primary",
+		SecondarySubnetID: "/subscriptions/sub/.../subnets/secondary",
+		UsePublicIP:       true,
+	}}
+
+	configs := p.buildNetworkConfigs("instance1", true)
+	if len(configs) != 2 {
+		t.Fatalf("expected 2 NIC configs, got %d", len(configs))
+	}
+
+	primary, secondary := configs[0], configs[1]
+
+	if *primary.Name != "instance1-net" {
+		t.Errorf("expected primary NIC name %q, got %q", "instance1-net", *primary.Name)
+	}
+	if !*primary.Properties.Primary {
+		t.Errorf("expected the first NIC to be marked primary")
+	}
+	if *primary.Properties.IPConfigurations[0].Properties.Subnet.ID != p.serviceConfig.SubnetID {
+		t.Errorf("expected primary NIC on subnet %q, got %q", p.serviceConfig.SubnetID, *primary.Properties.IPConfigurations[0].Properties.Subnet.ID)
+	}
+	if primary.Properties.IPConfigurations[0].Properties.PublicIPAddressConfiguration != nil {
+		t.Errorf("did not expect a public IP on the primary (control-plane) NIC in multi-NIC mode")
+	}
+
+	if *secondary.Name != "instance1-ext" {
+		t.Errorf("expected secondary NIC name %q, got %q", "instance1-ext", *secondary.Name)
+	}
+	if *secondary.Properties.Primary {
+		t.Errorf("expected the second NIC to not be marked primary")
+	}
+	if *secondary.Properties.IPConfigurations[0].Properties.Subnet.ID != p.serviceConfig.SecondarySubnetID {
+		t.Errorf("expected secondary NIC on subnet %q, got %q", p.serviceConfig.SecondarySubnetID, *secondary.Properties.IPConfigurations[0].Properties.Subnet.ID)
+	}
+	if secondary.Properties.IPConfigurations[0].Properties.PublicIPAddressConfiguration == nil {
+		t.Errorf("expected a public IP on the secondary (external) NIC since UsePublicIP is true")
+	}
+}
+
+func TestBuildNetworkConfigsMultiNICNoPublicIP(t *testing.T) {
+	p := &azureProvider{serviceConfig: &Config{
+		SubnetID:          "/subscriptions/sub/.../subnets/primary",
+		SecondarySubnetID: "/subscriptions/sub/.../subnets/secondary",
+		UsePublicIP:       false,
+	}}
+
+	configs := p.buildNetworkConfigs("instance1", true)
+	for _, nic := range configs {
+		if nic.Properties.IPConfigurations[0].Properties.PublicIPAddressConfiguration != nil {
+			t.Errorf("did not expect a public IP configuration on %q since UsePublicIP is false", *nic.Name)
+		}
+	}
+}
+
+func TestOrderByPrimary(t *testing.T) {
+	primaryIPC := &armnetwork.InterfaceIPConfiguration{
+		Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+			PrivateIPAddress: to.Ptr("10.0.0.4"),
+		},
+	}
+	secondaryIPC := &armnetwork.InterfaceIPConfiguration{
+		Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+			PrivateIPAddress: to.Ptr("192.168.0.4"),
+		},
+	}
+
+	primaryNic := &armnetwork.Interface{
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			Primary:          to.Ptr(true),
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{primaryIPC},
+		},
+	}
+	secondaryNic := &armnetwork.Interface{
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			Primary:          to.Ptr(false),
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{secondaryIPC},
+		},
+	}
+
+	t.Run("secondary returned by the API before primary is still reordered", func(t *testing.T) {
+		got := orderByPrimary([]*armnetwork.Interface{secondaryNic, primaryNic})
+		if len(got) != 2 {
+			t.Fatalf("expected 2 IP configurations, got %d", len(got))
+		}
+		if *got[0].Properties.PrivateIPAddress != "10.0.0.4" {
+			t.Errorf("expected the primary NIC's IP first, got %q", *got[0].Properties.PrivateIPAddress)
+		}
+		if *got[1].Properties.PrivateIPAddress != "192.168.0.4" {
+			t.Errorf("expected the secondary NIC's IP second, got %q", *got[1].Properties.PrivateIPAddress)
+		}
+	})
+
+	t.Run("single NIC is unaffected", func(t *testing.T) {
+		got := orderByPrimary([]*armnetwork.Interface{primaryNic})
+		if len(got) != 1 || *got[0].Properties.PrivateIPAddress != "10.0.0.4" {
+			t.Fatalf("unexpected result: %+v", got)
+		}
+	})
+}
+
+func TestConfigVerifierSecondarySubnet(t *testing.T) {
+	cases := []struct {
+		name      string
+		subnet    string
+		secondary string
+		wantErr   bool
+	}{
+		{name: "no secondary subnet configured", subnet: "subnet-a", secondary: "", wantErr: false},
+		{name: "distinct secondary subnet", subnet: "subnet-a", secondary: "subnet-b", wantErr: false},
+		{name: "secondary same as primary", subnet: "subnet-a", secondary: "subnet-a", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &azureProvider{serviceConfig: &Config{
+				ImageID:           "image-1",
+				SubnetID:          tc.subnet,
+				SecondarySubnetID: tc.secondary,
+			}}
+			err := p.ConfigVerifier()
+			if tc.wantErr && err == nil {
+				t.Errorf("expected an error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/src/cloud-providers/azure/provider.go
+++ b/src/cloud-providers/azure/provider.go
@@ -112,6 +112,29 @@ func generateSSHPublicKey() ([]byte, error) {
 	return publicKeyBytes, nil
 }
 
+// orderByPrimary returns the IP configurations of the given NICs with the
+// primary NIC's configurations first, followed by any secondary NICs'.
+// Azure does not guarantee the order in which
+// vm.Properties.NetworkProfile.NetworkInterfaces is returned, so callers
+// that depend on a stable "primary IP first" ordering (e.g. the worker node
+// connecting back to the Pod VM) must not rely on API response order alone.
+func orderByPrimary(nics []*armnetwork.Interface) []*armnetwork.InterfaceIPConfiguration {
+	var primary, secondary []*armnetwork.InterfaceIPConfiguration
+
+	for _, nic := range nics {
+		if nic.Properties == nil {
+			continue
+		}
+		if nic.Properties.Primary != nil && *nic.Properties.Primary {
+			primary = append(primary, nic.Properties.IPConfigurations...)
+		} else {
+			secondary = append(secondary, nic.Properties.IPConfigurations...)
+		}
+	}
+
+	return append(primary, secondary...)
+}
+
 func (p *azureProvider) getIPs(ctx context.Context, vm *armcompute.VirtualMachine) ([]netip.Addr, error) {
 	nicClient, err := armnetwork.NewInterfacesClient(p.serviceConfig.SubscriptionID, p.azureClient, nil)
 	if err != nil {
@@ -121,7 +144,7 @@ func (p *azureProvider) getIPs(ctx context.Context, vm *armcompute.VirtualMachin
 	nicRefs := vm.Properties.NetworkProfile.NetworkInterfaces
 
 	var ips []netip.Addr
-	var ipcs []*armnetwork.InterfaceIPConfiguration
+	var nics []*armnetwork.Interface
 
 	for _, nicRef := range nicRefs {
 		nicID := *nicRef.ID
@@ -131,8 +154,12 @@ func (p *azureProvider) getIPs(ctx context.Context, vm *armcompute.VirtualMachin
 		if err != nil {
 			return nil, fmt.Errorf("get network interface: %w", err)
 		}
-		ipcs = append(ipcs, nic.Properties.IPConfigurations...)
+		nics = append(nics, &nic.Interface)
 	}
+
+	// With a single NIC this is a no-op; with multiple NICs it guarantees
+	// the primary (control-plane) NIC's IPs come first.
+	ipcs := orderByPrimary(nics)
 
 	// we add the public ip addresses as first elements, if available
 	if p.serviceConfig.UsePublicIP {
@@ -202,17 +229,21 @@ func (p *azureProvider) create(ctx context.Context, parameters *armcompute.Virtu
 	return &resp.VirtualMachine, nil
 }
 
-func (p *azureProvider) buildNetworkConfig(nicName string) *armcompute.VirtualMachineNetworkInterfaceConfiguration {
+// buildNetworkConfig builds a single NIC configuration for the given subnet.
+// isPrimary marks the NIC (and its IP configuration) as the VM's primary
+// NIC; withPublicIP attaches a public IP configuration to it.
+func (p *azureProvider) buildNetworkConfig(nicName, subnetID string, isPrimary, withPublicIP bool) *armcompute.VirtualMachineNetworkInterfaceConfiguration {
 	ipConfig := armcompute.VirtualMachineNetworkInterfaceIPConfiguration{
 		Name: to.Ptr("ip-config"),
 		Properties: &armcompute.VirtualMachineNetworkInterfaceIPConfigurationProperties{
 			Subnet: &armcompute.SubResource{
-				ID: to.Ptr(p.serviceConfig.SubnetID),
+				ID: to.Ptr(subnetID),
 			},
+			Primary: to.Ptr(isPrimary),
 		},
 	}
 
-	if p.serviceConfig.UsePublicIP {
+	if withPublicIP {
 		publicIPConfig := armcompute.VirtualMachinePublicIPAddressConfiguration{
 			Name: to.Ptr(nicName),
 			Properties: &armcompute.VirtualMachinePublicIPAddressConfigurationProperties{
@@ -225,6 +256,7 @@ func (p *azureProvider) buildNetworkConfig(nicName string) *armcompute.VirtualMa
 	config := armcompute.VirtualMachineNetworkInterfaceConfiguration{
 		Name: to.Ptr(nicName),
 		Properties: &armcompute.VirtualMachineNetworkInterfaceConfigurationProperties{
+			Primary:          to.Ptr(isPrimary),
 			DeleteOption:     to.Ptr(armcompute.DeleteOptionsDelete),
 			IPConfigurations: []*armcompute.VirtualMachineNetworkInterfaceIPConfiguration{&ipConfig},
 		},
@@ -237,6 +269,27 @@ func (p *azureProvider) buildNetworkConfig(nicName string) *armcompute.VirtualMa
 	}
 
 	return &config
+}
+
+// buildNetworkConfigs returns the NIC configurations to attach to the VM at
+// creation time. Azure requires all NICs to be declared upfront in the VM
+// create request (unlike AWS, which attaches the secondary ENI after the
+// instance is running), so both NICs are built here when multiNic is set.
+//
+// In multi-NIC mode the primary NIC (on SubnetID) carries pod/cluster
+// traffic over the VXLAN tunnel and never gets a public IP; the secondary
+// NIC (on SecondarySubnetID) carries the Pod VM's external traffic and
+// optionally gets a public IP if UsePublicIP is set.
+func (p *azureProvider) buildNetworkConfigs(instanceName string, multiNic bool) []*armcompute.VirtualMachineNetworkInterfaceConfiguration {
+	primary := p.buildNetworkConfig(fmt.Sprintf("%s-net", instanceName), p.serviceConfig.SubnetID, true, p.serviceConfig.UsePublicIP && !multiNic)
+
+	if !multiNic {
+		return []*armcompute.VirtualMachineNetworkInterfaceConfiguration{primary}
+	}
+
+	secondary := p.buildNetworkConfig(fmt.Sprintf("%s-ext", instanceName), p.serviceConfig.SecondarySubnetID, false, p.serviceConfig.UsePublicIP)
+
+	return []*armcompute.VirtualMachineNetworkInterfaceConfiguration{primary, secondary}
 }
 
 func (p *azureProvider) CreateInstance(ctx context.Context, podName, sandboxID string, cloudConfig cloudinit.CloudConfigGenerator, spec provider.InstanceTypeSpec) (instance *provider.Instance, err error) {
@@ -254,7 +307,10 @@ func (p *azureProvider) CreateInstance(ctx context.Context, podName, sandboxID s
 	}
 
 	diskName := fmt.Sprintf("%s-disk", instanceName)
-	nicName := fmt.Sprintf("%s-net", instanceName)
+
+	if spec.MultiNic && p.serviceConfig.SecondarySubnetID == "" {
+		return nil, fmt.Errorf("multi-NIC pod networking was requested but AZURE_SECONDARY_SUBNET_ID is not configured")
+	}
 
 	sshPublicKeyPath := os.ExpandEnv(p.serviceConfig.SSHKeyPath)
 	var sshBytes []byte
@@ -294,12 +350,12 @@ func (p *azureProvider) CreateInstance(ctx context.Context, podName, sandboxID s
 		}
 	}
 
-	vmParameters, err := p.getVMParameters(instanceSize, diskName, cloudConfigData, sshBytes, instanceName, nicName, imageID, spec.Volumes)
+	vmParameters, err := p.getVMParameters(instanceSize, diskName, cloudConfigData, sshBytes, instanceName, imageID, spec.Volumes, spec.MultiNic)
 	if err != nil {
 		return nil, err
 	}
 
-	logger.Printf("CreateInstance: name: %q", instanceName)
+	logger.Printf("CreateInstance: name: %q, multi-NIC: %v", instanceName, spec.MultiNic)
 
 	vm, err := p.create(ctx, vmParameters)
 	if err != nil {
@@ -371,6 +427,11 @@ func (p *azureProvider) ConfigVerifier() error {
 			return fmt.Errorf("SSH key is invalid: %s", err)
 		}
 	}
+
+	if p.serviceConfig.SecondarySubnetID != "" && p.serviceConfig.SecondarySubnetID == p.serviceConfig.SubnetID {
+		return fmt.Errorf("AZURE_SECONDARY_SUBNET_ID must differ from AZURE_SUBNET_ID")
+	}
+
 	return nil
 }
 
@@ -535,7 +596,7 @@ func (p *azureProvider) getResourceTags() map[string]*string {
 	return tags
 }
 
-func (p *azureProvider) getVMParameters(instanceSize, diskName, cloudConfig string, sshBytes []byte, instanceName, nicName string, imageID string, csiVolumes []provider.CloudVolume) (*armcompute.VirtualMachine, error) {
+func (p *azureProvider) getVMParameters(instanceSize, diskName, cloudConfig string, sshBytes []byte, instanceName, imageID string, csiVolumes []provider.CloudVolume, multiNic bool) (*armcompute.VirtualMachine, error) {
 	userDataB64 := base64.StdEncoding.EncodeToString([]byte(cloudConfig))
 
 	// Azure limits the base64 encrypted userData to 64KB.
@@ -578,7 +639,7 @@ func (p *azureProvider) getVMParameters(instanceSize, diskName, cloudConfig stri
 		}
 	}
 
-	networkConfig := p.buildNetworkConfig(nicName)
+	networkConfigs := p.buildNetworkConfigs(instanceName, multiNic)
 
 	// Configure OS disk with optional root volume size
 	osDisk := &armcompute.OSDisk{
@@ -636,7 +697,7 @@ func (p *azureProvider) getVMParameters(instanceSize, diskName, cloudConfig stri
 			},
 			NetworkProfile: &armcompute.NetworkProfile{
 				NetworkAPIVersion:              to.Ptr(armcompute.NetworkAPIVersionTwoThousandTwenty1101),
-				NetworkInterfaceConfigurations: []*armcompute.VirtualMachineNetworkInterfaceConfiguration{networkConfig},
+				NetworkInterfaceConfigurations: networkConfigs,
 			},
 			SecurityProfile: securityProfile,
 			DiagnosticsProfile: &armcompute.DiagnosticsProfile{

--- a/src/cloud-providers/azure/types.go
+++ b/src/cloud-providers/azure/types.go
@@ -26,14 +26,19 @@ func (i *instanceSizes) Set(value string) error {
 }
 
 type Config struct {
-	SubscriptionID       string
-	ClientID             string
-	ClientSecret         string
-	TenantID             string
-	ResourceGroupName    string
-	Zone                 string
-	Region               string
-	SubnetID             string
+	SubscriptionID    string
+	ClientID          string
+	ClientSecret      string
+	TenantID          string
+	ResourceGroupName string
+	Zone              string
+	Region            string
+	SubnetID          string
+	// SecondarySubnetID is the subnet used for the secondary NIC attached to
+	// the Pod VM when multi-NIC pod networking is requested
+	// (EXTERNAL_NETWORK_VIA_PODVM). It must be a different subnet than
+	// SubnetID, in the same VNet. Leave empty to disable multi-NIC support.
+	SecondarySubnetID    string
 	SecurityGroupName    string
 	SecurityGroupID      string
 	Size                 string


### PR DESCRIPTION
## Summary

Attaches a second NIC to the Azure Pod VM so that pod traffic to destinations
outside the cluster can go directly over the Azure VNet instead of through
the worker node's VXLAN tunnel. This builds on the existing
`EXTERNAL_NETWORK_VIA_PODVM` mechanism already used by the AWS and Alibaba
Cloud providers — see [docs/azure-multi-nic.md](../blob/main/docs/azure-multi-nic.md)
for configuration and design details.

- Declares both NICs in the VM creation request (new `AZURE_SECONDARY_SUBNET_ID`
  config), since Azure doesn't support hot-attaching a NIC to a running VM
  without first deallocating it, unlike AWS's post-launch ENI attach.
- Orders the IPs returned from `getIPs` so the primary (control-plane) NIC's
  IPs always come first, regardless of the order Azure returns NICs in.
- `CreateInstance` fails fast with a clear error if multi-NIC pod networking
  is requested (`EXTERNAL_NETWORK_VIA_PODVM=true`) but
  `AZURE_SECONDARY_SUBNET_ID` isn't configured, instead of deferring to a
  runtime failure deep in pod network setup.
- Extends `pkg/podnetwork`'s secondary-interface discovery (shared with the
  AWS/Alibaba providers) to infer a gateway when the secondary NIC has no
  DHCP-assigned default route and isn't on the primary's subnet — the case
  on Azure, since its two NICs sit on different subnets by design. This is
  purely additive: existing discovery paths (own default route, or same
  subnet as primary) are checked first and unchanged.

## Test plan

- [x] `go build`/`go vet` clean for `src/cloud-providers/azure` and
      `src/cloud-api-adaptor/pkg/podnetwork` (Linux target)
- [x] `golangci-lint run` clean on both changed packages
- [x] `go mod tidy` produces no diff in either module
- [x] New unit tests added and passing:
  - `src/cloud-providers/azure/multinic_test.go`: NIC config building
    (single/multi-NIC, public IP placement), `orderByPrimary` IP ordering,
    `ConfigVerifier` subnet validation
  - `src/cloud-api-adaptor/pkg/podnetwork/common_test.go`: gateway
    inference, cross-subnet/same-subnet secondary interface discovery,
    end-to-end `setupExternalNetwork` via network namespaces (root-only,
    skipped locally on this dev machine — matches existing `podnetwork_test.go`
    convention, exercised by CI's `sudo make test`)
- [x] Live Azure e2e validation (VM creation with two NICs, actual traffic
      routing) — not exercised here after merging with latest code, the prototype was tested against 1.12 version of OSC on ARO.

## DCO

This PR was co-developed with @devansh1109, who prototyped the original
implementation; I reworked it against current `main` (which had diverged
significantly — CSI volume support landed since the prototype was written),
removed debug-only logging, added the test coverage and doc above, and am
submitting it with their permission. Both commits are signed off per DCO 1.1.