### PR TITLE
libvirt: thread context through volume operations to waitForSuccess

### DIFF
--- a/src/cloud-providers/libvirt/libvirt.go
+++ b/src/cloud-providers/libvirt/libvirt.go
@@ -95,7 +95,7 @@ func checkDomainExistsByName(name string, libvirtClient *libvirtClient) (exist b
 
 }
 
-func uploadIso(isoData []byte, isoVolName string, libvirtClient *libvirtClient) (string, error) {
+func uploadIso(ctx context.Context, isoData []byte, isoVolName string, libvirtClient *libvirtClient) (string, error) {
 
 	logger.Printf("Uploading iso file: %s\n", isoVolName)
 	volumeDef := newDefVolume(isoVolName)
@@ -114,7 +114,7 @@ func uploadIso(isoData []byte, isoVolName string, libvirtClient *libvirtClient) 
 	volumeDef.Capacity.Value = size
 	volumeDef.Target.Format.Type = "raw"
 
-	return uploadVolume(libvirtClient, volumeDef, img)
+	return uploadVolume(ctx, libvirtClient, volumeDef, img)
 
 }
 
@@ -585,7 +585,7 @@ func CreateDomain(ctx context.Context, libvirtClient *libvirtClient, v *vmConfig
 	}
 
 	rootVolName := v.name + "-root.qcow2"
-	err = createVolume(rootVolName, v.rootDiskSize, v.volName, libvirtClient)
+	err = createVolume(ctx, rootVolName, v.rootDiskSize, v.volName, libvirtClient)
 	if err != nil {
 		return nil, fmt.Errorf("Error in creating volume: %s", err)
 	}
@@ -596,7 +596,7 @@ func CreateDomain(ctx context.Context, libvirtClient *libvirtClient, v *vmConfig
 	}
 
 	isoVolName := v.name + "-cloudinit.iso"
-	isoVolFile, err := uploadIso(cloudInitIso, isoVolName, libvirtClient)
+	isoVolFile, err := uploadIso(ctx, cloudInitIso, isoVolName, libvirtClient)
 	if err != nil {
 		return nil, fmt.Errorf("Error in uploading iso volume: %s", err)
 	}
@@ -739,7 +739,7 @@ func DeleteDomain(ctx context.Context, libvirtClient *libvirtClient, domainUUID 
 		} else {
 			logger.Printf("domainDef %v", domainDef.Devices.Disks)
 			for _, diskPath := range getDeletableDiskPaths(&domainDef) {
-				err = deleteVolumeByPath(libvirtClient, diskPath)
+				err = deleteVolumeByPath(ctx, libvirtClient, diskPath)
 				if err != nil {
 					logger.Printf("Deleting volume (%s) returned error: %s", diskPath, err)
 					cleanupErrs = append(cleanupErrs, fmt.Sprintf("delete volume %s: %v", diskPath, err))

--- a/src/cloud-providers/libvirt/volume.go
+++ b/src/cloud-providers/libvirt/volume.go
@@ -8,6 +8,7 @@ package libvirt
 // Code copied from https://github.com/openshift/cluster-api-provider-libvirt
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -27,19 +28,38 @@ var waitSleepInterval = 1 * time.Second
 // waitTimeout time
 var waitTimeout = 5 * time.Minute
 
-// waitForSuccess wait for success and timeout after 5 minutes.
-func waitForSuccess(errorMessage string, f func() error) error {
+// waitForSuccess calls f repeatedly until it returns nil,
+// the context is cancelled, or waitTimeout elapses (whichever comes first).
+func waitForSuccess(ctx context.Context, errorMessage string, f func() error) error {
 	start := time.Now()
+
+	timer := time.NewTimer(0)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	defer timer.Stop()
+
+	var lastErr error
 	for {
-		err := f()
-		if err == nil {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("%s: %w", errorMessage, err)
+		}
+
+		lastErr = f()
+		if lastErr == nil {
 			return nil
 		}
-		logger.Printf("%s. Re-trying.\n", err)
+		logger.Printf("%s. Re-trying.\n", lastErr)
 
-		time.Sleep(waitSleepInterval)
 		if time.Since(start) > waitTimeout {
-			return fmt.Errorf("%s: %s", errorMessage, err)
+			return fmt.Errorf("%s: %w", errorMessage, lastErr)
+		}
+
+		timer.Reset(waitSleepInterval)
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%s: %w", errorMessage, ctx.Err())
+		case <-timer.C:
 		}
 	}
 }
@@ -106,11 +126,11 @@ func newDefVolumeFromXML(s string) (libvirtxml.StorageVolume, error) {
 	return volumeDef, nil
 }
 
-func uploadVolume(libvirtClient *libvirtClient, volumeDef libvirtxml.StorageVolume, img image) (volumeKey string, err error) {
+func uploadVolume(ctx context.Context, libvirtClient *libvirtClient, volumeDef libvirtxml.StorageVolume, img image) (volumeKey string, err error) {
 
 	// Refresh the pool of the volume so that libvirt knows it is
 	// not longer in use.
-	err = waitForSuccess("Error refreshing pool for volume", func() error {
+	err = waitForSuccess(ctx, "Error refreshing pool for volume", func() error {
 		return libvirtClient.pool.Refresh(0)
 	})
 	if err != nil {
@@ -210,7 +230,7 @@ func volumeCapacityBytes(volSizeGiB, backingCapacityBytes uint64) (uint64, error
 // createVolume creates a qcow2 volume backed by baseVolName.
 // volSizeGiB is the requested size in GiB; libvirt uses the larger of this
 // value and the backing image's actual capacity.
-func createVolume(volName string, volSizeGiB uint64, baseVolName string, libvirtClient *libvirtClient) (err error) {
+func createVolume(ctx context.Context, volName string, volSizeGiB uint64, baseVolName string, libvirtClient *libvirtClient) (err error) {
 	volumeDef := newDefVolume(volName)
 	volumeDef.Target.Format.Type = "qcow2"
 
@@ -247,7 +267,7 @@ func createVolume(volName string, volSizeGiB uint64, baseVolName string, libvirt
 	// create the volume
 	// Refresh the pool of the volume so that libvirt knows it is
 	// not longer in use.
-	err = waitForSuccess("error refreshing pool for volume", func() error {
+	err = waitForSuccess(ctx, "error refreshing pool for volume", func() error {
 		return libvirtClient.pool.Refresh(0)
 	})
 	if err != nil {
@@ -298,7 +318,7 @@ func volumeExists(libvirtClient *libvirtClient, volumeName string) (exist bool, 
 	return true, nil
 }
 
-func deleteVolumeByPath(libvirtClient *libvirtClient, path string) (err error) {
+func deleteVolumeByPath(ctx context.Context, libvirtClient *libvirtClient, path string) (err error) {
 
 	// Get volume name from path
 
@@ -317,11 +337,11 @@ func deleteVolumeByPath(libvirtClient *libvirtClient, path string) (err error) {
 		return err
 	}
 
-	return deleteVolume(libvirtClient, name)
+	return deleteVolume(ctx, libvirtClient, name)
 
 }
 
-func deleteVolume(libvirtClient *libvirtClient, name string) (err error) {
+func deleteVolume(ctx context.Context, libvirtClient *libvirtClient, name string) (err error) {
 	exists, err := volumeExists(libvirtClient, name)
 	if err != nil {
 		logger.Printf("Unable to check if volume (%s) exists", name)
@@ -352,7 +372,7 @@ func deleteVolume(libvirtClient *libvirtClient, name string) (err error) {
 		}
 	}()
 
-	err = waitForSuccess("Error refreshing pool for volume", func() error {
+	err = waitForSuccess(ctx, "Error refreshing pool for volume", func() error {
 		return volPool.Refresh(0)
 	})
 	if err != nil {

--- a/src/cloud-providers/libvirt/volume_test.go
+++ b/src/cloud-providers/libvirt/volume_test.go
@@ -6,6 +6,7 @@
 package libvirt
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -214,9 +215,8 @@ func TestWaitForSuccess(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			setWaitTimers(t, tt.timeout, tt.interval)
-
 			callCount := 0
-			err := waitForSuccess(testOperation, func() error {
+			err := waitForSuccess(context.Background(), testOperation, func() error {
 				callCount++
 				if tt.failCount == alwaysFails {
 					return errors.New(errPersistent)
@@ -235,6 +235,46 @@ func TestWaitForSuccess(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWaitForSuccess_ContextCancellation(t *testing.T) {
+	t.Run("pre-cancelled context returns context.Canceled without calling f", func(t *testing.T) {
+		setWaitTimers(t, 5*time.Second, 100*time.Millisecond)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // cancel before calling waitForSuccess
+
+		callCount := 0
+		err := waitForSuccess(ctx, testOperation, func() error {
+			callCount++
+			return errors.New(errPersistent)
+		})
+
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.ErrorContains(t, err, testOperation)
+		assert.Equal(t, 0, callCount)
+	})
+
+	t.Run("mid-flight cancellation stops retries and returns context.Canceled", func(t *testing.T) {
+		setWaitTimers(t, 5*time.Second, 50*time.Millisecond)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		callCount := 0
+		err := waitForSuccess(ctx, testOperation, func() error {
+			callCount++
+			if callCount == 2 {
+				cancel() // cancel on the second call, while f is running
+			}
+			return errors.New(errPersistent)
+		})
+
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.ErrorContains(t, err, testOperation)
+		// f was called at least twice (once before cancel, once to trigger it)
+		assert.GreaterOrEqual(t, callCount, 2)
+	})
 }
 
 func TestVolumeCapacityBytesTable(t *testing.T) {


### PR DESCRIPTION
uploadVolume, createVolume, deleteVolume, and deleteVolumeByPath had no context parameter, leaving the ctx argument to waitForSuccess undefined. This meant cancellation signals from the gRPC caller (e.g. kubelet deadline expiry) were never propagated — waitForSuccess would continue retrying libvirt pool refreshes for the full 5-minute waitTimeout even after the caller had given up.

Thread context.Context from CreateDomain and DeleteDomain down through uploadIso → uploadVolume, createVolume, and deleteVolumeByPath → deleteVolume so that waitForSuccess can exit immediately on cancellation. The waitTimeout floor is retained as a safety net when no deadline is set. 
fixes: #3231

Assisted-by: IBM Bob noreply@ibm.com