### PR TITLE
chore: bump golang to 1.25.13

### DIFF
--- a/src/cloud-api-adaptor/Dockerfile
+++ b/src/cloud-api-adaptor/Dockerfile
@@ -1,9 +1,9 @@
 ARG BUILD_TYPE=dev
-# golang:1.25.12 (based on Debian 13 trixie)
-ARG BUILDER_BASE=golang@sha256:d7912cedddfa15b2900a8dfb7187df0af5ec2cb424a371139b5b352fd3e6b740
-# debian:trixie-slim (matches golang:1.25.12 base for library compatibility)
+# golang:1.25.13 (based on Debian 13 trixie)
+ARG BUILDER_BASE=golang@sha256:cbff9d1a9041b316010f2da6b701b6c0d597718cb90928c85eb597334a0d23d4
+# debian:trixie-slim (matches golang:1.25.13 base for library compatibility)
 # Multi-arch manifest list digest supporting amd64, arm64, ppc64le, s390x
-ARG BASE=debian@sha256:28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2
+ARG BASE=debian@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258
 
 # This dockerfile uses Go cross-compilation to build the binary,
 # we build on the host platform ($BUILDPLATFORM) and then copy the

--- a/src/cloud-api-adaptor/docs/addnewprovider.md
+++ b/src/cloud-api-adaptor/docs/addnewprovider.md
@@ -219,8 +219,8 @@ go mod tidy
 
 ```bash
 cat > Dockerfile <<EOF
-# golang:1.25.12
-ARG BUILDER_BASE=golang@sha256:d7912cedddfa15b2900a8dfb7187df0af5ec2cb424a371139b5b352fd3e6b740
+# golang:1.25.13
+ARG BUILDER_BASE=golang@sha256:cbff9d1a9041b316010f2da6b701b6c0d597718cb90928c85eb597334a0d23d4
 FROM --platform="\$TARGETPLATFORM" \$BUILDER_BASE AS builder
 RUN apt-get update && apt-get install -y libvirt-dev pkg-config && rm -rf /var/lib/apt/lists/*
 WORKDIR /work

--- a/src/cloud-api-adaptor/go.mod
+++ b/src/cloud-api-adaptor/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -30,7 +30,7 @@ tools:
   cert-manager: v1.15.3
   bats: 1.10.0
   iptables-wrapper: bfef9e5087a198b50a4124bb9ce9d2c7c99025dd
-  golang: 1.25.12
+  golang: 1.25.13
   kcli: 99.0.202507200957
   mkosi: v26
   protoc: 3.16.0

--- a/src/cloud-providers/go.mod
+++ b/src/cloud-providers/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers
 
-go 1.25.12
+go 1.25.13
 
 require (
 	cloud.google.com/go/compute v1.64.0

--- a/src/peerpod-ctrl/Dockerfile
+++ b/src/peerpod-ctrl/Dockerfile
@@ -1,6 +1,6 @@
 # Build the manager binary
-# golang:1.25.12
-FROM --platform=$TARGETPLATFORM golang@sha256:d7912cedddfa15b2900a8dfb7187df0af5ec2cb424a371139b5b352fd3e6b740 AS builder
+# golang:1.25.13
+FROM --platform=$TARGETPLATFORM golang@sha256:cbff9d1a9041b316010f2da6b701b6c0d597718cb90928c85eb597334a0d23d4 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG CGO_ENABLED=1
@@ -35,8 +35,8 @@ COPY peerpod-ctrl/controllers/ controllers/
 RUN CC=gcc CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build ${GOFLAGS} -a -o manager main.go
 
 # Target Image
-# debian:trixie-slim (matches golang:1.25.12 base for library compatibility)
-FROM --platform=$TARGETPLATFORM debian@sha256:28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2
+# debian:trixie-slim (matches golang:1.25.13 base for library compatibility)
+FROM --platform=$TARGETPLATFORM debian@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258
 ARG CGO_ENABLED=1
 
 RUN if [ "$CGO_ENABLED" = 1 ] ; then \

--- a/src/peerpod-ctrl/go.mod
+++ b/src/peerpod-ctrl/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/peerpod-ctrl
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers v0.0.0-00010101000000-000000000000

--- a/src/webhook/Dockerfile
+++ b/src/webhook/Dockerfile
@@ -1,6 +1,6 @@
 # Build the manager binary
-# golang:1.25.12
-FROM --platform=$BUILDPLATFORM golang@sha256:d7912cedddfa15b2900a8dfb7187df0af5ec2cb424a371139b5b352fd3e6b740 AS builder
+# golang:1.25.13
+FROM --platform=$BUILDPLATFORM golang@sha256:cbff9d1a9041b316010f2da6b701b6c0d597718cb90928c85eb597334a0d23d4 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/src/webhook/go.mod
+++ b/src/webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/webhook
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
Upgrades golang from 1.25.12 to 1.25.13 to fix 6 standard library vulnerabilities:

- GO-2026-6089: Apply ReadHeaderTimeout for unencrypted HTTP/2 check (net/http)
- GO-2026-6090: Limit post-handshake messages (crypto/tls)
- GO-2026-6091: Fix Javascript regexp context tracking (html/template)
- GO-2026-6218: Avoid quadratic complexity in resolvePath (net/url)
- GO-2026-5972: Enforce maximum recursion depth (encoding/asn1)
- GO-2026-5026: Reject ASCII-only Punycode-encoded labels (golang.org/x/net/idna)

Updates go directive in go.mod files, golang image SHAs in Dockerfiles, and golang version in versions.yaml.

Generated-By: IBM Bob