### PR TITLE
libvirt: fix empty instanceID when domain already exists

### DIFF
--- a/src/cloud-providers/libvirt/libvirt.go
+++ b/src/cloud-providers/libvirt/libvirt.go
@@ -79,22 +79,6 @@ func createCloudInitISO(v *vmConfig) ([]byte, error) {
 	return createCloudInit([]byte(userData), []byte(metaData))
 }
 
-func checkDomainExistsByName(name string, libvirtClient *libvirtClient) (exist bool, err error) {
-
-	logger.Printf("Checking if instance (%s) exists", name)
-	domain, err := libvirtClient.connection.LookupDomainByName(name)
-	if err != nil {
-		if err.(libvirt.Error).Code == libvirt.ERR_NO_DOMAIN {
-			return false, nil
-		}
-		return false, err
-	}
-	defer freeDomain(domain, &err)
-
-	return true, nil
-
-}
-
 func uploadIso(ctx context.Context, isoData []byte, isoVolName string, libvirtClient *libvirtClient) (string, error) {
 
 	logger.Printf("Uploading iso file: %s\n", isoVolName)
@@ -573,15 +557,31 @@ func CreateDomain(ctx context.Context, libvirtClient *libvirtClient, v *vmConfig
 
 	v.rootDiskSize = normalizeRootDiskSize(v.rootDiskSize)
 
-	exists, err := checkDomainExistsByName(v.name, libvirtClient)
-	if err != nil {
-		return nil, fmt.Errorf("Error in checking instance: %s", err)
+	logger.Printf("Checking if instance (%s) exists", v.name)
+	domain, err := libvirtClient.connection.LookupDomainByName(v.name)
+	if err == nil {
+		// Domain already exists. Populate instanceID and ips so the caller
+		// has a valid UUID for cleanup if anything goes wrong subsequently.
+		defer freeDomain(domain, &err)
+		uuid, uuidErr := domain.GetUUIDString()
+		if uuidErr != nil {
+			return nil, fmt.Errorf("existing domain UUID retrieval failed: %w", uuidErr)
+		}
+		v.instanceID = uuid
+		ips, ipsErr := getDomainIPs(domain)
+		if ipsErr != nil {
+			// UUID is valid; return the instance so the caller can clean up
+			// even if IP retrieval fails (e.g. domain is shut off).
+			logger.Printf("existing domain IP retrieval failed (uuid=%s): %v", uuid, ipsErr)
+			return &createDomainOutput{instance: v}, fmt.Errorf("existing domain IP retrieval failed: %w", ipsErr)
+		}
+		v.ips = ips
+		logger.Printf("Instance already exists (uuid=%s)", uuid)
+		return &createDomainOutput{instance: v}, nil
 	}
-	if exists {
-		logger.Printf("Instance already exists ")
-		return &createDomainOutput{
-			instance: v,
-		}, nil
+	var libvirtErr libvirt.Error
+	if !errors.As(err, &libvirtErr) || libvirtErr.Code != libvirt.ERR_NO_DOMAIN {
+		return nil, fmt.Errorf("error checking instance: %w", err)
 	}
 
 	rootVolName := v.name + "-root.qcow2"

--- a/src/cloud-providers/libvirt/libvirt_test.go
+++ b/src/cloud-providers/libvirt/libvirt_test.go
@@ -4,6 +4,7 @@
 package libvirt
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -1315,4 +1316,73 @@ func TestNewDefVolumeCapacity(t *testing.T) {
 				"volume name should match input")
 		})
 	}
+}
+
+// TestCreateDomainExistingDomain verifies that an already-existing domain returns a populated instanceID equal to its UUID.
+// It pre-creates a domain via DomainDefineXML, then calls CreateDomain twice; both calls hit the existing-domain path and must return the same UUID.
+func TestCreateDomainExistingDomain(t *testing.T) {
+	checkConfig(t)
+
+	client, err := NewLibvirtClient(testCfg)
+	require.NoError(t, err)
+	defer client.connection.Close()
+
+	const domName = "TestCreateDomainExisting"
+
+	minimalXML := `<domain type='kvm'><name>` + domName + `</name>` +
+		`<memory unit='MiB'>64</memory><vcpu>1</vcpu>` +
+		`<os><type arch='x86_64'>hvm</type></os></domain>`
+	dom, err := client.connection.DomainDefineXML(minimalXML)
+	require.NoError(t, err, "failed to pre-create domain for test")
+
+	expectedUUID, err := dom.GetUUIDString()
+	require.NoError(t, err)
+	require.NoError(t, dom.Free())
+
+	defer func() {
+		d, lookupErr := client.connection.LookupDomainByName(domName)
+		if lookupErr != nil {
+			return
+		}
+		_ = d.Undefine()
+		_ = d.Free()
+	}()
+
+	// Both calls hit the existing-domain path since the domain was pre-created above.
+	v := &vmConfig{name: domName}
+	result, err := CreateDomain(context.Background(), client, v)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.instance)
+	assert.Equal(t, expectedUUID, result.instance.instanceID,
+		"instanceID must equal the existing domain's UUID on first call")
+
+	// Second call: same domain still exists, must return the same UUID.
+	v2 := &vmConfig{name: domName}
+	result2, err := CreateDomain(context.Background(), client, v2)
+
+	require.NoError(t, err)
+	require.NotNil(t, result2)
+	require.NotNil(t, result2.instance)
+	assert.Equal(t, expectedUUID, result2.instance.instanceID,
+		"instanceID must equal the existing domain's UUID on second call")
+}
+
+// TestCreateDomainNoExistingDomain verifies that a missing domain falls through to the normal create path.
+func TestCreateDomainNoExistingDomain(t *testing.T) {
+	checkConfig(t)
+
+	client, err := NewLibvirtClient(testCfg)
+	require.NoError(t, err)
+	defer client.connection.Close()
+
+	v := &vmConfig{
+		name:    "TestCreateDomainNonExistent",
+		volName: "nonexistent-backing.qcow2",
+	}
+
+	_, err = CreateDomain(context.Background(), client, v)
+	require.Error(t, err, "expected error from missing volume, not from domain lookup")
+	assert.ErrorContains(t, err, "volume")
 }


### PR DESCRIPTION
## Problem

When `CreateDomain` finds an existing domain via `checkDomainExistsByName`, it returns the input `vmConfig` unchanged. `v.instanceID` is still `""` at that point — the UUID is only assigned after `DomainDefineXML`/`GetUUIDString`, which the early-return path never reaches.

The empty ID propagates up through `CreateInstance` into `cloud.go`, where the deferred cleanup guard:

```go
if err != nil && instance != nil && instance.ID != "" {
    s.provider.DeleteInstance(cleanupCtx, instance.ID)
}
```

is always false, so the ghost domain is never cleaned up. Every subsequent create attempt for the same sandbox name hits the same path — self-reinforcing.

## Root Cause

`checkDomainExistsByName` calls `LookupDomainByName`, gets the domain handle, then immediately frees it and returns only a boolean. The UUID is discarded. The caller has no handle left to call `GetUUIDString` on.

## Fix

Inline `LookupDomainByName` into `CreateDomain`, populate `instanceID` and `ips` from the existing domain before returning, and remove `checkDomainExistsByName` (now dead code). This also eliminates the double libvirt round-trip the old pattern caused.

## Testing

Two integration tests added to `libvirt_test.go`, both gated by `checkConfig(t)` (require `LIBVIRT_URI`):

- `TestCreateDomainExistingDomain`: pre-creates a domain, calls `CreateDomain`, asserts `instanceID` equals the domain's UUID
- `TestCreateDomainNoExistingDomain`: no pre-existing domain, asserts the call falls through to the normal create path

## Related

Sibling of #2963 / #2964, which fixed the same class of problem on the new-domain path.

Fixes: #3247