### PR TITLE
podvm: remove quay.io secret from podvm builds

### DIFF
--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -61,7 +61,6 @@ jobs:
   podvm_mkosi_amd64:
     uses: ./.github/workflows/podvm_mkosi.yaml
     with:
-      registry: ${{ inputs.registry }}
       image_tag: ${{ inputs.podvm_image_tag }}
       git_ref: ${{ inputs.git_ref }}
       arch: amd64
@@ -72,13 +71,10 @@ jobs:
       id-token: write  # Required for OIDC authentication
       attestations: write  # Required to write attestations
       artifact-metadata: write  # Required by podvm_mkosi.yaml to write attestation metadata
-    secrets:
-      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 
   podvm_mkosi_s390x:
     uses: ./.github/workflows/podvm_mkosi.yaml
     with:
-      registry: ${{ inputs.registry }}
       image_tag: ${{ inputs.podvm_image_tag }}
       git_ref: ${{ inputs.git_ref }}
       arch: s390x
@@ -89,8 +85,6 @@ jobs:
       attestations: write  # Required to write attestations
       id-token: write  # Required for OIDC authentication
       artifact-metadata: write  # Required by podvm_mkosi.yaml to write attestation metadata
-    secrets:
-      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 
   podvm_mkosi_azure:
     uses: ./.github/workflows/podvm_mkosi.yaml
@@ -101,14 +95,11 @@ jobs:
       attestations: write # Required to publish the attestation provenance to ghcr
       artifact-metadata: write # Required by podvm_mkosi_ubuntu.yaml to write attestation metadata
     with:
-      registry: ghcr.io/${{ github.repository_owner }}
       image_tag: ${{ inputs.podvm_image_tag }}
       git_ref: ${{ github.sha }}
       arch: amd64
       debug: true
       tee-platform: az-cvm-vtpm
-    secrets:
-      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 
   caa_image_amd64:
     uses: ./.github/workflows/caa_build_and_push.yaml

--- a/.github/workflows/podvm_mkosi.yaml
+++ b/.github/workflows/podvm_mkosi.yaml
@@ -3,10 +3,6 @@ name: Create Pod VM image with mkosi
 on:
   workflow_dispatch:
     inputs:
-      registry:
-        default: 'quay.io/confidential-containers'
-        required: false
-        type: string
       image_tag:
         default: ''
         required: false
@@ -33,10 +29,6 @@ on:
 
   workflow_call:
     inputs:
-      registry:
-        default: 'quay.io/confidential-containers'
-        required: false
-        type: string
       image_tag:
         default: ''
         required: false
@@ -60,9 +52,6 @@ on:
         default: 'none'
         required: false
         type: string
-    secrets:
-      QUAY_PASSWORD:
-        required: true
     outputs:
       qcow2_oras_image:
         description: The location of the qcow2 oras container this workflow pushed
@@ -113,16 +102,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
-      - name: Login to quay Container Registry
-        if: ${{ startsWith(inputs.registry, 'quay.io') }}
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: quay.io
-          username: ${{ vars.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-
       - name: Login to the ghcr Container registry
-        if: ${{ startsWith(inputs.registry, 'ghcr.io') }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
@@ -198,7 +178,7 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
         env:
           DEBUG: ${{ inputs.debug == true && '1' || '' }}
-          REGISTRY: ${{ inputs.registry }}
+          REGISTRY: ghcr.io/${{ github.repository_owner }}
           ARCH: ${{ inputs.arch }}
           IMAGE_TAG: ${{ inputs.image_tag }}
           TEE_PLATFORM: ${{ inputs.tee-platform != 'none' && inputs.tee-platform || '' }}

--- a/.github/workflows/podvm_publish.yaml
+++ b/.github/workflows/podvm_publish.yaml
@@ -29,9 +29,6 @@ on:
         required: false
         type: string
         default: ''
-    secrets:
-      QUAY_PASSWORD:
-        required: true
 
 permissions: {}
 
@@ -53,6 +50,3 @@ jobs:
       image_tag: ${{ inputs.image_tag || github.sha }}
       arch: ${{ matrix.arch}}
       debug: false
-      registry: ${{ inputs.registry != '' && inputs.registry || (github.repository == 'confidential-containers/cloud-api-adaptor' && 'quay.io/confidential-containers' || format('ghcr.io/{0}', github.repository_owner)) }}
-    secrets:
-      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/podvm_publish.yaml
+++ b/.github/workflows/podvm_publish.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       registry:
-        description: 'Container registry to push images to (e.g., quay.io/your-username)'
+        description: 'Alternative container registry to push images to (e.g., quay.io/your-username)'
         required: false
         type: string
         default: ''
@@ -25,12 +25,19 @@ on:
         type: string
         default: ''
       registry:
-        description: 'Container registry to push images to (e.g., quay.io/your-username)'
+        description: 'Alternative container registry to push images to (e.g., quay.io/your-username)'
         required: false
         type: string
         default: ''
+    secrets:
+      QUAY_PASSWORD:
+        required: false
 
 permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.git_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   podvm:
@@ -50,3 +57,42 @@ jobs:
       image_tag: ${{ inputs.image_tag || github.sha }}
       arch: ${{ matrix.arch}}
       debug: false
+
+  push-to-quay:
+    name: Push podvm image to quay.io
+    permissions:
+      packages: read # Required to copy container images
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, s390x, arm64]
+    needs: podvm
+    if: ${{ startsWith(inputs.registry, 'quay.io') }}
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Login to ghcr.io container registry
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Login to quay.io container registry
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+      with:
+        registry: quay.io
+        username: ${{ vars.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
+
+    - name: Push podvm image to quay.io
+      env:
+        QUAY_REGISTRY: ${{ inputs.registry }}
+        GHCR_REGISTRY: ghcr.io/${{ github.repository_owner }}
+        ARCH: ${{ matrix.arch }}
+        IMAGE_TAG: ${{ inputs.image_tag || github.sha }}
+      run: |
+        ghcr_image="${GHCR_REGISTRY}/podvm-${ARCH}:${IMAGE_TAG}"
+        quay_image="${QUAY_REGISTRY}/$(basename "$ghcr_image")"
+        oras cp "$GHCR_IMAGE" "$quay_image"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,8 @@ jobs:
       id-token: write          # Required for attestation signing
       attestations: write      # Required for persisting attestations
       artifact-metadata: write # Required by podvm_mkosi.yaml to write attestation metadata
+    secrets:
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 
   podvm-byom-binaries:
     needs: podvm-images  # Depends on podvm-binaries-ubuntu-{arch} images

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,8 +44,6 @@ jobs:
       id-token: write          # Required for attestation signing
       attestations: write      # Required for persisting attestations
       artifact-metadata: write # Required by podvm_mkosi.yaml to write attestation metadata
-    secrets:
-      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 
   podvm-byom-binaries:
     needs: podvm-images  # Depends on podvm-binaries-ubuntu-{arch} images


### PR DESCRIPTION
Currently the builds pass through a secret to quay.io. This will prohibit the building of the images on forks for pull request builds, forcing the use of the insecure pull-request-target mechanism in e2e tests, even though podvm builds can be executed safely on forks.

This change removes the secret and its uses at the call site and hard codes it to ghcr.io, which can be used in forks.

We can specify an additional registry in the podvm_publish step that will mirror the built images from ghcr.io to that registry. If it's a quay.io registry we login to that registry.

related to #2214 