### PR TITLE
versions: Bump golang to 1.26.7

### DIFF
--- a/src/cloud-api-adaptor/Dockerfile
+++ b/src/cloud-api-adaptor/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_TYPE=dev
-# golang:1.25.13 (based on Debian 13 trixie)
-ARG BUILDER_BASE=golang@sha256:cbff9d1a9041b316010f2da6b701b6c0d597718cb90928c85eb597334a0d23d4
-# debian:trixie-slim (matches golang:1.25.13 base for library compatibility)
+# golang:1.26.7 (based on Debian 13 trixie)
+ARG BUILDER_BASE=golang@sha256:45a5f7a810238aabcbad211d70b9ae082022d96f7c7259e94041ad1b933575ac
+# debian:trixie-slim (matches golang:1.26.7 base for library compatibility)
 # Multi-arch manifest list digest supporting amd64, arm64, ppc64le, s390x
 ARG BASE=debian@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258
 

--- a/src/cloud-api-adaptor/docs/addnewprovider.md
+++ b/src/cloud-api-adaptor/docs/addnewprovider.md
@@ -219,8 +219,8 @@ go mod tidy
 
 ```bash
 cat > Dockerfile <<EOF
-# golang:1.25.13
-ARG BUILDER_BASE=golang@sha256:cbff9d1a9041b316010f2da6b701b6c0d597718cb90928c85eb597334a0d23d4
+# golang:1.26.7
+ARG BUILDER_BASE=golang@sha256:45a5f7a810238aabcbad211d70b9ae082022d96f7c7259e94041ad1b933575ac
 FROM --platform="\$TARGETPLATFORM" \$BUILDER_BASE AS builder
 RUN apt-get update && apt-get install -y libvirt-dev pkg-config && rm -rf /var/lib/apt/lists/*
 WORKDIR /work

--- a/src/cloud-api-adaptor/go.mod
+++ b/src/cloud-api-adaptor/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor
 
-go 1.25.13
+go 1.26.7
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1

--- a/src/cloud-api-adaptor/versions.yaml
+++ b/src/cloud-api-adaptor/versions.yaml
@@ -30,7 +30,7 @@ tools:
   cert-manager: v1.15.3
   bats: 1.10.0
   iptables-wrapper: bfef9e5087a198b50a4124bb9ce9d2c7c99025dd
-  golang: 1.25.13
+  golang: 1.26.7
   kcli: 99.0.202507200957
   mkosi: v26
   protoc: 3.16.0

--- a/src/cloud-providers/go.mod
+++ b/src/cloud-providers/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers
 
-go 1.25.13
+go 1.26.7
 
 require (
 	cloud.google.com/go/compute v1.64.0

--- a/src/peerpod-ctrl/Dockerfile
+++ b/src/peerpod-ctrl/Dockerfile
@@ -1,6 +1,6 @@
 # Build the manager binary
-# golang:1.25.13
-FROM --platform=$TARGETPLATFORM golang@sha256:cbff9d1a9041b316010f2da6b701b6c0d597718cb90928c85eb597334a0d23d4 AS builder
+# golang:1.26.7
+FROM --platform=$TARGETPLATFORM golang@sha256:45a5f7a810238aabcbad211d70b9ae082022d96f7c7259e94041ad1b933575ac AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG CGO_ENABLED=1
@@ -35,7 +35,7 @@ COPY peerpod-ctrl/controllers/ controllers/
 RUN CC=gcc CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build ${GOFLAGS} -a -o manager main.go
 
 # Target Image
-# debian:trixie-slim (matches golang:1.25.13 base for library compatibility)
+# debian:trixie-slim (matches golang:1.26.7 base for library compatibility)
 FROM --platform=$TARGETPLATFORM debian@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258
 ARG CGO_ENABLED=1
 

--- a/src/peerpod-ctrl/go.mod
+++ b/src/peerpod-ctrl/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/peerpod-ctrl
 
-go 1.25.13
+go 1.26.7
 
 require (
 	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers v0.0.0-00010101000000-000000000000

--- a/src/webhook/Dockerfile
+++ b/src/webhook/Dockerfile
@@ -1,6 +1,6 @@
 # Build the manager binary
-# golang:1.25.13
-FROM --platform=$BUILDPLATFORM golang@sha256:cbff9d1a9041b316010f2da6b701b6c0d597718cb90928c85eb597334a0d23d4 AS builder
+# golang:1.26.7
+FROM --platform=$BUILDPLATFORM golang@sha256:45a5f7a810238aabcbad211d70b9ae082022d96f7c7259e94041ad1b933575ac AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/src/webhook/go.mod
+++ b/src/webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/cloud-api-adaptor/src/webhook
 
-go 1.25.13
+go 1.26.7
 
 require (
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
Now that golang 1.25 is not supported, we should bump to the latest 1.26 release

Generated-By: IBM Bob