### PR TITLE
azure: default to TrustedLaunch VMs when DisableCVM is true

### DIFF
--- a/src/cloud-providers/azure/provider.go
+++ b/src/cloud-providers/azure/provider.go
@@ -544,29 +544,26 @@ func (p *azureProvider) getVMParameters(instanceSize, diskName, cloudConfig stri
 	if len(userDataB64) > 64*1024 {
 		return nil, fmt.Errorf("base64 encoded userData is greater than 64KB")
 	}
-	var managedDiskParams *armcompute.ManagedDiskParameters
 	var securityProfile *armcompute.SecurityProfile
+
+	securityType := armcompute.SecurityTypesTrustedLaunch
+	managedDiskParams := &armcompute.ManagedDiskParameters{
+		StorageAccountType: to.Ptr(armcompute.StorageAccountTypesPremiumLRS),
+	}
+
 	if !p.serviceConfig.DisableCVM {
-		managedDiskParams = &armcompute.ManagedDiskParameters{
-			StorageAccountType: to.Ptr(armcompute.StorageAccountTypesPremiumLRS),
-			SecurityProfile: &armcompute.VMDiskSecurityProfile{
-				SecurityEncryptionType: to.Ptr(armcompute.SecurityEncryptionTypesVMGuestStateOnly),
-			},
+		securityType = armcompute.SecurityTypesConfidentialVM
+		managedDiskParams.SecurityProfile = &armcompute.VMDiskSecurityProfile{
+			SecurityEncryptionType: to.Ptr(armcompute.SecurityEncryptionTypesVMGuestStateOnly),
 		}
+	}
 
-		securityProfile = &armcompute.SecurityProfile{
-			SecurityType: to.Ptr(armcompute.SecurityTypesConfidentialVM),
-			UefiSettings: &armcompute.UefiSettings{
-				SecureBootEnabled: to.Ptr(p.serviceConfig.EnableSecureBoot),
-				VTpmEnabled:       to.Ptr(true),
-			},
-		}
-	} else {
-		managedDiskParams = &armcompute.ManagedDiskParameters{
-			StorageAccountType: to.Ptr(armcompute.StorageAccountTypesPremiumLRS),
-		}
-
-		securityProfile = nil
+	securityProfile = &armcompute.SecurityProfile{
+		SecurityType: to.Ptr(securityType),
+		UefiSettings: &armcompute.UefiSettings{
+			SecureBootEnabled: to.Ptr(p.serviceConfig.EnableSecureBoot),
+			VTpmEnabled:       to.Ptr(true),
+		},
 	}
 
 	imgRef := &armcompute.ImageReference{


### PR DESCRIPTION
Instead of defaulting to normal VMs, default to TrustedLaunch.

When DisableCVM is false, the ConfidentialVM security profile with VMGuestStateOnly disk encryption is applied. For standard VM sizes, a TrustedLaunch security profile with Secure Boot and vTPM is used instead.

This also simplifies the security profile logic: TrustedLaunch is always set as the baseline (with SecureBoot and vTPM), and only upgraded to ConfidentialVM when the size supports it and CVM is not disabled.