### PR TITLE
byom: remove obsolete kata mount service from the setup script

### DIFF
--- a/src/cloud-api-adaptor/hack/setup-podvm-byom.sh
+++ b/src/cloud-api-adaptor/hack/setup-podvm-byom.sh
@@ -91,15 +91,7 @@ tar xvf ./${PODVM_BYOM_TAR_NAME} -C /tmp/files
 # Run the helper scripts from /tmp/files
 source /tmp/files/copy-files.sh
 
-# Change mount point of kata-containers to type tmpfs.
-KATA_MOUNT_FILE=/etc/systemd/system/'run-kata\x2dcontainers.mount'
-
-if grep -q '^Type=none' "$KATA_MOUNT_FILE" && grep -q '^Options=bind' "$KATA_MOUNT_FILE"; then
-  sudo sed -i 's/^Type=none/Type=tmpfs/; s/^Options=bind/Options=mode=0755,uid=root,gid=root/' "$KATA_MOUNT_FILE"
-  echo "Updated $KATA_MOUNT_FILE to Type=tmpfs and Options=mode=755"
-fi
-
-# Reload services 
+# Reload services
 systemctl daemon-reload
 systemctl enable process-user-data.path
 systemctl disable process-user-data.service
@@ -115,7 +107,6 @@ services=(
     media-cidata.mount
     process-user-data.path
     reboot-watcher.path
-    'run-kata\x2dcontainers.mount'
     sftp-dir.service
 )
 

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_byom_docker_provider
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_byom_docker_provider
@@ -43,16 +43,6 @@ COPY mkosi.skeleton-sftp/etc/ssh/sshd_config /etc/ssh/sshd_config
 # Update host key paths to use /etc/ssh instead of /run/ssh
 RUN sed -i 's|/run/ssh/ssh_host_|/etc/ssh/ssh_host_|g' /etc/ssh/sshd_config
 
-# Fix kata-containers mount configuration for BYOM to enable reuse of containers
-RUN set -e; \
-    KATA_MOUNT_FILE='/etc/systemd/system/run-kata\x2dcontainers.mount'; \
-    if [ -f "$KATA_MOUNT_FILE" ] && \
-       grep -q '^Type=none' "$KATA_MOUNT_FILE" && \
-       grep -q '^Options=bind' "$KATA_MOUNT_FILE"; then \
-        sed -i 's/^Type=none/Type=tmpfs/; s/^Options=bind/Options=mode=0755,uid=root,gid=root/' "$KATA_MOUNT_FILE" && \
-        echo "Updated $KATA_MOUNT_FILE to Type=tmpfs for BYOM"; \
-    fi
-
 # Enable SSH and SFTP-related services
 RUN systemctl enable ssh && \
     systemctl enable media-cidata.mount && \

--- a/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/run-kata\x2dcontainers.mount
+++ b/src/cloud-api-adaptor/podvm/files/etc/systemd/system/multi-user.target.wants/run-kata\x2dcontainers.mount
@@ -1,1 +1,0 @@
-../run-kata\x2dcontainers.mount

--- a/src/cloud-api-adaptor/podvm/go.mod
+++ b/src/cloud-api-adaptor/podvm/go.mod
@@ -1,4 +1,4 @@
-// Empty go.mod file to exclude the run-kata\x2dcontainers.mount file
+// Empty go.mod file to exclude the podvm directory
 // from the cloud-api-adaptor Go module when cloud-api-adaptor is
 // imported by other Go projects
 


### PR DESCRIPTION
The bind mount unit was deleted in b2ba085, remove the references to it in setup byom script and the Dockerfile.