### PR TITLE
caa: Add developer mode option

### DIFF
--- a/src/cloud-api-adaptor/cmd/cloud-api-adaptor/main.go
+++ b/src/cloud-api-adaptor/cmd/cloud-api-adaptor/main.go
@@ -48,7 +48,8 @@ func formatTLSWarnings(tlsConfig *tlsutil.TLSConfig, disableTLS bool, tlsCipherS
 			warnings = append(warnings, fmt.Sprintf(
 				"TLS profile (TLS_MIN_VERSION=%s, TLS_CIPHER_SUITES=%s) is baked into peer pod VMs at creation time via user-data. "+
 					"Existing peer pods will not pick up profile changes until deleted and recreated.",
-				tlsConfig.MinTLSVersion, tlsCipherSuites))
+				tlsConfig.MinTLSVersion, tlsCipherSuites,
+			))
 		}
 	}
 	return warnings
@@ -67,13 +68,12 @@ func printHelp(out io.Writer) {
 }
 
 func (cfg *daemonConfig) Setup() (cmd.Starter, error) {
-
 	if len(os.Args) < 2 {
 		printHelp(os.Stderr)
 		cmd.Exit(1)
 	}
 
-	//TODO: transition to better CLI library
+	// TODO: transition to better CLI library
 
 	cloudName := os.Args[1]
 
@@ -107,7 +107,6 @@ func (cfg *daemonConfig) Setup() (cmd.Starter, error) {
 	)
 
 	cmd.Parse(programName, os.Args[1:], func(flags *flag.FlagSet) {
-
 		flags.Usage = func() {
 			fmt.Fprintf(flags.Output(), "Usage: %s %s [options]\n\n", programName, cloudName)
 			fmt.Fprintf(flags.Output(), "The options for %q are:\n", cloudName)
@@ -136,6 +135,7 @@ func (cfg *daemonConfig) Setup() (cmd.Starter, error) {
 		reg.BoolWithEnv(&cfg.serverConfig.EnableScratchSpace, "enable-scratch-space", false, "ENABLE_SCRATCH_SPACE", "Enable encrypted scratch space for pod VMs")
 		reg.BoolWithEnv(&cfg.networkConfig.ExternalNetViaPodVM, "ext-network-via-podvm", false, "EXTERNAL_NETWORK_VIA_PODVM", "[EXPERIMENTAL] Enable external networking via pod VM")
 		reg.CustomTypeWithEnv(&cfg.networkConfig.PodSubnetCIDRs, "pod-subnet-cidrs", "", "POD_SUBNET_CIDRS", "[EXPERIMENTAL] Comma separated CIDRs for local pod subnets")
+		reg.BoolWithEnv(&cfg.serverConfig.DeveloperMode, "developer-mode", false, "PODVM_DEVELOPER_MODE", "Enable developer mode for disabling Peer Pod VM auto delete")
 
 		// Flags without environment variable support
 		flags.BoolVar(&disableTLS, "disable-tls", false, "Disable TLS encryption - use it only for testing")

--- a/src/cloud-api-adaptor/docs/troubleshooting/README.md
+++ b/src/cloud-api-adaptor/docs/troubleshooting/README.md
@@ -1,3 +1,11 @@
 # Troubleshooting
 
 The official documentation for Confidential Containers is currently under re-work. An archived version of the Peer pods troubleshooting guide can be found [here](https://github.com/confidential-containers/confidentialcontainers.org/blob/7a861f4d26c48100004d2c6e72298f2592cc04c0/content/en/docs/cloud-api-adaptor/troubleshooting.md).
+
+## Debugging peer pod VM images
+
+Sometimes when debugging peer pod VM images (e.g. during development), it is helpful to override the cloud-api-adaptor's
+default behaviour, which is to delete peer pod VM instances when it received the StopVM request. For example if there is
+a configuration issue in the peer pod VM, and it fails to connect to the cloud-api-adaptor process, then it will be
+automatically deleted, removing the ability to debug this problem. To override this behaviour, set
+`PODVM_DEVELOPER_MODE` to `true` in the peer-pods-cm configmap.

--- a/src/cloud-api-adaptor/docs/troubleshooting/README.md
+++ b/src/cloud-api-adaptor/docs/troubleshooting/README.md
@@ -9,3 +9,7 @@ default behaviour, which is to delete peer pod VM instances when it received the
 a configuration issue in the peer pod VM, and it fails to connect to the cloud-api-adaptor process, then it will be
 automatically deleted, removing the ability to debug this problem. To override this behaviour, set
 `PODVM_DEVELOPER_MODE` to `true` in the peer-pods-cm configmap.
+
+> [!NOTE]
+> In developer mode, the `PEERPODS_LIMIT_PER_NODE` defaults to 1 to avoid Kubernetes creating multiple instances of
+> pods that don't work. If you wish to override this then please set the value in peer-pods-cm.

--- a/src/cloud-api-adaptor/entrypoint.sh
+++ b/src/cloud-api-adaptor/entrypoint.sh
@@ -27,6 +27,10 @@ optionals+=""
 # handled directly by Go code via FlagRegistrar in main.go and no longer need
 # env-to-arg conversion here.
 
+if [[ "${PODVM_DEVELOPER_MODE}" == "true" && -z "${PEERPODS_LIMIT_PER_NODE}" ]]; then
+    optionals+="-peerpods-limit-per-node 1 "
+fi
+
 test_vars() {
     for i in "$@"; do
         [ -z "${!i}" ] && echo "\$$i is NOT set" && EXT=1

--- a/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
+++ b/src/cloud-api-adaptor/pkg/adaptor/cloud/cloud.go
@@ -47,6 +47,7 @@ type ServerConfig struct {
 	PeerPodsLimitPerNode    int
 	RootVolumeSize          int
 	EnableScratchSpace      bool
+	DeveloperMode           bool
 }
 
 var logger = log.New(log.Writer(), "[adaptor/cloud] ", log.LstdFlags|log.Lmsgprefix)
@@ -88,7 +89,8 @@ func (s *cloudService) removeSandbox(id sandboxID) error {
 }
 
 func NewService(provider provider.Provider, proxyFactory proxy.Factory, workerNode podnetwork.WorkerNode,
-	serverConfig *ServerConfig) Service {
+	serverConfig *ServerConfig,
+) Service {
 	var err error
 
 	s := &cloudService{
@@ -448,9 +450,16 @@ func (s *cloudService) StopVM(ctx context.Context, req *pb.StopVMRequest) (*pb.S
 		logger.Printf("stopping agent proxy: %v", err)
 	}
 
-	if err := s.provider.DeleteInstance(ctx, sandbox.instanceID); err != nil {
-		logger.Printf("Error deleting an instance %s: %v", sandbox.instanceID, err)
-	} else if s.ppService != nil {
+	var deleteErr error
+	if s.serverConfig.DeveloperMode {
+		logger.Printf("Running in developer mode, so leaving instance %s running", sandbox.instanceID)
+	} else {
+		if deleteErr = s.provider.DeleteInstance(ctx, sandbox.instanceID); deleteErr != nil {
+			logger.Printf("Error deleting an instance %s: %v", sandbox.instanceID, deleteErr)
+		}
+	}
+
+	if (s.serverConfig.DeveloperMode || deleteErr == nil) && s.ppService != nil {
 		if err := s.ppService.ReleasePeerPod(sandbox.podName, sandbox.podNamespace, sandbox.instanceID); err != nil {
 			logger.Printf("failed to release PeerPod %v", err)
 		}


### PR DESCRIPTION
During development, several of us have hit times where being able to access a failing peer pod VM has been crucial to debugging issues. The general approach to this is to add a sleep before, or comment out DeleteInstance, but this involved rebuilding the CAA image, so instead we can provide an option to set PEERPODS_DEVELOPER_MODE=true in peer-pods-cm which will skip this peer pod vm delete.