### PR TITLE
libvirt: emit launchSecurity for s390-pv in domain XML

### DIFF
--- a/src/cloud-providers/libvirt/libvirt.go
+++ b/src/cloud-providers/libvirt/libvirt.go
@@ -228,7 +228,7 @@ func createDomainXMLs390x(client *libvirtClient, cfg *domainConfig, vm *vmConfig
 		},
 	}
 
-	return &libvirtxml.Domain{
+	domain := &libvirtxml.Domain{
 		Type:        "kvm",
 		Name:        cfg.name,
 		Description: "This Virtual Machine is the peer-pod VM",
@@ -300,7 +300,19 @@ func createDomainXMLs390x(client *libvirtClient, cfg *domainConfig, vm *vmConfig
 				},
 			},
 		},
-	}, nil
+	}
+
+	switch vm.launchSecurityType {
+	case S390PV:
+		domain.LaunchSecurity = &libvirtxml.DomainLaunchSecurity{
+			S390PV: &libvirtxml.DomainLaunchSecurityS390PV{},
+		}
+		return domain, nil
+	case NoLaunchSecurity:
+		return domain, nil
+	default:
+		return nil, fmt.Errorf("launch security type %s is not supported for s390x", vm.launchSecurityType)
+	}
 }
 
 func createDomainXMLx86_64(client *libvirtClient, cfg *domainConfig, vm *vmConfig) (*libvirtxml.Domain, error) {

--- a/src/cloud-providers/libvirt/libvirt_test.go
+++ b/src/cloud-providers/libvirt/libvirt_test.go
@@ -968,6 +968,64 @@ func TestCreateDomainXMLArchitecturesWithMocks(t *testing.T) {
 	}
 }
 
+func TestCreateDomainXMLs390xLaunchSecurity(t *testing.T) {
+	mockCaps := createMockCaps(archS390x, "/usr/bin/qemu-system-s390x", libvirtxml.CapsGuestMachine{
+		Name:      "s390-ccw-virtio",
+		Canonical: "s390-ccw-virtio-rhel9.0.0",
+	})
+	mockClient := &libvirtClient{
+		caps:        mockCaps,
+		networkName: testNetworkName,
+	}
+	cfg := createTestDomainConfig("test-s390x-sec", 2, 2048, testNetworkName, testCiDataISO)
+
+	tests := []struct {
+		name           string
+		launchSecurity LaunchSecurityType
+		expectedError  string
+		expectS390PV   bool
+	}{
+		{
+			name:           "S390PV emits launchSecurity element",
+			launchSecurity: S390PV,
+			expectS390PV:   true,
+		},
+		{
+			name:           "NoLaunchSecurity omits launchSecurity element",
+			launchSecurity: NoLaunchSecurity,
+			expectS390PV:   false,
+		},
+		{
+			name:           "unknown security type returns error",
+			launchSecurity: LaunchSecurityType(99),
+			expectedError:  "launch security type unknown is not supported for s390x",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vm := &vmConfig{launchSecurityType: tt.launchSecurity}
+			domain, err := createDomainXMLs390x(mockClient, cfg, vm)
+
+			if tt.expectedError != "" {
+				assert.EqualError(t, err, tt.expectedError)
+				assert.Nil(t, domain)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, domain)
+
+			if tt.expectS390PV {
+				require.NotNil(t, domain.LaunchSecurity, "LaunchSecurity should be set for S390PV")
+				assert.NotNil(t, domain.LaunchSecurity.S390PV, "S390PV field should be non-nil")
+			} else {
+				assert.Nil(t, domain.LaunchSecurity, "LaunchSecurity should be nil for NoLaunchSecurity")
+			}
+		})
+	}
+}
+
 // TestCreateDomainXMLx86_64 tests x86_64 domain XML generation
 func TestCreateDomainXMLx86_64(t *testing.T) {
 	mockCaps := createMockCaps(archX86_64, "/usr/bin/qemu-system-x86_64")


### PR DESCRIPTION
createDomainXMLs390x accepted S390PV as the launch security type (set via --launch-security s390-pv or auto-detected on s390x hosts) but never wrote the <launchSecurity type='s390-pv'/> element to the domain XML. The VM was started as a plain KVM guest instead of an IBM Secure Execution protected guest.

Apply the same switch-on-launchSecurityType pattern used by createDomainXMLx86_64: emit the libvirtxml.DomainLaunchSecurity S390PV element when S390PV is requested, return the domain unchanged for NoLaunchSecurity, and return an error for any unrecognised type.

The libvirtxml library (v1.12002.0) already provides DomainLaunchSecurityS390PV and the correct MarshalXML implementation that emits type='s390-pv'; no extra fields are required.

Add TestCreateDomainXMLs390xLaunchSecurity covering all three cases.

fixes: #3268

Assisted-by: IBM Bob noreply@ibm.com