### PR TITLE
workflows: Add extra trigger to validate-config-extractor

### DIFF
--- a/.github/workflows/validate-config-extractor.yaml
+++ b/.github/workflows/validate-config-extractor.yaml
@@ -8,11 +8,13 @@ name: validate-config-extractor
 on:
   pull_request:
     paths:
+      - '.github/workflows/validate-config-extractor.yaml'
       - 'src/cloud-providers/**/manager.go'
       - 'src/cloud-providers/util.go'
       - 'src/cloud-providers/cmd/config-extractor/**'
       - 'src/cloud-providers/Makefile'
       - 'src/cloud-api-adaptor/install/charts/peerpods/providers/**'
+      - 'src/cloud-api-adaptor/cmd/cloud-api-adaptor/main.go'
   workflow_dispatch:
 
 concurrency:

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/alibabacloud.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/alibabacloud.yaml
@@ -62,6 +62,10 @@ providerConfigs:
     # (default: "")
     # PODS_DIR: ""
 
+    # Enable developer mode for disabling Peer Pod VM auto delete
+    # (default: "false")
+    # PODVM_DEVELOPER_MODE: "false"
+
     # Pod VM instance type
     # (default: "ecs.g8i.xlarge")
     # PODVM_INSTANCE_TYPE: "ecs.g8i.xlarge"

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/aws.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/aws.yaml
@@ -70,6 +70,10 @@ providerConfigs:
     # (required)
     PODVM_AMI_ID: ""
 
+    # Enable developer mode for disabling Peer Pod VM auto delete
+    # (default: "false")
+    # PODVM_DEVELOPER_MODE: "false"
+
     # Pod VM instance type
     # (default: "m6a.large")
     # PODVM_INSTANCE_TYPE: "m6a.large"

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/azure.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/azure.yaml
@@ -90,6 +90,10 @@ providerConfigs:
     # (default: "")
     # PODS_DIR: ""
 
+    # Enable developer mode for disabling Peer Pod VM auto delete
+    # (default: "false")
+    # PODVM_DEVELOPER_MODE: "false"
+
     # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
     # (default: "")
     # POD_SUBNET_CIDRS: ""

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/byom.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/byom.yaml
@@ -54,6 +54,10 @@ providerConfigs:
     # (default: "")
     # PODS_DIR: ""
 
+    # Enable developer mode for disabling Peer Pod VM auto delete
+    # (default: "false")
+    # PODVM_DEVELOPER_MODE: "false"
+
     # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
     # (default: "")
     # POD_SUBNET_CIDRS: ""

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/gcp.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/gcp.yaml
@@ -86,6 +86,10 @@ providerConfigs:
     # (default: "")
     # PODS_DIR: ""
 
+    # Enable developer mode for disabling Peer Pod VM auto delete
+    # (default: "false")
+    # PODVM_DEVELOPER_MODE: "false"
+
     # Pod VM image name
     # (default: "")
     # PODVM_IMAGE_NAME: ""

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/ibmcloud-powervs.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/ibmcloud-powervs.yaml
@@ -50,6 +50,10 @@ providerConfigs:
     # (default: "")
     # PODS_DIR: ""
 
+    # Enable developer mode for disabling Peer Pod VM auto delete
+    # (default: "false")
+    # PODVM_DEVELOPER_MODE: "false"
+
     # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
     # (default: "")
     # POD_SUBNET_CIDRS: ""

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/ibmcloud.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/ibmcloud.yaml
@@ -110,6 +110,10 @@ providerConfigs:
     # (default: "")
     # PODS_DIR: ""
 
+    # Enable developer mode for disabling Peer Pod VM auto delete
+    # (default: "false")
+    # PODVM_DEVELOPER_MODE: "false"
+
     # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
     # (default: "")
     # POD_SUBNET_CIDRS: ""

--- a/src/cloud-api-adaptor/install/charts/peerpods/providers/libvirt.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/providers/libvirt.yaml
@@ -99,6 +99,10 @@ providerConfigs:
     # (default: "")
     # PODS_DIR: ""
 
+    # Enable developer mode for disabling Peer Pod VM auto delete
+    # (default: "false")
+    # PODVM_DEVELOPER_MODE: "false"
+
     # [EXPERIMENTAL] Comma separated CIDRs for local pod subnets
     # (default: "")
     # POD_SUBNET_CIDRS: ""


### PR DESCRIPTION
In #3257 we found that the change made in #3261 caused a mis-match with the generated provider yaml. The cause was that the workflow job that checks it, didn't run on that PR, so add an extra path trigger to plug this gap.