### PR TITLE
Ibmcloud: improvements to readiness and error cases

### DIFF
--- a/src/cloud-providers/ibmcloud/provider.go
+++ b/src/cloud-providers/ibmcloud/provider.go
@@ -491,7 +491,8 @@ func (p *ibmcloudVPCProvider) CreateInstance(ctx context.Context, podName, sandb
 	}
 
 	instanceID := *vpcInstance.ID
-	numInterfaces := len(prototype.NetworkInterfaces)
+	// the primary interface plus any secondary interfaces in the prototype
+	numInterfaces := 1 + len(prototype.NetworkInterfaces)
 
 	// Create partial instance to return on error (allows caller to cleanup)
 	instance = &provider.Instance{

--- a/src/cloud-providers/ibmcloud/provider.go
+++ b/src/cloud-providers/ibmcloud/provider.go
@@ -26,8 +26,7 @@ import (
 )
 
 const (
-	maxRetries    = 10
-	queryInterval = 2
+	maxRetries = 10
 
 	clusterInfoCMName      = "cluster-info"
 	clusterInfoCMNamespace = "kube-system"
@@ -35,6 +34,9 @@ const (
 
 var logger = log.New(log.Writer(), "[adaptor/cloud/ibmcloud] ", log.LstdFlags|log.Lmsgprefix)
 var errNotReady = errors.New("address not ready")
+
+// queryInterval is a variable so tests can shorten the wait between polls
+var queryInterval = 2 * time.Second
 
 const maxInstanceNameLen = 63
 
@@ -510,14 +512,17 @@ func (p *ibmcloudVPCProvider) CreateInstance(ctx context.Context, podName, sandb
 			return instance, err
 		}
 
-		time.Sleep(time.Duration(queryInterval) * time.Second)
+		time.Sleep(queryInterval)
 
-		result, response, err := p.vpc.GetInstanceWithContext(ctx, &vpcv1.GetInstanceOptions{ID: &instanceID})
-		if err != nil {
-			logger.Printf("failed to get an instance : %v and the response is %s", err, response)
-			return instance, err
+		result, response, getErr := p.vpc.GetInstanceWithContext(ctx, &vpcv1.GetInstanceOptions{ID: &instanceID})
+		if getErr != nil {
+			logger.Printf("failed to get an instance : %v and the response is %s", getErr, response)
+			return instance, getErr
 		}
 		vpcInstance = result
+	}
+	if err != nil {
+		return instance, fmt.Errorf("instance %s network addresses not ready after %d attempts: %w", instanceID, maxRetries, err)
 	}
 
 	instance.IPs = ips

--- a/src/cloud-providers/ibmcloud/provider_test.go
+++ b/src/cloud-providers/ibmcloud/provider_test.go
@@ -22,6 +22,9 @@ import (
 
 type mockVPC struct {
 	prototype vpcv1.InstancePrototypeIntf
+	// createErr, when set, decides whether each CreateInstanceWithContext call fails
+	createErr   func(call int, prototype *vpcv1.InstancePrototype) error
+	createCalls int
 	// getInstance, when set, replaces the default GetInstanceWithContext response
 	getInstance func(call int) *vpcv1.Instance
 	getCalls    int
@@ -41,6 +44,12 @@ func ptr(s string) *string {
 func (v *mockVPC) CreateInstanceWithContext(ctx context.Context, opt *vpcv1.CreateInstanceOptions) (*vpcv1.Instance, *core.DetailedResponse, error) {
 
 	v.prototype = opt.InstancePrototype
+	v.createCalls++
+	if v.createErr != nil {
+		if err := v.createErr(v.createCalls, opt.InstancePrototype.(*vpcv1.InstancePrototype)); err != nil {
+			return nil, &core.DetailedResponse{StatusCode: http.StatusBadRequest}, err
+		}
+	}
 
 	instance := &vpcv1.Instance{
 		ID:  ptr("123"),
@@ -241,6 +250,90 @@ func TestCreateInstance(t *testing.T) {
 		assert.Equal(t, "192.0.1.1", instance.IPs[0].String())
 		assert.Equal(t, "192.0.2.1", instance.IPs[1].String())
 		assert.Equal(t, 2, vpc.getCalls)
+	})
+}
+
+func TestCreateInstanceWithFallback(t *testing.T) {
+
+	errHost := errors.New("dedicated host is full")
+	errGroup := errors.New("dedicated host group is full")
+
+	newProvider := func(vpc *mockVPC, hostID, groupID string) *ibmcloudVPCProvider {
+		return &ibmcloudVPCProvider{
+			vpc: vpc,
+			serviceConfig: &Config{
+				selectedDedicatedHostID:      hostID,
+				selectedDedicatedHostGroupID: groupID,
+			},
+		}
+	}
+	prototype := func(p *ibmcloudVPCProvider) *vpcv1.InstancePrototype {
+		return p.getInstancePrototype("podvm-pod1-999", "cloud config", "bx2-2x8", "image-1")
+	}
+	groupTarget := func(proto *vpcv1.InstancePrototype) (string, bool) {
+		target, ok := proto.PlacementTarget.(*vpcv1.InstancePlacementTargetPrototypeDedicatedHostGroupIdentityDedicatedHostGroupIdentityByID)
+		if !ok {
+			return "", false
+		}
+		return *target.ID, true
+	}
+
+	t.Run("does not retry when creation succeeds", func(t *testing.T) {
+		vpc := &mockVPC{}
+		p := newProvider(vpc, "host-1", "group-1")
+
+		instance, err := p.createInstanceWithFallback(context.Background(), prototype(p))
+
+		require.NoError(t, err)
+		assert.Equal(t, "123", *instance.ID)
+		assert.Equal(t, 1, vpc.createCalls)
+	})
+
+	t.Run("does not retry without a dedicated host group", func(t *testing.T) {
+		vpc := &mockVPC{createErr: func(int, *vpcv1.InstancePrototype) error { return errHost }}
+		p := newProvider(vpc, "host-1", "")
+
+		instance, err := p.createInstanceWithFallback(context.Background(), prototype(p))
+
+		require.ErrorIs(t, err, errHost)
+		assert.Nil(t, instance)
+		assert.Equal(t, 1, vpc.createCalls)
+	})
+
+	t.Run("retries on the dedicated host group when the host fails", func(t *testing.T) {
+		var retryTarget string
+		vpc := &mockVPC{createErr: func(call int, proto *vpcv1.InstancePrototype) error {
+			if call == 1 {
+				return errHost
+			}
+			retryTarget, _ = groupTarget(proto)
+			return nil
+		}}
+		p := newProvider(vpc, "host-1", "group-1")
+
+		instance, err := p.createInstanceWithFallback(context.Background(), prototype(p))
+
+		require.NoError(t, err)
+		assert.Equal(t, "123", *instance.ID)
+		assert.Equal(t, 2, vpc.createCalls)
+		assert.Equal(t, "group-1", retryTarget)
+	})
+
+	t.Run("reports both errors when the fallback also fails", func(t *testing.T) {
+		vpc := &mockVPC{createErr: func(call int, _ *vpcv1.InstancePrototype) error {
+			if call == 1 {
+				return errHost
+			}
+			return errGroup
+		}}
+		p := newProvider(vpc, "host-1", "group-1")
+
+		instance, err := p.createInstanceWithFallback(context.Background(), prototype(p))
+
+		require.ErrorIs(t, err, errHost)
+		require.ErrorIs(t, err, errGroup)
+		assert.Nil(t, instance)
+		assert.Equal(t, 2, vpc.createCalls)
 	})
 }
 

--- a/src/cloud-providers/ibmcloud/provider_test.go
+++ b/src/cloud-providers/ibmcloud/provider_test.go
@@ -9,16 +9,28 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/platform-services-go-sdk/globaltaggingv1"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	provider "github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockVPC struct {
 	prototype vpcv1.InstancePrototypeIntf
+	// getInstance, when set, replaces the default GetInstanceWithContext response
+	getInstance func(call int) *vpcv1.Instance
+	getCalls    int
+}
+
+func readyNIC(id, address string) *vpcv1.NetworkInterfaceInstanceContextReference {
+	return &vpcv1.NetworkInterfaceInstanceContextReference{
+		ID:        ptr(id),
+		PrimaryIP: &vpcv1.ReservedIPReference{Address: ptr(address)},
+	}
 }
 
 func ptr(s string) *string {
@@ -47,6 +59,11 @@ func (v *mockVPC) CreateInstanceWithContext(ctx context.Context, opt *vpcv1.Crea
 }
 
 func (v *mockVPC) GetInstanceWithContext(ctx context.Context, opt *vpcv1.GetInstanceOptions) (*vpcv1.Instance, *core.DetailedResponse, error) {
+
+	v.getCalls++
+	if v.getInstance != nil {
+		return v.getInstance(v.getCalls), nil, nil
+	}
 
 	instance := &vpcv1.Instance{
 		ID:  ptr("123"),
@@ -148,40 +165,60 @@ func (t *mockTagging) AttachTagWithContext(ctx context.Context, attachTagOptions
 }
 func TestCreateInstance(t *testing.T) {
 
-	vpc := &mockVPC{}
-	globalTagging := &mockTagging{}
+	// keep the readiness polling fast
+	savedInterval := queryInterval
+	queryInterval = time.Millisecond
+	t.Cleanup(func() { queryInterval = savedInterval })
 
-	images := make(Images, 0)
-	err := images.Set("valid-image-id")
-	if err != nil {
-		t.Errorf("Images.Set() error %v", err)
+	newProvider := func(vpc *mockVPC, config *Config) *ibmcloudVPCProvider {
+		images := make(Images, 0)
+		require.NoError(t, images.Set("valid-image-id"))
+		config.ProfileName = "bx2-2x8"
+		config.Images = images
+		return &ibmcloudVPCProvider{
+			vpc:           vpc,
+			globalTagging: &mockTagging{},
+			serviceConfig: config,
+		}
 	}
-	mockProvider := &ibmcloudVPCProvider{
-		vpc:           vpc,
-		globalTagging: globalTagging,
-		serviceConfig: &Config{
-			ProfileName: "bx2-2x8",
-			Images:      images,
-			DisableCVM:  true,
-		},
-	}
+	spec := provider.InstanceTypeSpec{InstanceType: "bx2-2x8"}
 
-	instance, err := mockProvider.CreateInstance(context.Background(), "pod1", "999", &mockCloudConfig{}, provider.InstanceTypeSpec{InstanceType: "bx2-2x8"})
+	t.Run("returns the instance and its addresses once ready", func(t *testing.T) {
+		vpc := &mockVPC{}
+		mockProvider := newProvider(vpc, &Config{DisableCVM: true})
 
-	assert.NoError(t, err)
-	assert.NotNil(t, instance)
-	assert.Equal(t, "123", instance.ID)
-	assert.Equal(t, "podvm-pod1-999", instance.Name)
-	assert.Len(t, instance.IPs, 2)
-	assert.Equal(t, "192.0.1.1", instance.IPs[0].String())
-	assert.Equal(t, "192.0.2.1", instance.IPs[1].String())
+		instance, err := mockProvider.CreateInstance(context.Background(), "pod1", "999", &mockCloudConfig{}, spec)
 
-	assert.NotNil(t, vpc.prototype)
-	p, ok := vpc.prototype.(*vpcv1.InstancePrototype)
-	assert.True(t, ok)
-	assert.Equal(t, "cloud config", *p.UserData)
-	assert.Equal(t, false, *p.EnableSecureBoot)
-	assert.Equal(t, "disabled", *p.ConfidentialComputeMode)
+		require.NoError(t, err)
+		require.NotNil(t, instance)
+		assert.Equal(t, "123", instance.ID)
+		assert.Equal(t, "podvm-pod1-999", instance.Name)
+		require.Len(t, instance.IPs, 2)
+		assert.Equal(t, "192.0.1.1", instance.IPs[0].String())
+		assert.Equal(t, "192.0.2.1", instance.IPs[1].String())
+
+		p, ok := vpc.prototype.(*vpcv1.InstancePrototype)
+		require.True(t, ok)
+		assert.Equal(t, "cloud config", *p.UserData)
+		assert.Equal(t, false, *p.EnableSecureBoot)
+		assert.Equal(t, "disabled", *p.ConfidentialComputeMode)
+	})
+
+	t.Run("fails when addresses never become ready", func(t *testing.T) {
+		vpc := &mockVPC{getInstance: func(int) *vpcv1.Instance {
+			return &vpcv1.Instance{ID: ptr("123"), CRN: ptr("crn-123"), PrimaryNetworkInterface: readyNIC("111", "0.0.0.0")}
+		}}
+		mockProvider := newProvider(vpc, &Config{})
+
+		instance, err := mockProvider.CreateInstance(context.Background(), "pod1", "999", &mockCloudConfig{}, spec)
+
+		require.ErrorIs(t, err, errNotReady)
+		// the partial instance lets the caller delete the VM
+		require.NotNil(t, instance)
+		assert.Equal(t, "123", instance.ID)
+		assert.Equal(t, maxRetries, vpc.getCalls)
+	})
+
 }
 
 func TestDeleteInstance(t *testing.T) {

--- a/src/cloud-providers/ibmcloud/provider_test.go
+++ b/src/cloud-providers/ibmcloud/provider_test.go
@@ -5,6 +5,7 @@ package ibmcloud
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -240,6 +241,53 @@ func TestCreateInstance(t *testing.T) {
 		assert.Equal(t, "192.0.1.1", instance.IPs[0].String())
 		assert.Equal(t, "192.0.2.1", instance.IPs[1].String())
 		assert.Equal(t, 2, vpc.getCalls)
+	})
+}
+
+func TestPickIDInZone(t *testing.T) {
+
+	zones := map[string]string{
+		"host-a": "eu-gb-1",
+		"host-b": "eu-gb-2",
+		"host-c": "eu-gb-2",
+	}
+	getZone := func(id string) (string, error) {
+		zone, ok := zones[id]
+		if !ok {
+			return "", fmt.Errorf("unknown id %s", id)
+		}
+		return zone, nil
+	}
+
+	t.Run("returns the id in the zone", func(t *testing.T) {
+		id, err := pickIDInZone([]string{"host-a", "host-b"}, "eu-gb-1", getZone, "Dedicated Host")
+
+		require.NoError(t, err)
+		assert.Equal(t, "host-a", id)
+	})
+
+	t.Run("returns the first of several ids in the zone", func(t *testing.T) {
+		id, err := pickIDInZone([]string{"host-a", "host-b", "host-c"}, "eu-gb-2", getZone, "Dedicated Host")
+
+		require.NoError(t, err)
+		assert.Equal(t, "host-b", id)
+	})
+
+	t.Run("fails when no id is in the zone", func(t *testing.T) {
+		id, err := pickIDInZone([]string{"host-a", "host-b"}, "eu-de-1", getZone, "Dedicated Host")
+
+		require.ErrorContains(t, err, "no Dedicated Host in zone eu-de-1")
+		assert.Equal(t, "", id)
+	})
+
+	t.Run("fails when a zone lookup fails", func(t *testing.T) {
+		errLookup := errors.New("lookup failed")
+		failing := func(string) (string, error) { return "", errLookup }
+
+		id, err := pickIDInZone([]string{"host-a"}, "eu-gb-1", failing, "Dedicated Host")
+
+		require.ErrorIs(t, err, errLookup)
+		assert.Equal(t, "", id)
 	})
 }
 

--- a/src/cloud-providers/ibmcloud/provider_test.go
+++ b/src/cloud-providers/ibmcloud/provider_test.go
@@ -219,6 +219,28 @@ func TestCreateInstance(t *testing.T) {
 		assert.Equal(t, maxRetries, vpc.getCalls)
 	})
 
+	t.Run("waits for the secondary interface address", func(t *testing.T) {
+		vpc := &mockVPC{getInstance: func(call int) *vpcv1.Instance {
+			instance := &vpcv1.Instance{ID: ptr("123"), CRN: ptr("crn-123"), PrimaryNetworkInterface: readyNIC("111", "192.0.1.1")}
+			// the secondary interface only shows up on the second poll
+			if call > 1 {
+				instance.NetworkInterfaces = []vpcv1.NetworkInterfaceInstanceContextReference{
+					*readyNIC("111", "192.0.1.1"),
+					*readyNIC("222", "192.0.2.1"),
+				}
+			}
+			return instance
+		}}
+		mockProvider := newProvider(vpc, &Config{SecondarySubnetID: "subnet-2", SecondarySecurityGroupID: "sg-2"})
+
+		instance, err := mockProvider.CreateInstance(context.Background(), "pod1", "999", &mockCloudConfig{}, spec)
+
+		require.NoError(t, err)
+		require.Len(t, instance.IPs, 2)
+		assert.Equal(t, "192.0.1.1", instance.IPs[0].String())
+		assert.Equal(t, "192.0.2.1", instance.IPs[1].String())
+		assert.Equal(t, 2, vpc.getCalls)
+	})
 }
 
 func TestDeleteInstance(t *testing.T) {

--- a/src/cloud-providers/ibmcloud/types_test.go
+++ b/src/cloud-providers/ibmcloud/types_test.go
@@ -1,5 +1,3 @@
-//go:build ibmcloud
-
 // (C) Copyright Confidential Containers Contributors
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
Improve the robustness of the wait for the pod VM and also add some more test coverage:
- ibmcloud: fail when pod VM addresses never ready
- ibmcloud: wait for secondary interface address
- ibmcloud: run types tests without a build tag
- ibmcloud: add pickIDInZone tests
- ibmcloud: add dedicated host fallback tests