### PR TITLE
ci: allow webhook build without quay secret

### DIFF
--- a/.github/workflows/e2e_run_all.yaml
+++ b/.github/workflows/e2e_run_all.yaml
@@ -165,14 +165,11 @@ jobs:
   webhook_image:
     uses: ./.github/workflows/webhook_image.yaml
     with:
-      registry: ${{ inputs.registry }}
       image_tags: ${{ inputs.caa_image_tag }}
       git_ref: ${{ inputs.git_ref }}
     permissions:
       contents: read
       packages: write # Required to publish the image to ghcr
-    secrets:
-      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 
   # Run AWS e2e tests if pull request labeled 'test_e2e_aws'
   aws:

--- a/.github/workflows/publish_images_on_push.yaml
+++ b/.github/workflows/publish_images_on_push.yaml
@@ -49,7 +49,7 @@ jobs:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 
   webhook:
-    uses: ./.github/workflows/webhook_image.yaml
+    uses: ./.github/workflows/webhook_image_publish.yaml
     with:
       image_tags: ${{ github.sha }},latest
       git_ref: ${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,10 +60,11 @@ jobs:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 
   webhook:
-    uses: ./.github/workflows/webhook_image.yaml
+    uses: ./.github/workflows/webhook_image_publish.yaml
     with:
       image_tags: ${{ github.event.release.tag_name }}
       git_ref: ${{ github.ref }}
+      registry: quay.io/confidential-containers
     permissions:
       contents: read  # Required to checkout code
       packages: write  # Required to push container images

--- a/.github/workflows/webhook_image.yaml
+++ b/.github/workflows/webhook_image.yaml
@@ -7,11 +7,6 @@ name: (Callable) Build and push webhook image
 on:
   workflow_call:
     inputs:
-      registry:
-        default: 'quay.io/confidential-containers'
-        description: 'Image registry (e.g. "ghcr.io/confidential-containers") where the built image will be pushed to'
-        required: false
-        type: string
       image_tags:
         description: 'Comma-separated list of tags for the dev built image (e.g. latest,ci-dev). By default uses the values from hack/build.sh'
         required: true
@@ -21,9 +16,10 @@ on:
         description: Git ref to checkout the cloud-api-adaptor repository. Defaults to main.
         required: false
         type: string
-    secrets:
-      QUAY_PASSWORD:
-        required: true
+    outputs:
+      image-name:
+        description: 'The name of the built image'
+        value: ${{ jobs.build_push_webhook.outputs.image-name }}
 
 permissions: {}
 
@@ -37,6 +33,8 @@ jobs:
     permissions:
       contents: read  # Required to checkout code
       packages: write  # Required to push container images
+    outputs:
+      image-name: ${{ steps.build-and-push-image.outputs.image-name }}
     steps:
       - name: Checkout the code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -58,24 +56,18 @@ jobs:
           cache: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-      - name: Login to quay Container Registry
-        if: ${{ startsWith(inputs.registry, 'quay.io') }}
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: quay.io
-          username: ${{ vars.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
       - name: Login to Github Container Registry
-        if: ${{ startsWith(inputs.registry, 'ghcr.io') }}
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push image
+        id: build-and-push-image
         env:
           IMAGE_TAGS: ${{ inputs.image_tags }}
-          REGISTRY: ${{ inputs.registry }}
+          REGISTRY: ghcr.io/${{ github.repository_owner }}
+          IMAGE_NAME: peer-pods-webhook
         run: |
           tags="${IMAGE_TAGS}"
           latest=0
@@ -84,12 +76,13 @@ jobs:
               latest=1
             else
               echo "::group::Build and push tag ${t}"
-              make docker-load docker-push IMG="${REGISTRY}/peer-pods-webhook:${t}"
+              make docker-load docker-push IMG="${REGISTRY}/${IMAGE_NAME}:${t}"
               echo "::endgroup::"
             fi
           done
           if [ $latest -eq 1 ]; then
             echo "::group::Push latest"
-            make docker-push IMG="${REGISTRY}/peer-pods-webhook:latest"
+            make docker-push IMG="${REGISTRY}/${IMAGE_NAME}:latest"
             echo "::endgroup::"
           fi
+          echo "image-name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/webhook_image_publish.yaml
+++ b/.github/workflows/webhook_image_publish.yaml
@@ -1,0 +1,102 @@
+# Copyright Confidential Containers Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build and push the peer pod webhook image
+---
+name: Publish peerpod webhook images
+on:
+  workflow_dispatch:
+    inputs:
+      registry:
+        description: 'Alternative container registry to push images to (e.g., quay.io/your-username)'
+        required: false
+        type: string
+        default: ''
+  workflow_call:
+    inputs:
+      git_ref:
+        description: 'Git ref to build from'
+        required: false
+        type: string
+        default: ''
+      image_tags:
+        description: 'Comma-separated list of tags for the dev built image (e.g. latest,ci-dev). By default uses the values from hack/build.sh'
+        required: false
+        type: string
+        default: ''
+      registry:
+        description: 'Alternative container registry to push images to (e.g., quay.io/your-username)'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      QUAY_PASSWORD:
+        required: false
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.git_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  webhook:
+    uses: ./.github/workflows/webhook_image.yaml
+    with:
+      image_tags: ${{ inputs.image_tags || github.sha }}
+      git_ref: ${{ inputs.git_ref || github.sha }}
+    permissions:
+      contents: read  # Required to checkout code
+      packages: write  # Required to push container images
+
+  push-to-quay:
+    name: Push webhook image to quay.io
+    permissions:
+      packages: read # Required to copy container images
+    needs: webhook
+    if: ${{ startsWith(inputs.registry, 'quay.io') }}
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Login to ghcr.io container registry
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Login to quay.io container registry
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+      with:
+        registry: quay.io
+        username: ${{ vars.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
+
+    - name: Push webhook image to quay.io
+      env:
+        QUAY_REGISTRY: ${{ inputs.registry }}
+        GHCR_REGISTRY: ghcr.io/${{ github.repository_owner }}
+        IMAGE_TAGS: ${{ inputs.image_tags || github.sha }}
+        IMAGE_NAME: ${{ needs.webhook.outputs.image-name }}
+      run: |
+        tags="${IMAGE_TAGS}"
+        latest=0
+        for t in ${tags//,/ }; do
+          if [ "$t" = "latest" ]; then
+            latest=1
+          else
+            echo "::group::Copy tag ${t}"
+            ghcr_image="${GHCR_REGISTRY}/${IMAGE_NAME}:${t}"
+            quay_image="${QUAY_REGISTRY}/$(basename "$ghcr_image")"
+            oras cp "$ghcr_image" "$quay_image"
+            echo "::endgroup::"
+          fi
+        done
+        if [ $latest -eq 1 ]; then
+          echo "::group::Copy latest"
+          ghcr_image="${GHCR_REGISTRY}/${IMAGE_NAME}:latest"
+          quay_image="${QUAY_REGISTRY}/$(basename "$ghcr_image")"
+          oras cp "$ghcr_image" "$quay_image"
+          echo "::endgroup::"
+        fi


### PR DESCRIPTION
Currently a webhook builds require a secret to quay.io. This will prohibit the building of the images on forks. This is part of an effort to allow running full e2e tests on forks, thus reducing the security problems of sharing repo secrets via pull_request_target.

This change removes the secret from the build step. We decouple the quay.io pushes into a new "webhook_image_publish" workflow, that will mirror and image from ghcr to quay.io. The publish workflow is invoked from both "release" and "publish_images_on_push" workflows.