### PR TITLE
byom: load podvm binaries image locally for the BYOM build

### DIFF
--- a/.github/workflows/podvm_byom_binaries_publish.yaml
+++ b/.github/workflows/podvm_byom_binaries_publish.yaml
@@ -99,7 +99,8 @@ jobs:
           REGISTRY: ${{ inputs.registry != '' && inputs.registry || 'quay.io/confidential-containers' }}
           PODVM_TAG: ${{ inputs.image_tag || github.sha }}
           ARCH: ${{ inputs.arch }}
-          PUSH: "true"
+          # Load the binaries image locally for the BYOM build to use as base.
+          EXPORT_BINARIES: "false"
 
       - name: Build BYOM binaries image
         working-directory: src/cloud-api-adaptor/podvm

--- a/src/cloud-api-adaptor/podvm/Makefile
+++ b/src/cloud-api-adaptor/podvm/Makefile
@@ -83,7 +83,7 @@ endif
 		--build-arg VERIFY_PROVENANCE=$(VERIFY_PROVENANCE) \
 		$(if $(AUTHFILE),--build-arg AUTHFILE=$(AUTHFILE),) \
 		$(if $(DEFAULT_AGENT_POLICY_FILE),--build-arg DEFAULT_AGENT_POLICY_FILE=$(DEFAULT_AGENT_POLICY_FILE),) \
-		$(if $(filter $(EXPORT_BINARIES),false),,-o type=local,dest="./resources/binaries-tree") \
+		$(if $(filter $(EXPORT_BINARIES),false),--load,-o type=local,dest="./resources/binaries-tree") \
 		$(DOCKER_OPTS) \
 		-f Dockerfile.podvm_binaries ../../
 


### PR DESCRIPTION
The BYOM binaries workflow needs the podvm-binaries image available as the base image for the BYOM image build.

Load the image into the local Docker daemon via `DOCKER_OPTS=--load`, and set `EXPORT_BINARIES=false` so the default buildx driver has a single output.

This fixes the failing workflow to publish the BYOM binaries image- https://github.com/confidential-containers/cloud-api-adaptor/actions/runs/33856485393/job/100970893431