### PR TITLE
tests/aws: retry ImportSnapshot on IAM propagation delay

### DIFF
--- a/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
+++ b/src/cloud-api-adaptor/test/provisioner/aws/provision_common.go
@@ -999,8 +999,10 @@ func NewAMIImage(client *ec2.Client, properties map[string]string) *AMIImage {
 
 // importEBSSnapshot Imports the disk image into the EBS
 func (i *AMIImage) importEBSSnapshot(bucket *S3Bucket) error {
-	// Create the import snapshot task
-	importSnapshotOutput, err := i.Client.ImportSnapshot(context.TODO(), &ec2.ImportSnapshotInput{
+	// Create the import snapshot task, retrying on IAM propagation delay.
+	// IAM role creation is eventually consistent and EC2 may return InvalidParameter
+	// immediately after CreateRole/PutRolePolicy completes (observed in CI).
+	input := &ec2.ImportSnapshotInput{
 		Description: aws.String("Peer Pod VM disk snapshot"),
 		DiskContainer: &ec2types.SnapshotDiskContainer{
 			Description: aws.String(i.DiskDescription),
@@ -1012,8 +1014,23 @@ func (i *AMIImage) importEBSSnapshot(bucket *S3Bucket) error {
 		},
 		RoleName:          aws.String(i.VMImportRole),
 		TagSpecifications: defaultTagSpecifications(i.BaseName+"-snap", ec2types.ResourceTypeImportSnapshotTask),
-	})
-	if err != nil {
+	}
+	const (
+		maxRetries    = 6
+		retryInterval = 5 * time.Second
+	)
+	var importSnapshotOutput *ec2.ImportSnapshotOutput
+	var err error
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		importSnapshotOutput, err = i.Client.ImportSnapshot(context.TODO(), input)
+		if err == nil {
+			break
+		}
+		if strings.Contains(err.Error(), "does not exist or does not have sufficient permissions") && attempt < maxRetries {
+			log.Infof("ImportSnapshot: IAM role not yet propagated, retrying in %s (attempt %d/%d)", retryInterval, attempt, maxRetries)
+			time.Sleep(retryInterval)
+			continue
+		}
 		return err
 	}
 


### PR DESCRIPTION
The vmimport service role is created immediately before the S3 upload, and the servicerole isn't checked for readiness, resulting in us sometimes getting:
```
The service role ... does not exist or does not have sufficient permissions.
```

Retry ImportSnapshot up to 30s of additional wait time for IAM propagation to complete.
Fixes: #3286

Generated-By: IBM Bob