### PR TITLE
install/charts: set disableAll to "true" for shims

### DIFF
--- a/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
+++ b/src/cloud-api-adaptor/install/charts/peerpods/values.yaml
@@ -168,37 +168,6 @@ kata-deploy:
     s390x: remote
     ppc64le: remote
   shims:
-    clh:
-      enabled: false
-    cloud-hypervisor:
-      enabled: false
-    dragonball:
-      enabled: false
-    fc:
-      enabled: false
-    qemu:
-      enabled: false
-    qemu-runtime-rs:
-      enabled: false
-    qemu-nvidia-gpu:
-      enabled: false
-    qemu-nvidia-gpu-snp:
-      enabled: false
-    qemu-nvidia-gpu-tdx:
-      enabled: false
-    qemu-snp:
-      enabled: false
-    qemu-tdx:
-      enabled: false
-    qemu-se:
-      enabled: false
-    qemu-se-runtime-rs:
-      enabled: false
-    qemu-cca:
-      enabled: false
-    qemu-coco-dev:
-      enabled: false
-    qemu-coco-dev-runtime-rs:
-      enabled: false
+    disableAll: true
     remote:
       enabled: true


### PR DESCRIPTION
Currently rendered helm installs all shims even they are disabled in values. Kata deploy contains special flag to disableAll and turn on only required ones.