### PR TITLE
peerpod-ctrl: add additionalPrinterColumns for PeerPod

### DIFF
--- a/src/peerpod-ctrl/api/v1alpha1/peerpod_types.go
+++ b/src/peerpod-ctrl/api/v1alpha1/peerpod_types.go
@@ -36,6 +36,9 @@ type PeerPodStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Cloud Provider",type="string",JSONPath=".spec.cloudProvider"
+//+kubebuilder:printcolumn:name="Instance ID",type="string",JSONPath=".spec.instanceID"
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // PeerPod is the Schema for the peerpods API
 type PeerPod struct {

--- a/src/peerpod-ctrl/chart/crds/confidentialcontainers.org_peerpods.yaml
+++ b/src/peerpod-ctrl/chart/crds/confidentialcontainers.org_peerpods.yaml
@@ -15,7 +15,17 @@ spec:
     singular: peerpod
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.cloudProvider
+      name: Cloud Provider
+      type: string
+    - jsonPath: .spec.instanceID
+      name: Instance ID
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: PeerPod is the Schema for the peerpods API


### PR DESCRIPTION
Currently listing PeerPods is a little spartan, just showing name and age. Add additional columns for cloud provider and the instance ID